### PR TITLE
Slurm: decrease SlurmdTimeout to 120 seconds

### DIFF
--- a/templates/default/slurm.conf.erb
+++ b/templates/default/slurm.conf.erb
@@ -55,7 +55,7 @@ ReturnToService=1
 #
 # TIMERS
 SlurmctldTimeout=300
-SlurmdTimeout=300
+SlurmdTimeout=120
 InactiveLimit=0
 MinJobAge=300
 KillWait=30


### PR DESCRIPTION
SlurmdTimeout: the interval, in seconds, that the Slurm controller waits for slurmd to respond before configuring that node's state to DOWN.

Reducing it in order to have a faster reaction to nodes that are failing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
