### PR TITLE
ami_cleanup: remove ifcfg-eth0 in centos7

### DIFF
--- a/files/default/ami_cleanup.sh
+++ b/files/default/ami_cleanup.sh
@@ -6,5 +6,12 @@ rm -f /var/lib/cloud/instance
 rm -rf /etc/ssh/ssh_host_*
 rm -f /etc/udev/rules.d/70-persistent-net.rules
 grep -l "Created by cloud-init on instance boot automatically" /etc/sysconfig/network-scripts/ifcfg-* | xargs rm -f
+
+# https://bugs.centos.org/view.php?id=13836#c33128
+source /etc/os-release
+if [ "${ID}${VERSION_ID}" == "centos7" ]; then
+    rm -f /etc/sysconfig/network-scripts/ifcfg-eth0
+fi
+
 find /var/log -type f -exec /bin/rm -v {} \;
 touch /var/log/lastlog


### PR DESCRIPTION
Related bug https://bugs.centos.org/view.php?id=13836#c33128

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
