### PR TITLE
Remove unneeded config values from node daemons configs

### DIFF
--- a/templates/default/jobwatcher.cfg.erb
+++ b/templates/default/jobwatcher.cfg.erb
@@ -4,4 +4,3 @@ scheduler = <%= node['cfncluster']['cfn_scheduler'] %>
 stack_name = <%= node['cfncluster']['stack_name'] %>
 cfncluster_dir = <%= node['cfncluster']['base_dir'] %>
 proxy = <%= node['cfncluster']['cfn_proxy'] %>
-compute_instance_type = <%= node['cfncluster']['compute_instance_type'] %>

--- a/templates/default/sqswatcher.cfg.erb
+++ b/templates/default/sqswatcher.cfg.erb
@@ -5,5 +5,4 @@ table_name = <%= node['cfncluster']['cfn_ddb_table'] %>
 scheduler = <%= node['cfncluster']['cfn_scheduler'] %>
 cluster_user = <%= node['cfncluster']['cfn_cluster_user'] %>
 proxy = <%= node['cfncluster']['cfn_proxy'] %>
-max_queue_size = <%= node['cfncluster']['cfn_max_queue_size'] %>
 stack_name = <%= node['cfncluster']['stack_name'] %>


### PR DESCRIPTION
Removing compute_instance_type and max_queue_size config values since they are now dynamically fetched by the daemons.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
