### PR TITLE
Fix nfs mount in compute node

### DIFF
--- a/recipes/_compute_base_config.rb
+++ b/recipes/_compute_base_config.rb
@@ -81,28 +81,30 @@ end
 
 # Parse shared directory info and turn into an array
 shared_dir_array = node['cfncluster']['cfn_shared_dir'].split(',')
-shared_dir_array.each_with_index do |dir, index|
-  shared_dir_array[index] = dir.strip
-  shared_dir_array[index] = "/" + shared_dir_array[index] unless shared_dir_array[index].start_with?("/")
-end
 
 # Mount each volume with NFS
-shared_dir_array.each do |dirname|
-  # Created shared mount point
-  directory dirname do
-    mode '1777'
-    owner 'root'
-    group 'root'
-    recursive true
-    action :create
-  end
+shared_dir_array.each do |dir|
+  dirname = dir.strip
 
-  # Mount shared volume over NFS
-  mount dirname do
-    device "#{nfs_master}:#{dirname}"
-    fstype 'nfs'
-    options 'hard,intr,noatime,vers=3,_netdev'
-    action %i[mount enable]
+  unless dirname == "NONE"
+    dirname = "/" + dirname unless dirname.start_with?("/")
+
+    # Created shared mount point
+    directory dirname do
+      mode '1777'
+      owner 'root'
+      group 'root'
+      recursive true
+      action :create
+    end
+
+    # Mount shared volume over NFS
+    mount dirname do
+      device "#{nfs_master}:#{dirname}"
+      fstype 'nfs'
+      options 'hard,intr,noatime,vers=3,_netdev'
+      action %i[mount enable]
+    end
   end
 end
 


### PR DESCRIPTION
Fixes bug in compute nodes at pcluster create at NFS mount.

The issue has been introduced with the https://github.com/aws/aws-parallelcluster/pull/1298 refactoring, on which the `SharedDir` behaviour has been aligned with all the others EBS related parameters, by adding a comma separated list of `NONE` for the not used ebs shared_dir parameters.

Before the refactoring the `SharedDir` param was just `/shared`, now it is `/shared,NONE,NONE,NONE,NONE` when at least one `[ebs ..]` section is defined. 

The recipes to mount the volume was considering NONE as a valid mount point.
With this patch we are aligning the behaviour with FSX and RAID on which NONE is not considered a valid mount point.