### PR TITLE
Fix getting the right aws-cfn-bootstrap-latest from cn-north-1

### DIFF
--- a/amis/packer_ubuntu1404.json
+++ b/amis/packer_ubuntu1404.json
@@ -246,7 +246,7 @@
       "inline" : [
         "region=\"{{user `region`}}\"",
         "bucket=\"s3.${region}.amazonaws.com\"",
-        "[[ ${region} =~ ^cn- ]] && bucket=\"s3.${region}.amazonaws.com.cn\"",
+        "[[ ${region} =~ ^cn- ]] && bucket=\"s3.cn-north-1.amazonaws.com.cn\"",
         "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
         "sudo pip install /tmp/aws-cfn-bootstrap-latest.tar.gz"
       ]
@@ -257,7 +257,7 @@
       "inline" : [
         "region=\"{{user `region`}}\"",
         "bucket=\"s3.${region}.amazonaws.com\"",
-        "[[ ${region} =~ ^cn- ]] && bucket=\"s3.cn-north-1.amazonaws.com.cn\"",
+        "[[ ${region} =~ ^cn- ]] && bucket=\"s3.${region}.amazonaws.com.cn\"",
         "sudo curl --retry 3 https://${bucket}/${region}-aws-parallelcluster/cookbooks/aws-parallelcluster-cookbook-{{user `parallelcluster_cookbook_version`}}.tgz --silent --location -o /etc/chef/aws-parallelcluster-cookbook.tgz"
       ]
     },


### PR DESCRIPTION
The package aws-cfn-bootstrap-latest.tar.gz does not exist in
cn-northwest-1

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
