### PR TITLE
slurm: declare nodes in separate config file and use FUTURE for dummy nodes

### DIFF
--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -34,6 +34,13 @@ template '/opt/slurm/etc/slurm.conf' do
   mode '0644'
 end
 
+template '/opt/slurm/etc/slurm_parallelcluster_nodes.conf' do
+  source 'slurm_parallelcluster_nodes.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end
+
 cookbook_file '/opt/slurm/etc/slurm.sh' do
   source 'slurm.sh'
   owner 'root'

--- a/templates/default/slurm.conf.erb
+++ b/templates/default/slurm.conf.erb
@@ -102,15 +102,5 @@ JobCompType=jobcomp/none
 # when manually editing! Default node is there to allow
 # submission of jobs to an empty cluster.
 #PARTITION:compute
-<%
-def append_dummy
-    if node['cfncluster']['cfn_max_queue_size'].to_i > 1
-        "dummy-compute[1-" + node['cfncluster']['cfn_max_queue_size'] + "]"
-    else
-        "dummy-compute"
-    end
-end
-%>
-NodeName=<%= append_dummy %> Procs=2048 State=UNKNOWN
-#NodeName= Procs=1 State=UNKNOWN
-PartitionName=compute Nodes=<%= append_dummy %> Default=YES MaxTime=INFINITE State=UP
+include slurm_parallelcluster_nodes.conf
+PartitionName=compute Nodes=ALL Default=YES MaxTime=INFINITE State=UP

--- a/templates/default/slurm_parallelcluster_nodes.conf.erb
+++ b/templates/default/slurm_parallelcluster_nodes.conf.erb
@@ -1,0 +1,8 @@
+<%
+  def append_dummy
+    if node['cfncluster']['cfn_max_queue_size'].to_i > 0
+        "dummy-compute[1-" + node['cfncluster']['cfn_max_queue_size'] + "]"
+    end
+  end
+%>
+NodeName=<%= append_dummy %> CPUs=2048 State=FUTURE


### PR DESCRIPTION
Slightly refactored slurm.conf in order to include a separate config files
where nodes are declared. This allows the sqswatcher to regenerate the nodes
file when it needs to add or remove an host rather than modifying based on
regexes the full slurm.conf file

Also using FUTURE state for dummy nodes so that Slurm does not try to contact
all dummy nodes at every reboot. For a cluster with max size equals 1000 this
was causing a reboot delay of about 40 seconds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
