### PR TITLE
Fix DCV recipes execution for empty AMIs and graphic instances

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,7 +70,8 @@ default['cfncluster']['env2']['url'] = 'https://sourceforge.net/projects/env2/fi
 # NICE DCV
 default['cfncluster']['dcv']['installed'] = 'yes'
 default['cfncluster']['dcv']['version'] = '2019.1-7644'
-default['cfncluster']['dcv']['url'] = "https://d1uj6qtbmh3dt5.cloudfront.net/2019.1/Servers/nice-dcv-#{node['cfncluster']['dcv']['version']}-el7.tgz"
+default['cfncluster']['dcv']['package'] = "nice-dcv-#{node['cfncluster']['dcv']['version']}-el7"
+default['cfncluster']['dcv']['url'] = "https://d1uj6qtbmh3dt5.cloudfront.net/2019.1/Servers/#{node['cfncluster']['dcv']['package']}.tgz"
 default['cfncluster']['dcv']['server'] = "nice-dcv-server-2019.1.7644-1.el7.x86_64.rpm"  # NICE DCV server package
 default['cfncluster']['dcv']['xdcv'] = "nice-xdcv-2019.1.226-1.el7.x86_64.rpm"  # required to create virtual sessions
 default['cfncluster']['dcv']['gl'] = "nice-dcv-gl-2019.1.544-1.el7.x86_64.rpm"  # required to enable GPU sharing

--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -34,7 +34,7 @@ def allow_gpu_acceleration
   end
 
   # dcvgl package must be installed after NVIDIA and before starting up X
-  dcv_gl = "#{Chef::Config[:file_cache_path]}/#{node['cfncluster']['dcv']['package']}/#{node['cfncluster']['dcv']['gl']}"
+  dcv_gl = "#{node['cfncluster']['sources_dir']}/#{node['cfncluster']['dcv']['package']}/#{node['cfncluster']['dcv']['gl']}"
   package dcv_gl do
     action :install
     source dcv_gl

--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -59,6 +59,10 @@ def allow_gpu_acceleration
 end
 
 if node['platform'] == 'centos' && node['platform_version'].to_i == 7 && node['cfncluster']['cfn_node_type'] == "MasterServer"
+
+  # be sure to have DCV packages installed
+  include_recipe "aws-parallelcluster::dcv_install"
+
   node.default['cfncluster']['dcv']['is_graphic_instance'] = graphic_instance?
 
   if node.default['cfncluster']['dcv']['is_graphic_instance']

--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -34,7 +34,7 @@ def allow_gpu_acceleration
   end
 
   # dcvgl package must be installed after NVIDIA and before starting up X
-  dcv_gl = "#{Chef::Config[:file_cache_path]}/nice-dcv-#{node['cfncluster']['dcv']['version']}-el7/#{node['cfncluster']['dcv']['gl']}"
+  dcv_gl = "#{Chef::Config[:file_cache_path]}/#{node['cfncluster']['dcv']['package']}/#{node['cfncluster']['dcv']['gl']}"
   package dcv_gl do
     action :install
     source dcv_gl

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -98,7 +98,7 @@ if node['platform'] == 'centos' && node['platform_version'].to_i == 7 && !File.e
 
     # Install server and xdcv packages
     dcv_packages = %W[#{node['cfncluster']['dcv']['server']} #{node['cfncluster']['dcv']['xdcv']}]
-    dcv_packages_path = "#{Chef::Config[:file_cache_path]}/nice-dcv-#{node['cfncluster']['dcv']['version']}-el7/"
+    dcv_packages_path = "#{node['cfncluster']['sources_dir']}/#{node['cfncluster']['dcv']['package']}/"
     # Rewrite dcv_packages object by cycling each package file name and appending the path to them
     dcv_packages.map! { |package| dcv_packages_path + package }
     install_rpm_packages(dcv_packages)

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -91,7 +91,7 @@ if node['platform'] == 'centos' && node['platform_version'].to_i == 7 && !File.e
       end
 
       bash 'extract dcv packages' do
-        cwd Chef::Config[:file_cache_path]
+        cwd node['cfncluster']['sources_dir']
         code "tar -xvzf #{dcv_tarball}"
       end
     end


### PR DESCRIPTION
This patch defines a chef variable for dcv package and fixes DCV recipe execution for empty AMIs and graphic instances.

## 1. Graphic instances fix: Use a permanent folder to extract dcv package

The chef cache path is not available in the `dcv_config` recipe if the extraction of DCV packages is performed at AMI creation time.  By using `sources` dir we are sure to have it at runtime.


## 2. Empty AMIs fix: Be sure to have dcv installed at runtime

The `dcv_install` recipe is not called at runtime, because it is included in the `default.rb` and it is called only at AMI creation time.

At runtime the entry point is the `<scheduler>_config`, that calls `base_config` and `base_install`,
so the `dcv_install` was not included.

From now we are calling the `dcv_install` at runtime case too, the recipe is idempotent.
