### PR TITLE
Add ffi-libarchive gem to support line vendoring with ChefDK < 3.0.36-1

### DIFF
--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -176,7 +176,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}}"
+        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {

--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -183,7 +183,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}}"
+        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -190,7 +190,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}}"
+        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {

--- a/amis/packer_ubuntu1404.json
+++ b/amis/packer_ubuntu1404.json
@@ -190,7 +190,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}}"
+        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -193,7 +193,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}}"
+        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -193,7 +193,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}}"
+        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {


### PR DESCRIPTION
We recently updated line and nfs cookbooks (with line dependency).
Commit: https://github.com/aws/aws-parallelcluster-cookbook/pull/379/commits/2a93f3acfe915cdb72cd3ac3e77b87b6d957011f

This breaks compatibility with ChefDK < 3.0.36-1.
We are adding this dependency we support custom ami creation with "any" version of ChefDK.

See:
https://github.com/sous-chefs/line/issues/92
https://github.com/berkshelf/berkshelf/issues/1744

Related PR for to fix runtime vendoring: https://github.com/aws/aws-parallelcluster/pull/1319