### PR TITLE
Enable EFA Kitchen Test on Supported Instances

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -70,6 +70,7 @@ suites:
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        enable_efa: <%= ENV['ENABLE_EFA'] || "NONE" %>
 
   - name: sge_config_MasterServer
     run_list:
@@ -92,6 +93,7 @@ suites:
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        enable_efa: <%= ENV['ENABLE_EFA'] || "NONE" %>
 
   - name: torque_config_MasterServer
     run_list:
@@ -114,6 +116,7 @@ suites:
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        enable_efa: <%= ENV['ENABLE_EFA'] || "NONE" %>
 
   - name: slurm_config_MasterServer
     run_list:
@@ -136,6 +139,7 @@ suites:
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        enable_efa: <%= ENV['ENABLE_EFA'] || "NONE" %>
 
   - name: sge_config_ComputeFleet
     run_list:
@@ -158,6 +162,7 @@ suites:
         cfn_master: <%= ENV['CFN_MASTER'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        enable_efa: <%= ENV['ENABLE_EFA'] || "NONE" %>
 
   - name: torque_config_ComputeFleet
     run_list:
@@ -180,6 +185,7 @@ suites:
         cfn_master: <%= ENV['CFN_MASTER'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        enable_efa: <%= ENV['ENABLE_EFA'] || "NONE" %>
 
   - name: slurm_config_ComputeFleet
     run_list:
@@ -202,3 +208,4 @@ suites:
         cfn_master: <%= ENV['CFN_MASTER'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        enable_efa: <%= ENV['ENABLE_EFA'] || "NONE" %>

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -99,7 +99,8 @@ if node['cfncluster']['cfn_scheduler'] == 'slurm'
   end
 end
 
-if node['cfncluster']['os'] == 'alinux' || node['cfncluster']['os'] == 'centos7'
+# Test EFA is installed
+if node['cfncluster']['enable_efa'] == 'compute'
   execute 'check efa rpm installed' do
     command "rpm -qa | grep libfabric && rpm -qa | grep efa-"
     user node['cfncluster']['cfn_cluster_user']


### PR DESCRIPTION
This enables EFA Kitchen tests only when the instance is supported. We set the `enable_efa = compute` flag for instances that are supported.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
