### PR TITLE
Increase SlurmdTimeout and UnkillableStepTimeout

### DIFF
--- a/templates/default/slurm.conf.erb
+++ b/templates/default/slurm.conf.erb
@@ -55,7 +55,8 @@ ReturnToService=1
 #
 # TIMERS
 SlurmctldTimeout=300
-SlurmdTimeout=120
+SlurmdTimeout=180
+UnkillableStepTimeout=180
 InactiveLimit=0
 MinJobAge=300
 KillWait=30


### PR DESCRIPTION
UnkillableStepTimeout: The length of time, in seconds, that Slurm will wait before deciding that
processes in a job step are unkillable (after they have been signaled with SIGKILL). The default timeout value is 60 seconds. If exceeded, the compute node will be drained to prevent future jobs from being scheduled on the node.

SlurmdTimeouti: The interval, in seconds, that the Slurm controller waits for slurmd to respond
before configuring that node's state to DOWN.

Increased UnkillableStepTimeout to 180 seconds and SlurmdTimeout to 180 seconds to allow
scheduler to recover especially when under heavy load.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
