### PR TITLE
Fix openfile ulimit for EFA case

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,6 +62,10 @@ default['openssh']['server']['x11_forwarding'] = 'yes'
 default['openssh']['server']['subsystem'] = 'sftp /usr/libexec/openssh/sftp-server'
 default['openssh']['client']['gssapi_authentication'] = 'yes'
 
+# ulimit settings
+default['cfncluster']['filehandle_limit'] = 10000
+default['cfncluster']['memory_limit'] = 'unlimited'
+
 # Platform defaults
 case node['platform_family']
 when 'rhel', 'amazon'

--- a/recipes/_default_pre.rb
+++ b/recipes/_default_pre.rb
@@ -13,8 +13,9 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Calling user_ulimit will override every existing limit
 user_ulimit "*" do
-  filehandle_limit 10000
+  filehandle_limit "#{node['cfncluster']['filehandle_limit']}"
 end
 
 include_recipe 'aws-parallelcluster::_update_packages'

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -63,7 +63,9 @@ include_recipe 'aws-parallelcluster::fsx_mount'
 if node['cfncluster']['enable_efa'] == 'compute' && node['cfncluster']['cfn_node_type'] == 'ComputeFleet'
   include_recipe "aws-parallelcluster::_efa_enable"
 elsif node['cfncluster']['enable_efa'] == 'compute'
+  # Calling user_ulimit will override every existing limit
   user_ulimit "*" do
-    memory_limit 'unlimited'
+    filehandle_limit "#{node['cfncluster']['filehandle_limit']}"
+    memory_limit "#{node['cfncluster']['memory_limit']}"
   end
 end


### PR DESCRIPTION
When setting memory_limit for EFA case, it was overriding filehandle_limit property

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

Issue:
```
  * user_ulimit[*] action create
    * template[/etc/security/limits.d/00_all_limits.conf] action create
      - update content in file /etc/security/limits.d/00_all_limits.conf from af6af2 to e8216f
      --- /etc/security/limits.d/00_all_limits.conf     2019-06-10 21:02:12.640410768 +0000
      +++ /etc/security/limits.d/.chef-00_all_limits20190617-1901-13ac63l.conf  2019-06-17 07:03:31.993303657 +0000
      @@ -1,10 +1,12 @@
       # Limits settings for *

      -* - nofile 10000




      +
      +
      +* - memlock unlimited
```
After fix
```
  * user_ulimit[*] action create
    * template[/etc/security/limits.d/00_all_limits.conf] action create
      - update content in file /etc/security/limits.d/00_all_limits.conf from af6af2 to a52775
      --- /etc/security/limits.d/00_all_limits.conf     2019-06-10 21:02:12.640410768 +0000
      +++ /etc/security/limits.d/.chef-00_all_limits20190617-1979-cljins.conf   2019-06-17 08:25:23.953792524 +0000
      @@ -5,6 +5,7 @@



      +* - memlock unlimited
```

File content /etc/security/limits.d/00_all_limits.conf
```
# Limits settings for *

* - nofile 10000




* - memlock unlimited
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
