### PR TITLE
Fix installation of kernel devel packages on Ubuntu 14

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -125,7 +125,8 @@ when 'debian'
                                               apache2 libboost-dev libdb-dev tcsh libssl-dev libncurses5-dev libpam0g-dev libxt-dev
                                               libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev libopenmpi-dev
                                               r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev mdadm]
-  default['cfncluster']['kernel_devel_pkg']['name'] = "linux-generic"
+  default['cfncluster']['kernel_generic_pkg'] = "linux-generic"
+  default['cfncluster']['kernel_extra_pkg'] = "linux-image-extra-#{node['kernel']['release']}"
   default['cfncluster']['ganglia']['apache_user'] = 'www-data'
   default['cfncluster']['ganglia']['gmond_service'] = 'ganglia-monitor'
   default['cfncluster']['ganglia']['httpd_service'] = 'apache2'

--- a/recipes/_nvidia_install.rb
+++ b/recipes/_nvidia_install.rb
@@ -16,12 +16,15 @@
 # Only run if node['cfncluster']['nvidia']['enabled'] = 'yes'
 if node['cfncluster']['nvidia']['enabled'] == 'yes'
 
-  if node['cfncluster']['kernel_devel_pkg']['name'] != ""
-    case node['platform_family']
-    when 'rhel', 'amazon'
-      yum_package node['cfncluster']['kernel_devel_pkg']['name']
-    when 'debian'
-      apt_package node['cfncluster']['kernel_devel_pkg']['name']
+  case node['platform_family']
+  when 'rhel', 'amazon'
+    yum_package node['cfncluster']['kernel_devel_pkg']['name']
+  when 'debian'
+    # Needed for new kernel version
+    apt_package node['cfncluster']['kernel_generic_pkg']
+    # Needed for old kernel version
+    apt_package node['cfncluster']['kernel_extra_pkg'] do
+      ignore_failure true
     end
   end
 


### PR DESCRIPTION
Kernel devel packages are needed for NVIDIA driver installation.
For older kernel version install linux-image-extra
For newer kernel version install linux-generic

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
