### PR TITLE
Enable flock and user_xattr Lustre options by default

### DIFF
--- a/recipes/fsx_mount.rb
+++ b/recipes/fsx_mount.rb
@@ -29,13 +29,19 @@ if fsx_shared_dir != "NONE"
     action :create
   end
 
+  mount_options = %w[defaults _netdev flock user_xattr noatime]
+
+  if node['init_package'] == 'systemd'
+    mount_options.push(%w[noauto x-systemd.automount x-systemd.requires=lnet.service])
+  end
+
   # Mount FSx over NFS
   mount fsx_shared_dir do
     device "#{node['cfncluster']['cfn_fsx_fs_id']}.fsx.#{node['cfncluster']['cfn_region']}.amazonaws.com@tcp:/fsx"
     fstype 'lustre'
     dump 0
     pass 0
-    options %w[defaults _netdev]
+    options mount_options
     action %i[mount enable]
   end
 


### PR DESCRIPTION
From the [lustre docs](http://wiki.lustre.org/Mounting_a_Lustre_File_System_on_Client_Nodes):

> `flock`: This has no measurable performance impact in modern (2.x) versions of Lustre (this page previously stated there was a performance impact; this is not correct for modern versions). This is the recommended mode, and is enabled by default in Lustre 2.13 and newer.

> `user_xattr`: Enable support for user extended attributes. Extended attributes are name:value pairs associated permanently with files and directories, similar to the environment strings associated with a process.

> `noatime` This option turns off inode access time updates.

For `systemd` based systems I've added two more options:

> `x-systemd.automount` adds to `fstab` so filesystem is automatically mounted after reboots.

> `x-systemd.requires=lnet.service` requires lustre kernel module

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
