### PR TITLE
Reload httpd_service when ganglia conf is copied in sites-enabled folder

### DIFF
--- a/recipes/_ganglia_install.rb
+++ b/recipes/_ganglia_install.rb
@@ -143,6 +143,7 @@ if node['cfncluster']['ganglia_enabled'] == 'yes'
     # Setup ganglia-web.conf apache config
     execute "copy ganglia apache conf" do
       command "cp /etc/ganglia-webfrontend/apache.conf /etc/apache2/sites-enabled/ganglia.conf"
+      notifies :reload, "service[#{node['cfncluster']['ganglia']['httpd_service']}]", :immediately
       not_if "test -f /etc/apache2/sites-enabled/ganglia.conf"
     end
 

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -150,7 +150,7 @@ if node['cfncluster']['ganglia_enabled'] == 'yes'
   end
 
   service node['cfncluster']['ganglia']['httpd_service'] do
-    supports restart: true
+    supports restart: true, reload: true
     action %i[enable start]
   end
 end


### PR DESCRIPTION
This fix https://github.com/aws/aws-parallelcluster/issues/1322

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
