### PR TITLE
Changed cfncluster_version to parallelcluster_version

### DIFF
--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -1,7 +1,7 @@
 {
   "variables" : {
-    "cfncluster_version" : "",
-    "cfncluster_cookbook_version" : "",
+    "parallelcluster_version" : "",
+    "parallelcluster_cookbook_version" : "",
     "chef_version" : "",
     "ridley_version" : "",
     "berkshelf_version" : "",
@@ -36,7 +36,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ec2-user",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `cfncluster_version`}}-amzn-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-amzn-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
@@ -45,11 +45,11 @@
       "ena_support" : true,
       "shutdown_behavior" : "terminate",
       "tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "run_tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "launch_block_device_mappings" : [
@@ -89,7 +89,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ec2-user",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `cfncluster_version`}}-amzn-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-amzn-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
@@ -98,12 +98,12 @@
       "ena_support" : true,
       "shutdown_behavior" : "terminate",
       "tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "run_tags" : {
         "Name": "Packer Builder {{user `custom_ami_id`}}",
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "launch_block_device_mappings" : [
@@ -229,14 +229,14 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo curl https://s3.amazonaws.com/us-east-1-aws-parallelcluster/cookbooks/aws-parallelcluster-cookbook-{{user `cfncluster_cookbook_version`}}.tgz --silent --location -o /etc/chef/aws-parallelcluster-cookbook.tgz"
+        "sudo curl https://s3.amazonaws.com/us-east-1-aws-parallelcluster/cookbooks/aws-parallelcluster-cookbook-{{user `parallelcluster_cookbook_version`}}.tgz --silent --location -o /etc/chef/aws-parallelcluster-cookbook.tgz"
       ]
     },
     {
       "type" : "shell",
       "inline" : [
         "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
-        "echo aws-parallelcluster-{{user `cfncluster_version`}} | sudo tee /opt/parallelcluster/.bootstrapped"
+        "echo aws-parallelcluster-{{user `parallelcluster_version`}} | sudo tee /opt/parallelcluster/.bootstrapped"
       ]
     },
     {

--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -1,7 +1,7 @@
 {
   "variables" : {
-    "cfncluster_version" : "",
-    "cfncluster_cookbook_version" : "",
+    "parallelcluster_version" : "",
+    "parallelcluster_cookbook_version" : "",
     "chef_version" : "",
     "ridley_version" : "",
     "berkshelf_version" : "",
@@ -36,7 +36,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "centos",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `cfncluster_version`}}-centos6-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-centos6-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
@@ -45,11 +45,11 @@
       "ena_support" : true,
       "shutdown_behavior" : "terminate",
       "tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "run_tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "launch_block_device_mappings" : [
@@ -89,7 +89,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "centos",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `cfncluster_version`}}-centos6-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-centos6-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
@@ -98,12 +98,12 @@
       "ena_support" : true,
       "shutdown_behavior" : "terminate",
       "tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "run_tags" : {
         "Name": "Packer Builder {{user `custom_ami_id`}}",
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "launch_block_device_mappings" : [
@@ -245,14 +245,14 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo curl https://s3.amazonaws.com/us-east-1-aws-parallelcluster/cookbooks/aws-parallelcluster-cookbook-{{user `cfncluster_cookbook_version`}}.tgz --silent --location -o /etc/chef/aws-parallelcluster-cookbook.tgz"
+        "sudo curl https://s3.amazonaws.com/us-east-1-aws-parallelcluster/cookbooks/aws-parallelcluster-cookbook-{{user `parallelcluster_cookbook_version`}}.tgz --silent --location -o /etc/chef/aws-parallelcluster-cookbook.tgz"
       ]
     },
     {
       "type" : "shell",
       "inline" : [
         "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
-        "echo aws-parallelcluster-{{user `cfncluster_version`}} | sudo tee /opt/parallelcluster/.bootstrapped"
+        "echo aws-parallelcluster-{{user `parallelcluster_version`}} | sudo tee /opt/parallelcluster/.bootstrapped"
       ]
     },
     {

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -1,7 +1,7 @@
 {
   "variables" : {
-    "cfncluster_version" : "",
-    "cfncluster_cookbook_version" : "",
+    "parallelcluster_version" : "",
+    "parallelcluster_cookbook_version" : "",
     "chef_version" : "",
     "ridley_version" : "",
     "berkshelf_version" : "",
@@ -36,7 +36,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "centos",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `cfncluster_version`}}-centos7-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-centos7-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
@@ -45,11 +45,11 @@
       "ena_support" : true,
       "shutdown_behavior" : "terminate",
       "tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "run_tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "launch_block_device_mappings" : [
@@ -89,7 +89,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "centos",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `cfncluster_version`}}-centos7-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-centos7-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
@@ -97,12 +97,12 @@
       "sriov_support" : true,
       "ena_support" : true,
       "tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "run_tags" : {
         "Name": "Packer Builder {{user `custom_ami_id`}}",
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "launch_block_device_mappings" : [
@@ -243,14 +243,14 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo curl https://s3.amazonaws.com/us-east-1-aws-parallelcluster/cookbooks/aws-parallelcluster-cookbook-{{user `cfncluster_cookbook_version`}}.tgz --silent --location -o /etc/chef/aws-parallelcluster-cookbook.tgz"
+        "sudo curl https://s3.amazonaws.com/us-east-1-aws-parallelcluster/cookbooks/aws-parallelcluster-cookbook-{{user `parallelcluster_cookbook_version`}}.tgz --silent --location -o /etc/chef/aws-parallelcluster-cookbook.tgz"
       ]
     },
     {
       "type" : "shell",
       "inline" : [
         "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
-        "echo aws-parallelcluster-{{user `cfncluster_version`}} | sudo tee /opt/parallelcluster/.bootstrapped"
+        "echo aws-parallelcluster-{{user `parallelcluster_version`}} | sudo tee /opt/parallelcluster/.bootstrapped"
       ]
     },
     {

--- a/amis/packer_ubuntu1404.json
+++ b/amis/packer_ubuntu1404.json
@@ -1,7 +1,7 @@
 {
   "variables" : {
-    "cfncluster_version" : "",
-    "cfncluster_cookbook_version" : "",
+    "parallelcluster_version" : "",
+    "parallelcluster_cookbook_version" : "",
     "chef_version" : "",
     "ridley_version" : "",
     "berkshelf_version" : "",
@@ -36,7 +36,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `cfncluster_version`}}-ubuntu-1404-lts-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-ubuntu-1404-lts-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
@@ -45,11 +45,11 @@
       "ena_support" : true,
       "shutdown_behavior" : "terminate",
       "tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "run_tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "launch_block_device_mappings" : [
@@ -89,7 +89,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `cfncluster_version`}}-ubuntu-1404-lts-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-ubuntu-1404-lts-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
@@ -98,12 +98,12 @@
       "ena_support" : true,
       "shutdown_behavior" : "terminate",
       "tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "run_tags" : {
         "Name": "Packer Builder {{user `custom_ami_id`}}",
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "launch_block_device_mappings" : [
@@ -250,14 +250,14 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo curl https://s3.amazonaws.com/us-east-1-aws-parallelcluster/cookbooks/aws-parallelcluster-cookbook-{{user `cfncluster_cookbook_version`}}.tgz --silent --location -o /etc/chef/aws-parallelcluster-cookbook.tgz"
+        "sudo curl https://s3.amazonaws.com/us-east-1-aws-parallelcluster/cookbooks/aws-parallelcluster-cookbook-{{user `parallelcluster_cookbook_version`}}.tgz --silent --location -o /etc/chef/aws-parallelcluster-cookbook.tgz"
       ]
     },
     {
       "type" : "shell",
       "inline" : [
         "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
-        "echo aws-parallelcluster-{{user `cfncluster_version`}} | sudo tee /opt/parallelcluster/.bootstrapped"
+        "echo aws-parallelcluster-{{user `parallelcluster_version`}} | sudo tee /opt/parallelcluster/.bootstrapped"
       ]
     },
     {

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -1,7 +1,7 @@
 {
   "variables" : {
-    "cfncluster_version" : "",
-    "cfncluster_cookbook_version" : "",
+    "parallelcluster_version" : "",
+    "parallelcluster_cookbook_version" : "",
     "chef_version" : "",
     "ridley_version" : "",
     "berkshelf_version" : "",
@@ -36,7 +36,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `cfncluster_version`}}-ubuntu-1604-lts-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-ubuntu-1604-lts-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
@@ -45,11 +45,11 @@
       "ena_support" : true,
       "shutdown_behavior" : "terminate",
       "tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "run_tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "launch_block_device_mappings" : [
@@ -89,7 +89,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `cfncluster_version`}}-ubuntu-1604-lts-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-ubuntu-1604-lts-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
@@ -98,12 +98,12 @@
       "ena_support" : true,
       "shutdown_behavior" : "terminate",
       "tags" : {
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "run_tags" : {
         "Name": "Packer Builder {{user `custom_ami_id`}}",
-        "cfncluster_version" : "aws-parallelcluster-{{user `cfncluster_version`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
         "build_date" : "{{user `build_date`}}"
       },
       "launch_block_device_mappings" : [
@@ -253,14 +253,14 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo curl https://s3.amazonaws.com/us-east-1-aws-parallelcluster/cookbooks/aws-parallelcluster-cookbook-{{user `cfncluster_cookbook_version`}}.tgz --silent --location -o /etc/chef/aws-parallelcluster-cookbook.tgz"
+        "sudo curl https://s3.amazonaws.com/us-east-1-aws-parallelcluster/cookbooks/aws-parallelcluster-cookbook-{{user `parallelcluster_cookbook_version`}}.tgz --silent --location -o /etc/chef/aws-parallelcluster-cookbook.tgz"
       ]
     },
     {
       "type" : "shell",
       "inline" : [
         "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
-        "echo aws-parallelcluster-{{user `cfncluster_version`}} | sudo tee /opt/parallelcluster/.bootstrapped"
+        "echo aws-parallelcluster-{{user `parallelcluster_version`}} | sudo tee /opt/parallelcluster/.bootstrapped"
       ]
     },
     {

--- a/amis/packer_variables.json
+++ b/amis/packer_variables.json
@@ -1,6 +1,6 @@
 {
-  "cfncluster_version": "2.1.0",
-  "cfncluster_cookbook_version": "2.1.0",
+  "parallelcluster_version": "2.1.0",
+  "parallelcluster_cookbook_version": "2.1.0",
   "chef_version": "14.2.0",
   "ridley_version": "5.1.1",
   "berkshelf_version": "7.0.4"


### PR DESCRIPTION
```
$ grep -r "cfncluster_version" .
[nothing]
$ grep -r "cfncluster_cookbook_version" .
[nothing]
```

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
