### PR TITLE
Prepend / to RAID Shared Directory

### DIFF
--- a/recipes/_compute_base_config.rb
+++ b/recipes/_compute_base_config.rb
@@ -32,6 +32,11 @@ include_recipe 'aws-parallelcluster::efs_mount'
 # Parse and get RAID shared directory info and turn into an array
 raid_shared_dir = node['cfncluster']['cfn_raid_parameters'].split(',')[0]
 
+# Path needs to be fully qualified, for example "shared/temp" becomes "/shared/temp"
+if !raid_shared_dir.start_with?("/")
+  raid_shared_dir = "/" + raid_shared_dir
+end
+
 if raid_shared_dir != "NONE"
   # Created RAID shared mount point
   directory raid_shared_dir do

--- a/recipes/setup_raid_on_master.rb
+++ b/recipes/setup_raid_on_master.rb
@@ -17,6 +17,11 @@
 # Parse and get RAID shared directory info and turn into an array
 raid_shared_dir = node['cfncluster']['cfn_raid_parameters'].split(',')[0]
 
+# Path needs to be fully qualified, for example "shared/temp" becomes "/shared/temp"
+if !raid_shared_dir.start_with?("/")
+  raid_shared_dir = "/" + raid_shared_dir
+end
+
 if raid_shared_dir != "NONE"
 
   # Parse and determine RAID type (cast into integer)


### PR DESCRIPTION
In the documentation, the raid shared directory can be specified as `shared` and not `/shared`. However, currently the code expects a full path. For EBS we add the preceeding `/`.

https://aws-parallelcluster.readthedocs.io/en/latest/configuration.html#id8

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
