### PR TITLE
Skip Slurm installation on compute node

### DIFF
--- a/recipes/slurm_config.rb
+++ b/recipes/slurm_config.rb
@@ -37,7 +37,6 @@ cookbook_file '/etc/init.d/slurm' do
   only_if { node['init_package'] != 'systemd' }
 end
 
-# case node['cfncluster']['cfn_node_type']
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer'
   include_recipe 'aws-parallelcluster::_master_slurm_config'


### PR DESCRIPTION
Slurm installation folder is mounted from master node
The installation is done when "cfn_node_type" is "MasterServer" (at runtime)
or is "nil" (at packer time)

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
