### PR TITLE
Increase timeout for ami build

### DIFF
--- a/amis/build_ami.sh
+++ b/amis/build_ami.sh
@@ -160,6 +160,9 @@ do_command() {
       export BUILD_DATE=${_build_date}
     fi
 
+    # set it to try for 1 hour, this is to resolve ami copy timeout issue
+    # https://github.com/hashicorp/packer/issues/6536
+    export AWS_TIMEOUT_SECONDS=3600
 
     case ${_os} in
       all)


### PR DESCRIPTION
* `AWS_MAX_ATTEMPTS` - This is how many times to re-send a status update request. Excepting tasks that we know can take an extremely long time, this defaults to 40 tries.
* `AWS_POLL_DELAY_SECONDS` - How many seconds to wait in between status update requests. Generally defaults to 2 or 5 seconds, depending on the task.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
