### PR TITLE
Upgrade slurm version to 19.05.3-2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,8 +44,8 @@ default['cfncluster']['sge']['url'] = 'https://arc.liv.ac.uk/downloads/SGE/relea
 default['cfncluster']['torque']['version'] = '6.1.2'
 default['cfncluster']['torque']['url'] = 'https://github.com/adaptivecomputing/torque/archive/6.1.2.tar.gz'
 # Slurm software
-default['cfncluster']['slurm']['version'] = '18-08-6-2'
-default['cfncluster']['slurm']['url'] = 'https://github.com/SchedMD/slurm/archive/slurm-18-08-6-2.tar.gz'
+default['cfncluster']['slurm']['version'] = '19-05-3-2'
+default['cfncluster']['slurm']['url'] = 'https://github.com/SchedMD/slurm/archive/slurm-19-05-3-2.tar.gz'
 # Munge
 default['cfncluster']['munge']['munge_version'] = '0.5.13'
 default['cfncluster']['munge']['munge_url'] = "https://github.com/dun/munge/archive/munge-#{node['cfncluster']['munge']['munge_version']}.tar.gz"

--- a/templates/default/slurm.conf.erb
+++ b/templates/default/slurm.conf.erb
@@ -68,13 +68,6 @@ SchedulerType=sched/backfill
 #SchedulerRootFilter=
 SelectType=select/cons_res
 SelectTypeParameters=CR_CPU
-
-# FastSchedule is deprecated in release 19.05.3-x
-# Disable fastscheduling to fall back on resource
-# metrics reported by compute nodes, slower scheduling
-# but more flexible if using different ec2 instance types
-#FastSchedule=0
-
 #PriorityType=priority/multifactor
 #PriorityDecayHalfLife=14-0
 #PriorityUsageResetPeriod=14-0

--- a/templates/default/slurm.conf.erb
+++ b/templates/default/slurm.conf.erb
@@ -69,10 +69,11 @@ SchedulerType=sched/backfill
 SelectType=select/cons_res
 SelectTypeParameters=CR_CPU
 
+# FastSchedule is deprecated in release 19.05.3-x
 # Disable fastscheduling to fall back on resource
 # metrics reported by compute nodes, slower scheduling
 # but more flexible if using different ec2 instance types
-FastSchedule=0
+#FastSchedule=0
 
 #PriorityType=priority/multifactor
 #PriorityDecayHalfLife=14-0


### PR DESCRIPTION
* Change slurm verison and url in attributes/default.rb
* Remove deprecated option FastSchedule from slurm.conf

Signed-off-by: Rex <shuningc@amazon.com>



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
