### PR TITLE
Add finalize recipe for supervisord and compute_ready

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -75,6 +75,7 @@ suites:
     run_list:
       - recipe[aws-parallelcluster::_prep_env]
       - recipe[aws-parallelcluster::sge_config]
+      - recipe[aws-parallelcluster::finalize]
       - recipe[aws-parallelcluster::tests]
     attributes:
       cfncluster:
@@ -96,6 +97,7 @@ suites:
     run_list:
       - recipe[aws-parallelcluster::_prep_env]
       - recipe[aws-parallelcluster::torque_config]
+      - recipe[aws-parallelcluster::finalize]
       - recipe[aws-parallelcluster::tests]
     attributes:
       cfncluster:
@@ -117,6 +119,7 @@ suites:
     run_list:
       - recipe[aws-parallelcluster::_prep_env]
       - recipe[aws-parallelcluster::slurm_config]
+      - recipe[aws-parallelcluster::finalize]
       - recipe[aws-parallelcluster::tests]
     attributes:
       cfncluster:
@@ -138,6 +141,7 @@ suites:
     run_list:
       - recipe[aws-parallelcluster::_prep_env]
       - recipe[aws-parallelcluster::sge_config]
+      - recipe[aws-parallelcluster::finalize]
       - recipe[aws-parallelcluster::tests]
     attributes:
       cfncluster:
@@ -159,6 +163,7 @@ suites:
     run_list:
       - recipe[aws-parallelcluster::_prep_env]
       - recipe[aws-parallelcluster::torque_config]
+      - recipe[aws-parallelcluster::finalize]
       - recipe[aws-parallelcluster::tests]
     attributes:
       cfncluster:
@@ -180,6 +185,7 @@ suites:
     run_list:
       - recipe[aws-parallelcluster::_prep_env]
       - recipe[aws-parallelcluster::slurm_config]
+      - recipe[aws-parallelcluster::finalize]
       - recipe[aws-parallelcluster::tests]
     attributes:
       cfncluster:

--- a/files/default/compute_ready
+++ b/files/default/compute_ready
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 . /etc/parallelcluster/cfnconfig
 

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -53,12 +53,6 @@ template '/etc/parallelcluster/parallelcluster_supervisord.conf' do
   mode '0644'
 end
 
-# Restart supervisord
-service "supervisord" do
-  supports restart: true
-  action %i[enable start]
-end
-
 # Only run FSx on centos for now
 if node['platform'] == 'centos' or node['platform'] == 'amazon'
   # Mount FSx

--- a/recipes/finalize.rb
+++ b/recipes/finalize.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: finalize
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Restart supervisord
+service "supervisord" do
+  supports restart: true
+  action %i[enable start]
+end
+
+execute "compute_ready" do
+  command "/opt/parallelcluster/scripts/compute_ready"
+  only_if { node['cfncluster']['cfn_node_type'] == 'ComputeFleet' }
+end


### PR DESCRIPTION
move supervisord start at the end of the user data in a finalize chef recipe. This solves the problem of the nodewatcher that was started before the end of chef recipes and post_install script and therefore the idletime was being mistakenly computed.

Also add the -e flag to the compute_ready script in order to handle its failures as well.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
