### PR TITLE
FSx Support for Ubuntu 1604

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -108,6 +108,12 @@ when 'debian'
                                               apache2 libboost-dev libdb-dev tcsh libssl-dev libncurses5-dev libpam0g-dev libxt-dev
                                               libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev libopenmpi-dev
                                               r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev mdadm]
+
+  # Lustre Drivers for Ubuntu 16.04
+  default['cfncluster']['lustre']['version'] = '2.10.6'
+  default['cfncluster']['lustre']['client'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/ubuntu1604/client/lustre-client-modules-4.4.0-131-generic_2.10.6-1_amd64.deb'
+  default['cfncluster']['lustre']['utils'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/ubuntu1604/client/lustre-utils_2.10.6-1_amd64.deb'
+
   if Chef::VersionConstraint.new('< 16.04').include?(node['platform_version'])
     default['cfncluster']['kernel_devel_pkg']['name'] = "linux-image-extra"
     default['cfncluster']['kernel_devel_pkg']['version'] = node['kernel']['release']

--- a/recipes/_default_pre.rb
+++ b/recipes/_default_pre.rb
@@ -56,3 +56,14 @@ if tagged?('rebooted')
     end
   end
 end
+
+# For FSx Lustre, we need to install the 4.4.0-131 kernel and restart
+if node['platform'] == 'ubuntu' && node['platform_version'] == '16.04'
+  package 'linux-image-4.4.0-131-generic'
+  package 'linux-headers-4.4.0-131-generic'
+
+  # Change Grub to use 4.4.0-131-generic kernel
+  execute 'GRUB' do
+    command "sed -i 's/GRUB_DEFAULT=.\+/GRUB\_DEFAULT=\"Advanced options for Ubuntu>Ubuntu, with Linux 4.4.0-131-generic\"/' /etc/default/grub && update-grub"
+  end
+end

--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -1,0 +1,81 @@
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: lustre_install
+#
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+case node['platform']
+when "centos"
+
+  lustre_kmod_rpm = "#{node['cfncluster']['sources_dir']}/kmod-lustre-client-#{node['cfncluster']['lustre']['version']}.x86_64.rpm"
+  lustre_client_rpm = "#{node['cfncluster']['sources_dir']}/lustre-client-#{node['cfncluster']['lustre']['version']}.x86_64.rpm"
+
+  # Get Lustre Kernel Module RPM
+  remote_file lustre_kmod_rpm do
+    source node['cfncluster']['lustre']['kmod_url']
+    mode '0644'
+    retries 3
+    retry_delay 5
+    not_if { ::File.exist?(lustre_kmod_rpm) }
+  end
+
+  # Get Lustre Client RPM
+  remote_file lustre_client_rpm do
+    source node['cfncluster']['lustre']['client_url']
+    mode '0644'
+    retries 3
+    retry_delay 5
+    not_if { ::File.exist?(lustre_client_rpm) }
+  end
+
+  # Install lustre mount drivers
+  yum_package 'lustre_kmod' do
+    source lustre_kmod_rpm
+  end
+
+  # Install lustre mount drivers
+  yum_package 'lustre_client' do
+    source lustre_client_rpm
+  end
+
+when "ubuntu"
+  lustre_client_modules = "#{node['cfncluster']['sources_dir']}/lustre-client-modules-4.4.0-131-generic_#{node['cfncluster']['lustre']['version']}_amd64.deb"
+  lustre_utils = "#{node['cfncluster']['sources_dir']}/lustre-utils_#{node['cfncluster']['lustre']['version']}_amd64.deb"
+
+  # Get Lustre Client Module
+  remote_file lustre_client_modules do
+    source node['cfncluster']['lustre']['client']
+    mode '0644'
+    retries 3
+    retry_delay 5
+    not_if { ::File.exist?(lustre_client_modules) }
+  end
+
+  # Get Lustre Client Utils
+  remote_file lustre_utils do
+    source node['cfncluster']['lustre']['utils']
+    mode '0644'
+    retries 3
+    retry_delay 5
+    not_if { ::File.exist?(lustre_utils) }
+  end
+
+  # Install lustre mount drivers
+  package 'lustre_client_modules' do
+    source lustre_client_modules
+  end
+
+  # Install lustre mount drivers
+  package 'lustre_utils' do
+    source lustre_utils
+  end
+end


### PR DESCRIPTION
### Testing

Needs reboot, hence making it difficult to test. Here's how I did it:

1. Create a ubuntu1604 cluster with fsx options:
```ini
[cluster fsx]
...
base_os = ubuntu1604
template_url = https://s3.amazonaws.com/[bucket]/templates/aws-parallelcluster-2.1.1.cfn.json
custom_chef_cookbook = https://s3.amazonaws.com/[bucket]/cookbooks/aws-parallelcluster-cookbook-2.1.1.tgz
fsx_settings = fs

[fsx fs]
shared_dir = /fsx
# must be in the same vpc as cluster and have post 988 open in it's SG
fsx_fs_id = fs-073c3703dca3e28b6
```
2. Cluster fails creation
3. SSH in and pull down this branch
```bash
cd /etc/chef/cookbooks/
git clone https://github.com/sean-smith/cfncluster-cookbook.git
cd cfncluster-cookbook/
git checkout fsx-ubuntu # this is further complicated by the fact you need to combine fsx-support and fsx-ubuntu branches
```
4. Run chef `_default_pre` recipe
5. Reboot
```bash
sudo reboot
```
6. Run chef to install lustre modules
7. Run chef to mount FS

### Reference

See https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
