### PR TITLE
Pin supervisord to version 3.4.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@ default['cfncluster']['license_dir'] = "#{node['cfncluster']['base_dir']}/licens
 # Python packages
 default['cfncluster']['cfncluster-version'] = '2.3.1'
 default['cfncluster']['cfncluster-node-version'] = '2.3.1'
-default['cfncluster']['cfncluster-supervisor-version'] = '3.3.1'
+default['cfncluster']['supervisor-version'] = '3.4.0'
 # URLs to software packages used during install recipes
 # Gridengine software
 default['cfncluster']['sge']['version'] = '8.1.9'


### PR DESCRIPTION
This is the latest version with Python 2.6 support

Fix also the variable name, which is referenced in https://github.com/aws/aws-parallelcluster-cookbook/blob/9f25f6f44ff507bc873d349aa896e2c7c7e85f48/recipes/base_install.rb#L193

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
