### PR TITLE
ami_cleanup: remove network interface configs only if created by cloud-init

### DIFF
--- a/files/default/ami_cleanup.sh
+++ b/files/default/ami_cleanup.sh
@@ -5,12 +5,6 @@ rm -rf /var/lib/cloud/instances/*
 rm -f /var/lib/cloud/instance
 rm -rf /etc/ssh/ssh_host_*
 rm -f /etc/udev/rules.d/70-persistent-net.rules
-for ifcfg in $(ls /etc/sysconfig/network-scripts/ifcfg-*)
-do
-    if [ "$(basename ${ifcfg})" != "ifcfg-lo" ]
-    then
-        rm -f "${ifcfg}"
-    fi
-done
+grep -l "Created by cloud-init on instance boot automatically" /etc/sysconfig/network-scripts/ifcfg-* | xargs rm -f
 find /var/log -type f -exec /bin/rm -v {} \;
 touch /var/log/lastlog


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
