### PR TITLE
slurm.conf: set ReturnToService=1

### DIFF
--- a/templates/default/slurm.conf.erb
+++ b/templates/default/slurm.conf.erb
@@ -31,7 +31,11 @@ ProctrackType=proctrack/pgid
 #PluginDir=
 CacheGroups=0
 #FirstJobId=
-ReturnToService=0
+# A DOWN node will become available for use upon registration with a valid configuration only if it was set DOWN due to
+# being non-responsive. If the node was set DOWN for any other reason (low memory, unexpected reboot, etc.), its state
+# will not automatically be changed. A node registers with a valid configuration if its memory, GRES, CPU count, etc.
+# are equal to or greater than the values configured in slurm.conf.
+ReturnToService=1
 #MaxJobCount=
 #PlugStackConfig=
 #PropagatePrioProcess=


### PR DESCRIPTION
This is useful to recover compute nodes set in DOWN state because
for some reason the master couldn't contact them when they were added

ReturnToService controls when a DOWN node will be returned to service.
A DOWN node will become available for use upon registration with a valid
configuration only if it was set DOWN due to being non-responsive. If
the node was set DOWN for any other reason (low memory, unexpected
reboot, etc.), its state will not automatically be changed. A node
registers with a valid configuration if its memory, GRES, CPU count,
etc. are equal to or greater than the values configured in slurm.conf.

Signed-off-by: Francesco De Martino <fdm@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
