### PR TITLE
use full master FQDN when mounting nfs

### DIFF
--- a/recipes/_compute_base_config.rb
+++ b/recipes/_compute_base_config.rb
@@ -13,8 +13,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-node.default['cfncluster']['cfn_master'] = node['cfncluster']['cfn_master'].split('.')[0]
-
 nfs_master = node['cfncluster']['cfn_master']
 
 # Mount EFS directory with efs_mount recipe

--- a/recipes/_compute_sge_config.rb
+++ b/recipes/_compute_sge_config.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Mount /opt/sge over NFS
-nfs_master = node['cfncluster']['cfn_master'].split('.')[0]
+nfs_master = node['cfncluster']['cfn_master']
 mount '/opt/sge' do
   device "#{nfs_master}:/opt/sge"
   fstype "nfs"

--- a/recipes/_compute_slurm_config.rb
+++ b/recipes/_compute_slurm_config.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Mount /opt/slurm over NFS
-nfs_master = node['cfncluster']['cfn_master'].split('.')[0]
+nfs_master = node['cfncluster']['cfn_master']
 mount '/opt/slurm' do
   device "#{nfs_master}:/opt/slurm"
   fstype "nfs"


### PR DESCRIPTION
We were using the hostname (first part of the fqdn) for mounting /opt/sge and /opt/slurm but using the fqdn for mounting /home and /shared.

This was causing some issues with some networking setups/custom dns. Switch to using always full fqdn.

Note: this inconsistency was due to the fact that the following line did not have any effect on variable assignment `node.default['cfncluster']['cfn_master'] = node['cfncluster']['cfn_master'].split('.')[0]`. This is most likely due to the fact that if `node['cfncluster']['cfn_master']` has already a value then you cannot assign with default.

https://docs.chef.io/attributes.html#attribute-types

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
