### PR TITLE
torque: remove profile files generated at installation time

### DIFF
--- a/files/default/torque.csh
+++ b/files/default/torque.csh
@@ -1,0 +1,1 @@
+set path = (/opt/torque/bin /opt/torque/sbin $path)

--- a/recipes/torque_config.rb
+++ b/recipes/torque_config.rb
@@ -73,6 +73,14 @@ cookbook_file "/etc/profile.d/torque.sh" do
   action :create
 end
 
+cookbook_file "/etc/profile.d/torque.csh" do
+  source 'torque.csh'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  action :create
+end
+
 # case node['cfncluster']['cfn_node_type']
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer'

--- a/recipes/torque_install.rb
+++ b/recipes/torque_install.rb
@@ -42,6 +42,8 @@ bash 'make install' do
     make -j $CORES
     make install
     cp -vpR contrib /opt/torque
+    # Removing torque generated profiles. These will be restored at runtime when scheduler is torque
+    rm -f /etc/profile.d/torque.csh /etc/profile.d/torque.sh
   TORQUE
   # Only perform if running version doesn't match desired
   not_if "/opt/torque/bin/pbsnodes --version 2>&1 | grep -q #{node['cfncluster']['torque']['version']}"


### PR DESCRIPTION
Torque 6.1.2 is generating at installation time profile files that when sourced are adding the torque executable to the shell PATH. This is breaking sge that uses binaries with the same name.
Removing these files after installing torque and restoring them at runtime fixed the problem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
