### PR TITLE
 Add LocalHostname to parallelcluster:COMPUTE_READY event

### DIFF
--- a/files/default/compute_ready
+++ b/files/default/compute_ready
@@ -5,4 +5,6 @@
 # Notify compute is ready
 instance_id_url="http://169.254.169.254/latest/meta-data/instance-id"
 instance_id=$(curl --retry 3 --retry-delay 0 --silent --fail ${instance_id_url})
-aws --region ${cfn_region} sqs send-message --queue-url ${cfn_sqs_queue} --message-body '{"Type" : "Notification", "Message" : "{\"StatusCode\":\"Complete\",\"Description\":\"Succesfully launched '${instance_id}'\",\"Event\":\"parallelcluster:COMPUTE_READY\",\"EC2InstanceId\":\"'${instance_id}'\",\"Slots\":\"'${cfn_instance_slots}'\"}"}'
+local_hostname_url="http://169.254.169.254/latest/meta-data/local-hostname"
+local_hostname=$(curl --retry 3 --retry-delay 0 --silent --fail ${local_hostname_url})
+aws --region ${cfn_region} sqs send-message --queue-url ${cfn_sqs_queue} --message-body '{"Type" : "Notification", "Message" : "{\"StatusCode\":\"Complete\",\"Description\":\"Succesfully launched '${instance_id}'\",\"Event\":\"parallelcluster:COMPUTE_READY\",\"EC2InstanceId\":\"'${instance_id}'\",\"Slots\":\"'${cfn_instance_slots}'\",\"LocalHostname\":\"'${local_hostname}'\"}"}'


### PR DESCRIPTION
This allows the node to retrieve the hostname from the event and drop the calls to ec2.describe_instances


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
