### PR TITLE
Adding support for multiple EBS volumes

### DIFF
--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -25,66 +25,92 @@ execute "add_configure-pat" do
   not_if 'grep -qx /usr/local/sbin/configure-pat.sh /etc/rc.local'
 end
 
-dev_path = "/dev/disk/by-ebs-volumeid/#{node['cfncluster']['cfn_volume']}"
-
-# Attach EBS volume
-execute "attach_volume" do
-  command "/usr/local/sbin/attachVolume.py #{node['cfncluster']['cfn_volume']}"
-  creates dev_path
+# Parse shared directory info and turn into an array
+_shared_dir_array = node['cfncluster']['cfn_shared_dir'].split(',')
+_shared_dir_array.each_with_index do |dir, index|
+    _shared_dir_array[index] = dir.strip
+    _shared_dir_array[index] = "/"+_shared_dir_array[index]
+    puts "Shared directory #{index}: #{dir}"
 end
 
-# wait for the drive to attach, before making a filesystem
-ruby_block "sleeping_for_volume" do
-  block do
-    wait_for_block_dev(dev_path)
-  end
-  action :nothing
-  subscribes :run, "execute[attach_volume]", :immediately
+# Parse volume info into an arary
+_vol_array = node['cfncluster']['cfn_volume'].split(',')
+_vol_array.each_with_index do |vol, index|
+    _vol_array[index] = vol.strip
+    puts "Shared directory #{index}: #{vol}"
 end
 
-# Setup disk, will be formatted xfs if empty
-ruby_block "setup_disk" do
-  block do
-    fs_type = setup_disk(dev_path)
-    node.default['cfncluster']['cfn_volume_fs_type'] = fs_type
-  end
-  action :nothing
-  subscribes :run, "ruby_block[sleeping_for_volume]", :immediately
-end
+# Mount each volume
+dev_path = []
 
-# Create the shared directory
-directory node['cfncluster']['cfn_shared_dir'] do
-  owner 'root'
-  group 'root'
-  mode '1777'
-  recursive true
-  action :create
-end
+_vol_array.each_with_index do |volumeid, index|
+    dev_path[index] = "/dev/disk/by-ebs-volumeid/#{volumeid}"
 
-# Add volume to /etc/fstab
-mount node['cfncluster']['cfn_shared_dir'] do
-  device dev_path
-  fstype(DelayedEvaluator.new { node['cfncluster']['cfn_volume_fs_type'] })
-  options "_netdev"
-  pass 0
-  action %i[mount enable]
-end
 
-# Make sure shared directory permissions are correct
-directory node['cfncluster']['cfn_shared_dir'] do
-  owner 'root'
-  group 'root'
-  mode '1777'
-end
+    # Attach EBS volume
+    execute "attach_volume_#{index}" do
+        command "/usr/local/sbin/attachVolume.py #{volumeid}"
+        creates dev_path[index]
+        puts "Attached index: #{index}, VolID: #{volumeid}"
+    end
 
-# Get VPC CIDR
-node.default['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block'] = get_vpc_ipv4_cidr_block(node['macaddress'])
+    # wait for the drive to attach, before making a filesystem
+    ruby_block "sleeping_for_volume_#{index}" do
+      block do
+         wait_for_block_dev(dev_path[index])
+      end
+      action :nothing
+      subscribes :run, "execute[attach_volume_#{index}]", :immediately
+    end
 
-# Export shared dir
-nfs_export node['cfncluster']['cfn_shared_dir'] do
-  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
-  writeable true
-  options ['no_root_squash']
+    # Setup disk, will be formatted xfs if empty
+    ruby_block "setup_disk_#{index}" do
+        puts "Setting up #{dev_path[index]}"
+        block do
+            fs_type = setup_disk(dev_path[index])
+            node.default['cfncluster']['cfn_volume_fs_type'] = fs_type
+        end
+        action :nothing
+        subscribes :run, "ruby_block[sleeping_for_volume_#{index}]", :immediately
+
+        puts "Finished Setup #{dev_path[index]}"
+    end
+
+    # Create the shared directories
+    directory _shared_dir_array[index] do
+      owner 'root'
+      group 'root'
+      mode '1777'
+      recursive true
+      action :create
+    end
+
+    # Add volume to /etc/fstab
+    mount _shared_dir_array[index] do
+      device dev_path[index]
+      fstype(DelayedEvaluator.new { node['cfncluster']['cfn_volume_fs_type'] })
+      options "_netdev"
+      pass 0
+      action %i[mount enable]
+    end
+
+    # Get VPC CIDR
+    node.default['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block'] = get_vpc_ipv4_cidr_block(node['macaddress'])
+
+    # Make sure shared directory permissions are correct
+    directory _shared_dir_array[index] do
+      owner 'root'
+      group 'root'
+      mode '1777'
+    end
+
+    # Export shared dir
+    nfs_export _shared_dir_array[index] do
+      network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+      writeable true
+      options ['no_root_squash']
+    end
+
 end
 
 # Export /home


### PR DESCRIPTION
- Takes in comma separated list of shared directory name and volume-id as string through dna.json, parse into list in program.

- Run for each loop for each volume-id, and carry out all attach and mounting procedure in _master_base_config. Note: it is crucial the execute or ruby block within the for each loop to have a unique name, so that the workflow is independent for each volume-id.

- Run for each loop for each shared directory, and carry out all NFS mounting procedure in _compute_base_config.

- Note: it is crucial to use mountpoints throughout the program, for example, if the user want to mount to a share directory called "apps", we need to mount to "/apps" throughout the program. Mounting to "apps", without the slash, will cause lots of error and prevent AutoScalingGroup from creating.

- This change is to prepare cfncluster for mounting multiple EBS volumes. This cookbook modification should remain valid for arbitary number of EBS volumes, as long as the input format is consistent.

Signed-off-by: Rex Chen <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
