### PR TITLE
Install slurm libpmi/libpmi2

### DIFF
--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -40,6 +40,7 @@ bash 'make install' do
     CORES=$(grep processor /proc/cpuinfo | wc -l)
     make -j $CORES
     make install
+    make install-contrib
   SLURM
   # TODO: Fix, so it works for upgrade
   creates '/opt/slurm/bin/srun'


### PR DESCRIPTION
The libpmi is now in a separate slurm package see https://bugs.schedmd.com/show_bug.cgi?id=4511
so it needs to be installed explicitly

This will solve https://github.com/aws/aws-parallelcluster/issues/1008

Before
```
$ ls -la /opt/slurm/lib/
total 111692
drwxr-xr-x. 3 root root      237 Apr 19 07:09 .
drwxr-xr-x. 7 root root       68 Apr 19 07:09 ..
-rw-r--r--. 1 root root 47007194 Apr 19 07:09 libslurm.a
-rw-r--r--. 1 root root 52601492 Apr 19 07:09 libslurmdb.a
-rwxr-xr-x. 1 root root      980 Apr 19 07:09 libslurmdb.la
lrwxrwxrwx. 1 root root       20 Apr 19 07:09 libslurmdb.so -> libslurmdb.so.33.0.0
lrwxrwxrwx. 1 root root       20 Apr 19 07:09 libslurmdb.so.33 -> libslurmdb.so.33.0.0
-rwxr-xr-x. 1 root root  7428488 Apr 19 07:09 libslurmdb.so.33.0.0
-rwxr-xr-x. 1 root root      966 Apr 19 07:09 libslurm.la
lrwxrwxrwx. 1 root root       18 Apr 19 07:09 libslurm.so -> libslurm.so.33.0.0
lrwxrwxrwx. 1 root root       18 Apr 19 07:09 libslurm.so.33 -> libslurm.so.33.0.0
-rwxr-xr-x. 1 root root  7301704 Apr 19 07:09 libslurm.so.33.0.0
drwxr-xr-x. 3 root root    12288 Apr 19 07:09 slurm
```

After
```
$ ls -la /opt/slurm/lib
total 112936
drwxr-xr-x. 3 root root     4096 Apr 17 15:24 .
drwxr-xr-x. 8 root root       81 Apr 17 15:24 ..
-rw-r--r--. 1 root root   459736 Apr 17 15:24 libpmi2.a
-rwxr-xr-x. 1 root root      940 Apr 17 15:24 libpmi2.la
lrwxrwxrwx. 1 root root       16 Apr 17 15:24 libpmi2.so -> libpmi2.so.0.0.0
lrwxrwxrwx. 1 root root       16 Apr 17 15:24 libpmi2.so.0 -> libpmi2.so.0.0.0
-rwxr-xr-x. 1 root root   199560 Apr 17 15:24 libpmi2.so.0.0.0
-rw-r--r--. 1 root root   381328 Apr 17 15:24 libpmi.a
-rwxr-xr-x. 1 root root     1007 Apr 17 15:24 libpmi.la
lrwxrwxrwx. 1 root root       15 Apr 17 15:24 libpmi.so -> libpmi.so.0.0.0
lrwxrwxrwx. 1 root root       15 Apr 17 15:24 libpmi.so.0 -> libpmi.so.0.0.0
-rwxr-xr-x. 1 root root   214160 Apr 17 15:24 libpmi.so.0.0.0
-rw-r--r--. 1 root root 47006522 Apr 17 15:24 libslurm.a
-rw-r--r--. 1 root root 52600740 Apr 17 15:24 libslurmdb.a
-rwxr-xr-x. 1 root root      980 Apr 17 15:24 libslurmdb.la
lrwxrwxrwx. 1 root root       20 Apr 17 15:24 libslurmdb.so -> libslurmdb.so.33.0.0
lrwxrwxrwx. 1 root root       20 Apr 17 15:24 libslurmdb.so.33 -> libslurmdb.so.33.0.0
-rwxr-xr-x. 1 root root  7428584 Apr 17 15:24 libslurmdb.so.33.0.0
-rwxr-xr-x. 1 root root      966 Apr 17 15:24 libslurm.la
lrwxrwxrwx. 1 root root       18 Apr 17 15:24 libslurm.so -> libslurm.so.33.0.0
lrwxrwxrwx. 1 root root       18 Apr 17 15:24 libslurm.so.33 -> libslurm.so.33.0.0
-rwxr-xr-x. 1 root root  7301760 Apr 17 15:24 libslurm.so.33.0.0
drwxr-xr-x. 3 root root    12288 Apr 17 15:24 slurm
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
