### PR TITLE
Cleanup AMI

### DIFF
--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -246,7 +246,6 @@
     },
     {
       "type" : "shell",
-      "only": ["custom-alinux"],
       "inline" : [
         "sudo /usr/local/sbin/ami_cleanup.sh"
       ]

--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -265,7 +265,6 @@
     },
     {
       "type" : "shell",
-      "only": ["custom-centos6"],
       "inline" : [
         "sudo /usr/local/sbin/ami_cleanup.sh"
       ]

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -277,7 +277,6 @@
     },
     {
       "type" : "shell",
-      "only": ["custom-centos7"],
       "inline" : [
         "sudo /usr/local/sbin/ami_cleanup.sh"
       ]

--- a/amis/packer_ubuntu1404.json
+++ b/amis/packer_ubuntu1404.json
@@ -271,7 +271,6 @@
     },
     {
       "type" : "shell",
-      "only": ["custom-ubuntu1404"],
       "inline" : [
         "sudo /usr/local/sbin/ami_cleanup.sh"
       ]

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -274,7 +274,6 @@
     },
     {
       "type" : "shell",
-      "only": ["custom-ubuntu1604"],
       "inline" : [
         "sudo /usr/local/sbin/ami_cleanup.sh"
       ]

--- a/files/default/ami_cleanup.sh
+++ b/files/default/ami_cleanup.sh
@@ -5,5 +5,12 @@ rm -rf /var/lib/cloud/instances/*
 rm -f /var/lib/cloud/instance
 rm -rf /etc/ssh/ssh_host_*
 rm -f /etc/udev/rules.d/70-persistent-net.rules
+for ifcfg in $(ls /etc/sysconfig/network-scripts/ifcfg-*)
+do
+    if [ "$(basename ${ifcfg})" != "ifcfg-lo" ]
+    then
+        rm -f "${ifcfg}"
+    fi
+done
 find /var/log -type f -exec /bin/rm -v {} \;
 touch /var/log/lastlog


### PR DESCRIPTION
* Avoids network service restart failures when a configuration file of an old network interface (not present anymore in the current instance launch) was found

* Execute cleanup script also for official released AMI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
