### PR TITLE
Fix gpg command parsing issues

### DIFF
--- a/files/default/requirements.txt
+++ b/files/default/requirements.txt
@@ -2,3 +2,4 @@ awscli
 boto3
 supervisor
 requests
+python-gnupg

--- a/files/default/verify_cloudwatch_agent_public_key_fingerprint.py
+++ b/files/default/verify_cloudwatch_agent_public_key_fingerprint.py
@@ -1,39 +1,26 @@
 #!/usr/bin/env python
 """Verify the fingerprint for the CloudWatch agent's public key is as expected."""
 
-import re
-import subprocess
 import sys
+import gnupg
 
 # This value comes from the CloudWatch agent's documentation:
 # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/verify-CloudWatch-Agent-Package-Signature.html
-EXPECTED_FINGERPRINT = "9376 16F3 450B 7D80 6CBD  9725 D581 6730 3B78 9C72"
+EXPECTED_FINGERPRINT = "937616F3450B7D806CBD9725D58167303B789C72"
 
 
-def get_key_identifier():
-    """Get identifier for cloudwatch agent's key."""
-    output = subprocess.check_output(['gpg', '--list-keys', 'Amazon CloudWatch Agent']).decode('utf-8')
-    for line in output.splitlines():
-        match = re.search(r'^pub\s+.*/([0-9A-Z]+)', line.strip())
-        if match:
-            return match.group(1)
-    sys.exit('Unable to get identifier for cloudwatch agent public key')
-
-
-def get_key_fingerprint(key_id):
-    """Get the fingerprint for the key with ID key_id."""
-    output = subprocess.check_output(['gpg', '--fingerprint', key_id]).decode('utf-8')
-    for line in output.splitlines():
-        match = re.search(r'Key fingerprint = (.*)', line.strip())
-        if match:
-            return match.group(1)
-    sys.exit('Unable to get fingerprint for cloudwatch agent public key')
+def get_key_fingerprint():
+    """Get identifier for CloudWatch agent's key."""
+    keys = gnupg.GPG().list_keys(keys='Amazon CloudWatch Agent')
+    for key in keys:
+        if "Amazon CloudWatch Agent" in key.get("uids"):
+            return key.get("fingerprint")
+    sys.exit("Unable to get CloudWatch Agent's public key fingerprint.")
 
 
 def main():
     """Run the script."""
-    key_id = get_key_identifier()
-    fingerprint = get_key_fingerprint(key_id)
+    fingerprint = get_key_fingerprint()
     if fingerprint != EXPECTED_FINGERPRINT:
         sys.exit(
             'Observed fingerprint of cloudwatch agent public key ({observed}) '


### PR DESCRIPTION
The recipe for installing the CloudWatch agent verifies that the public
key provided by the service has the expected fingerprint. To do this, the
output of the `gpg` command was being parsed. As it turns out, there are
some differences in the way the output is formatted on ubuntu18 as
opposed to the other supported distros.

On ubuntu18, the output of the command that was being used looks like
this:
```
root@ip-172-31-27-82:~# gpg --list-keys 'Amazon CloudWatch Agent'
pub   rsa2048 2017-11-14 [SC]
      937616F3450B7D806CBD9725D58167303B789C72
uid           [ unknown] Amazon CloudWatch Agent
```

On the other supported distros (namely, amazon linux in the following
example) the output looks like this:
```
[root@ip-172-31-23-223 ~]# gpg --list-keys 'Amazon CloudWatch Agent'
pub   2048R/3B789C72 2017-11-14
uid       [ unknown] Amazon CloudWatch Agent
```

Instead of trying to modify the parsing logic, I thought it best to handle it
using the [python-gnupg](https://pypi.org/project/python-gnupg/) module.

*Non-technical question*: is this allowed, since we distribute the
packages we install in the cookbook via our AMIs? It uses a BSD license.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
