### PR TITLE
sqswatcher: add max_queue_size to config

### DIFF
--- a/templates/default/sqswatcher.cfg.erb
+++ b/templates/default/sqswatcher.cfg.erb
@@ -5,3 +5,4 @@ table_name = <%= node['cfncluster']['cfn_ddb_table'] %>
 scheduler = <%= node['cfncluster']['cfn_scheduler'] %>
 cluster_user = <%= node['cfncluster']['cfn_cluster_user'] %>
 proxy = <%= node['cfncluster']['cfn_proxy'] %>
+max_queue_size = <%= node['cfncluster']['cfn_max_queue_size'] %>


### PR DESCRIPTION
Needed to configured max cluster size in schedulers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
