### PR TITLE
Remove awsbatch from ParallelCluster logs

### DIFF
--- a/files/default/cloudwatch_log_files.json
+++ b/files/default/cloudwatch_log_files.json
@@ -150,7 +150,6 @@
       "file_path": "/var/log/nodewatcher",
       "log_stream_name": "nodewatcher",
       "schedulers": [
-        "awsbatch",
         "sge",
         "slurm",
         "torque"
@@ -169,7 +168,6 @@
       "file_path": "/var/log/jobwatcher",
       "log_stream_name": "jobwatcher",
       "schedulers": [
-        "awsbatch",
         "sge",
         "slurm",
         "torque"
@@ -188,7 +186,6 @@
       "file_path": "/var/log/sqswatcher",
       "log_stream_name": "sqswatcher",
       "schedulers": [
-        "awsbatch",
         "sge",
         "slurm",
         "torque"


### PR DESCRIPTION
This PR remove awsbatch from the list of schedulers for which the
ParallelCluster logs (sqswatcher, jobwatcher, nodewatcher) are
applicable.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
