### PR TITLE
torque: starting pbs_mom and restart on network/hostname changes

### DIFF
--- a/recipes/_compute_torque_config.rb
+++ b/recipes/_compute_torque_config.rb
@@ -35,6 +35,7 @@ end
 # order to wait for the hostname changes to be applied
 service "pbs_mom" do
   supports restart: true
-  action :enable
-  subscribes :restart, 'service[network]', :immediately
+  action %i[enable start]
+  subscribes :restart, 'service[network]', :delayed
+  subscribes :restart, 'ohai[reload_hostname]', :delayed
 end


### PR DESCRIPTION
- restarting with delayed flag in order to be sure that pbs_mom is installed
- starting pbs_mom in the first place and restarting on network/hostname changes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
