### PR TITLE
Fix block device conversion

### DIFF
--- a/files/default/attachVolume.py
+++ b/files/default/attachVolume.py
@@ -15,7 +15,7 @@ def convert_dev(dev):
     # FIXME This approach could be broken in some OS variants, see
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
     if '/nvme' in dev:
-        return '/dev/' + os.popen('sudo /usr/local/sbin/parallelcluster-ebsnvme-id -b ' + dev).read().strip()
+        return '/dev/' + os.popen('sudo /usr/local/sbin/parallelcluster-ebsnvme-id -u -b ' + dev).read().strip()
     elif '/hd' in dev:
         return dev.replace('hd', 'sd')
     elif '/xvd' in dev:


### PR DESCRIPTION
The block device returned by the parallelcluster-ebsnvme-id script must
be in format suitable for udev rules

E.g.
- without -u flag
parallelcluster-ebsnvme-id -b /dev/nvme0n1 return sda1
parallelcluster-ebsnvme-id -b /dev/nvme1n1 return /dev/sdb

- with -u flag
parallelcluster-ebsnvme-id -u -b /dev/nvme0n1 return sda1
parallelcluster-ebsnvme-id -u -b /dev/nvme1n1 return sdb

This fix https://github.com/aws/aws-parallelcluster/issues/823

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
