### PR TITLE
Install linux-generic package in place of linux-image-extra

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -125,13 +125,7 @@ when 'debian'
                                               apache2 libboost-dev libdb-dev tcsh libssl-dev libncurses5-dev libpam0g-dev libxt-dev
                                               libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev libopenmpi-dev
                                               r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev mdadm]
-  if Chef::VersionConstraint.new('< 16.04').include?(node['platform_version'])
-    default['cfncluster']['kernel_devel_pkg']['name'] = "linux-image-extra"
-    default['cfncluster']['kernel_devel_pkg']['version'] = node['kernel']['release']
-  else
-    default['cfncluster']['kernel_devel_pkg']['name'] = ""
-    default['cfncluster']['kernel_devel_pkg']['version'] = ""
-  end
+  default['cfncluster']['kernel_devel_pkg']['name'] = "linux-generic"
   default['cfncluster']['ganglia']['apache_user'] = 'www-data'
   default['cfncluster']['ganglia']['gmond_service'] = 'ganglia-monitor'
   default['cfncluster']['ganglia']['httpd_service'] = 'apache2'

--- a/recipes/_nvidia_install.rb
+++ b/recipes/_nvidia_install.rb
@@ -21,8 +21,7 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
     when 'rhel', 'amazon'
       yum_package node['cfncluster']['kernel_devel_pkg']['name']
     when 'debian'
-      package = "#{node['cfncluster']['kernel_devel_pkg']['name']}-#{node['cfncluster']['kernel_devel_pkg']['version']}"
-      apt_package package
+      apt_package node['cfncluster']['kernel_devel_pkg']['name']
     end
   end
 


### PR DESCRIPTION
We were using the kernel-release as linux-image-extra package version.
In this specific moment the kernel is `3.13.0-167-generic` but the
`linux-image-extra-3.13.0-167-generic` doesn't exist.

We do not want to install the image-extra package directly.
Instead, we are now using the `linux-generic` meta-package,
which will ensure that upgrades work correctly, and that supporting
packages are also installed.

NOTE: this package is required for nvidia driver installation.
