### PR TITLE
Add Ubuntu to Kitchen Tests

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -99,9 +99,15 @@ if node['cfncluster']['cfn_scheduler'] == 'slurm'
   end
 end
 
-if node['cfncluster']['os'] == 'alinux' || node['cfncluster']['os'] == 'centos7'
+case node['cfncluster']['os']
+when 'alinux', 'centos7'
   execute 'check efa rpm installed' do
     command "rpm -qa | grep libfabric && rpm -qa | grep efa-"
+    user node['cfncluster']['cfn_cluster_user']
+  end
+when 'ubuntu1604'
+  execute 'check efa rpm installed' do
+    command "dpkg -l | grep libfabric && dpkg -l | grep 'efa '"
     user node['cfncluster']['cfn_cluster_user']
   end
 end


### PR DESCRIPTION
```bash
$ dpkg -l | grep libfabric
ii  libfabric-bin                         1.7.0amzn1.1                               amd64        Diagnosis programs for the libfabric communication library
ii  libfabric-dev                         1.7.0amzn1.1                               amd64        Development files for libfabric1
ii  libfabric1                            1.7.0amzn1.1                               amd64        libfabric communication library
```

```bash
$ dpkg -l | grep "efa "
ii  efa                                   0.9.2-1.amzn1                              amd64        Linux kernel driver for Elastic Fabric Adapter (EFA)
```

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
