### PR TITLE
Fix for when ParallelCluster version contains letters e.g. (2.3.2a1)

### DIFF
--- a/util/bump-version.sh
+++ b/util/bump-version.sh
@@ -10,7 +10,7 @@ fi
 NEW_VERSION=$1
 CURRENT_VERSION=$(sed -ne "s/^version '\(.*\)'/\1/p" metadata.rb)
 
-sed -i -e "s/\(.*parallelcluster.*version.*\)$CURRENT_VERSION\(.*\)/\1$NEW_VERSION\2/g" amis/packer_variables.json
+sed -i -e "s/\(.*parallelcluster.*version.*\)$CURRENT_VERSION.*\(\".*\)/\1$NEW_VERSION\2/g" amis/packer_variables.json
 sed -i "s/default\['cfncluster'\]\['cfncluster-version'\] = '$CURRENT_VERSION'/default['cfncluster']['cfncluster-version'] = '$NEW_VERSION'/g" attributes/default.rb
 sed -i "s/default\['cfncluster'\]\['cfncluster-node-version'\] = '$CURRENT_VERSION'/default['cfncluster']['cfncluster-node-version'] = '$NEW_VERSION'/g" attributes/default.rb
 sed -i "s/version '$CURRENT_VERSION'/version '$NEW_VERSION'/g" metadata.rb


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
