### PR TITLE
Add Recipes for installing and configuring Cloudwatch logging

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,6 +66,9 @@ default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia
 default['cfncluster']['efa']['installer_url'] = 'https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.6.2.tar.gz'
 # ENV2 - tool to capture environment and create modulefiles
 default['cfncluster']['env2']['url'] = 'https://sourceforge.net/projects/env2/files/env2/download'
+# CloudWatch Agent
+default['cfncluster']['cloudwatch']['public_key_url'] = "https://s3.amazonaws.com/amazoncloudwatch-agent/assets/amazon-cloudwatch-agent.gpg"
+default['cfncluster']['cloudwatch']['public_key_local_path'] = "#{node['cfncluster']['sources_dir']}/amazon-cloudwatch-agent.gpg"
 
 # Reboot after default_pre recipe
 default['cfncluster']['default_pre_reboot'] = 'true'

--- a/files/default/cloudwatch_log_files.json
+++ b/files/default/cloudwatch_log_files.json
@@ -1,0 +1,302 @@
+{
+  "timestamp_formats": {
+    "month_first": "%b %-d %H:%M:%S",
+    "default": "%Y-%m-%d %H:%M:%S,%f",
+    "slurm": "%Y-%m-%dT%H:%M:%S.%f",
+    "sge": "%m/%d/%Y %H:%M:%S",
+    "torque_compute": "%Y-%m-%d %H:%M:%S.%f",
+    "torque_master": "%m/%d/%Y %H:%M:%S.%f"
+  },
+  "log_configs": [
+    {
+      "timestamp_format_key": "month_first",
+      "file_path": "/var/log/messages",
+      "log_stream_name": "system-messages",
+      "schedulers": [
+        "awsbatch",
+        "sge",
+        "slurm",
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos"
+      ],
+      "node_roles": [
+        "ComputeFleet",
+        "MasterServer"
+      ]
+    },
+    {
+      "timestamp_format_key": "month_first",
+      "file_path": "/var/log/syslog",
+      "log_stream_name": "syslog",
+      "schedulers": [
+        "awsbatch",
+        "sge",
+        "slurm",
+        "torque"
+      ],
+      "platforms": [
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet",
+        "MasterServer"
+      ]
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/cfn-init-cmd.log",
+      "log_stream_name": "cfn-init-cmd",
+      "schedulers": [
+        "awsbatch",
+        "sge",
+        "slurm",
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet",
+        "MasterServer"
+      ]
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/cfn-init.log",
+      "log_stream_name": "cfn-init",
+      "schedulers": [
+        "awsbatch",
+        "sge",
+        "slurm",
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet",
+        "MasterServer"
+      ]
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/cfn-wire.log",
+      "log_stream_name": "cfn-wire",
+      "schedulers": [
+        "awsbatch",
+        "sge",
+        "slurm",
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet",
+        "MasterServer"
+      ]
+    },
+    {
+      "timestamp_format_key": "month_first",
+      "file_path": "/var/log/cloud-init.log",
+      "log_stream_name": "cloud-init",
+      "schedulers": [
+        "awsbatch",
+        "sge",
+        "slurm",
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet",
+        "MasterServer"
+      ]
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/supervisord.log",
+      "log_stream_name": "supervisord",
+      "schedulers": [
+        "awsbatch",
+        "sge",
+        "slurm",
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet",
+        "MasterServer"
+      ]
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/nodewatcher",
+      "log_stream_name": "nodewatcher",
+      "schedulers": [
+        "awsbatch",
+        "sge",
+        "slurm",
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet"
+      ]
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/jobwatcher",
+      "log_stream_name": "jobwatcher",
+      "schedulers": [
+        "awsbatch",
+        "sge",
+        "slurm",
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "MasterServer"
+      ]
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/sqswatcher",
+      "log_stream_name": "sqswatcher",
+      "schedulers": [
+        "awsbatch",
+        "sge",
+        "slurm",
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "MasterServer"
+      ]
+    },
+    {
+      "timestamp_format_key": "slurm",
+      "file_path": "/var/log/slurmd.log",
+      "log_stream_name": "slurmd",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet"
+      ]
+    },
+    {
+      "timestamp_format_key": "slurm",
+      "file_path": "/var/log/slurmctld.log",
+      "log_stream_name": "slurmctld",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "MasterServer"
+      ]
+    },
+    {
+      "timestamp_format_key": "sge",
+      "file_path": "/var/spool/sge/*/messages",
+      "log_stream_name": "sge-exec-daemon",
+      "schedulers": [
+        "sge"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet"
+      ]
+    },
+    {
+      "timestamp_format_key": "sge",
+      "file_path": "/opt/sge/default/spool/qmaster/messages",
+      "log_stream_name": "sge-qmaster",
+      "schedulers": [
+        "sge"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "MasterServer"
+      ]
+    },
+    {
+      "timestamp_format_key": "torque_compute",
+      "file_path": "/var/spool/torque/client_logs/*",
+      "log_stream_name": "torque-client",
+      "schedulers": [
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet"
+      ]
+    },
+    {
+      "timestamp_format_key": "torque_master",
+      "file_path": "/var/spool/torque/server_logs/*",
+      "log_stream_name": "torque-server",
+      "schedulers": [
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "MasterServer"
+      ]
+    }
+  ]
+}

--- a/files/default/verify_cloudwatch_agent_public_key_fingerprint.py
+++ b/files/default/verify_cloudwatch_agent_public_key_fingerprint.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""Verify the fingerprint for the CloudWatch agent's public key is as expected."""
+
+import re
+import subprocess
+import sys
+
+# This value comes from the CloudWatch agent's documentation:
+# https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/verify-CloudWatch-Agent-Package-Signature.html
+EXPECTED_FINGERPRINT = "9376 16F3 450B 7D80 6CBD  9725 D581 6730 3B78 9C72"
+
+
+def get_key_identifier():
+    """Get identifier for cloudwatch agent's key."""
+    output = subprocess.check_output(['gpg', '--list-keys', 'Amazon CloudWatch Agent']).decode('utf-8')
+    for line in output.splitlines():
+        match = re.search(r'^pub\s+.*/([0-9A-Z]+)', line.strip())
+        if match:
+            return match.group(1)
+    sys.exit('Unable to get identifier for cloudwatch agent public key')
+
+
+def get_key_fingerprint(key_id):
+    """Get the fingerprint for the key with ID key_id."""
+    output = subprocess.check_output(['gpg', '--fingerprint', key_id]).decode('utf-8')
+    for line in output.splitlines():
+        match = re.search(r'Key fingerprint = (.*)', line.strip())
+        if match:
+            return match.group(1)
+    sys.exit('Unable to get fingerprint for cloudwatch agent public key')
+
+
+def main():
+    """Run the script."""
+    key_id = get_key_identifier()
+    fingerprint = get_key_fingerprint(key_id)
+    if fingerprint != EXPECTED_FINGERPRINT:
+        sys.exit(
+            'Observed fingerprint of cloudwatch agent public key ({observed}) '
+            'does not match expected fingerprint ({expected}).'
+            .format(observed=fingerprint, expected=EXPECTED_FINGERPRINT)
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/files/default/write_cloudwatch_agent_json.py
+++ b/files/default/write_cloudwatch_agent_json.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""
+Write the CloudWatch agent configuration file.
+
+Write the JSON used to configure the CloudWatch agent on an instance conditional
+on the scheduler to be used, the platform (OS family) in use and the instance's role in the cluster.
+"""
+
+import argparse
+import json
+import socket
+
+
+AWS_CLOUDWATCH_CFG_PATH = '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json'
+
+
+def parse_args():
+    """Parse CL args and return an argparse.Namespace."""
+    parser = argparse.ArgumentParser(
+        description='Create the cloudwatch agent config file'
+    )
+    parser.add_argument('--config',
+                        help='Path to JSON file describing logs that should be monitored',
+                        required=True)
+    parser.add_argument('--platform',
+                        help='OS family of this instance',
+                        choices=['amazon', 'centos', 'ubuntu'],
+                        required=True)
+    parser.add_argument('--log-group',
+                        help='Name of the log group',
+                        required=True)
+    parser.add_argument('--node-role',
+                        required=True,
+                        choices=['MasterServer', 'ComputeFleet'],
+                        help='Role this node plays in the cluster '
+                             '(i.e., is it a compute node or the master?)')
+    parser.add_argument('--scheduler',
+                        required=True,
+                        choices=['slurm', 'sge', 'torque', 'awsbatch'],
+                        help='Scheduler')
+    return parser.parse_args()
+
+
+def gethostname():
+    """Return hostname of this instance."""
+    return socket.gethostname().split('.')[0]
+
+
+def write_config(config):
+    """Write config to AWS_CLOUDWATCH_CFG_PATH."""
+    with open(AWS_CLOUDWATCH_CFG_PATH, 'w+') as output_config_file:
+        json.dump(config, output_config_file, indent=4)
+
+
+def add_log_group_name_params(log_group_name, configs):
+    """Add a "log_group_name": log_group_name to every config."""
+    for config in configs:
+        config.update({'log_group_name': log_group_name})
+    return configs
+
+
+def add_instance_log_stream_prefixes(configs):
+    """Prefix all log_stream_name fields with instance identifiers."""
+    for config in configs:
+        config['log_stream_name'] = '{host}.{{instance_id}}.{log_stream_name}'.format(
+            host=gethostname(),
+            log_stream_name=config['log_stream_name']
+        )
+    return configs
+
+
+def read_data(config_path):
+    """Read in log configuration data from config_path."""
+    with open(config_path) as infile:
+        return json.load(infile)
+
+
+def select_configs_for_scheduler(configs, scheduler):
+    """Filter out from configs those entries whose 'schedulers' list does not contain scheduler."""
+    return [config for config in configs if scheduler in config['schedulers']]
+
+
+def select_configs_for_node_role(configs, node_role):
+    """Filter out from configs those entries whose 'node_roles' list does not contain node_role."""
+    return [config for config in configs if node_role in config['node_roles']]
+
+
+def select_configs_for_platform(configs, platform):
+    """Filter out from configs those entries whose 'platforms' list does not contain platform."""
+    return [config for config in configs if platform in config['platforms']]
+
+
+def select_logs(configs, args):
+    """Select the appropriate set of log configs."""
+    selected_configs = select_configs_for_scheduler(configs, args.scheduler)
+    selected_configs = select_configs_for_node_role(selected_configs, args.node_role)
+    selected_configs = select_configs_for_platform(selected_configs, args.platform)
+    return selected_configs
+
+
+def add_timestamps(configs, timestamps_dict):
+    """For each config, set its timestamp_format field based on its timestamp_format_key field."""
+    for config in configs:
+        config['timestamp_format'] = timestamps_dict[config['timestamp_format_key']]
+    return configs
+
+
+def filter_output_fields(configs):
+    """Remove fields that are not required by CloudWatch agent config file."""
+    desired_keys = ['log_stream_name', 'file_path', 'timestamp_format', 'log_group_name']
+    return [{desired_key: config[desired_key] for desired_key in desired_keys} for config in configs]
+
+
+def create_config(log_configs):
+    """Return a dict representing the structure of the output JSON."""
+    return {
+        "logs": {
+            "logs_collected": {
+                "files": {
+                    "collect_list": log_configs
+                }
+            },
+            "log_stream_name": "{host}.{{instance_id}}.default-log-stream".format(host=gethostname())
+        }
+    }
+
+
+def main():
+    """Create cloudwatch agent config file."""
+    args = parse_args()
+    config_data = read_data(args.config)
+    log_configs = select_logs(config_data['log_configs'], args)
+    log_configs = add_timestamps(log_configs, config_data['timestamp_formats'])
+    log_configs = add_log_group_name_params(args.log_group, log_configs)
+    log_configs = add_instance_log_stream_prefixes(log_configs)
+    log_configs = filter_output_fields(log_configs)
+    write_config(create_config(log_configs))
+
+
+if __name__ == '__main__':
+    main()

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -29,6 +29,9 @@ execute 'setup ephemeral' do
   creates '/scratch'
 end
 
+# Write cloudwatch log config and start it.
+include_recipe "aws-parallelcluster::cloudwatch_agent_config"
+
 # case node['cfncluster']['cfn_node_type']
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer'

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -195,3 +195,6 @@ end
 if (node['platform'] == 'centos' && node['platform_version'].to_i >= 7)
   include_recipe "aws-parallelcluster::intel_install"
 end
+
+# Install the AWS cloudwatch agent
+include_recipe "aws-parallelcluster::cloudwatch_agent_install"

--- a/recipes/cloudwatch_agent_config.rb
+++ b/recipes/cloudwatch_agent_config.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: cloudwatch_agent_config
+#
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+config_script_path = '/usr/local/bin/write_cloudwatch_agent_json.py'
+cookbook_file 'write_cloudwatch_agent_json.py' do
+  not_if { ::File.exist?(config_script_path) }
+  path config_script_path
+  user 'root'
+  group 'root'
+  mode '0755'
+end
+
+config_data_path = '/usr/local/etc/cloudwatch_log_files.json'
+cookbook_file 'cloudwatch_log_files.json' do
+  not_if { ::File.exist?(config_data_path) }
+  path config_data_path
+  user 'root'
+  group 'root'
+  mode '0644'
+end
+
+execute "cloudwatch-config-creation" do
+  user 'root'
+  environment(
+    'LOG_GROUP_NAME' => "/aws/parallelcluster/#{node['cfncluster']['stack_name'].split(/^parallelcluster-/)[1]}",
+    'SCHEDULER' => node['cfncluster']['cfn_scheduler'],
+    'NODE_ROLE' => node['cfncluster']['cfn_node_type'],
+    'CONFIG_DATA_PATH' => config_data_path
+  )
+  not_if { ::File.exist?('/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json') }
+  command "#{node.default['cfncluster']['cookbook_virtualenv_path']}/bin/python #{config_script_path} "\
+          "--platform #{node['platform']} --config $CONFIG_DATA_PATH --log-group $LOG_GROUP_NAME "\
+          "--scheduler $SCHEDULER --node-role $NODE_ROLE"
+end
+
+execute "cloudwatch-agent-start" do
+  user 'root'
+  command "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
+  not_if do
+    system("[[ $(/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | jq --raw-output .status) = running ]]") ||
+      node['cfncluster']['cfn_cluster_cw_logging_enabled'] != 'true'
+  end
+end

--- a/recipes/cloudwatch_agent_install.rb
+++ b/recipes/cloudwatch_agent_install.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: cloudwatch_agent_install
+#
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Download the cloudwatch agent's public key. Note that the domain used to get
+# the public key must NOT be regionalized.
+remote_file node['cfncluster']['cloudwatch']['public_key_local_path'] do
+  source node['cfncluster']['cloudwatch']['public_key_url']
+  retries 3
+  retry_delay 5
+  not_if { ::File.exist?(node['cfncluster']['cloudwatch']['public_key_local_path']) }
+end
+
+# Set the s3 domain name to use for all download URLs
+s3_domain = "https://s3.#{node['cfncluster']['cfn_region']}.amazonaws.com"
+s3_domain = "#{s3_domain}.cn" if node['cfncluster']['cfn_region'].start_with?("cn-")
+
+# Set URLs used to download the package and expected signature based on platform
+package_url_prefix = "#{s3_domain}/amazoncloudwatch-agent-#{node['cfncluster']['cfn_region']}"
+case node['platform']
+when 'ubuntu'
+  package_url = "#{package_url_prefix}/#{node['platform']}/amd64/latest/amazon-cloudwatch-agent.deb"
+  package_path = "#{node['cfncluster']['sources_dir']}/amazon-cloudwatch-agent.deb"
+when 'amazon'
+  # NOTE: the URL used to get amazon linux's package does not use node['platform']
+  package_url = "#{package_url_prefix}/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm"
+  package_path = "#{node['cfncluster']['sources_dir']}/amazon-cloudwatch-agent.rpm"
+when 'centos'
+  package_url = "#{package_url_prefix}/#{node['platform']}/amd64/latest/amazon-cloudwatch-agent.rpm"
+  package_path = "#{node['cfncluster']['sources_dir']}/amazon-cloudwatch-agent.rpm"
+end
+signature_url = "#{package_url}.sig"
+signature_path = "#{package_path}.sig"
+
+# Download package and its expected signature
+remote_file signature_path do
+  source signature_url
+  retries 3
+  retry_delay 5
+  not_if { ::File.exist?(signature_path) }
+end
+remote_file package_path do
+  source package_url
+  retries 3
+  retry_delay 5
+  not_if { ::File.exist?(package_path) }
+end
+
+# Import cloudwatch agent's public key to the keyring
+execute "import-cloudwatch-agent-key" do
+  command "gpg --import #{node['cfncluster']['cloudwatch']['public_key_local_path']}"
+  user 'root'
+end
+
+# Verify that cloudwatch agent's public key has expected fingerprint
+cookbook_file 'verify_cloudwatch_agent_public_key_fingerprint.py' do
+  not_if { ::File.exist?('/usr/local/bin/verify_cloudwatch_agent_public_key_fingerprint.py') }
+  path '/usr/local/bin/verify_cloudwatch_agent_public_key_fingerprint.py'
+  user 'root'
+  group 'root'
+  mode '0755'
+end
+execute "verify-cloudwatch-agent-public-key-fingerprint" do
+  command "#{node.default['cfncluster']['cookbook_virtualenv_path']}/bin/python /usr/local/bin/verify_cloudwatch_agent_public_key_fingerprint.py"
+  user 'root'
+end
+
+# Verify that the cloudwatch agent package matches its expected signature
+execute "verify-cloudwatch-agent-rpm-signature" do
+  command "gpg --verify #{signature_path} #{package_path}"
+end
+
+# Install package.
+case node['platform']
+when 'ubuntu'
+  # Use dpkg for ubuntu because apt provider doesn't work for local installs
+  dpkg_package package_path do
+    source package_path
+  end
+when 'amazon', 'centos'
+  package package_path
+end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -205,3 +205,18 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
     TESTCUDA
   end
 end
+
+# Verify that the CloudWatch agent is running or not depending on
+# whether or not the feature is enabled.
+case node['cfncluster']['cfn_cluster_cw_logging_enabled']
+when 'true'
+  execute 'cloudwatch-agent-status-running' do
+    user 'root'
+    command "[[ $(/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | jq --raw-output .status) = running ]] || exit 1"
+  end
+else
+  execute 'cloudwatch-agent-status-not-running' do
+    user 'root'
+    command "[[ $(/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | jq --raw-output .status) = stopped ]] || exit 1"
+  end
+end


### PR DESCRIPTION
Add recipes for installing and configuring the cloudwatch logging agent. Add a kitchen test to verify that the agent is up and running.

Signed-off-by: Tim Lane <tilne@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
