### PR TITLE
Apply patch to fix issue in sge_edit_mod_attr script

### DIFF
--- a/recipes/_master_sge_config.rb
+++ b/recipes/_master_sge_config.rb
@@ -80,6 +80,7 @@ end
 # ENABLE_RESCHEDULE_KILL: reschedule_unknown parameter affects also jobs which have the rerun flag not activated
 bash "configure_unknown_hosts_behaviour" do
   code <<-CONFIGUNKNOWN
+    set -e
     . /opt/sge/default/common/settings.sh
     /opt/sge/util/qconf_mod_attr -mconf max_unheard 00:03:00 global
     /opt/sge/util/qconf_mod_attr -mconf reschedule_unknown 00:00:30 global

--- a/recipes/sge_install.rb
+++ b/recipes/sge_install.rb
@@ -62,8 +62,13 @@ when 'MasterServer', nil
 
   bash "extract_qconf_util" do
     code <<-EXTRACTQCONFUTIL
+      set -e
       tar xf /opt/sge/util/qconf_scripts.tar.gz -C /opt/sge/util --strip-components=1 --no-same-permissions --no-same-owner
+      # applying small patch for a bug in sge_edit_mod_attr script
+      # [[]] is incompatible with dash which is the default sh in ubuntu
+      sed -i 's/if \\[\\[ $cc -eq 0 ]]/if [ $cc -eq 0 ]/g' /opt/sge/util/sge_edit_mod_attr
     EXTRACTQCONFUTIL
+    creates '/opt/sge/util/sge_edit_mod_attr'
   end
 
   # Disbale the AddQueue, so that we can manage slots per instance


### PR DESCRIPTION
/opt/sge/util/sge_edit_mod_attr uses bash specific syntax but declares /bin/sh in the shebang. This makes the execution to fail on ubuntu where the default sh points to dash and not bash.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
