### PR TITLE
Regionalize Nvidia download URL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,6 +57,9 @@ default['cfncluster']['ganglia']['web_url'] = 'https://github.com/ganglia/gangli
 # NVIDIA
 default['cfncluster']['nvidia']['enabled'] = 'no'
 default['cfncluster']['nvidia']['driver_url'] = 'http://download.nvidia.com/XFree86/Linux-x86_64/418.56/NVIDIA-Linux-x86_64-418.56.run'
+if node['cfncluster']['cfn_region'].start_with?("cn-")
+  default['cfncluster']['nvidia']['driver_url'] = 'http://cn.download.nvidia.com/XFree86/Linux-x86_64/418.56/NVIDIA-Linux-x86_64-418.56.run'
+end
 default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_410.48_linux'
 # EFA
 default['cfncluster']['efa']['installer_url'] = 'https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.5.3.tar.gz'


### PR DESCRIPTION
curl -L http://download.nvidia.com/XFree86/Linux-x86_64/418.56/NVIDIA-Linux-x86_64-418.56.run -o nvidia-commercial
curl -L http://cn.download.nvidia.com/XFree86/Linux-x86_64/418.56/NVIDIA-Linux-x86_64-418.56.run -o nvidia-china

md5sum nvidia-*
d1cf6dc33af48b53edbae5d6f31a6f89  nvidia-commercial
d1cf6dc33af48b53edbae5d6f31a6f89  nvidia-china

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
