### PR TITLE
Fix conflict between EFA package and openmpi-devel package

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -85,7 +85,7 @@ when 'rhel', 'amazon'
     if node['platform_version'].to_i >= 7
       default['cfncluster']['base_packages'] = %w[vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                                   libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
-                                                  httpd boost-devel redhat-lsb mlocate lvm2 mpich-devel openmpi-devel R atlas-devel
+                                                  httpd boost-devel redhat-lsb mlocate lvm2 mpich-devel R atlas-devel
                                                   blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                                   libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel mdadm]
       if node['platform_version'].split('.')[1] == '6'
@@ -107,7 +107,7 @@ when 'rhel', 'amazon'
   when 'amazon'
     default['cfncluster']['base_packages'] = %w[vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                                 libXmu-devel hwloc-devel db4-devel tcl-devel automake autoconf pyparted libtool
-                                                httpd boost-devel redhat-lsb mlocate mpich-devel openmpi-devel R atlas-devel fftw-devel
+                                                httpd boost-devel redhat-lsb mlocate mpich-devel R atlas-devel fftw-devel
                                                 libffi-devel openssl-devel dkms mysql-devel libedit-devel postgresql-devel postgresql-server
                                                 sendmail cmake byacc libglvnd-devel mdadm]
   end

--- a/recipes/_efa_install.rb
+++ b/recipes/_efa_install.rb
@@ -26,12 +26,13 @@ end
 
 bash "install efa" do
   cwd Chef::Config[:file_cache_path]
-  code <<-NODE
+  code <<-EFAINSTALL
     # default openmpi installation conflicts with new install
     # new one is installed in /opt/amazon/efa/bin/
     yum remove -y openmpi openmpi-devel
     tar -xzf #{efa_tarball}
     cd aws-efa-installer
     ./efa_installer.sh -y
-  NODE
+  EFAINSTALL
+  creates '/opt/amazon/efa/bin/mpirun'
 end

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -238,5 +238,12 @@ include_recipe "aws-parallelcluster::_lustre_install"
 
 # Install EFA
 if (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) || node['platform'] == 'amazon'
-  include_recipe "aws-parallelcluster::_efa_install" unless node['cfncluster']['cfn_region'].start_with?("cn-")
+  unless node['cfncluster']['cfn_region'].start_with?("cn-")
+    include_recipe "aws-parallelcluster::_efa_install"
+  else
+    package 'openmpi-devel' do
+      retries 3
+      retry_delay 5
+    end
+  end
 end


### PR DESCRIPTION
Once the EFA package is installed, it is not possible to install the
openmpi-devel package. Make installation conditional depending on the OS
 and region

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
