### PR TITLE
Change nfs export to work with VPC containing multiple CIDR blocks

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -95,14 +95,15 @@ def get_1st_partition(device)
 end
 
 #
-# Get vpc-ipv4-cidr-block
+# Get vpc-ipv4-cidr-blocks
 #
-def get_vpc_ipv4_cidr_block(eth0_mac)
-  uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{eth0_mac.downcase}/vpc-ipv4-cidr-block")
+def get_vpc_ipv4_cidr_blocks(eth0_mac)
+  uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{eth0_mac.downcase}/vpc-ipv4-cidr-blocks")
   res = Net::HTTP.get_response(uri)
-  vpc_ipv4_cidr_block = res.body if res.code == '200'
-
-  vpc_ipv4_cidr_block
+  vpc_ipv4_cidr_blocks = res.body if res.code == '200'
+  # Parse into array
+  vpc_ipv4_cidr_blocks = vpc_ipv4_cidr_blocks.split("\n")
+  vpc_ipv4_cidr_blocks
 end
 
 def get_instance_type()

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -28,7 +28,7 @@ execute "add_configure-pat" do
 end
 
 # Get VPC CIDR
-node.default['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block'] = get_vpc_ipv4_cidr_block(node['macaddress'])
+node.default['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks'] = get_vpc_ipv4_cidr_blocks(node['macaddress'])
 
 # Parse shared directory info and turn into an array
 shared_dir_array = node['cfncluster']['cfn_shared_dir'].split(',')
@@ -115,7 +115,7 @@ vol_array.each_with_index do |volumeid, index|
 
   # Export shared dir
   nfs_export shared_dir_array[index] do
-    network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+    network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
     writeable true
     options ['no_root_squash']
   end
@@ -123,14 +123,14 @@ end
 
 # Export /home
 nfs_export "/home" do
-  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
   writeable true
   options ['no_root_squash']
 end
 
 # Export /opt/intel if it exists
 nfs_export "/opt/intel" do
-  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
   writeable true
   options ['no_root_squash']
   only_if { ::File.directory?("/opt/intel") }

--- a/recipes/_master_sge_config.rb
+++ b/recipes/_master_sge_config.rb
@@ -17,7 +17,7 @@
 
 # Export /opt/sge
 nfs_export "/opt/sge" do
-  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
   writeable true
   options ['no_root_squash']
 end

--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -17,7 +17,7 @@
 
 # Export /opt/slurm
 nfs_export "/opt/slurm" do
-  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
   writeable true
   options ['no_root_squash']
 end

--- a/recipes/setup_raid_on_master.rb
+++ b/recipes/setup_raid_on_master.rb
@@ -112,7 +112,7 @@ if raid_shared_dir != "NONE"
 
   # Export RAID directory via nfs
   nfs_export raid_shared_dir do
-    network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+    network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
     writeable true
     options ['no_root_squash']
   end


### PR DESCRIPTION
* Changed from getting vpc-ipv4-cidr-block, which only returns the first CIDR block, to getting vpc-ipv4-cidr-blocks, which returns all CIDR blocks for a VPC, from metadata call.
* Changed all nfs export to export to all CIDR blocks in a VPC

Signed-off-by: Rex <shuningc@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
