### PR TITLE
Set openSSH StrictHostKeyChecking property to "no"

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,6 +61,7 @@ default['openssh']['server']['gssapi_clean_up_credentials'] = 'yes'
 default['openssh']['server']['x11_forwarding'] = 'yes'
 default['openssh']['server']['subsystem'] = 'sftp /usr/libexec/openssh/sftp-server'
 default['openssh']['client']['gssapi_authentication'] = 'yes'
+default["openssh"]["client"]["strict_host_key_checking"] = "no"
 
 # Platform defaults
 case node['platform_family']


### PR DESCRIPTION
Use authorized_keys in place of authorized_keys2, which is deprecated,
to store the public key created for the cluster

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
