### PR TITLE
Set PATH as in the UserData script of the CloudFormation template

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -90,6 +90,8 @@ end
 bash 'execute jq' do
   cwd Chef::Config[:file_cache_path]
   code <<-JQMERGE
+    # Set PATH as in the UserData script of the CloudFormation template
+    export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin"
     echo '{"cfncluster": {"cfn_region": "eu-west-3"}, "run_list": "recipe[aws-parallelcluster::sge_config]"}' > /tmp/dna.json
     echo '{ "cfncluster" : { "ganglia_enabled" : "yes" } }' > /tmp/extra.json
     jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster' || exit 1


### PR DESCRIPTION
In this way, during the test we are sure we do have the same PATH set
during the executing of the UserData script

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
