### PR TITLE
torque: restarting pbs_mom only when hostaname changes get applied

### DIFF
--- a/recipes/_compute_torque_config.rb
+++ b/recipes/_compute_torque_config.rb
@@ -31,7 +31,10 @@ remote_file "install pbs_mom service" do
 end
 
 # Enable and start pbs_mom service
+# pbs_mom is restarted only after network service is restarted in
+# order to wait for the hostname changes to be applied
 service "pbs_mom" do
   supports restart: true
-  action %i[enable restart]
+  action :enable
+  subscribes :restart, 'service[network]', :immediately
 end


### PR DESCRIPTION
This fixes the issue with torque on centos 7

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
