### PR TITLE
Add stack_name to sqswatcher config

### DIFF
--- a/templates/default/sqswatcher.cfg.erb
+++ b/templates/default/sqswatcher.cfg.erb
@@ -6,3 +6,4 @@ scheduler = <%= node['cfncluster']['cfn_scheduler'] %>
 cluster_user = <%= node['cfncluster']['cfn_cluster_user'] %>
 proxy = <%= node['cfncluster']['cfn_proxy'] %>
 max_queue_size = <%= node['cfncluster']['cfn_max_queue_size'] %>
+stack_name = <%= node['cfncluster']['stack_name'] %>


### PR DESCRIPTION
Needed to retrieve asg name and settings so that we can dynamically update cluster size.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
