### PR TITLE
Enable EFA on Ubuntu1604

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -125,8 +125,11 @@ when 'debian'
   default['cfncluster']['base_packages'] = %w[vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-tools libhwloc-dev dkms
                                               tcl-dev automake autoconf python-parted libtool librrd-dev libapr1-dev libconfuse-dev
                                               apache2 libboost-dev libdb-dev tcsh libssl-dev libncurses5-dev libpam0g-dev libxt-dev
-                                              libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev libopenmpi-dev
+                                              libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev
                                               r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev mdadm]
+  if node['platform_version'] == '14.04'
+    default['cfncluster']['base_packages'].push('libopenmpi-dev')
+  end
   default['cfncluster']['kernel_generic_pkg'] = "linux-generic"
   default['cfncluster']['kernel_extra_pkg'] = "linux-image-extra-#{node['kernel']['release']}"
   default['cfncluster']['ganglia']['apache_user'] = 'www-data'

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -237,13 +237,15 @@ include_recipe "aws-parallelcluster::_nvidia_install"
 include_recipe "aws-parallelcluster::_lustre_install"
 
 # Install EFA
-if (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) || node['platform'] == 'amazon'
+if (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) || node['platform'] == 'amazon' || (node['platform'] == 'ubuntu' && node['platform_version'] == "16.04")
   unless node['cfncluster']['cfn_region'].start_with?("cn-")
     include_recipe "aws-parallelcluster::_efa_install"
   else
-    package 'openmpi-devel' do
-      retries 3
-      retry_delay 5
+    case node['platform_family']
+      when 'rhel', 'amazon'
+        package %w[openmpi-devel openmpi]
+      when 'debian'
+        package "libopenmpi-dev"
     end
   end
 end


### PR DESCRIPTION
* Installs EFA on Ubuntu1604
* Default openmpi is specified in default/attributes.rb
  * no longer needs to be added in china regions

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
