### PR TITLE
Add PATH for aws cli when executing compute_ready

### DIFF
--- a/recipes/finalize.rb
+++ b/recipes/finalize.rb
@@ -21,5 +21,6 @@ end
 
 execute "compute_ready" do
   command "/opt/parallelcluster/scripts/compute_ready"
+  environment('PATH' => '/usr/local/bin:/usr/bin/:$PATH')
   only_if { node['cfncluster']['cfn_node_type'] == 'ComputeFleet' }
 end


### PR DESCRIPTION
PATH is normally set in cfn userdata. In order to have chef recipes independent from userdata I'm setting explicitly the PATH for this command.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
