### PR TITLE
Double the retry limit to cope with the throttling error "Request limit exceeded"

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -2,6 +2,7 @@
 driver_config:
   retryable_sleep: 15
   retryable_tries: 20
+  retry_limit: 6
   aws_ssh_key_id: <%= ENV['AWS_KEYPAIR_NAME'] %>
   region: <%= ENV['AWS_DEFAULT_REGION'] %>
   instance_type: <%= ENV['AWS_FLAVOR_ID'] %>


### PR DESCRIPTION
Doc https://docs.aws.amazon.com/sdkforruby/api/Aws/ConfigService/Client.html

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
