### PR TITLE
slurm: upgrade to version 18.08.6.2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,8 +30,8 @@ default['cfncluster']['sge']['url'] = 'https://arc.liv.ac.uk/downloads/SGE/relea
 default['cfncluster']['torque']['version'] = '6.0.2'
 default['cfncluster']['torque']['url'] = 'https://github.com/adaptivecomputing/torque/archive/6.0.2.tar.gz'
 # Slurm software
-default['cfncluster']['slurm']['version'] = '16-05-3-1'
-default['cfncluster']['slurm']['url'] = 'https://github.com/SchedMD/slurm/archive/slurm-16-05-3-1.tar.gz'
+default['cfncluster']['slurm']['version'] = '18-08-6-2'
+default['cfncluster']['slurm']['url'] = 'https://github.com/SchedMD/slurm/archive/slurm-18-08-6-2.tar.gz'
 # Munge
 default['cfncluster']['munge']['munge_version'] = '0.5.12'
 default['cfncluster']['munge']['munge_url'] = 'https://github.com/dun/munge/archive/munge-0.5.12.tar.gz'


### PR DESCRIPTION
https://github.com/SchedMD/slurm/blob/master/NEWS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
