### PR TITLE
Fix CloudWatch agent kitchen test

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -220,11 +220,11 @@ case node['cfncluster']['cfn_cluster_cw_logging_enabled']
 when 'true'
   execute 'cloudwatch-agent-status-running' do
     user 'root'
-    command "[[ $(/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | jq --raw-output .status) = running ]] || exit 1"
+    command "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | grep status | grep running || exit 1"
   end
 else
   execute 'cloudwatch-agent-status-not-running' do
     user 'root'
-    command "[[ $(/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | jq --raw-output .status) = stopped ]] || exit 1"
+    command "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | grep status | grep stopped || exit 1"
   end
 end


### PR DESCRIPTION
This PR fixes two issues with the CloudWatch agent kitchen test:
1. The original version uses the `[[` conditional operator, which is not
provided in every shell. This was causing test failures when running on
ubuntu AMIs.
2. The original version also assumes that `jq` is installed. After
looking at the process used to select the custom AMIs used in the
kitchen tests, this is definitely not a valid assumption.

The fix uses the return code from `grep`ing the following JSON format:
```
ubuntu@ip-172-31-3-190:~$ /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status
{
  "status": "running",
  "starttime": "2019-11-21T21:08:13+00:00",
  "version": "1.231221.0"
}
```

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
