### PR TITLE
Remove duplicated (and wrong) mount point for ebs volumes

### DIFF
--- a/recipes/_compute_base_config.rb
+++ b/recipes/_compute_base_config.rb
@@ -13,15 +13,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Created shared mount point
-directory node['cfncluster']['cfn_shared_dir'] do
-  mode '1777'
-  owner 'root'
-  group 'root'
-  recursive true
-  action :create
-end
-
 node.default['cfncluster']['cfn_master'] = node['cfncluster']['cfn_master'].split('.')[0]
 
 nfs_master = node['cfncluster']['cfn_master']


### PR DESCRIPTION
This mount point is wrong when the customer is using multiple ebs volumes because the `cfn_shared_dir` contains the comma separated list of the mount points:
```
less /etc/parallelcluster/cfnconfig
...
cfn_shared_dir=shared,software
```

Furthermore the same action is performed in the same script, few lines below, by splitting by comma.

I replicated the https://github.com/aws/aws-parallelcluster/issues/995.
Before the patch we have:
```
drwxrwxrwt    2 root root    6 Apr 11 14:02 scratch
drwxrwxrwt    3 root root 4096 Apr 11 13:58 shared
drwxrwxrwt    2 root root    6 Apr 11 14:02 shared,software
drwxrwxrwt    3 root root 4096 Apr 11 13:58 software
```
after:
```
drwxrwxrwt    2 root root    6 Apr 11 14:26 scratch
drwxrwxrwt    3 root root 4096 Apr 11 14:22 shared
drwxrwxrwt    3 root root 4096 Apr 11 14:22 software
```
