### PR TITLE
Unconditionally attempt fsx mount.

### DIFF
--- a/recipes/_compute_base_config.rb
+++ b/recipes/_compute_base_config.rb
@@ -15,9 +15,6 @@
 
 nfs_master = node['cfncluster']['cfn_master']
 
-# Mount EFS directory with efs_mount recipe
-include_recipe 'aws-parallelcluster::efs_mount'
-
 # Parse and get RAID shared directory info and turn into an array
 raid_shared_dir = node['cfncluster']['cfn_raid_parameters'].split(',')[0]
 

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -28,9 +28,6 @@ end
 # Get VPC CIDR
 node.default['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block'] = get_vpc_ipv4_cidr_block(node['macaddress'])
 
-# Mount EFS directory with efs_mount recipe
-include_recipe 'aws-parallelcluster::efs_mount'
-
 # Parse shared directory info and turn into an array
 shared_dir_array = node['cfncluster']['cfn_shared_dir'].split(',')
 shared_dir_array.each_with_index do |dir, index|

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -53,11 +53,11 @@ template '/etc/parallelcluster/parallelcluster_supervisord.conf' do
   mode '0644'
 end
 
-# Run FSx on centos and alinux
-if node['platform'] == 'centos' || node['platform'] == 'amazon'
-  # Mount FSx
-  include_recipe 'aws-parallelcluster::fsx_mount'
-end
+# Mount EFS directory with efs_mount recipe
+include_recipe 'aws-parallelcluster::efs_mount'
+
+# Mount FSx directory with fsx_mount recipe
+include_recipe 'aws-parallelcluster::fsx_mount'
 
 # Enable EFA
 if node['cfncluster']['enable_efa'] == 'compute' && node['cfncluster']['cfn_node_type'] == 'ComputeFleet'


### PR DESCRIPTION
Update base_config recipe to perform an unconditional attempt of fsx
filesysterm mount, rather than restricting to alinux/centos. Supports
cases with custom ubuntu amis with fsx extensions installed. This is
a no-op change in the default parallelcluster configuration, as the
client also verifies os compatibility during configuration validation.

Tidy tcommon call of efs mount from master/compute recipes into
base_config along fsx mount.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
