### PR TITLE
Add Lustre drivers for Centos 7.7

### DIFF
--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -47,8 +47,49 @@ if node['platform'] == 'centos' && (5..6).cover?(node['platform_version'].split(
   end
 
   kernel_module 'lnet'
+elsif node['platform'] == 'centos' && node['platform_version'].split('.')[1].to_i == 7
+
+  # Install build dependencies
+  package %w[libselinux-devel libyaml-devel rpm-build gcc git make] do
+    retries 3
+    retry_delay 5
+  end
+
+  # grab lustre source
+  bash "clone github repo" do
+    cwd node['cfncluster']['sources_dir']
+    code <<-LUSTREBUILD
+      set -e
+      git clone git://git.whamcloud.com/fs/lustre-release.git --depth 2 -b 2.10.8
+      LUSTREBUILD
+    not_if { ::Dir.exist?("#{node['cfncluster']['sources_dir']}/lustre-release") }
+  end
+
+  # Make RPMS
+  bash "make rpms" do
+    cwd "#{node['cfncluster']['sources_dir']}/lustre-release"
+    code <<-LUSTREBUILD
+      set -e
+      sh ./autogen.sh
+      ./configure --disable-server --with-o2ib=no
+      make rpms
+    LUSTREBUILD
+    not_if { ::File.exist?("#{node['cfncluster']['sources_dir']}/lustre-release/kmod-lustre-client-2.10.8-1.el7.x86_64.rpm") }
+  end
+
+  # Install lustre mount drivers
+  yum_package 'lustre_kmod' do
+    source "#{node['cfncluster']['sources_dir']}/lustre-release/kmod-lustre-client-2.10.8-1.el7.x86_64.rpm"
+  end
+
+  # Install lustre mount drivers
+  yum_package 'lustre_client' do
+    source "#{node['cfncluster']['sources_dir']}/lustre-release/lustre-client-2.10.8-1.el7.x86_64.rpm"
+  end
+
+  kernel_module 'lnet'
 elsif node['platform'] == 'centos'
-  Chef::Log.warn("Unsupported version of Centos, #{node['platform_version']}, supported versions are 7.6 and 7.5")
+  Chef::Log.warn("Unsupported version of Centos, #{node['platform_version']}, supported versions are 7.5, 7.6 and 7.7")
 elsif node['platform'] == 'amazon'
 
   # Install lustre client module


### PR DESCRIPTION
Tested on Centos 7.7 with `3.10.0-1062.1.1.el7.x86_64` kernel:

```bash
[centos@ip-172-31-12-240 ~]$ df -h
Filesystem                               Size  Used Avail Use% Mounted on
...
172.31.0.6@tcp:/fsx  3.4T   14M  3.4T   1% /fsx
...
[centos@ip-172-31-10-58 ~]$ ssh ip-172-31-12-240
Last login: Mon Sep 30 23:59:12 2019 from ip-172-31-10-58.ec2.internal
[centos@ip-172-31-12-240 ~]$ df -h
Filesystem                               Size  Used Avail Use% Mounted on
...
172.31.0.6@tcp:/fsx                      3.4T   14M  3.4T   1% /fsx
...
```

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
