### PR TITLE
Enable udev network access

### DIFF
--- a/files/ubuntu-18.04/udev-override.conf
+++ b/files/ubuntu-18.04/udev-override.conf
@@ -1,0 +1,2 @@
+[Service]
+IPAddressAllow=any

--- a/recipes/_ec2_udev_rules.rb
+++ b/recipes/_ec2_udev_rules.rb
@@ -49,6 +49,25 @@ cookbook_file 'attachVolume.py' do
   mode '0755'
 end
 
+if node['platform'] == 'ubuntu' && node['platform_version'] == "18.04"
+  # allow Ubuntu 18 udev to do network call
+  execute 'udev-daemon-reload' do
+    command 'udevadm control --reload'
+    action :nothing
+  end
+
+  directory '/etc/systemd/system/systemd-udevd.service.d'
+
+  # Disable udev network sandbox and notify udev to reload configuration
+  cookbook_file 'udev-override.conf' do
+    path '/etc/systemd/system/systemd-udevd.service.d/override.conf'
+    user 'root'
+    group 'root'
+    mode '0644'
+    notifies :run, "execute[udev-daemon-reload]", :immediately
+  end
+end
+
 service "ec2blkdev" do
   supports restart: true
   action %i[enable start]


### PR DESCRIPTION
Network sandbox was introduced with udev 237 in Ubuntu 18, see https://manpages.ubuntu.com/manpages/bionic/man7/udev.7.html
Network calls are done to get the volume ID of the attached disk device (xvd* type) e.g. describe_instance_attribute
This align the behaviour with the other OSs

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
