### PR TITLE
Remove double quotes from post install args variable

### DIFF
--- a/templates/default/cfnconfig.erb
+++ b/templates/default/cfnconfig.erb
@@ -2,7 +2,7 @@ stack_name=<%= node['cfncluster']['stack_name'] %>
 cfn_preinstall=<%= node['cfncluster']['cfn_preinstall'] %>
 cfn_preinstall_args=<%= node['cfncluster']['cfn_preinstall_args'] %>
 cfn_postinstall=<%= node['cfncluster']['cfn_postinstall'] %>
-cfn_postinstall_args="<%= node['cfncluster']['cfn_postinstall_args'] %>"
+cfn_postinstall_args=<%= node['cfncluster']['cfn_postinstall_args'] %>
 cfn_region=<%= node['cfncluster']['cfn_region'] %>
 cfn_scheduler=<%= node['cfncluster']['cfn_scheduler'] %>
 cfn_scheduler_slots=<%= node['cfncluster']['cfn_scheduler_slots'] %>


### PR DESCRIPTION
In this way the `cfn_postinstall_args` is aligned with the `cfn_preinstall_args` variable,
the quoting is left to the user in both the cases.

This fixes https://github.com/aws/aws-parallelcluster/issues/966

