### PR TITLE
Add recipes to install/configure NICE DCV on CentOS7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,20 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 2.5.0
 -----
+
+**ENHANCEMENTS**
+- CentOS7 AMI:
+  - Install NICE DCV packages and its requirements (it includes Gnome and Xorg packages) 
+  NOTE: NICE DCV is installed but can be used only if explicitly enabled from the configuration file
+  at cluster creation time.
+
 **CHANGES**
 - Upgrade to EFA Installer 1.6.2, this also upgrades Open MPI to 4.0.2
+- CentOS7 AMI:
+  - Disable X11Forwarding by default
+  - Limit SSH Ciphers to `aes256-gcm@openssh.com,aes256-ctr,aes256-cbc`
+  - Limit SSH MACs to `hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256`
+
 
 2.4.1
 -----

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -10,6 +10,7 @@
     "build_date" : "{{env `BUILD_DATE`}}",
     "vendor_path" : "{{env `VENDOR_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
+    "dcv_installed": "{{env `DCV_INSTALLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
     "security_group_id" : "{{env `AWS_SECURITY_GROUP_ID`}}",
@@ -230,6 +231,9 @@
           "cfn_region": "{{user `region`}}",
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
+          },
+          "dcv": {
+            "installed" : "{{user `dcv_installed`}}"
           },
           "custom_node_package" : "{{user `custom_node_package`}}"
         }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -67,6 +67,20 @@ default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia
 default['cfncluster']['efa']['installer_url'] = 'https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.6.2.tar.gz'
 # ENV2 - tool to capture environment and create modulefiles
 default['cfncluster']['env2']['url'] = 'https://sourceforge.net/projects/env2/files/env2/download'
+# NICE DCV
+default['cfncluster']['dcv']['installed'] = 'yes'
+default['cfncluster']['dcv']['version'] = '2019.1-7644'
+default['cfncluster']['dcv']['url'] = "https://d1uj6qtbmh3dt5.cloudfront.net/2019.1/Servers/nice-dcv-#{node['cfncluster']['dcv']['version']}-el7.tgz"
+default['cfncluster']['dcv']['server'] = "nice-dcv-server-2019.1.7644-1.el7.x86_64.rpm"  # NICE DCV server package
+default['cfncluster']['dcv']['xdcv'] = "nice-xdcv-2019.1.226-1.el7.x86_64.rpm"  # required to create virtual sessions
+default['cfncluster']['dcv']['gl'] = "nice-dcv-gl-2019.1.544-1.el7.x86_64.rpm"  # required to enable GPU sharing
+# DCV external authenticator configuration
+default['cfncluster']['dcv']['authenticator']['user'] = "dcvextauth"
+default['cfncluster']['dcv']['authenticator']['user_home'] = "/home/#{node['cfncluster']['dcv']['authenticator']['user']}"
+default['cfncluster']['dcv']['authenticator']['certificate'] = "/etc/parallelcluster/ext-auth-certificate.pem"
+default['cfncluster']['dcv']['authenticator']['private_key'] = "/etc/parallelcluster/ext-auth-private-key.pem"
+default['cfncluster']['dcv']['authenticator']['virtualenv'] = "dcv_authenticator_virtualenv"
+default['cfncluster']['dcv']['authenticator']['virtualenv_path'] = "#{node['cfncluster']['dcv']['authenticator']['user_home']}/.pyenv/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['dcv']['authenticator']['virtualenv']}"
 
 # Reboot after default_pre recipe
 default['cfncluster']['default_pre_reboot'] = 'true'
@@ -78,8 +92,9 @@ default['openssh']['server']['permit_root_login'] = 'forced-commands-only'
 default['openssh']['server']['password_authentication'] = 'no'
 default['openssh']['server']['gssapi_authentication'] = 'yes'
 default['openssh']['server']['gssapi_clean_up_credentials'] = 'yes'
-default['openssh']['server']['x11_forwarding'] = 'yes'
 default['openssh']['server']['subsystem'] = 'sftp /usr/libexec/openssh/sftp-server'
+default['openssh']['server']['ciphers'] = 'aes256-gcm@openssh.com,aes256-ctr,aes256-cbc'
+default['openssh']['server']['m_a_cs'] = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256'
 default['openssh']['client']['gssapi_authentication'] = 'yes'
 
 # ulimit settings

--- a/files/default/dcv/10_org.gnome.desktop.screensaver.gschema.override
+++ b/files/default/dcv/10_org.gnome.desktop.screensaver.gschema.override
@@ -1,0 +1,2 @@
+[org.gnome.desktop.screensaver]
+lock-enabled = false

--- a/files/default/dcv/__init__.py
+++ b/files/default/dcv/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.

--- a/files/default/dcv/generate_certificate.sh
+++ b/files/default/dcv/generate_certificate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+
+# Generate a 5 year self-signed certificate and a new RSA private key and copy in the given path.
+# The command must be executed as root.
+
+# Usage:
+# ./generate_certificate.sh \
+#     "/etc/parallelcluster/ext-auth-certificate.pem" \
+#     "/etc/parallelcluster/ext-auth-private-key.pem" \
+#     dcv-ext-auth-user \
+#     dcv-ext-auth-user-group
+
+_check_param() {
+    paramValue="$1"
+    errorMessage="$2"
+    if [[ -z "${paramValue}" ]]; then
+        >&2 echo "${errorMessage}"
+        exit 1
+    fi
+}
+
+main() {
+    certificatePath="$1"
+    privateKeyPath="$2"
+    user="$3"
+    group="$4"
+
+    _check_param "${certificatePath}" "Certificate file path required"
+    _check_param "${privateKeyPath}" "Private Key file path required"
+    _check_param "${user}" "User required"
+    _check_param "${group}" "Group required"
+
+    # Generate a new certificate and a new RSA private key
+    openssl req -newkey rsa:2048 -sha256 -x509 -days 1825 -subj "/CN=localhost" -out "${certificatePath}" -nodes -keyout "${privateKeyPath}"
+    chmod 440 "${certificatePath}" "${privateKeyPath}"
+    chown "${user}":"${group}" "${certificatePath}" "${privateKeyPath}"
+}
+
+main "$@"

--- a/files/default/dcv/pcluster_dcv_authenticator.py
+++ b/files/default/dcv/pcluster_dcv_authenticator.py
@@ -1,0 +1,497 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import argparse
+import errno
+import hashlib
+import json
+import logging
+import os
+import random
+import re
+import ssl
+import string
+import subprocess
+import time
+from collections import OrderedDict, namedtuple
+from datetime import datetime, timedelta
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from logging.handlers import RotatingFileHandler
+from pwd import getpwuid
+from socketserver import ThreadingMixIn
+from urllib.parse import parse_qsl, urlparse
+
+AUTHORIZATION_FILE_DIR = "/var/spool/parallelcluster/pcluster_dcv_authenticator"
+LOG_FILE_PATH = "/var/log/parallelcluster/pcluster_dcv_authenticator.log"
+
+
+def retry(func, func_args, attempts=1, wait=0):
+    """
+    Call function and re-execute it if it raises an Exception.
+
+    :param func: the function to execute.
+    :param func_args: the positional arguments of the function.
+    :param attempts: the maximum number of attempts. Default: 1.
+    :param wait: delay between attempts. Default: 0.
+    :returns: the result of the function.
+    """
+    while attempts:
+        try:
+            return func(*func_args)
+        except Exception as e:
+            attempts -= 1
+            if not attempts:
+                raise e
+
+            LOGGER.info("{0}, retrying in {1} seconds..".format(e, wait))
+            time.sleep(wait)
+
+
+def generate_random_token(token_length):
+    """Generate CSPRNG compliant random tokens."""
+    allowed_chars = "".join((string.ascii_letters, string.digits, "_", "-"))
+    max_int = len(allowed_chars) - 1
+    system_random = random.SystemRandom()
+
+    return "".join(allowed_chars[system_random.randint(0, max_int)] for _ in range(token_length))
+
+
+class OneTimeTokenHandler:
+    """
+    Store in memory tokens and information associated with them.
+
+    The handler maintains a limited number of tokens in memory with a FIFO logic when the limits are reached.
+    """
+
+    def __init__(self, max_number_of_tokens):
+        self._tokens = OrderedDict()
+        self._max_number_of_tokens = max_number_of_tokens
+
+    def add_token(self, token, token_info):
+        """
+        Add token and his corresponding information in the storage.
+
+        :param token the token to store
+        :param token_info a tuple of values associated to the token to store
+        """
+        while len(self._tokens) >= self._max_number_of_tokens:
+            # Remove the first token stored
+            self._tokens.popitem(last=False)
+
+        self._tokens[token] = token_info
+
+    def get_token_info(self, token):
+        """Pop the token and return the related information if the token is present, else returns None."""
+        return self._tokens.pop(token, None)
+
+
+class DCVAuthenticator(BaseHTTPRequestHandler):
+    """
+    Simple HTTP server to handle NICE DCV authentication process.
+
+    The authentication process to access to a DCV session is performed by the following steps:
+    1. Obtain a Request Token:
+    - an user declares himself and asks for a Request Token for a given DCV Session:
+        - curl -X GET -G http://localhost:<port> -d action=requestToken -d authUser=<username> -d sessionID=<ID>
+    - the authenticator will return a json containing requestToken and accessFile values:
+        - the requestToken must be used as parameter for the Session Token request
+        - the accessFile is used to verify the user identity in the Session Token request
+
+    2. Obtain a DCV Session Token:
+    - the user must create an "access file" in the AUTHORIZATION_FILE_DIR, named as the retrieved accessFile value
+    - the user asks for a SessionToken (the real token to access to the DCV session)
+        - curl -X GET -G http://localhost:<port> -d action=sessionToken -d requestToken=<tr>
+    - the authenticator verifies the owner of the access file, the validity of the requestToken and returns
+      a Session Token
+    - the user can use the retrieved Session Token to connect to the DCV session.
+
+    3. DCV connection:
+    - the Session Token must be used in the web browser to access to the DCV Session
+    - the DCV process, running in the same instance of the authenticator, will ask to validate the token:
+        - curl -k http://localhost:<port> -d sessionId=<session-id> -d authenticationToken=<token>
+    - the authenticator verifies the validity of the authenticationToken and permits the user to access to the session.
+    """
+
+    class IncorrectRequestException(Exception):
+        pass
+
+    USER_REGEX = r"^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$"
+    SESSION_ID_REGEX = r"^([a-zA-Z0-9_-]{0,128})$"
+    TOKEN_REGEX = r"^([a-zA-Z0-9_-]{256})$"
+
+    MAX_NUMBER_OF_REQUEST_TOKENS = 500
+    MAX_NUMBER_OF_SESSION_TOKENS = 100
+    REQUEST_TOKEN_EXPIRE_SECONDS = 10
+    SESSION_TOKEN_EXPIRE_SECONDS = 30
+
+    # Define the information associated to a specific token
+    RequestTokenInfo = namedtuple("RequestTokenInfo", "user dcv_session_id creation_time access_file")
+    SessionTokenInfo = namedtuple("SessionTokenInfo", "user dcv_session_id creation_time")
+
+    # Define two token handlers with different capacity and expiration
+    request_token_manager = OneTimeTokenHandler(max_number_of_tokens=MAX_NUMBER_OF_REQUEST_TOKENS)
+    request_token_ttl = timedelta(seconds=REQUEST_TOKEN_EXPIRE_SECONDS)
+    session_token_manager = OneTimeTokenHandler(max_number_of_tokens=MAX_NUMBER_OF_SESSION_TOKENS)
+    session_token_ttl = timedelta(seconds=SESSION_TOKEN_EXPIRE_SECONDS)
+
+    def do_GET(self):  # noqa N802
+        """
+        Handle GET requests coming from the user to obtain request and session tokens.
+
+        The format of the request should be:
+            curl -X GET -G http://localhost:<port> -d action=requestToken -d authUser=<username> -d sessionID=<ID>
+            curl -X GET -G http://localhost:<port> -d action=sessionToken -d requestToken=<tr>
+        """
+        try:
+            LOGGER.info("Validating user request..")
+            # validate number of parameters
+            parameters = dict(parse_qsl(urlparse(self.path).query))
+            if not parameters or len(parameters) > 3:
+                raise DCVAuthenticator.IncorrectRequestException(
+                    "Incorrect number of parameters passed.\nParameters: {0}".format(parameters)
+                )
+
+            # evaluate action parameter
+            action = self._extract_parameters_values(parameters, ["action"])[0]
+            if action == "requestToken":
+                username, session_id = self._extract_parameters_values(parameters, ["authUser", "sessionID"])
+                result = self._get_request_token(username, session_id)
+            elif action == "sessionToken":
+                request_token = self._extract_parameters_values(parameters, ["requestToken"])[0]
+                result = self._get_session_token(request_token)
+            else:
+                raise DCVAuthenticator.IncorrectRequestException(
+                    "The action specified '{0}' is not valid.".format(action)
+                )
+
+            self._set_headers(400, content="application/json")
+            self.wfile.write(result.encode())
+
+        except DCVAuthenticator.IncorrectRequestException as e:
+            LOGGER.error(e)
+            self._return_bad_request(e)
+
+    def do_POST(self):  # noqa N802
+        """
+        Handle POST requests, coming from NICE DCV server.
+
+        The format of the request is the following:
+            curl -k http://localhost:<port> -d sessionId=<session-id> -d authenticationToken=<token>
+        """
+        try:
+            length = int(self.headers["Content-Length"])
+            field_data = self.rfile.read(length).decode("utf-8")
+            parameters = dict(parse_qsl(field_data))
+            if len(parameters) != 3:
+                raise DCVAuthenticator.IncorrectRequestException(
+                    "Incorrect number of parameters passed.\nParameters: {0}".format(parameters)
+                )
+            session_token, session_id = self._extract_parameters_values(
+                parameters, ["authenticationToken", "sessionId"]
+            )
+
+            authorized_user = self._check_auth(session_id, session_token)
+            if authorized_user:
+                self._return_auth_ok(username=authorized_user)
+            else:
+                raise DCVAuthenticator.IncorrectRequestException("The session token is not valid")
+
+        except DCVAuthenticator.IncorrectRequestException as e:
+            LOGGER.error(e)
+            self._return_auth_ko(e)
+
+    def log_message(self, fmt, *args):
+        """Override Server log message by removing authentication actions."""
+        if all(auth_action not in args[0] for auth_action in ["requestToken", "sectionToken"]):
+            LOGGER.info(fmt % args)
+
+    def _set_headers(self, response, content="text/xml", length=None):
+        self.send_response(response)
+        self.send_header("Content-type", content)
+        if length:
+            self.send_header("Content-Length", length)
+        self.end_headers()
+
+    def _return_auth_ko(self, message):
+        http_string = '<auth result="no"><message>{0}</message></auth>'.format(message)
+        self._set_headers(200, length=len(http_string))
+        self.wfile.write(http_string.encode())
+
+    def _return_auth_ok(self, username):
+        http_string = '<auth result="yes"><username>{0}</username></auth>'.format(username)
+        self._set_headers(200, length=len(http_string))
+        self.wfile.write(http_string.format(username).encode())
+
+    def _return_bad_request(self, message):
+        self._set_headers(200)
+        self.wfile.write("{0}\n".format(message).encode())
+
+    @staticmethod
+    def _extract_parameters_values(parameters, keys):
+        try:
+            return [parameters[key] for key in keys]
+        except KeyError:
+            raise DCVAuthenticator.IncorrectRequestException(
+                "Wrong parameters. Required parameters are {0}".format(", ".join(keys))
+            )
+
+    @classmethod
+    def _check_auth(cls, session_id, session_token):
+        """Check session token expiration to see if it is still valid for the given DCV session id."""
+        # validate session and session token
+        DCVAuthenticator._validate_param(session_id, DCVAuthenticator.SESSION_ID_REGEX, "sessionId")
+        DCVAuthenticator._validate_param(session_token, DCVAuthenticator.TOKEN_REGEX, "sessionToken")
+
+        # search for token in the internal authenticator token storage
+        token_info = cls.session_token_manager.get_token_info(session_token)
+        if (
+            token_info
+            and token_info.dcv_session_id == session_id
+            and datetime.utcnow() - token_info.creation_time <= cls.session_token_ttl
+        ):
+            return token_info.user
+
+    @classmethod
+    def _get_request_token(cls, user, session_id):
+        """
+        Obtain the request token and the "access file" name required to obtain the session token.
+
+        Generate a Request token, store in memory and returns a json containing the token itself
+        and the name of the file the user must create in the AUTHORIZATION_FILE_DIR.
+        """
+        LOGGER.info("New request for Request Token from user '{0}' and DCV Session Id '{1}'.".format(user, session_id))
+        # validate user and session
+        DCVAuthenticator._validate_param(user, DCVAuthenticator.USER_REGEX, "authUser")
+        DCVAuthenticator._validate_param(session_id, DCVAuthenticator.SESSION_ID_REGEX, "sessionId")
+        DCVAuthenticator._verify_session_existence(user, session_id)
+        LOGGER.info("DCV session id and user are valid.")
+
+        # create and register internally a request token to use to retrieve the session token
+        LOGGER.info("Generating new Request Token and Access File..")
+        request_token = generate_random_token(256)
+        access_file = generate_sha512_hash(request_token)
+        cls.request_token_manager.add_token(
+            request_token, DCVAuthenticator.RequestTokenInfo(user, session_id, datetime.utcnow(), access_file)
+        )
+        LOGGER.info("Request Token and Access File generated correctly.")
+
+        return json.dumps({"requestToken": request_token, "accessFile": access_file})
+
+    @classmethod
+    def _get_session_token(cls, request_token):
+        """
+        Obtain the session token to connect to the DCV session.
+
+        Generate a Session token, store in memory and returns a json containing the token itself.
+        """
+        LOGGER.info("New request for Session Token.")
+        DCVAuthenticator._validate_param(request_token, DCVAuthenticator.TOKEN_REGEX, "requestToken")
+
+        # retrieve request token information to validate it
+        LOGGER.info("Validating Request Token..")
+        token_info = cls.request_token_manager.get_token_info(request_token)
+        if not token_info:
+            raise DCVAuthenticator.IncorrectRequestException("The requestToken parameter is not valid")
+        user = token_info.user
+        session_id = token_info.dcv_session_id
+        access_file = token_info.access_file
+        LOGGER.info("Request Token is valid.")
+
+        # verify token expiration
+        LOGGER.info("Verifying Request Token..")
+        if datetime.utcnow() - token_info.creation_time > cls.request_token_ttl:
+            raise DCVAuthenticator.IncorrectRequestException("The requestToken is not valid anymore")
+        LOGGER.info("Request Token is valid.")
+
+        # verify user by checking if the access_file is created by the user asking the session token
+        LOGGER.info("Verifying Access File..")
+        try:
+            access_file_path = "{0}/{1}".format(AUTHORIZATION_FILE_DIR, access_file)
+            file_details = os.stat(access_file_path)
+            if getpwuid(file_details.st_uid).pw_name != user:
+                raise DCVAuthenticator.IncorrectRequestException("The user is not the one that created the access file")
+            if datetime.utcnow() - datetime.utcfromtimestamp(file_details.st_mtime) > cls.request_token_ttl:
+                raise DCVAuthenticator.IncorrectRequestException("The access file has expired")
+            LOGGER.info("Access File is valid. User identified correctly.")
+            os.remove(access_file_path)
+            LOGGER.info("Access File removed correctly.")
+        except OSError:
+            raise DCVAuthenticator.IncorrectRequestException("The Access File does not exist")
+
+        # create and register internally a session token
+        LOGGER.info("Generating new Session Token..")
+        DCVAuthenticator._verify_session_existence(user, session_id)
+        session_token = generate_random_token(256)
+        cls.session_token_manager.add_token(
+            session_token, DCVAuthenticator.SessionTokenInfo(user, session_id, datetime.utcnow())
+        )
+        LOGGER.info("Session Token created successfully.")
+
+        return json.dumps({"sessionToken": session_token})
+
+    @staticmethod
+    def _validate_param(string_to_test, regex, resource_name):
+        if not re.match(regex, string_to_test):
+            raise DCVAuthenticator.IncorrectRequestException("The {0} parameter is not valid".format(resource_name))
+
+    @staticmethod
+    def _is_session_valid(user, session_id):
+        """
+        Verify if the DCV session exists and the ownership.
+
+        # We are using ps aux to retrieve the list of sessions
+        # because currently DCV doesn't allow list-session to list all session even for non-root user.
+        # TODO change this method if DCV updates his behaviour.
+        """
+        LOGGER.info("Verifying NICE DCV session validity..")
+        # Remove the first and the last because they are the heading and empty, respectively
+        processes = subprocess.check_output(["ps", "aux"]).decode("utf-8").split("\n")[1:-1]
+
+        # Check the filter is empty
+        if not next(
+            filter(lambda process: DCVAuthenticator.check_dcv_process(process, user, session_id), processes), None
+        ):
+            raise DCVAuthenticator.IncorrectRequestException("The given session does not exists")
+        LOGGER.info("The NICE DCV session is valid.")
+
+    @staticmethod
+    def _verify_session_existence(user, session_id):
+        retry(DCVAuthenticator._is_session_valid, func_args=[user, session_id], attempts=5, wait=1)
+
+    @staticmethod
+    def check_dcv_process(row, user, session_id):
+        """Check if there is a dcvagent process running for the given user and for the given session_id."""
+        # row example:
+        # centos 63 0.0 0.0 4348844 3108   ??  Ss   23Jul19   2:32.46  /usr/libexec/dcv/dcvagent --session-id mysession
+        fields = row.split()
+        command_index = 10
+        session_name_index = 12
+        user_index = 0
+        dcv_agent_path = "/usr/libexec/dcv/dcvagent"
+
+        return (
+            fields[command_index] == dcv_agent_path
+            and fields[user_index] == user
+            and fields[session_name_index] == session_id
+        )
+
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    """Handle requests in a separate thread."""
+
+
+def _run_server(port, certificate=None, key=None):
+    """
+    Run NICE DCV authenticator server on localhost.
+
+    The NICE DCV authenticator server *must* run with an appropriate user.
+
+    :param port: the port in which you want to start the server
+    :param certificate: the certificate to use if HTTPSs
+    :param key: the private key to use if HTTPSs
+    """
+    server_address = ("localhost", port)
+    httpd = ThreadedHTTPServer(server_address, DCVAuthenticator)
+
+    if certificate:
+        if key:
+            httpd.socket = ssl.wrap_socket(httpd.socket, certfile=certificate, keyfile=key, server_side=True)
+        else:
+            httpd.socket = ssl.wrap_socket(httpd.socket, certfile=certificate, server_side=True)
+    print(
+        "Starting DCV external authenticator {PROTOCOL} server on port {PORT}, use <Ctrl-C> to stop".format(
+            PROTOCOL="HTTPS" if certificate else "HTTP", PORT=port
+        )
+    )
+    httpd.serve_forever()
+
+
+def _parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Execute the ParallelCluster DCV External Authenticator")
+    parser.add_argument("--port", help="The port in which you want to start the HTTP server", type=int)
+    parser.add_argument("--certificate", help="The certificate to use to run in HTTPS. It must be a .pem file")
+    parser.add_argument("--key", help="The private key of the certificate")
+    return parser.parse_args()
+
+
+def generate_sha512_hash(*args):
+    """Generate a salted sha512 of the given token."""
+    salt = generate_random_token(256)
+
+    hash_handler = hashlib.sha512()
+    for item in args, salt:
+        hash_handler.update(str(item).encode("utf-8"))
+
+    return hash_handler.hexdigest()
+
+
+def _prepare_auth_folder():
+    """Delete old authorization files."""
+    for access_file in os.listdir(AUTHORIZATION_FILE_DIR):
+        os.remove(os.path.join(AUTHORIZATION_FILE_DIR, access_file))
+
+
+def fail(message):
+    """
+    Print error message and exit(1).
+
+    :param message: message to print
+    """
+    LOGGER.error(message)
+    exit(1)
+
+
+def _config_logger():
+    """
+    Define a logger for pcluster_dcv_authenticator.
+
+    :return: the logger
+    """
+    try:
+        logfile = os.path.expanduser(LOG_FILE_PATH)
+        logdir = os.path.dirname(logfile)
+        os.makedirs(logdir)
+    except OSError as e:
+        if e.errno == errno.EEXIST and os.path.isdir(logdir):
+            pass
+        else:
+            fail("Cannot create log file (%s). Failed with exception: %s" % (logfile, e))
+
+    formatter = logging.Formatter("%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s")
+
+    logfile_handler = RotatingFileHandler(logfile, maxBytes=5 * 1024 * 1024, backupCount=1)
+    logfile_handler.setFormatter(formatter)
+
+    logger = logging.getLogger("pcluster_dcv_authenticator")
+    logger.addHandler(logfile_handler)
+
+    logger.setLevel("INFO")
+    return logger
+
+
+LOGGER = _config_logger()
+
+
+def main():
+    try:
+        LOGGER.info("Starting NICE DCV authenticator server")
+        args = _parse_args()
+        _prepare_auth_folder()
+        _run_server(port=args.port if args.port else 8444, certificate=args.certificate, key=args.key)
+    except KeyboardInterrupt:
+        LOGGER.info("Closing NICE DCV authenticator server")
+    except Exception as e:
+        fail("Unexpected error of type {0}: {1}".format(type(e).__name__, e))
+
+
+if __name__ == "__main__":
+    main()

--- a/files/default/dcv/pcluster_dcv_connect.sh
+++ b/files/default/dcv/pcluster_dcv_connect.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# Cookbook Name:: aws-parallelcluster
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script must be executed by the user who want to connect to DCV to obtain a Session Token.
+#
+# It performs the following steps:
+# 1. Asks the ParallelCluster DCV External Authenticator for a Request Token and the Access File name
+# 2. Creates the "access file" in the AUTHORIZATION_FILE_DIR folder (to confirm user identity)
+# 3. Asks the ParallelCluster DCV External Authenticator for a SessionToken (the real token to access to the DCV session)
+# 4. Returns DCV Session Id, DCV Server Port and the Session Token
+
+# Requirements:
+# jq, curl, awk, xargs, shuf, cat, grep, systemctl
+
+# Usage:
+# The script requires the ParallelCluster shared folder as input parameter
+# The ParallelCluster shared folder will be used as session storage folder for DCV.
+# It enables the clients to share files while connected to the session.
+# ./pcluster_dcv_connect.sh "/shared"
+
+
+# Returns the sessionid, the port and the tokenid (256 character long).
+# Example: mysession 8443 adfsaklcxzvsadkhfgsdkhjfag-__bafbdajshsdjfh
+
+AUTHORIZATION_FILE_DIR="/var/spool/parallelcluster/pcluster_dcv_authenticator"
+DCV_SESSION_FOLDER="${HOME}/.parallelcluster/dcv"
+LOG_FILE_PATH="/var/log/parallelcluster/pcluster_dcv_connect.log"
+LOG_FILE_MAX_SIZE=5242880 # 5MB
+
+
+_fail() {
+  message=$1
+  >&2 echo "ERROR: ${message}"
+  exit 1
+}
+
+_check_if_empty() {
+  variable=$1
+  message=$2
+  if [[ -z "${variable}" ]]; then
+      _fail "${message}"
+  fi
+}
+
+_atomic_touch() {
+    file_path="$1"
+
+    _umask=$(umask)
+    umask 0022 && touch "${file_path}"
+    umask ${_umask}
+
+    if [[ ! -f "${file_path}" ]]; then
+        _fail "Unable to create the file in the $(dirname "${file_path}") folder. Exiting.."
+    fi
+}
+
+_log() {
+    text=$1
+
+    log_time=$(date "+%Y-%m-%d %H:%M:%S")
+
+    file_size=$(du -b ${LOG_FILE_PATH} | awk '{print $1}')
+
+    [[ -f "${LOG_FILE_PATH}" ]] || _atomic_touch "${LOG_FILE_PATH}"
+
+    if [[ ${file_size} -gt ${LOG_FILE_MAX_SIZE} ]]; then
+        mv "${LOG_FILE_PATH}" "${LOG_FILE_PATH}.1"
+        echo "[${log_time}]: ${text}" > "${LOG_FILE_PATH}"
+    else
+        echo "[${log_time}]: ${text}" >> "${LOG_FILE_PATH}"
+    fi
+}
+
+_create_dcv_session() {
+    dcv_session_file="$1"
+    shared_folder_path="$2"
+
+    _log "Creating a new NICE DCV session..."
+    # Generate a random session id
+    sessionid=$(shuf -zer -n20  {A..Z} {a..z} {0..9})
+    echo "${sessionid}" > "${dcv_session_file}"
+    dcv create-session --type virtual --storage-root "${shared_folder_path}" "${sessionid}"
+    _log "NICE DCV session created successfully."
+
+    echo "${sessionid}"
+}
+
+main() {
+    _log "--- Initializing NICE DCV authentication... ---"
+
+    if [[ -z "$1" ]]; then
+        _fail "The script requires the shared folder as input parameter."
+    fi
+
+    shared_folder_path="$1"
+    user=$(whoami)
+    os=$(< /etc/chef/dna.json jq -r .cfncluster.cfn_base_os)
+    _log "Input parameters: user: ${user}, OS: ${os}, shared_folder_path: ${shared_folder_path}."
+
+    if [[ ${os} != "centos7" ]]; then
+        _fail "OS not supported."
+    fi
+
+    if ! systemctl is-active --quiet dcvserver; then
+        _fail "NICE DCV service is not active on the given instance."
+    fi
+
+    # Create a session with session storage enabled.
+    mkdir -p "${DCV_SESSION_FOLDER}"
+    dcv_session_file="${DCV_SESSION_FOLDER}/dcv_session"
+    if [[ ! -e ${dcv_session_file} ]]; then
+        sessionid=$(_create_dcv_session "${dcv_session_file}" "${shared_folder_path}")
+    else
+        sessionid=$(cat "${dcv_session_file}")
+        _log "Reusing existing NICE DCV session for the current user."
+
+        # number of session can either be 0 or 1
+        number_of_sessions=$(dcv list-sessions |& grep "${user}" | grep -c "${sessionid}")
+        if (( number_of_sessions == 0 )); then
+            # There is no running session (e.g. the system has been rebooted)
+            _log "There are no running sessions for the current user, creating a new one.."
+            sessionid=$(_create_dcv_session "${dcv_session_file}" "${shared_folder_path}")
+        fi
+    fi
+
+    # xargs to remove eventual whitespaces
+    dcv_server_port=$(grep web-port= /etc/dcv/dcv.conf| awk -F'=' '{ print $2 }' | xargs)
+    ext_auth_port=$((dcv_server_port + 1))
+
+    # Retrieve Request Token and Access File name
+    _log "Retrieving Request Token and Access File name.."
+    user_token_request=$(curl --retry 3 --max-time 5 -s -k -X GET -G "https://localhost:${ext_auth_port}" -d action=requestToken -d authUser="${user}" -d sessionID="${sessionid}")
+    _check_if_empty "${user_token_request}" "Unable to obtain the Request Token from the NICE DCV external authenticator."
+    request_token=$(echo "${user_token_request}" | jq -r .requestToken)
+    access_file=$(echo "${user_token_request}" | jq -r .accessFile)
+    _log "Request Token and Access File name obtained successfully."
+
+    # Create the access file in the AUTHORIZATION_FILE_DIR with 644 permissions
+    # This is used by the external authenticator to verify the user declares himself as who he really is
+    _log "Creating access file.."
+    _atomic_touch "${AUTHORIZATION_FILE_DIR}/${access_file}"
+    _log "Access file created successfully."
+
+
+    # Retrieve Session Token
+    _log "Retrieving Session Token.."
+    session_token_request=$(curl --retry 3 --max-time 5 -s -k -X GET -G "https://localhost:${ext_auth_port}" -d action=sessionToken -d requestToken="${request_token}")
+    _check_if_empty "${session_token_request}" "Unable to obtain the Session Token from the NICE DCV external authenticator."
+    session_token=$(echo "${session_token_request}" | jq -r .sessionToken)
+    _log "Session Token obtained successfully."
+
+    if [[ -z "${dcv_server_port}" ]]; then
+      dcv_server_port=8443
+    fi
+
+    _log "--- NICE DCV authentication performed successfully. ---"
+    echo "PclusterDcvServerPort=${dcv_server_port} PclusterDcvSessionId=${sessionid} PclusterDcvSessionToken=${session_token}"
+}
+
+main "$@"

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -105,6 +105,14 @@ def get_vpc_ipv4_cidr_block(eth0_mac)
   vpc_ipv4_cidr_block
 end
 
+def get_instance_type()
+  uri = URI("http://169.254.169.254/latest/meta-data/instance-type")
+  res = Net::HTTP.get_response(uri)
+  master_instance_type = res.body if res.code == '200'
+
+  master_instance_type
+end
+
 def pip_install_package(package, version)
   command = Mixlib::ShellOut.new("pip install #{package}==#{version}").run_command
   Chef::Application.fatal!("Failed to install package #{package} #{version}", command.exitstatus) unless command.exitstatus.zero?

--- a/recipes/_compute_base_config.rb
+++ b/recipes/_compute_base_config.rb
@@ -76,7 +76,7 @@ end
 # Setup cluster user
 user node['cfncluster']['cfn_cluster_user'] do
   manage_home false
-  comment 'cfncluster user'
+  comment 'AWS ParallelCluster user'
   home "/home/#{node['cfncluster']['cfn_cluster_user']}"
   shell '/bin/bash'
 end

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -174,7 +174,7 @@ end
 # Setup cluster user
 user node['cfncluster']['cfn_cluster_user'] do
   manage_home true
-  comment 'cfncluster user'
+  comment 'AWS ParallelCluster user'
   home "/home/#{node['cfncluster']['cfn_cluster_user']}"
   shell '/bin/bash'
 end

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -219,3 +219,8 @@ template '/etc/sqswatcher.cfg' do
   group 'root'
   mode '0644'
 end
+
+if node['cfncluster']['dcv_enabled'] == "master"
+  # Activate DCV on master Node
+  include_recipe 'aws-parallelcluster::dcv_config'
+end

--- a/recipes/_prep_env.rb
+++ b/recipes/_prep_env.rb
@@ -28,6 +28,13 @@ directory '/etc/parallelcluster'
 directory '/opt/parallelcluster'
 directory '/opt/parallelcluster/scripts'
 
+# Create ParallelCluster log folder
+directory '/var/log/parallelcluster/' do
+  owner 'root'
+  mode '1777'
+  recursive true
+end
+
 template '/etc/parallelcluster/cfnconfig' do
   source 'cfnconfig.erb'
   mode '0644'

--- a/recipes/_setup_python.rb
+++ b/recipes/_setup_python.rb
@@ -4,7 +4,7 @@
 # Cookbook Name:: aws-parallelcluster
 # Recipe:: _setup_python
 #
-# Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -14,40 +14,21 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-
-pyenv_user_install 'root'
-
-pyenv_python node['cfncluster']['python-version'] do
-  user 'root'
+install_pyenv "root" do
+  python_version node['cfncluster']['python-version']
 end
 
-pyenv_plugin 'virtualenv' do
-  git_url 'https://github.com/pyenv/pyenv-virtualenv'
-  user 'root'
-end
-
-pyenv_script 'pyenv virtualenv cookbook' do
-  code "pyenv virtualenv #{node['cfncluster']['python-version']} #{node['cfncluster']['cookbook_virtualenv']}"
-  user 'root'
+activate_virtual_env node['cfncluster']['cookbook_virtualenv'] do
+  pyenv_path node['cfncluster']['cookbook_virtualenv_path']
+  pyenv_user "root"
+  python_version node['cfncluster']['python-version']
+  requirements_path "requirements.txt"
   not_if { ::File.exist?("#{node['cfncluster']['cookbook_virtualenv_path']}/bin/activate") }
 end
 
-pyenv_script 'pyenv virtualenv node' do
-  code "pyenv virtualenv #{node['cfncluster']['python-version']} #{node['cfncluster']['node_virtualenv']}"
-  user 'root'
+activate_virtual_env node['cfncluster']['node_virtualenv'] do
+  pyenv_path node['cfncluster']['node_virtualenv_path']
+  pyenv_user "root"
+  python_version node['cfncluster']['python-version']
   not_if { ::File.exist?("#{node['cfncluster']['node_virtualenv_path']}/bin/activate") }
-end
-
-# Install requirements file
-cookbook_file "#{node['cfncluster']['cookbook_virtualenv_path']}/requirements.txt" do
-  source 'requirements.txt'
-  owner 'root'
-  group 'root'
-  mode '0755'
-end
-
-pyenv_pip "#{node['cfncluster']['cookbook_virtualenv_path']}/requirements.txt" do
-  virtualenv "#{node['cfncluster']['cookbook_virtualenv_path']}"
-  requirement true
-  user 'root'
 end

--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: dcv_config
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+# This recipe install the prerequisites required to use NICE DCV on a Linux server
+# Source: https://docs.aws.amazon.com/en_us/dcv/latest/adminguide/setting-up-installing-linux-prereq.html
+
+
+# Configure the system to enable NICE DCV to have direct access to the Linux server's GPU and enable GPU sharing.
+def allow_gpu_acceleration
+
+  # Turn off X
+  execute "Turn off X" do
+    command "systemctl set-default multi-user.target"
+  end
+
+  # Update the xorg.conf to set up NVIDIA drivers.
+  # NOTE: --enable-all-gpus parameter is needed to support servers with more than one NVIDIA GPU.
+  execute "Set up Nvidia drivers for X configuration" do
+    user 'root'
+    command "nvidia-xconfig --preserve-busid --enable-all-gpus"
+  end
+
+  # dcvgl package must be installed after NVIDIA and before starting up X
+  dcv_gl = "#{Chef::Config[:file_cache_path]}/nice-dcv-#{node['cfncluster']['dcv']['version']}-el7/#{node['cfncluster']['dcv']['gl']}"
+  package dcv_gl do
+    action :install
+    source dcv_gl
+  end
+
+  # Configure the X server to start automatically when the Linux server boots and start the X server in background
+  bash 'Launch X' do
+    user 'root'
+    code <<-SETUPX
+      systemctl set-default graphical.target
+      systemctl isolate graphical.target &
+    SETUPX
+  end
+
+  # Verify that the X server is running
+  execute 'Wait for X to start' do
+    user 'root'
+    command "pidof X || pidof Xorg"
+    retries 5
+    retry_delay 5
+  end
+end
+
+if node['platform'] == 'centos' && node['platform_version'].to_i == 7 && node['cfncluster']['cfn_node_type'] == "MasterServer"
+  node.default['cfncluster']['dcv']['is_graphic_instance'] = graphic_instance?
+
+  if node.default['cfncluster']['dcv']['is_graphic_instance']
+    # Enable graphic acceleration in dcv conf file for graphic instances.
+    allow_gpu_acceleration
+  end
+
+  # Install utility file to generate HTTPs certificates for the DCV external authenticator and generate a new one
+  cookbook_file "/etc/parallelcluster/generate_certificate.sh" do
+    source 'dcv/generate_certificate.sh'
+    owner 'root'
+    mode '0700'
+  end
+  execute "certificate generation" do
+    command "/etc/parallelcluster/generate_certificate.sh \"#{node['cfncluster']['dcv']['authenticator']['certificate']}\" \"#{node['cfncluster']['dcv']['authenticator']['private_key']}\" #{node['cfncluster']['dcv']['authenticator']['user']} dcv"
+    user 'root'
+  end
+
+  # Generate dcv.conf starting from template
+  template "/etc/dcv/dcv.conf" do
+    action :create
+    source 'dcv.conf.erb'
+    owner 'root'
+    group 'root'
+    mode '0755'
+  end
+
+  # Create directory for the external authenticator to store access file created by the users
+  directory '/var/spool/parallelcluster/pcluster_dcv_authenticator' do
+    owner node['cfncluster']['dcv']['authenticator']['user']
+    mode '1733'
+    recursive true
+  end
+
+  # Install DCV external authenticator
+  cookbook_file "#{node['cfncluster']['dcv']['authenticator']['user_home']}/pcluster_dcv_authenticator.py" do
+    source 'dcv/pcluster_dcv_authenticator.py'
+    owner node['cfncluster']['dcv']['authenticator']['user']
+    mode '0700'
+  end
+
+  # Start NICE DCV server
+  service "dcvserver" do
+    action [:start, :enable]
+  end
+end

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: dcv_install
+#
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+# Utility function to install a list of rpm packages
+def install_rpm_packages(packages)
+  packages.each do |package_name|
+    package package_name do
+      action :install
+      source package_name
+    end
+  end
+end
+
+# Function to install and activate a Python virtual env to run the the External authenticator daemon
+def install_ext_auth_virtual_env
+  return if File.exist?("#{node['cfncluster']['dcv']['authenticator']['virtualenv_path']}/bin/activate")
+
+  install_pyenv node['cfncluster']['dcv']['authenticator']['user'] do
+    python_version node['cfncluster']['python-version']
+  end
+
+  activate_virtual_env node['cfncluster']['dcv']['authenticator']['virtualenv'] do
+    pyenv_path node['cfncluster']['dcv']['authenticator']['virtualenv_path']
+    pyenv_user node['cfncluster']['dcv']['authenticator']['user']
+    python_version node['cfncluster']['python-version']
+  end
+end
+
+
+# Function to disable lock screen since default EC2 users don't have a password
+def disable_lock_screen
+  # Override default GSettings to disable lock screen for all the users
+  cookbook_file "/usr/share/glib-2.0/schemas/10_org.gnome.desktop.screensaver.gschema.override" do
+    source 'dcv/10_org.gnome.desktop.screensaver.gschema.override'
+    owner 'root'
+    group 'root'
+    mode '0755'
+  end
+
+  # compile gsettings schemas
+  execute 'Compile gsettings schema' do
+    command "glib-compile-schemas /usr/share/glib-2.0/schemas/"
+  end
+end
+
+
+# Install pcluster_dcv_connect.sh script in all the OSes to use it for error handling
+cookbook_file "#{node['cfncluster']['scripts_dir']}/pcluster_dcv_connect.sh" do
+  source 'dcv/pcluster_dcv_connect.sh'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  not_if { ::File.exist?("#{node['cfncluster']['scripts_dir']}/pcluster_dcv_connect.sh") }
+end
+
+
+if node['platform'] == 'centos' && node['platform_version'].to_i == 7 && !File.exist?("/etc/dcv/dcv.conf")
+  case node['cfncluster']['cfn_node_type']
+  when 'MasterServer', nil
+    dcv_tarball = "#{node['cfncluster']['sources_dir']}/dcv-#{node['cfncluster']['dcv']['version']}.tgz"
+
+    # Install the desktop environment and the desktop manager packages
+    execute 'Install gnome desktop' do
+      command 'yum -y install @gnome'
+    end
+    disable_lock_screen
+
+    # Install X Window System (required when using GPU acceleration)
+    package "xorg-x11-server-Xorg"
+
+    # Extract DCV packages
+    unless File.exist?(dcv_tarball)
+      remote_file dcv_tarball do
+        source node['cfncluster']['dcv']['url']
+        mode '0644'
+        retries 3
+        retry_delay 5
+      end
+
+      bash 'extract dcv packages' do
+        cwd Chef::Config[:file_cache_path]
+        code "tar -xvzf #{dcv_tarball}"
+      end
+    end
+
+    # Install server and xdcv packages
+    dcv_packages = %W[#{node['cfncluster']['dcv']['server']} #{node['cfncluster']['dcv']['xdcv']}]
+    dcv_packages_path = "#{Chef::Config[:file_cache_path]}/nice-dcv-#{node['cfncluster']['dcv']['version']}-el7/"
+    # Rewrite dcv_packages object by cycling each package file name and appending the path to them
+    dcv_packages.map! { |package| dcv_packages_path + package }
+    install_rpm_packages(dcv_packages)
+
+    # Create user and Python virtual env for the external authenticator
+    user node['cfncluster']['dcv']['authenticator']['user'] do
+      manage_home true
+      home node['cfncluster']['dcv']['authenticator']['user_home']
+      comment 'NICE DCV External Authenticator user'
+      system true
+      shell '/bin/bash'
+    end
+    install_ext_auth_virtual_env
+
+  when 'ComputeFleet'
+    user node['cfncluster']['dcv']['authenticator']['user'] do
+      manage_home false
+      home node['cfncluster']['dcv']['authenticator']['user_home']
+      comment 'NICE DCV External Authenticator user'
+      system true
+      shell '/bin/bash'
+    end
+  end
+
+  # stop firewall
+  service "firewalld" do
+    action %i[disable stop]
+  end
+
+  # Disable selinux
+  selinux_state "SELinux Disabled" do
+    action :disabled
+    only_if 'which getenforce'
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,3 +18,7 @@
 include_recipe 'aws-parallelcluster::sge_install'
 include_recipe 'aws-parallelcluster::torque_install'
 include_recipe 'aws-parallelcluster::slurm_install'
+
+# DCV recipe installs Gnome, X and their dependencies so it must be installed as latest to not break the environment
+# used to build the schedulers packages
+include_recipe "aws-parallelcluster::dcv_install"

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -113,17 +113,25 @@ if node['cfncluster']['cfn_scheduler'] == 'slurm'
   end
 end
 
-
-case node['cfncluster']['os']
-when 'alinux', 'centos7'
-  execute 'check efa rpm installed' do
-    command "rpm -qa | grep libfabric && rpm -qa | grep efa-"
-    user node['cfncluster']['cfn_cluster_user']
+if node['cfncluster']['cfn_node_type'] == "MasterServer" and node['cfncluster']['os'] == 'centos7' and node['cfncluster']['dcv']['installed'] == 'yes'
+  execute 'check dcv installed' do
+    command 'dcv version'
   end
-when 'ubuntu1604', 'ubuntu1804'
-  execute 'check efa rpm installed' do
-    command "dpkg -l | grep libfabric && dpkg -l | grep 'efa '"
-    user node['cfncluster']['cfn_cluster_user']
+end
+
+
+unless node['cfncluster']['cfn_region'].start_with?("cn-")
+  case node['cfncluster']['os']
+  when 'alinux', 'centos7'
+    execute 'check efa rpm installed' do
+      command "rpm -qa | grep libfabric && rpm -qa | grep efa-"
+      user node['cfncluster']['cfn_cluster_user']
+    end
+  when 'ubuntu1604', 'ubuntu1804'
+    execute 'check efa rpm installed' do
+      command "dpkg -l | grep libfabric && dpkg -l | grep 'efa '"
+      user node['cfncluster']['cfn_cluster_user']
+    end
   end
 end
 

--- a/resources/activate_virtual_env.rb
+++ b/resources/activate_virtual_env.rb
@@ -1,0 +1,36 @@
+resource_name :activate_virtual_env
+provides :activate_virtual_env
+
+# Resource to create a Python virtual environment for a given user and install a list of packages on it
+
+property :pyenv_name, String, name_property: true
+property :pyenv_path, String, required: true
+property :pyenv_user, String, default: 'root'
+property :python_version, String, required: true
+property :requirements_path, String, default: ""
+
+default_action :run
+
+action :run do
+  pyenv_script "pyenv virtualenv #{new_resource.pyenv_name}" do
+    code "pyenv virtualenv #{new_resource.python_version} #{new_resource.pyenv_name}"
+    user new_resource.pyenv_user
+  end
+
+  unless new_resource.requirements_path.empty?
+    # Copy requirements file
+    cookbook_file "#{new_resource.pyenv_path}/requirements.txt" do
+      source new_resource.requirements_path
+      owner new_resource.pyenv_user
+      group new_resource.pyenv_user
+      mode '0755'
+    end
+
+    # Install given requirements in the virtual environment
+    pyenv_pip "#{new_resource.pyenv_path}/requirements.txt" do
+      virtualenv new_resource.pyenv_path
+      requirement true
+      user new_resource.pyenv_user
+    end
+  end
+end

--- a/resources/install_pyenv.rb
+++ b/resources/install_pyenv.rb
@@ -1,0 +1,23 @@
+resource_name :install_pyenv
+provides :install_pyenv
+
+# Resource to create a Python virtual environment for a given user
+
+property :pyenv_user, String, name_property: true
+property :python_version, String, required: true
+
+default_action :run
+
+action :run do
+
+  pyenv_user_install new_resource.pyenv_user
+
+  pyenv_python new_resource.python_version do
+    user new_resource.pyenv_user
+  end
+
+  pyenv_plugin 'virtualenv' do
+    git_url 'https://github.com/pyenv/pyenv-virtualenv'
+    user new_resource.pyenv_user
+  end
+end

--- a/templates/default/dcv.conf.erb
+++ b/templates/default/dcv.conf.erb
@@ -1,0 +1,155 @@
+###############################################################################
+## Section "license" contains properties to configure the the license management
+###############################################################################
+
+[license]
+
+# Property "license-file" specifies the path to a demo license file or the name
+# of the license server used by the rlm daemon, in the format port@host
+# (for example 5053@licserver).
+# The port number must be the same as that specified in the HOST line of the
+# license file.
+# If empty or not specified, a default path to a demo license file will be
+# used (e.g: /usr/share/dcv/license/license.lic). If the default file does not
+# exists a demo license will be used.
+#license-file = ""
+
+###############################################################################
+## Section "log" contains properties to configure the DCV logging system
+###############################################################################
+
+[log]
+
+# Property "level" contains the logging level used by DCV.
+# Can be set to ERROR, WARNING, INFO or DEBUG (in ascending level of verbosity).
+# If not specified, the default level is INFO
+#level = "INFO"
+
+###############################################################################
+## Section "session-management" contains the properties of DCV session creation
+###############################################################################
+
+[session-management]
+
+# Property "create-session" requests to automatically create a console session
+# (with ID "console") at DCV startup.
+# Can be set to true or false.
+# If not specified, no console session will be automatically created.
+#create-session = true
+
+# Property "enable-gl-in-virtual-sessions" specifies whether to employ the
+# 'dcv-gl' feature (a specific license will be required).
+# Allowed values: 'always-on', 'always-off', 'default-on', 'default-off'.
+# If not specified, the default value is 'default-on'.
+#enable-gl-in-virtual-sessions = "default-on"
+
+###############################################################################
+## Section "session-management/defaults" contains the default properties of DCV sessions
+###############################################################################
+
+[session-management/defaults]
+
+# Property "permissions-file" specifies the path to the permissions file
+# automatically merged with the permissions selected by the user for each session.
+# If empty or absent, use the default file in /etc/dcv/default.perm.
+#permissions-file = ""
+
+###############################################################################
+## Section "session-management.automatic-console-session" contains the properties
+## to be applied ONLY to the "console" session automatically created at server startup
+## when the create-session setting of section 'session-management' is set to true.
+###############################################################################
+
+[session-management/automatic-console-session]
+
+# Property "owner" specifies the username of the owner of the automatically
+# created "console" session.
+#owner = ""
+
+# Property "permissions-file" specifies the file that contains the permissions
+# to be used to check user access to DCV features.
+# If empty, only the owner will have full access to the session.
+#permissions-file = ""
+
+# Property "max-concurrent-clients" specifies the maximum number of concurrent
+# clients per session.
+# If set to -1, no limit is enforced. Default value -1;
+#max-concurrent-clients = -1
+
+# Property "storage-root" specifies the path to the folder that will be used
+# as root-folder for file storage operations.
+# The file storage will be disabled if the storage-root is empty or the folder
+# does not exist.
+#storage-root = ""
+
+###############################################################################
+## Section "display" contains the properties of the dcv remote display
+###############################################################################
+
+[display]
+
+# Property "target-fps" specifies which is the upper limit to the frames per
+# second that are sent to the client. A higher value consumes more bandwidth
+# and resources. By default it is set to 25. Set to 0 for no limit
+#target-fps = 30
+<% unless node['cfncluster']['dcv']['is_graphic_instance'] %>
+display-encoders=['turbojpeg', 'lz4', 'ffmpeg']
+<% end %>
+
+
+###############################################################################
+## Section "connectivity" contains the properties of the dcv connection
+###############################################################################
+
+[connectivity]
+
+# Property "web-port" specifies on which TCP port the DCV server listens on
+# It must be a number between 1024 and 65535 representing an
+# available TCP port on which the web server embedded in the DCV Server will
+# listen for connection requests to serve HTTP(S) pages and WebSocket
+# connections
+# If not specified, DCV will use port 8443
+web-port=<%= node['cfncluster']['dcv_port'] %>
+
+# Property "web-url-path" specifies a URL path for the embedded web server.
+# The path must start with /. For instance setting it to "/test/foo" means the
+# web server will be reachable at https://host:port/test/foo.
+# This property is especially useful when setting up a gateway that then
+# routes each connection to a different DCV server.
+# If not specified DCV uses "/", which means it will be reachable at
+# https://host:port
+#web-url-path="/dcv"
+
+# Property "idle-timeout" specifies a timeout in minutes after which
+# a client that does not send keyboard or mouse events is considered idle
+# and hence disconnected.
+# By default it is set to 60 (1 hour). Set to 0 to never disconnect
+# idle clients.
+#idle-timeout=120
+
+###############################################################################
+## Section "security" contains the properties related to authentication and security
+###############################################################################
+
+[security]
+
+# Property "authentication" specifies the client authentication method used by
+# the DCV server. Use 'system' to delegate client authentication to the
+# underlying operating system. Use 'none' to disable client authentication and
+# grant access to all clients.
+#authentication="none"
+
+# Property "pam-service-name" specifies the name of the PAM configuration file
+# used by DCV. The default PAM service name is 'dcv' and corresponds with
+# the /etc/pam.d/dcv configuration file. This parameter is only used if
+# the 'system' authentication method is used.
+#pam-service-name="dcv-custom"
+
+# Property "auth-token-verifier" specifies an endpoint (URL) for an external
+# the authentication token verifier. If empty or not specified, the internal
+# authentication token verifier is used
+auth-token-verifier="https://localhost:<%= Integer(node['cfncluster']['dcv_port']) + 1 %>"
+
+# Property "ca-file" specifies the file containing the certificate authorities (CAs)
+# trusted by the DCV server.
+ca-file="<%= node['cfncluster']['dcv']['authenticator']['certificate'] %>"

--- a/templates/default/parallelcluster_supervisord.conf.erb
+++ b/templates/default/parallelcluster_supervisord.conf.erb
@@ -13,9 +13,17 @@ stdout_logfile = /var/log/sqswatcher
 command = <%= node['cfncluster']['node_virtualenv_path'] %>/bin/jobwatcher
 redirect_stderr = true
 stdout_logfile = /var/log/jobwatcher
-
 <% end -%>
 
+<% if node['cfncluster']['dcv_enabled'] == "master" -%>
+[program:pcluster_dcv_authenticator]
+command = <%= node['cfncluster']['dcv']['authenticator']['virtualenv_path'] %>/bin/python <%= node['cfncluster']['dcv']['authenticator']['user_home'] %>/pcluster_dcv_authenticator.py
+      --port <%= Integer(node['cfncluster']['dcv_port']) + 1 %>
+      --certificate <%= node['cfncluster']['dcv']['authenticator']['certificate'] %>
+      --key <%= node['cfncluster']['dcv']['authenticator']['private_key'] %>
+user = <%= node['cfncluster']['dcv']['authenticator']['user'] %>
+environment = HOME="<%= node['cfncluster']['dcv']['authenticator']['user_home'] %>",USER="<%= node['cfncluster']['dcv']['authenticator']['user'] %>"
+<% end -%>
 <%# ComputeFleet -%>
 <% when 'ComputeFleet' -%>
 [program:nodewatcher]

--- a/test/unit/test_dcv_authenticator.py
+++ b/test/unit/test_dcv_authenticator.py
@@ -1,0 +1,299 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import json
+import string
+import time
+from datetime import datetime
+
+import pytest
+from assertpy import assert_that
+from pcluster_dcv_authenticator import (
+    DCVAuthenticator,
+    OneTimeTokenHandler,
+    generate_random_token,
+    generate_sha512_hash,
+)
+
+AUTH_MODULE_MOCK_PATH = "pcluster_dcv_authenticator."
+AUTH_CLASS_MOCK_PATH = AUTH_MODULE_MOCK_PATH + "DCVAuthenticator."
+
+
+class TestOneTimeTokenHandler:
+    """Class to test the characteristics of the OneTimeTokenHandler class."""
+
+    @staticmethod
+    def test_token_capacity():
+        """
+        Test token capacity.
+
+        Create a token handler with a defined size, add a number of items exceeding the internal capacity
+        and verify the first one is not present.
+        """
+        storage = OneTimeTokenHandler(3)
+        storage.add_token("token1", ("some_value", 1, 15.2, ["a", 2]))
+        storage.add_token("token2", (1, 2))
+        storage.add_token("token3", 5)
+        storage.add_token("1", 15)
+        assert_that(storage.get_token_info("token1")).is_none()
+
+    @staticmethod
+    def test_token_storage():
+        """Add tokens and their corresponding information in the storage and verify they are correctly stored."""
+        storage = OneTimeTokenHandler(3)
+        storage.add_token("token1", ("some_value", 1, 15.2, ["a", 2]))
+        storage.add_token("token2", (1, 2))
+        storage.add_token("token3", 5)
+        assert_that(storage.get_token_info("token1")).is_equal_to(("some_value", 1, 15.2, ["a", 2]))
+        assert_that(storage.get_token_info("token2")).is_equal_to((1, 2))
+        assert_that(storage.get_token_info("token3")).is_equal_to(5)
+
+    @staticmethod
+    def test_one_time_token():
+        """Add a token and verify it is correctly removed once used."""
+        storage = OneTimeTokenHandler(5)
+        storage.add_token(1, "some_value")
+        storage.get_token_info(1)
+        assert_that(storage.get_token_info(1)).is_none()
+
+
+def test_one_time_token_handler():
+    TestOneTimeTokenHandler.test_token_capacity()
+    TestOneTimeTokenHandler.test_token_storage()
+    TestOneTimeTokenHandler.test_one_time_token()
+
+
+def test_token_generator():
+    # Verify token length and correctness
+    assert_that(generate_random_token(256)).is_not_equal_to(generate_random_token(256))
+    assert_that(len(generate_random_token(128))).is_equal_to(128)
+    allowed_chars = "".join((string.ascii_letters, string.digits, "_", "-"))
+    assert_that(allowed_chars).contains(*list(generate_random_token(256)))
+
+
+def test_sha_generator():
+    # Verify SHA512 generation and salt adding
+    assert_that(len(generate_sha512_hash("hash"))).is_equal_to(128)
+    assert_that(generate_sha512_hash("hash")).is_not_equal_to(generate_sha512_hash("hash"))
+    assert_that(generate_sha512_hash("hash1", "hash2")).is_not_equal_to(generate_sha512_hash("hash1", "hash2"))
+    assert_that(generate_sha512_hash([1, 2, 4])).is_not_equal_to(generate_sha512_hash([1, 2, 4]))
+
+
+@pytest.mark.parametrize(
+    "user, command, session_id, result",
+    [
+        ("user1", "/usr/libexec/dcv/dcvagent", "mysession", True),
+        ("user1", "/usr/libexec/dcv/dcvagent2", "mysession", False),
+        ("wrong", "/usr/libexec/dcv/dcvagent", "mysession", False),
+        ("user1", "/usr/libexec/dcv/dcvagent", "wrong", False),
+    ],
+)
+def test_is_process_valid(user, command, session_id, result):
+    expected_session_id = "mysession"
+    expected_user = "user1"
+
+    ps_aux_output = (
+        "{USER}                63   0.0  0.0  4348844   3108   ??  Ss   23Jul19   2:32.46 {COMMAND} "
+        "--session-id {SESSION}".format(USER=user, COMMAND=command, SESSION=session_id)
+    )
+
+    assert_that(DCVAuthenticator.check_dcv_process(ps_aux_output, expected_user, expected_session_id)).is_equal_to(
+        result
+    )
+
+
+def mock_generate_random_token(mocker, value):
+    mocker.patch(AUTH_MODULE_MOCK_PATH + "generate_random_token", return_value=value)
+
+
+def mock_verify_session_existence(mocker, exists):
+    def _return_value(user, sessionid):
+        if not exists:
+            raise DCVAuthenticator.IncorrectRequestException("The given session for the user does not exists")
+
+    mocker.patch(AUTH_CLASS_MOCK_PATH + "_verify_session_existence", side_effect=_return_value)
+
+
+def mock_os(mocker, user, timestamp):
+    class FileProperty(object):
+        pass
+
+    file_property = FileProperty
+    file_property.st_uid = 1
+    file_property.st_size = b"800"
+    file_property.st_mtime = timestamp
+    file_property.pw_name = user
+    file_property.st_mode = 0
+
+    mocker.patch(AUTH_MODULE_MOCK_PATH + "os.stat", return_value=file_property, autospec=True)
+    mocker.patch(AUTH_MODULE_MOCK_PATH + "os.remove")
+    mocker.patch(AUTH_MODULE_MOCK_PATH + "getpwuid", autospec=True, return_value=file_property)
+
+
+@pytest.mark.parametrize(
+    "parameters, keys, result",
+    [
+        ({"a": "5", "b": "2"}, ["authUser", "sessionID"], DCVAuthenticator.IncorrectRequestException),
+        ({"authUser": "5", "b": "2"}, ["authUser", "sessionID"], DCVAuthenticator.IncorrectRequestException),
+        ({"a": "5", "sessionID": "2"}, ["authUser", "sessionID"], DCVAuthenticator.IncorrectRequestException),
+        ({"authUser": "user1", "sessionID": "1234"}, ["authUser", "sessionID"], ["user1", "1234"]),
+        ({"requestToken": "token1"}, ["requestToken"], ["token1"]),
+    ],
+)
+def test_get_request_token_parameter(parameters, keys, result):
+    if isinstance(result, list):
+        assert_that(DCVAuthenticator._extract_parameters_values(parameters, keys)).is_equal_to(result)
+    else:
+        with pytest.raises(result):
+            DCVAuthenticator._extract_parameters_values(parameters, keys)
+
+
+def test_get_request_token(mocker):
+    """Verify the first step of the authentication process, the retrieval of the Request Token."""
+    token_value = "1234abcd_-"
+    user = "centos"
+    session_id = "mysession"
+
+    mock_verify_session_existence(mocker, exists=True)
+    mock_generate_random_token(mocker, token_value)
+
+    # all correct
+    assert_that(DCVAuthenticator._get_request_token(user, session_id)).is_equal_to(
+        json.dumps({"requestToken": token_value, "accessFile": generate_sha512_hash(token_value)})
+    )
+    assert_that(DCVAuthenticator.request_token_manager.get_token_info(token_value)[:-2]).is_equal_to((user, session_id))
+
+    # session does not exists
+    mock_verify_session_existence(mocker, exists=False)
+    with pytest.raises(DCVAuthenticator.IncorrectRequestException):
+        DCVAuthenticator._get_request_token(user, session_id)
+
+
+@pytest.mark.parametrize(
+    "user, session_id",
+    [
+        ("-1234abcd_-", "mysession"),
+        ("a^mc", "mysession"),
+        ("aAmc", "mysession"),
+        ('a"mc', "mysession"),
+        ("a1234abcd_-", "^mysession"),
+        ("a1234abcd_-", "mys+ession"),
+        ("a1234abcd_-", "".join(("c" for _ in range(129)))),
+        ("".join(("c" for _ in range(33))), "mysession"),
+    ],
+)
+def test_get_request_token_regex(user, session_id):
+    with pytest.raises(DCVAuthenticator.IncorrectRequestException):
+        DCVAuthenticator._get_request_token(user, session_id)
+
+
+@pytest.mark.parametrize("token", ["assvbsd", "?" + "".join(("c" for _ in range(255)))])
+def test_get_session_token_regex(token):
+    with pytest.raises(DCVAuthenticator.IncorrectRequestException):
+        DCVAuthenticator._get_session_token(token)
+
+
+def test_check_auth(mocker):
+    """
+    Verify the DCVAuthenticator._check_auth method.
+
+    The method verifies the token validity for the given DCV session id.
+    """
+    token = generate_random_token(256)
+    user = "centos"
+    session_id = "mysession"
+    mock_verify_session_existence(mocker, exists=True)
+
+    # valid
+    DCVAuthenticator.session_token_manager.add_token(
+        token, DCVAuthenticator.SessionTokenInfo(user, session_id, datetime.utcnow())
+    )
+    assert_that(DCVAuthenticator._check_auth(session_id, token)).is_equal_to(user)
+
+    # expired
+    DCVAuthenticator.session_token_manager.add_token(
+        token,
+        DCVAuthenticator.SessionTokenInfo(user, session_id, datetime.utcnow() - DCVAuthenticator.session_token_ttl),
+    )
+    time.sleep(1)
+    assert_that(DCVAuthenticator._check_auth(session_id, token)).is_none()
+
+    # wrong session
+    DCVAuthenticator.session_token_manager.add_token(
+        token, DCVAuthenticator.SessionTokenInfo(user, session_id, datetime.utcnow())
+    )
+    assert_that(DCVAuthenticator._check_auth("mysession2", token)).is_none()
+
+
+# py 2.7 compatibility
+def obtain_timestamp(date):
+    return (date - datetime(1970, 1, 1)).total_seconds()
+
+
+def test_get_session_token(mocker):
+    """Verify the second step of the authentication process, the retrieval of the Session Token."""
+    request_token = "".join("a" for _ in range(256))
+    user = "centos"
+    session_id = "mysession"
+    access_file = "access_file"
+    mock_verify_session_existence(mocker, exists=True)
+
+    # empty
+    with pytest.raises(DCVAuthenticator.IncorrectRequestException):
+        DCVAuthenticator._get_session_token(request_token)
+
+    # expired
+    DCVAuthenticator.request_token_manager.add_token(
+        request_token,
+        DCVAuthenticator.RequestTokenInfo(
+            user, session_id, datetime.utcnow() - DCVAuthenticator.request_token_ttl, access_file
+        ),
+    )
+    with pytest.raises(DCVAuthenticator.IncorrectRequestException):
+        DCVAuthenticator._get_session_token(request_token)
+
+    # file does not exist
+    DCVAuthenticator.request_token_manager.add_token(
+        request_token, DCVAuthenticator.RequestTokenInfo(user, session_id, datetime.utcnow(), access_file)
+    )
+    with pytest.raises(DCVAuthenticator.IncorrectRequestException):
+        DCVAuthenticator._get_session_token(request_token)
+
+    # user is different
+    mock_os(mocker, "centos2", obtain_timestamp(datetime.utcnow()))
+    DCVAuthenticator.request_token_manager.add_token(
+        request_token, DCVAuthenticator.RequestTokenInfo(user, session_id, datetime.utcnow(), access_file)
+    )
+    with pytest.raises(DCVAuthenticator.IncorrectRequestException):
+        DCVAuthenticator._get_session_token(request_token)
+
+    # file is expired
+    mock_os(mocker, user, obtain_timestamp(datetime.utcnow() - DCVAuthenticator.request_token_ttl))
+    DCVAuthenticator.request_token_manager.add_token(
+        request_token, DCVAuthenticator.RequestTokenInfo(user, session_id, datetime.utcnow(), access_file)
+    )
+    with pytest.raises(DCVAuthenticator.IncorrectRequestException):
+        DCVAuthenticator._get_session_token(request_token)
+
+    # working
+    mock_os(mocker, user, obtain_timestamp(datetime.utcnow()))
+    mock_verify_session_existence(mocker, exists=True)
+    session_token = "1234"
+    mock_generate_random_token(mocker, session_token)
+    DCVAuthenticator.request_token_manager.add_token(
+        request_token, DCVAuthenticator.RequestTokenInfo(user, session_id, datetime.utcnow(), access_file)
+    )
+    assert_that(DCVAuthenticator._get_session_token(request_token)).is_equal_to(
+        json.dumps({"sessionToken": session_token})
+    )
+    assert_that(DCVAuthenticator.session_token_manager.get_token_info(session_token)[:-1]).is_equal_to(
+        (user, session_id)
+    )


### PR DESCRIPTION
This patch adds a new set or recipes and utility files required to integrate NICE DCV with ParallelCluster.

We are preparing the environment to enable the user to connect through NICE DCV to the master instance.

NICE DCV will be installed at AMI creation time and configured/enabled at runtime according to the user's choiches.

We added `pcluster_dcv_connect.sh` script to manage the DCV session/creation for the ec2-user and a new External Authenticator for DCV (`pcluster_dcv_authenticator.py`).

The external authenticator is a python WebServer, managed as a service by supervisord, that will run in a private virtual environment.

DCV will be automatically configured to use the ext authenticator.

___

This patch replaces the https://github.com/aws/aws-parallelcluster-cookbook/pull/349 and adds the following changes:
+ Rebased the code with the latest changes
+ Reworded the commit messages 
+ Add support for GPU acceleration on NICE DCV
+ Improve security of hash creation
With this patch I'm differentiating `RequestTokenValues` and `SessionTokenValues`
named tuples, to have the access_file hash stored in memory with the token itself
The advantage is we can use avoid to define the "salt" as global var and use
different salt for each hash creation.
Before of this page the same SALT was used for the whole `DCVAuthenticator` lifecycle.
+ Add comments, refactor code and add unit tests
+ Renamed functions, variables and added newlines to split code blocks
+ Renamed `requiredFile` parameter to `accessFile`
+ Renamed `pyenv_install` resource to `install_pyenv` to avoid confusion
  with `pyenv_*` resources included in the pyenv cookbook recipes:
  https://supermarket.chef.io/cookbooks/pyenv
+ Add unit tests and add comments to them
+ Refactored `install_rpm_packages_from_path` function
+ Use definitive `dna.json` to retrieve base os and not the temporary one
+ Install Xorg at AMI creation time and improve X running verification
+ Improve certificate and private key creation by creating different files
+ Explicitly define private key size RSA signature alghoritm
They are already the defaults: 2048-bit private key size, SHA-256 with RSA signature algorithm
+ Add logging for pcluster_dcv_connect bash script
+ rename `pcluster_dcv_ext_auth` log file to be aligned with py module name
+ Fix code to cleanup old authorization files
The code was deleting the files and the AUTHORIZATION_DIR folder too so
the authentication flow didn't work after server restart.
+ Remove init method from test class
Pytest is not able to collect method from a test Class with init method
+ Define `_atomic_touch` function in `pcluster_dcv_connect.sh`
+ Use a simple bash log rotation
The log will rotate if the size is greater than 5MB.
A backup of the log will be saved.
+ Remove future and retry external dependency and use py logging library
+ Add log messages to understand who is doing what (and when)
+ Override `server.log_message` to not print `requestToken` and `sectionToken` GET details.
+ Rename `ext_auth_files` folder to dcv
+ Add missing init file for dcv Python folder
+ Improve naming of DCV related stuff
    + `pcluster_dcv_ext_auth` -> `pcluster_dcv_authenticator`
    + `/var/spool/dcv_ext_auth` -> `/var/spool/parallelcluster/pcluster_dcv_authenticator`
    + `/var/log/parallelcluster/pcluster_dcv_ext_auth.log` -> `/var/log/parallelcluster/pcluster_dcv_authenticator.log`
    + `['dcv']['ext_auth_*']` -> `['dcv']['authenticator']['*']`
+ Improve SSH configuration
    + Disable X11Forwarding
    + Limit Ciphers and MACs
+ Create ParallelCluster log folder in _prep_env recipe
+ Update NICE DCV version from 2019.1-7423 to 2019.1-7644
+ Move installation of pcluster_dcv_connect.sh into the dcv_install recipe
+ Disable lock screen by default for all the users
It is required since default EC2 users don't have a password
References: https://developer.gnome.org/gio//2.48/glib-compile-schemas.html
