### PR TITLE
Pin awscli version on Ubuntu14

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -69,9 +69,9 @@ end
 
 # Install AWSCLI
 if node['platform'] == 'ubuntu' && node['platform_version'] == "14.04"
-  package 'awscli' do
-    retries 3
-    retry_delay 5
+  # For Ubuntu 14 manually install dependencies, in order to not break cloud-init
+  python_package 'awscli' do
+    version '1.15.85' # This imply botocore 1.10.84 which does not require urllib3
   end
 else
   python_package 'awscli'


### PR DESCRIPTION
This is done in order to pin botocore to version 1.10.84 which
doesn't break the cloud-init package installed into the OS

The package version that need to be preserved is urllib3
awscli -> botocore -> urllib3
cloud-init -> urllib3

The version of the awscli from repository depends on an old version of
botocore that does not works with newest regions.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
