### PR TITLE
slurm: set EnforcePartLimits=ALL in scheduler config

### DIFF
--- a/templates/default/slurm.conf.erb
+++ b/templates/default/slurm.conf.erb
@@ -62,6 +62,7 @@ KillWait=30
 Waittime=0
 #
 # SCHEDULING
+EnforcePartLimits=ALL
 SchedulerType=sched/backfill
 #SchedulerAuth=
 #SchedulerPort=


### PR DESCRIPTION
If set to "ALL" then jobs which exceed a partition's size and/or time limits will be rejected at submission time.

https://slurm.schedmd.com/slurm.conf.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
