### PR TITLE
Add set -e on top of each bash script in cookbooks

### DIFF
--- a/recipes/_ganglia_install.rb
+++ b/recipes/_ganglia_install.rb
@@ -42,6 +42,7 @@ if node['cfncluster']['ganglia_enabled'] == 'yes'
       group 'root'
       cwd Chef::Config[:file_cache_path]
       code <<-GANGLIA
+        set -e
         tar xf #{ganglia_tarball}
         cd monitor-core-#{node['cfncluster']['ganglia']['version']}
         ./bootstrap
@@ -97,6 +98,7 @@ if node['cfncluster']['ganglia_enabled'] == 'yes'
       group 'root'
       cwd Chef::Config[:file_cache_path]
       code <<-GANGLIAWEB
+        set -e
         tar xf #{ganglia_web_tarball}
         cd ganglia-web-#{node['cfncluster']['ganglia']['web_version']}
         make install APACHE_USER=#{node['cfncluster']['ganglia']['apache_user']}
@@ -128,6 +130,7 @@ if node['cfncluster']['ganglia_enabled'] == 'yes'
       group 'root'
       cwd Chef::Config[:file_cache_path]
       code <<-GANGLIALICENSE
+        set -e
         cd monitor-core-#{node['cfncluster']['ganglia']['version']}
         cp -v COPYING #{node['cfncluster']['license_dir']}/ganglia/COPYING
       GANGLIALICENSE

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -187,6 +187,7 @@ end
 bash "ssh-keygen" do
   cwd "/home/#{node['cfncluster']['cfn_cluster_user']}"
   code <<-KEYGEN
+    set -e
     su - #{node['cfncluster']['cfn_cluster_user']} -c \"ssh-keygen -q -t rsa -f ~/.ssh/id_rsa -N ''\"
   KEYGEN
   not_if { ::File.exist?("/home/#{node['cfncluster']['cfn_cluster_user']}/.ssh/id_rsa") }
@@ -195,6 +196,7 @@ end
 bash "copy_and_perms" do
   cwd "/home/#{node['cfncluster']['cfn_cluster_user']}"
   code <<-PERMS
+    set -e
     su - #{node['cfncluster']['cfn_cluster_user']} -c \"cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys && chmod 0600 ~/.ssh/authorized_keys && touch ~/.ssh/authorized_keys_cluster\"
   PERMS
   not_if { ::File.exist?("/home/#{node['cfncluster']['cfn_cluster_user']}/.ssh/authorized_keys_cluster") }
@@ -203,6 +205,7 @@ end
 bash "ssh-keyscan" do
   cwd "/home/#{node['cfncluster']['cfn_cluster_user']}"
   code <<-KEYSCAN
+    set -e
     su - #{node['cfncluster']['cfn_cluster_user']} -c \"ssh-keyscan #{node['hostname']} > ~/.ssh/known_hosts && chmod 0600 ~/.ssh/known_hosts\"
   KEYSCAN
   not_if { ::File.exist?("/home/#{node['cfncluster']['cfn_cluster_user']}/.ssh/known_hosts") }

--- a/recipes/_master_sge_config.rb
+++ b/recipes/_master_sge_config.rb
@@ -52,6 +52,7 @@ end
 
 bash "add_host_as_master" do
   code <<-ADDHOST
+    set -e
     . /opt/sge/default/common/settings.sh
     qconf -as #{node['hostname']}
   ADDHOST
@@ -59,6 +60,7 @@ end
 
 bash "set_accounting_summary" do
   code <<-SETAS
+    set -e
     . /opt/sge/default/common/settings.sh
     TMPFILE=/tmp/pe.txt
     qconf -sp mpi | grep -v 'accounting_summary' > $TMPFILE
@@ -71,6 +73,7 @@ end
 # Enable non-admin users to force delete a job
 bash "enable_forced_qdel" do
   code <<-ENABLEFORCEDQDEL
+    set -e
     . /opt/sge/default/common/settings.sh
     /opt/sge/util/qconf_add_list_value -mconf qmaster_params ENABLE_FORCED_QDEL global
   ENABLEFORCEDQDEL

--- a/recipes/_master_torque_config.rb
+++ b/recipes/_master_torque_config.rb
@@ -18,6 +18,7 @@
 # Run torque.setup
 bash "run-torque-setup" do
   code <<-SETUPTORQUE
+    set -e
     . /etc/profile.d/torque.sh
     ./torque.setup root
   SETUPTORQUE

--- a/recipes/awsbatch_config.rb
+++ b/recipes/awsbatch_config.rb
@@ -41,6 +41,7 @@ if !node['cfncluster']['custom_awsbatchcli_package'].nil? && !node['cfncluster']
   bash "install aws-parallelcluster-awsbatch-cli" do
     cwd Chef::Config[:file_cache_path]
     code <<-CLI
+      set -e
       source /tmp/proxy.sh
       curl --retry 3 -v -L -o aws-parallelcluster.tgz #{node['cfncluster']['custom_awsbatchcli_package']}
       tar -xzf aws-parallelcluster.tgz

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -56,6 +56,7 @@ end
 bash "install awscli" do
   cwd Chef::Config[:file_cache_path]
   code <<-CLI
+    set -e
     curl --retry 5 --retry-delay 5 "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
     unzip awscli-bundle.zip
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
@@ -120,9 +121,13 @@ if !node['cfncluster']['custom_node_package'].nil? && !node['cfncluster']['custo
   bash "install aws-parallelcluster-node" do
     cwd Chef::Config[:file_cache_path]
     code <<-NODE
+      set -e
       [[ ":$PATH:" != *":/usr/local/bin:"* ]] && PATH="/usr/local/bin:${PATH}"
       echo "PATH is $PATH"
-      source /tmp/proxy.sh
+      PROXY_FILE=/tmp/proxy.sh
+      if [ -f "$PROXY_FILE" ]; then
+              source $PROXY_FILE
+      fi
       source #{node['cfncluster']['node_virtualenv_path']}/bin/activate
       pip uninstall --yes aws-parallelcluster-node
       curl --retry 3 -v -L -o aws-parallelcluster-node.tgz #{node['cfncluster']['custom_node_package']}

--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -44,6 +44,7 @@ def allow_gpu_acceleration
   bash 'Launch X' do
     user 'root'
     code <<-SETUPX
+      set -e
       systemctl set-default graphical.target
       systemctl isolate graphical.target &
     SETUPX

--- a/recipes/munge_install.rb
+++ b/recipes/munge_install.rb
@@ -39,6 +39,7 @@ bash 'make install' do
   group 'root'
   cwd Chef::Config[:file_cache_path]
   code <<-MUNGE
+    set -e
     tar xf #{munge_tarball}
     cd munge-munge-#{node['cfncluster']['munge']['munge_version']}
     ./bootstrap

--- a/recipes/sge_install.rb
+++ b/recipes/sge_install.rb
@@ -120,6 +120,7 @@ when 'MasterServer', nil
     group 'root'
     cwd Chef::Config[:file_cache_path]
     code <<-SGELICENSE
+      set -e
       cd sge-#{node['cfncluster']['sge']['version']}/LICENCES
       cp -v SISSL #{node['cfncluster']['license_dir']}/sge/SISSL
     SGELICENSE

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -68,6 +68,7 @@ when 'MasterServer', nil
     group 'root'
     cwd Chef::Config[:file_cache_path]
     code <<-SLURMLICENSE
+      set -e
       cd slurm-slurm-#{node['cfncluster']['slurm']['version']}
       cp -v COPYING #{node['cfncluster']['license_dir']}/slurm/COPYING
       cp -v DISCLAIMER #{node['cfncluster']['license_dir']}/slurm/DISCLAIMER

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -29,11 +29,12 @@ end
 bash 'check awscli regions' do
   cwd Chef::Config[:file_cache_path]
   code <<-AWSREGIONS
+    set -e
     export PATH="/usr/local/bin:/usr/bin/:$PATH"
     regions=($(#{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws ec2 describe-regions --region us-east-1 --query "Regions[].{Name:RegionName}" --output text))
     for region in "${regions[@]}"
     do
-      #{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws ec2 describe-regions --region "${region}" >/dev/null 2>&1 || exit 1
+      #{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws ec2 describe-regions --region "${region}" >/dev/null 2>&1
     done
   AWSREGIONS
 end
@@ -139,11 +140,12 @@ unless node['cfncluster']['os'].end_with?("-custom")
   bash 'execute jq' do
     cwd Chef::Config[:file_cache_path]
     code <<-JQMERGE
+      set -e
       # Set PATH as in the UserData script of the CloudFormation template
       export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin"
       echo '{"cfncluster": {"cfn_region": "eu-west-3"}, "run_list": "recipe[aws-parallelcluster::sge_config]"}' > /tmp/dna.json
       echo '{ "cfncluster" : { "ganglia_enabled" : "yes" } }' > /tmp/extra.json
-      jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster' || exit 1
+      jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster'
     JQMERGE
   end
 end

--- a/recipes/torque_install.rb
+++ b/recipes/torque_install.rb
@@ -110,6 +110,7 @@ bash 'copy license stuff' do
   group 'root'
   cwd Chef::Config[:file_cache_path]
   code <<-TORQUEINSTALL
+    set -e
     cd torque-#{node['cfncluster']['torque']['version']}
     cp -v PBS_License.txt #{node['cfncluster']['license_dir']}/torque/PBS_License.txt
     cp -v LICENSE #{node['cfncluster']['license_dir']}/torque/LICENSE


### PR DESCRIPTION
This commit adds the missing "set -e" instructions to all bash scripts
to make them fail in case of errors.