### PR TITLE
Use pip to install a custom node

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -138,12 +138,14 @@ if !node['cfncluster']['custom_node_package'].nil? && !node['cfncluster']['custo
   bash "install aws-parallelcluster-node" do
     cwd Chef::Config[:file_cache_path]
     code <<-NODE
+      [[ ":$PATH:" != *":/usr/local/bin:"* ]] && PATH="/usr/local/bin:${PATH}"
+      echo "PATH is $PATH"
       source /tmp/proxy.sh
       pip uninstall --yes aws-parallelcluster-node
       curl --retry 3 -v -L -o aws-parallelcluster-node.tgz #{node['cfncluster']['custom_node_package']}
       tar -xzf aws-parallelcluster-node.tgz
       cd *aws-parallelcluster-node-*
-      /usr/bin/python setup.py install
+      pip install .
     NODE
   end
 elsif node['platform_family'] == 'rhel' && node['platform_version'].to_i < 7


### PR DESCRIPTION
Doing this we are aligning the tool used to install the node package in the two cases, custom and non-custom.

This solves the problem encountered in Centos7 using old setuptools version (used through setup.py) due to this change https://github.com/pyca/cryptography/commit/4941fc5c01cf1222ce04d1389e5821fea40a8c76 

The PATH setup is needed because on Amazon Linux during the Chef execution of the bash resource the PATH is missing /usr/local/bin

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
