### PR TITLE
Explicitly check for packer and berks install

### DIFF
--- a/amis/build_ami.sh
+++ b/amis/build_ami.sh
@@ -20,14 +20,14 @@
 #   build-date: timestamp to append to the AMIs names (optional)
 
 requirements_check() {
-    which packer >/dev/null 2>&1
+    packer build --help >/dev/null 2>&1
     if [ $? -ne 0 ] ; then
       echo "packer command not found. Is Packer installed?"
       echo "Please visit https://www.packer.io/downloads.html for instruction on how to download and install"
       exit 1
     fi
 
-    which berks >/dev/null 2>&1
+    berks vendor --help >/dev/null 2>&1
     if [ $? -ne 0 ] ; then
       echo "berks command not found. Is ChefDK installed?"
       echo "Please visit https://downloads.chef.io/chefdk/ for instruction on how to download and install"


### PR DESCRIPTION
Here's an example of the exit code, notice I changed `packer->packers` and `berks->berk`

## packer
```bash
$ packer build --help >/dev/null 2>&1
$ echo $?
0
$ packers build --help >/dev/null 2>&1
$ echo $?
127
```

## berks
```bash
$ berks vendor --help >/dev/null 2>&1
$ echo $?
0
$ berk vendor --help >/dev/null 2>&1
$ echo $?
127
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
