### PR TITLE
Set skip_if_unavailable to true for yum intel repositories

### DIFF
--- a/recipes/intel_install.rb
+++ b/recipes/intel_install.rb
@@ -19,6 +19,7 @@ bash "install intel hpc platform" do
   code <<-INTEL
     set -e
     yum-config-manager --add-repo http://yum.repos.intel.com/hpc-platform/el7/setup/intel-hpc-platform.repo
+    yum-config-manager --save --setopt=intel-hpc-platform.skip_if_unavailable=true
     rpm --import http://yum.repos.intel.com/hpc-platform/el7/setup/PUBLIC_KEY.PUB
     yum -y install intel-hpc-platform-*
   INTEL
@@ -32,6 +33,7 @@ bash "install intel psxe" do
     set -e
     rpm --import https://yum.repos.intel.com/2019/setup/RPM-GPG-KEY-intel-psxe-runtime-2019
     yum -y install https://yum.repos.intel.com/2019/setup/intel-psxe-runtime-2019-reposetup-1-0.noarch.rpm
+    yum-config-manager --save --setopt=intel-psxe-runtime-2019.skip_if_unavailable=true
     yum -y install intel-psxe-runtime-#{node['cfncluster']['psxe']['version']}
   INTEL
   creates '/opt/intel/psxe_runtime'
@@ -43,6 +45,7 @@ bash "install intel python" do
   code <<-INTEL
     set -e
     yum-config-manager --add-repo https://yum.repos.intel.com/intelpython/setup/intelpython.repo
+    yum-config-manager --save --setopt=intelpython.skip_if_unavailable=true
     yum -y install intelpython2 intelpython3
   INTEL
   creates '/opt/intel/intelpython2'

--- a/recipes/intel_mpi.rb
+++ b/recipes/intel_mpi.rb
@@ -36,3 +36,10 @@ bash "install intel mpi" do
   INTELMPI
   creates '/opt/intel/impi'
 end
+
+if (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
+  || node['platform'] == 'amazon'
+  execute 'yum-config-manager_skip_if_unavail_intel_mpi' do
+    command "yum-config-manager --save --setopt=intel-mpi.skip_if_unavailable=true"
+  end
+end


### PR DESCRIPTION
Setting skip_if_unavailable=true because it is not reasonable to fail the installation of a package if just a single repository (unrelated to the package you want to install) is down.
This align with what was already done in base_install.rb#23

We are not hiding any error in the case we want to install something from the broken repository, because of the `set -e` setting.

Without patch
```
yum install package_from_broken_repo
ERROR

yum install wget
ERROR
```

With patch
```
yum install package_from_broken_repo
echo $? -> 1

yum install wget
OK
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
