### PR TITLE
Define Lustre variables only for Centos

### DIFF
--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -13,10 +13,10 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-lustre_kmod_rpm = "#{node['cfncluster']['sources_dir']}/kmod-lustre-client-#{node['cfncluster']['lustre']['version']}.x86_64.rpm"
-lustre_client_rpm = "#{node['cfncluster']['sources_dir']}/lustre-client-#{node['cfncluster']['lustre']['version']}.x86_64.rpm"
-
 if node['platform'] == 'centos'
+  lustre_kmod_rpm = "#{node['cfncluster']['sources_dir']}/kmod-lustre-client-#{node['cfncluster']['lustre']['version']}.x86_64.rpm"
+  lustre_client_rpm = "#{node['cfncluster']['sources_dir']}/lustre-client-#{node['cfncluster']['lustre']['version']}.x86_64.rpm"
+
   # Get Lustre Kernel Module RPM
   remote_file lustre_kmod_rpm do
     source node['cfncluster']['lustre']['kmod_url']


### PR DESCRIPTION
Lustre version is defined only in Centos

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
