### PR TITLE
Re-add CloudWatch agent install recipe

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -190,3 +190,6 @@ if (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
   include_recipe "aws-parallelcluster::_efa_install"
   include_recipe "aws-parallelcluster::intel_mpi"
 end
+
+# Install the AWS cloudwatch agent
+include_recipe "aws-parallelcluster::cloudwatch_agent_install"


### PR DESCRIPTION
I accidentally removed the line in the base install recipe that includes
the CloudWatch agent's installation recipe. This adds that line back.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
