### PR TITLE
Don't upgrade EFA

### DIFF
--- a/recipes/_efa_install.rb
+++ b/recipes/_efa_install.rb
@@ -44,5 +44,5 @@ bash "install efa" do
     cd aws-efa-installer
     ./efa_installer.sh -y --skip-limit-conf
   EFAINSTALL
-  creates '/opt/amazon/efa/bin/mpirun'
+  not_if { ::Dir.exist?('/opt/amazon/efa') }
 end


### PR DESCRIPTION
Tested on `alinux`:

```bash
Recipe: aws-parallelcluster::_efa_install
  * remote_file[/opt/parallelcluster/sources/aws-efa-installer-latest.tar.gz] action create (skipped due to not_if)
  * yum_package[openmpi-devel, openmpi] action remove
    - remove package ["openmpi-devel", "openmpi"]
  * bash[install efa] action run (skipped due to not_if)
```

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
