### PR TITLE
Install Lustre on Centos 7.6 & 7.5

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -86,11 +86,17 @@ when 'rhel', 'amazon'
                                                   httpd boost-devel redhat-lsb mlocate lvm2 mpich-devel openmpi-devel R atlas-devel
                                                   blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                                   libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel mdadm]
-
-      # Lustre Drivers for Centos 7.6
-      default['cfncluster']['lustre']['version'] = '2.10.6'
-      default['cfncluster']['lustre']['kmod_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/kmod-lustre-client-2.10.6-1.el7.x86_64.rpm'
-      default['cfncluster']['lustre']['client_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/lustre-client-2.10.6-1.el7.x86_64.rpm'
+      if node['platform_version'].split('.')[1] == '6'
+        # Lustre Drivers for Centos 7.6
+        default['cfncluster']['lustre']['version'] = '2.10.6'
+        default['cfncluster']['lustre']['kmod_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/kmod-lustre-client-2.10.6-1.el7.x86_64.rpm'
+        default['cfncluster']['lustre']['client_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/lustre-client-2.10.6-1.el7.x86_64.rpm'
+      elsif node['platform_version'].split('.')[1] == '5'
+        # Lustre Drivers for Centos 7.5
+        default['cfncluster']['lustre']['version'] = '2.10.5'
+        default['cfncluster']['lustre']['kmod_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/kmod-lustre-client-2.10.5-1.el7.x86_64.rpm'
+        default['cfncluster']['lustre']['client_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/lustre-client-2.10.5-1.el7.x86_64.rpm'
+      end
     end
     default['cfncluster']['kernel_devel_pkg']['name'] = "kernel-lt-devel" if node['platform'] == 'centos' && node['platform_version'].to_i >= 6 && node['platform_version'].to_i < 7
     default['cfncluster']['rhel']['extra_repo'] = 'rhui-REGION-rhel-server-releases-optional' if node['platform'] == 'redhat' && node['platform_version'].to_i >= 6 && node['platform_version'].to_i < 7

--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -13,7 +13,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-if node['platform'] == 'centos'
+# Install only on Centos 7.6 and 7.5
+if node['platform'] == 'centos' && (5..6).cover?(node['platform_version'].split('.')[1].to_i)
   lustre_kmod_rpm = "#{node['cfncluster']['sources_dir']}/kmod-lustre-client-#{node['cfncluster']['lustre']['version']}.x86_64.rpm"
   lustre_client_rpm = "#{node['cfncluster']['sources_dir']}/lustre-client-#{node['cfncluster']['lustre']['version']}.x86_64.rpm"
 
@@ -44,4 +45,6 @@ if node['platform'] == 'centos'
   yum_package 'lustre_client' do
     source lustre_client_rpm
   end
+elsif node['platform'] == 'centos'
+  Chef::Log.warn("Unsupported version of Centos, #{node['platform_version']}, supported versions are 7.6 and 7.5")
 end


### PR DESCRIPTION
Only install Lustre Modules on Centos 7.6 and 7.5.

If the centos version isn't supported, log it, but don't fail. This is because the `_lustre_install.rb` is run regardless of if FSx is used.

The `.cover?` function works like so:

```ruby
> (5..6).cover?(5)
True
> (5..6).cover?(6)
True
> (5..6).cover?(7)
False
```

### Testing

#### Centos 7.6
Tested with `base_os = centos7`

```ini
[cluster fsx]
...
base_os = centos7
fsx_settings = fs

[fsx fs]
shared_dir = /fsx
fsx_fs_id = fs-073c3703dca3e28b6
```

#### Centos 7.5
I have not tested, as I couldn't find a working ami, but here's the strategy: set `custom_ami = ami-017b013ef58a362fb` (This is an old parallelcluster release)

```ini
[cluster fsx]
...
custom_ami = ami-017b013ef58a362fb
fsx_settings = fs

[fsx fs]
shared_dir = /fsx
fsx_fs_id = fs-073c3703dca3e28b6
```

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
