### PR TITLE
Remove extra leading / in ebs mount

### DIFF
--- a/recipes/_compute_base_config.rb
+++ b/recipes/_compute_base_config.rb
@@ -90,7 +90,7 @@ end
 shared_dir_array = node['cfncluster']['cfn_shared_dir'].split(',')
 shared_dir_array.each_with_index do |dir, index|
   shared_dir_array[index] = dir.strip
-  shared_dir_array[index] = "/" + shared_dir_array[index]
+  shared_dir_array[index] = "/" + shared_dir_array[index] unless shared_dir_array[index].start_with?("/")
 end
 
 # Mount each volume with NFS

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -35,7 +35,7 @@ include_recipe 'aws-parallelcluster::efs_mount'
 shared_dir_array = node['cfncluster']['cfn_shared_dir'].split(',')
 shared_dir_array.each_with_index do |dir, index|
   shared_dir_array[index] = dir.strip
-  shared_dir_array[index] = "/" + shared_dir_array[index]
+  shared_dir_array[index] = "/" + shared_dir_array[index] unless shared_dir_array[index].start_with?("/")
 end
 
 # Parse volume info into an arary

--- a/recipes/efs_mount.rb
+++ b/recipes/efs_mount.rb
@@ -14,10 +14,14 @@
 # limitations under the License.
 
 # Get shared_dir path and mount EFS filesystem
-efs_shared_dir = "/" + node['cfncluster']['cfn_efs_shared_dir'].split(',')[0]
+efs_shared_dir =  node['cfncluster']['cfn_efs_shared_dir'].split(',')[0]
 
 # Check to see if EFS is created
-if efs_shared_dir != "/NONE"
+if efs_shared_dir != "NONE"
+
+  # Path needs to be fully qualified, for example "shared/temp" becomes "/shared/temp"
+  efs_shared_dir = "/" + efs_shared_dir unless efs_shared_dir.start_with?("/")
+
   # Create the EFS shared directory
   directory efs_shared_dir do
     owner 'root'


### PR DESCRIPTION
There is an extra leading `/` in the fstab when mounting ebs volumes.

```
[ec2-user@ip-10-0-0-217 ~]$ cat /etc/fstab
...
/dev/disk/by-ebs-volumeid/vol-0ebd5252323ea4071 //ebs_mount_dir_0 ext4 _netdev 0 0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
