### PR TITLE
torque: use :immediately when subscribed to restart on service[network]

### DIFF
--- a/recipes/_compute_torque_config.rb
+++ b/recipes/_compute_torque_config.rb
@@ -36,6 +36,6 @@ end
 service "pbs_mom" do
   supports restart: true
   action %i[enable start]
-  subscribes :restart, 'service[network]', :delayed
+  subscribes :restart, 'service[network]', :immediately
   subscribes :restart, 'ohai[reload_hostname]', :delayed
 end


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
