### PR TITLE
Back-port fixes to release-2.5 branch

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -92,6 +92,7 @@ suites:
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        ganglia_enabled: <%= ENV['GANGLIA_ENABLED'] %>
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
@@ -116,6 +117,7 @@ suites:
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        ganglia_enabled: <%= ENV['GANGLIA_ENABLED'] %>
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
@@ -140,6 +142,7 @@ suites:
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        ganglia_enabled: <%= ENV['GANGLIA_ENABLED'] %>
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
@@ -164,6 +167,7 @@ suites:
         cfn_master: <%= ENV['CFN_MASTER'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        ganglia_enabled: <%= ENV['GANGLIA_ENABLED'] %>
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
@@ -188,6 +192,7 @@ suites:
         cfn_master: <%= ENV['CFN_MASTER'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        ganglia_enabled: <%= ENV['GANGLIA_ENABLED'] %>
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
@@ -212,5 +217,6 @@ suites:
         cfn_master: <%= ENV['CFN_MASTER'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        ganglia_enabled: <%= ENV['GANGLIA_ENABLED'] %>
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -92,6 +92,8 @@ suites:
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        nvidia:
+          enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
   - name: torque_config_MasterServer
     run_list:
@@ -114,6 +116,8 @@ suites:
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        nvidia:
+          enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
   - name: slurm_config_MasterServer
     run_list:
@@ -136,6 +140,8 @@ suites:
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        nvidia:
+          enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
   - name: sge_config_ComputeFleet
     run_list:
@@ -158,6 +164,8 @@ suites:
         cfn_master: <%= ENV['CFN_MASTER'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        nvidia:
+          enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
   - name: torque_config_ComputeFleet
     run_list:
@@ -180,6 +188,8 @@ suites:
         cfn_master: <%= ENV['CFN_MASTER'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        nvidia:
+          enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
   - name: slurm_config_ComputeFleet
     run_list:
@@ -202,3 +212,5 @@ suites:
         cfn_master: <%= ENV['CFN_MASTER'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
+        nvidia:
+          enabled: <%= ENV['NVIDIA_ENABLED'] %>

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-AlignParameters:
+ParameterAlignment:
   Enabled: false
 
 Encoding:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+2.5.1
+-----
+
+**CHANGES**
+- Upgrade NVIDIA driver to Tesla version 440.33.01.
+- Upgrade CUDA library to version 10.2.
+
+**BUG FIXES**
+- Correctly install NVIDIA drivers on Ubuntu 18.
+
 2.5.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade CUDA library to version 10.2.
 
 **BUG FIXES**
-- Correctly install NVIDIA drivers on Ubuntu 18.
+- Fix installation of NVIDIA drivers on Ubuntu 18.
+- Fix installation of CUDA toolkit on Centos 6.
+- Increase default root volume size in Centos 6 AMI to 25GB.
 
 2.5.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **BUG FIXES**
 - Fix installation of NVIDIA drivers on Ubuntu 18.
 - Fix installation of CUDA toolkit on Centos 6.
-- Increase default root volume size in Centos 6 AMI to 25GB.
 
 2.5.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **BUG FIXES**
 - Fix installation of NVIDIA drivers on Ubuntu 18.
 - Fix installation of CUDA toolkit on Centos 6.
+- Fix installation of Munge on all but Ubuntu 18.
+- Avoid mounting EBS volumes when not configured.
+- Export shared directories to all CIDR blocks in a VPC rather than just the first one.
 
 2.5.0
 -----

--- a/amis/packer_variables.json
+++ b/amis/packer_variables.json
@@ -1,6 +1,6 @@
 {
-  "parallelcluster_version": "2.5.0",
-  "parallelcluster_cookbook_version": "2.5.0",
+  "parallelcluster_version": "2.5.1",
+  "parallelcluster_cookbook_version": "2.5.1",
   "chef_version": "14.2.0",
   "ridley_version": "5.1.1",
   "berkshelf_version": "7.0.4"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,10 +62,10 @@ default['cfncluster']['ganglia']['web_url'] = 'https://github.com/ganglia/gangli
 # NVIDIA
 default['cfncluster']['nvidia']['enabled'] = 'no'
 # domain has dynamic DNS resolution, will resolve to a server in Tokyo when called from China
-default['cfncluster']['nvidia']['driver_version'] = '418.87.01'
-default['cfncluster']['nvidia']['driver_url'] = 'https://us.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.01.run'
-default['cfncluster']['nvidia']['cuda_version'] = '10.1'
-default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_418.87.00_linux.run'
+default['cfncluster']['nvidia']['driver_version'] = '440.33.01'
+default['cfncluster']['nvidia']['driver_url'] = 'https://us.download.nvidia.com/tesla/440.33.01/NVIDIA-Linux-x86_64-440.33.01.run'
+default['cfncluster']['nvidia']['cuda_version'] = '10.2'
+default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run'
 # EFA
 default['cfncluster']['efa']['installer_url'] = 'https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.7.0.tar.gz'
 # ENV2 - tool to capture environment and create modulefiles

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,7 +65,11 @@ default['cfncluster']['nvidia']['enabled'] = 'no'
 default['cfncluster']['nvidia']['driver_version'] = '440.33.01'
 default['cfncluster']['nvidia']['driver_url'] = 'https://us.download.nvidia.com/tesla/440.33.01/NVIDIA-Linux-x86_64-440.33.01.run'
 default['cfncluster']['nvidia']['cuda_version'] = '10.2'
-default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run'
+if node['platform'] == 'centos' && node['platform_version'].to_i < 7
+  default['cfncluster']['nvidia']['cuda_url'] = 'http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_rhel6.run'
+else
+  default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run'
+end
 # EFA
 default['cfncluster']['efa']['installer_url'] = 'https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.7.0.tar.gz'
 # ENV2 - tool to capture environment and create modulefiles

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,8 +38,8 @@ default['cfncluster']['psxe']['version'] = '2019.5'
 default['cfncluster']['intelhpc']['version'] = '2018.0-1.el7'
 default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/impi/latest/modulefiles/mpi"
 # Python packages
-default['cfncluster']['cfncluster-version'] = '2.5.0'
-default['cfncluster']['cfncluster-node-version'] = '2.5.0'
+default['cfncluster']['cfncluster-version'] = '2.5.1'
+default['cfncluster']['cfncluster-node-version'] = '2.5.1'
 # URLs to software packages used during install recipes
 # Gridengine software
 default['cfncluster']['sge']['version'] = '8.1.9'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,7 +62,9 @@ default['cfncluster']['ganglia']['web_url'] = 'https://github.com/ganglia/gangli
 # NVIDIA
 default['cfncluster']['nvidia']['enabled'] = 'no'
 # domain has dynamic DNS resolution, will resolve to a server in Tokyo when called from China
+default['cfncluster']['nvidia']['driver_version'] = '418.87.01'
 default['cfncluster']['nvidia']['driver_url'] = 'https://us.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.01.run'
+default['cfncluster']['nvidia']['cuda_version'] = '10.1'
 default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_418.87.00_linux.run'
 # EFA
 default['cfncluster']['efa']['installer_url'] = 'https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.7.0.tar.gz'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -179,7 +179,7 @@ when 'debian'
                                               r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev mdadm]
   if node['platform_version'] == '18.04'
     default['cfncluster']['base_packages'].delete('libatlas-dev')
-    default['cfncluster']['base_packages'].push('libatlas-base-dev', 'libgcrypt20-dev', 'libssl1.0-dev')
+    default['cfncluster']['base_packages'].push('libatlas-base-dev', 'libgcrypt20-dev', 'libssl1.0-dev', 'libglvnd-dev')
     default['cfncluster']['sge']['version'] = '8.1.9+dfsg-9build1'
   end
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -130,7 +130,8 @@ when 'rhel', 'amazon'
                                                 libXmu-devel hwloc-devel db4-devel tcl-devel automake autoconf pyparted libtool
                                                 httpd boost-devel redhat-lsb mlocate mpich-devel openmpi-devel R atlas-devel
                                                 blas-devel fftw-devel libffi-devel openssl-devel dkms mysql-devel libedit-devel
-                                                libical-devel postgresql-devel postgresql-server sendmail mdadm python python-pip]
+                                                libical-devel postgresql-devel postgresql-server sendmail mdadm python python-pip
+                                                libgcrypt-devel]
 
     # Lustre Drivers for Centos 6
     default['cfncluster']['lustre']['version'] = '2.10.6'
@@ -143,7 +144,7 @@ when 'rhel', 'amazon'
                                                   httpd boost-devel redhat-lsb mlocate lvm2 mpich-devel R atlas-devel
                                                   blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                                   libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel mdadm python python-pip
-                                                  libssh2-devel]
+                                                  libssh2-devel libgcrypt-devel]
       if node['platform_version'].split('.')[1] == '6'
         # Lustre Drivers for Centos 7.6
         default['cfncluster']['lustre']['version'] = '2.10.6'
@@ -165,7 +166,7 @@ when 'rhel', 'amazon'
                                                 libXmu-devel hwloc-devel db4-devel tcl-devel automake autoconf pyparted libtool
                                                 httpd boost-devel redhat-lsb mlocate mpich-devel R atlas-devel fftw-devel
                                                 libffi-devel dkms mysql-devel libedit-devel postgresql-devel postgresql-server
-                                                sendmail cmake byacc libglvnd-devel mdadm]
+                                                sendmail cmake byacc libglvnd-devel mdadm libgcrypt-devel]
   end
 
   default['cfncluster']['ganglia']['apache_user'] = 'apache'
@@ -182,10 +183,11 @@ when 'debian'
                                               tcl-dev automake autoconf python-parted libtool librrd-dev libapr1-dev libconfuse-dev
                                               apache2 libboost-dev libdb-dev tcsh libssl-dev libncurses5-dev libpam0g-dev libxt-dev
                                               libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev python python-pip
-                                              r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev mdadm]
+                                              r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev mdadm
+                                              libgcrypt20-dev]
   if node['platform_version'] == '18.04'
     default['cfncluster']['base_packages'].delete('libatlas-dev')
-    default['cfncluster']['base_packages'].push('libatlas-base-dev', 'libgcrypt20-dev', 'libssl1.0-dev', 'libglvnd-dev')
+    default['cfncluster']['base_packages'].push('libatlas-base-dev', 'libssl1.0-dev', 'libglvnd-dev')
     default['cfncluster']['sge']['version'] = '8.1.9+dfsg-9build1'
   end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -95,14 +95,15 @@ def get_1st_partition(device)
 end
 
 #
-# Get vpc-ipv4-cidr-block
+# Get vpc-ipv4-cidr-blocks
 #
-def get_vpc_ipv4_cidr_block(eth0_mac)
-  uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{eth0_mac.downcase}/vpc-ipv4-cidr-block")
+def get_vpc_ipv4_cidr_blocks(eth0_mac)
+  uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{eth0_mac.downcase}/vpc-ipv4-cidr-blocks")
   res = Net::HTTP.get_response(uri)
-  vpc_ipv4_cidr_block = res.body if res.code == '200'
-
-  vpc_ipv4_cidr_block
+  vpc_ipv4_cidr_blocks = res.body if res.code == '200'
+  # Parse into array
+  vpc_ipv4_cidr_blocks = vpc_ipv4_cidr_blocks.split("\n")
+  vpc_ipv4_cidr_blocks
 end
 
 def get_instance_type()

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ long_description 'Installs/Configures AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
 chef_version '14.2.0'
-version '2.5.0'
+version '2.5.1'
 
 supports 'amazon'
 supports 'centos', '= 6'

--- a/recipes/_ganglia_install.rb
+++ b/recipes/_ganglia_install.rb
@@ -42,6 +42,7 @@ if node['cfncluster']['ganglia_enabled'] == 'yes'
       group 'root'
       cwd Chef::Config[:file_cache_path]
       code <<-GANGLIA
+        set -e
         tar xf #{ganglia_tarball}
         cd monitor-core-#{node['cfncluster']['ganglia']['version']}
         ./bootstrap
@@ -97,6 +98,7 @@ if node['cfncluster']['ganglia_enabled'] == 'yes'
       group 'root'
       cwd Chef::Config[:file_cache_path]
       code <<-GANGLIAWEB
+        set -e
         tar xf #{ganglia_web_tarball}
         cd ganglia-web-#{node['cfncluster']['ganglia']['web_version']}
         make install APACHE_USER=#{node['cfncluster']['ganglia']['apache_user']}
@@ -128,6 +130,7 @@ if node['cfncluster']['ganglia_enabled'] == 'yes'
       group 'root'
       cwd Chef::Config[:file_cache_path]
       code <<-GANGLIALICENSE
+        set -e
         cd monitor-core-#{node['cfncluster']['ganglia']['version']}
         cp -v COPYING #{node['cfncluster']['license_dir']}/ganglia/COPYING
       GANGLIALICENSE

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -187,6 +187,7 @@ end
 bash "ssh-keygen" do
   cwd "/home/#{node['cfncluster']['cfn_cluster_user']}"
   code <<-KEYGEN
+    set -e
     su - #{node['cfncluster']['cfn_cluster_user']} -c \"ssh-keygen -q -t rsa -f ~/.ssh/id_rsa -N ''\"
   KEYGEN
   not_if { ::File.exist?("/home/#{node['cfncluster']['cfn_cluster_user']}/.ssh/id_rsa") }
@@ -195,6 +196,7 @@ end
 bash "copy_and_perms" do
   cwd "/home/#{node['cfncluster']['cfn_cluster_user']}"
   code <<-PERMS
+    set -e
     su - #{node['cfncluster']['cfn_cluster_user']} -c \"cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys && chmod 0600 ~/.ssh/authorized_keys && touch ~/.ssh/authorized_keys_cluster\"
   PERMS
   not_if { ::File.exist?("/home/#{node['cfncluster']['cfn_cluster_user']}/.ssh/authorized_keys_cluster") }
@@ -203,6 +205,7 @@ end
 bash "ssh-keyscan" do
   cwd "/home/#{node['cfncluster']['cfn_cluster_user']}"
   code <<-KEYSCAN
+    set -e
     su - #{node['cfncluster']['cfn_cluster_user']} -c \"ssh-keyscan #{node['hostname']} > ~/.ssh/known_hosts && chmod 0600 ~/.ssh/known_hosts\"
   KEYSCAN
   not_if { ::File.exist?("/home/#{node['cfncluster']['cfn_cluster_user']}/.ssh/known_hosts") }

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -48,6 +48,10 @@ dev_path = [] # device labels
 dev_uuids = [] # device uuids
 
 vol_array.each_with_index do |volumeid, index|
+
+  # Skips volume if shared_dir is /NONE
+  next if shared_dir_array[index] == "/NONE"
+
   dev_path[index] = "/dev/disk/by-ebs-volumeid/#{volumeid}"
 
   # Attach EBS volume

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -28,7 +28,7 @@ execute "add_configure-pat" do
 end
 
 # Get VPC CIDR
-node.default['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block'] = get_vpc_ipv4_cidr_block(node['macaddress'])
+node.default['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks'] = get_vpc_ipv4_cidr_blocks(node['macaddress'])
 
 # Parse shared directory info and turn into an array
 shared_dir_array = node['cfncluster']['cfn_shared_dir'].split(',')
@@ -119,7 +119,7 @@ vol_array.each_with_index do |volumeid, index|
 
   # Export shared dir
   nfs_export shared_dir_array[index] do
-    network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+    network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
     writeable true
     options ['no_root_squash']
   end
@@ -127,14 +127,14 @@ end
 
 # Export /home
 nfs_export "/home" do
-  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
   writeable true
   options ['no_root_squash']
 end
 
 # Export /opt/intel if it exists
 nfs_export "/opt/intel" do
-  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
   writeable true
   options ['no_root_squash']
   only_if { ::File.directory?("/opt/intel") }

--- a/recipes/_master_sge_config.rb
+++ b/recipes/_master_sge_config.rb
@@ -17,7 +17,7 @@
 
 # Export /opt/sge
 nfs_export "/opt/sge" do
-  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
   writeable true
   options ['no_root_squash']
 end

--- a/recipes/_master_sge_config.rb
+++ b/recipes/_master_sge_config.rb
@@ -52,6 +52,7 @@ end
 
 bash "add_host_as_master" do
   code <<-ADDHOST
+    set -e
     . /opt/sge/default/common/settings.sh
     qconf -as #{node['hostname']}
   ADDHOST
@@ -59,6 +60,7 @@ end
 
 bash "set_accounting_summary" do
   code <<-SETAS
+    set -e
     . /opt/sge/default/common/settings.sh
     TMPFILE=/tmp/pe.txt
     qconf -sp mpi | grep -v 'accounting_summary' > $TMPFILE
@@ -71,6 +73,7 @@ end
 # Enable non-admin users to force delete a job
 bash "enable_forced_qdel" do
   code <<-ENABLEFORCEDQDEL
+    set -e
     . /opt/sge/default/common/settings.sh
     /opt/sge/util/qconf_add_list_value -mconf qmaster_params ENABLE_FORCED_QDEL global
   ENABLEFORCEDQDEL

--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -17,7 +17,7 @@
 
 # Export /opt/slurm
 nfs_export "/opt/slurm" do
-  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+  network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
   writeable true
   options ['no_root_squash']
 end

--- a/recipes/_master_torque_config.rb
+++ b/recipes/_master_torque_config.rb
@@ -18,6 +18,7 @@
 # Run torque.setup
 bash "run-torque-setup" do
   code <<-SETUPTORQUE
+    set -e
     . /etc/profile.d/torque.sh
     ./torque.setup root
   SETUPTORQUE

--- a/recipes/_nvidia_install.rb
+++ b/recipes/_nvidia_install.rb
@@ -45,7 +45,7 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
     mode '0755'
     retries 3
     retry_delay 5
-    not_if { ::File.exist?(nvidia_tmp_runfile) }
+    not_if { ::File.exist?('/usr/bin/nvidia-smi') }
   end
 
   # Install NVIDIA driver
@@ -54,8 +54,9 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
     group 'root'
     cwd '/tmp'
     code <<-NVIDIA
-    ./nvidia.run --silent --no-network --dkms
-    rm -f /tmp/nvidia.run
+      set -e
+      ./nvidia.run --silent --dkms
+      rm -f /tmp/nvidia.run
     NVIDIA
     creates '/usr/bin/nvidia-smi'
   end
@@ -67,7 +68,7 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
     mode '0755'
     retries 3
     retry_delay 5
-    not_if { ::File.exist?(cuda_tmp_runfile) }
+    not_if { ::File.exist?("/usr/local/cuda-#{node['cfncluster']['nvidia']['cuda_version']}") }
   end
 
   # Install CUDA driver
@@ -76,10 +77,11 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
     group 'root'
     cwd '/tmp'
     code <<-CUDA
-    ./cuda.run --silent --toolkit
-    rm -f /tmp/cuda.run
+      set -e
+      ./cuda.run --silent --toolkit
+      rm -f /tmp/cuda.run
     CUDA
-    creates '/usr/local/cuda-10.0'
+    creates "/usr/local/cuda-#{node['cfncluster']['nvidia']['cuda_version']}"
   end
 
   cookbook_file 'blacklist-nouveau.conf' do

--- a/recipes/awsbatch_config.rb
+++ b/recipes/awsbatch_config.rb
@@ -41,6 +41,7 @@ if !node['cfncluster']['custom_awsbatchcli_package'].nil? && !node['cfncluster']
   bash "install aws-parallelcluster-awsbatch-cli" do
     cwd Chef::Config[:file_cache_path]
     code <<-CLI
+      set -e
       source /tmp/proxy.sh
       curl --retry 3 -v -L -o aws-parallelcluster.tgz #{node['cfncluster']['custom_awsbatchcli_package']}
       tar -xzf aws-parallelcluster.tgz

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -56,6 +56,7 @@ end
 bash "install awscli" do
   cwd Chef::Config[:file_cache_path]
   code <<-CLI
+    set -e
     curl --retry 5 --retry-delay 5 "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
     unzip awscli-bundle.zip
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
@@ -120,9 +121,13 @@ if !node['cfncluster']['custom_node_package'].nil? && !node['cfncluster']['custo
   bash "install aws-parallelcluster-node" do
     cwd Chef::Config[:file_cache_path]
     code <<-NODE
+      set -e
       [[ ":$PATH:" != *":/usr/local/bin:"* ]] && PATH="/usr/local/bin:${PATH}"
       echo "PATH is $PATH"
-      source /tmp/proxy.sh
+      PROXY_FILE=/tmp/proxy.sh
+      if [ -f "$PROXY_FILE" ]; then
+              source $PROXY_FILE
+      fi
       source #{node['cfncluster']['node_virtualenv_path']}/bin/activate
       pip uninstall --yes aws-parallelcluster-node
       curl --retry 3 -v -L -o aws-parallelcluster-node.tgz #{node['cfncluster']['custom_node_package']}

--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -44,6 +44,7 @@ def allow_gpu_acceleration
   bash 'Launch X' do
     user 'root'
     code <<-SETUPX
+      set -e
       systemctl set-default graphical.target
       systemctl isolate graphical.target &
     SETUPX

--- a/recipes/munge_install.rb
+++ b/recipes/munge_install.rb
@@ -39,6 +39,7 @@ bash 'make install' do
   group 'root'
   cwd Chef::Config[:file_cache_path]
   code <<-MUNGE
+    set -e
     tar xf #{munge_tarball}
     cd munge-munge-#{node['cfncluster']['munge']['munge_version']}
     ./bootstrap

--- a/recipes/setup_raid_on_master.rb
+++ b/recipes/setup_raid_on_master.rb
@@ -112,7 +112,7 @@ if raid_shared_dir != "NONE"
 
   # Export RAID directory via nfs
   nfs_export raid_shared_dir do
-    network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-block']
+    network node['cfncluster']['ec2-metadata']['vpc-ipv4-cidr-blocks']
     writeable true
     options ['no_root_squash']
   end

--- a/recipes/sge_install.rb
+++ b/recipes/sge_install.rb
@@ -120,6 +120,7 @@ when 'MasterServer', nil
     group 'root'
     cwd Chef::Config[:file_cache_path]
     code <<-SGELICENSE
+      set -e
       cd sge-#{node['cfncluster']['sge']['version']}/LICENCES
       cp -v SISSL #{node['cfncluster']['license_dir']}/sge/SISSL
     SGELICENSE

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -68,6 +68,7 @@ when 'MasterServer', nil
     group 'root'
     cwd Chef::Config[:file_cache_path]
     code <<-SLURMLICENSE
+      set -e
       cd slurm-slurm-#{node['cfncluster']['slurm']['version']}
       cp -v COPYING #{node['cfncluster']['license_dir']}/slurm/COPYING
       cp -v DISCLAIMER #{node['cfncluster']['license_dir']}/slurm/DISCLAIMER

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -117,6 +117,7 @@ end
 if node['cfncluster']['cfn_node_type'] == "MasterServer" and node['cfncluster']['os'] == 'centos7' and node['cfncluster']['dcv']['installed'] == 'yes'
   execute 'check dcv installed' do
     command 'dcv version'
+    user node['cfncluster']['cfn_cluster_user']
   end
 end
 

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -29,11 +29,12 @@ end
 bash 'check awscli regions' do
   cwd Chef::Config[:file_cache_path]
   code <<-AWSREGIONS
+    set -e
     export PATH="/usr/local/bin:/usr/bin/:$PATH"
     regions=($(#{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws ec2 describe-regions --region us-east-1 --query "Regions[].{Name:RegionName}" --output text))
     for region in "${regions[@]}"
     do
-      #{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws ec2 describe-regions --region "${region}" >/dev/null 2>&1 || exit 1
+      #{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws ec2 describe-regions --region "${region}" >/dev/null 2>&1
     done
   AWSREGIONS
 end
@@ -139,11 +140,12 @@ unless node['cfncluster']['os'].end_with?("-custom")
   bash 'execute jq' do
     cwd Chef::Config[:file_cache_path]
     code <<-JQMERGE
+      set -e
       # Set PATH as in the UserData script of the CloudFormation template
       export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin"
       echo '{"cfncluster": {"cfn_region": "eu-west-3"}, "run_list": "recipe[aws-parallelcluster::sge_config]"}' > /tmp/dna.json
       echo '{ "cfncluster" : { "ganglia_enabled" : "yes" } }' > /tmp/extra.json
-      jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster' || exit 1
+      jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster'
     JQMERGE
   end
 end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -148,65 +148,61 @@ unless node['cfncluster']['os'].end_with?("-custom")
   end
 end
 
-# only test on GPU instances
-if node['cfncluster']['nvidia']['enabled'] == 'yes'
+bash 'test nvidia driver install' do
+  cwd Chef::Config[:file_cache_path]
+  code <<-TESTNVIDIA
+    has_gpu=$(lspci | grep -o "NVIDIA")
+    if [ -z "$has_gpu" ]; then
+      echo "No GPU detected, no test needed."
+      exit 0
+    fi
 
-  bash 'test nvidia driver install' do
-    cwd Chef::Config[:file_cache_path]
-    code <<-TESTNVIDIA
-      has_gpu=$(lspci | grep -o "NVIDIA")
-      if [ -z "$has_gpu" ]; then
-        echo "No GPU detected, no test needed."
-        exit 0
-      fi
+    set -e
+    driver_ver="#{node['cfncluster']['nvidia']['driver_version']}"
+    export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin"
 
-      set -e
-      driver_ver="#{node['cfncluster']['nvidia']['driver_version']}"
-      export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin"
+    # Test NVIDIA Driver installation
+    echo "Testing NVIDIA driver install..."
+    # grep driver version from nvidia-smi output. If driver is not installed nvidia-smi command will fail
+    driver_output=$(nvidia-smi | grep -E -o "Driver Version: [0-9]+.[0-9]+")
+    if [ "$driver_output" != "Driver Version: $driver_ver" ]; then
+      echo "NVIDIA driver installed incorrectly! Installed $driver_output but expected version $driver_ver"
+      exit 1
+    else
+      echo "Correctly installed NVIDIA $driver_output"
+    fi
+  TESTNVIDIA
+end
 
-      # Test NVIDIA Driver installation
-      echo "Testing NVIDIA driver install..."
-      # grep driver version from nvidia-smi output. If driver is not installed nvidia-smi command will fail
-      driver_output=$(nvidia-smi | grep -E -o "Driver Version: [0-9]+.[0-9]+")
-      if [ "$driver_output" != "Driver Version: $driver_ver" ]; then
-        echo "NVIDIA driver installed incorrectly! Installed $driver_output but expected version $driver_ver"
-        exit 1
-      else
-        echo "Correctly installed NVIDIA $driver_output"
-      fi
-    TESTNVIDIA
-  end
+bash 'test CUDA install' do
+  cwd Chef::Config[:file_cache_path]
+  code <<-TESTCUDA
+    has_gpu=$(lspci | grep -o "NVIDIA")
+    if [ -z "$has_gpu" ]; then
+      echo "No GPU detected, no test needed."
+      exit 0
+    fi
 
-  bash 'test CUDA install' do
-    cwd Chef::Config[:file_cache_path]
-    code <<-TESTCUDA
-      has_gpu=$(lspci | grep -o "NVIDIA")
-      if [ -z "$has_gpu" ]; then
-        echo "No GPU detected, no test needed."
-        exit 0
-      fi
+    set -e
+    cuda_ver="#{node['cfncluster']['nvidia']['cuda_version']}"
+    # Test CUDA installation
+    echo "Testing CUDA install with nvcc..."
+    export PATH=/usr/local/cuda-$cuda_ver/bin:$PATH
+    export LD_LIBRARY_PATH=/usr/local/cuda-$cuda_ver/lib64:$LD_LIBRARY_PATH
+    # grep CUDA version from nvcc output. If CUDA is not installed nvcc command will fail
+    cuda_output=$(nvcc -V | grep -E -o "release [0-9]+.[0-9]+")
+    if [ "$cuda_output" != "release $cuda_ver" ]; then
+      echo "CUDA installed incorrectly! Installed $cuda_output but expected $cuda_ver"
+      exit 1
+    else
+      echo "CUDA nvcc test passed, $cuda_output"
+    fi
 
-      set -e
-      cuda_ver="#{node['cfncluster']['nvidia']['cuda_version']}"
-      # Test CUDA installation
-      echo "Testing CUDA install with nvcc..."
-      export PATH=/usr/local/cuda-$cuda_ver/bin:$PATH
-      export LD_LIBRARY_PATH=/usr/local/cuda-$cuda_ver/lib64:$LD_LIBRARY_PATH
-      # grep CUDA version from nvcc output. If CUDA is not installed nvcc command will fail
-      cuda_output=$(nvcc -V | grep -E -o "release [0-9]+.[0-9]+")
-      if [ "$cuda_output" != "release $cuda_ver" ]; then
-        echo "CUDA installed incorrectly! Installed $cuda_output but expected $cuda_ver"
-        exit 1
-      else
-        echo "CUDA nvcc test passed, $cuda_output"
-      fi
-
-      # Test deviceQuery
-      echo "Testing CUDA install with deviceQuery..."
-      sudo make --directory=/usr/local/cuda-$cuda_ver/samples/1_Utilities/deviceQuery/
-      exec /usr/local/cuda-$cuda_ver/samples/1_Utilities/deviceQuery/deviceQuery | grep -o "Device [0-9]+: .*"
-      echo "CUDA deviceQuery test passed"
-      echo "Correctly installed CUDA $cuda_output"
-    TESTCUDA
-  end
+    # Test deviceQuery
+    echo "Testing CUDA install with deviceQuery..."
+    sudo make --directory=/usr/local/cuda-$cuda_ver/samples/1_Utilities/deviceQuery/
+    exec /usr/local/cuda-$cuda_ver/samples/1_Utilities/deviceQuery/deviceQuery | grep -o "Device [0-9]+: .*"
+    echo "CUDA deviceQuery test passed"
+    echo "Correctly installed CUDA $cuda_output"
+  TESTCUDA
 end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -46,6 +46,13 @@ unless node['cfncluster']['os'].end_with?("-custom")
   end
 end
 
+if node['cfncluster']['cfn_scheduler'] == 'torque' or node['cfncluster']['cfn_scheduler'] == 'slurm'
+  execute 'check munge installed' do
+    command 'munge --version'
+    user node['cfncluster']['cfn_cluster_user']
+  end
+end
+
 if node['cfncluster']['cfn_scheduler'] == 'sge'
   case node['cfncluster']['cfn_node_type']
   when 'MasterServer'

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -150,9 +150,6 @@ end
 
 # only test on GPU instances
 if node['cfncluster']['nvidia']['enabled'] == 'yes'
-  # extract driver and CUDA version from url
-  url_driver_ver = node['cfncluster']['nvidia']['driver_url'][/(\d+.\d+)/, 0]
-  url_cuda_ver = node['cfncluster']['nvidia']['cuda_url'][/(\d+.\d+)/, 0]
 
   bash 'test nvidia driver install' do
     cwd Chef::Config[:file_cache_path]
@@ -164,7 +161,7 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
       fi
 
       set -e
-      driver_ver="#{url_driver_ver}"
+      driver_ver="#{node['cfncluster']['nvidia']['driver_version']}"
       export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin"
 
       # Test NVIDIA Driver installation
@@ -190,7 +187,7 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
       fi
 
       set -e
-      cuda_ver="#{url_cuda_ver}"
+      cuda_ver="#{node['cfncluster']['nvidia']['cuda_version']}"
       # Test CUDA installation
       echo "Testing CUDA install with nvcc..."
       export PATH=/usr/local/cuda-$cuda_ver/bin:$PATH

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -164,7 +164,7 @@ bash 'test nvidia driver install' do
     # Test NVIDIA Driver installation
     echo "Testing NVIDIA driver install..."
     # grep driver version from nvidia-smi output. If driver is not installed nvidia-smi command will fail
-    driver_output=$(nvidia-smi | grep -E -o "Driver Version: [0-9]+.[0-9]+")
+    driver_output=$(nvidia-smi | grep -E -o "Driver Version: [0-9.]+")
     if [ "$driver_output" != "Driver Version: $driver_ver" ]; then
       echo "NVIDIA driver installed incorrectly! Installed $driver_output but expected version $driver_ver"
       exit 1
@@ -200,8 +200,7 @@ bash 'test CUDA install' do
 
     # Test deviceQuery
     echo "Testing CUDA install with deviceQuery..."
-    sudo make --directory=/usr/local/cuda-$cuda_ver/samples/1_Utilities/deviceQuery/
-    exec /usr/local/cuda-$cuda_ver/samples/1_Utilities/deviceQuery/deviceQuery | grep -o "Device [0-9]+: .*"
+    /usr/local/cuda-$cuda_ver/extras/demo_suite/deviceQuery | grep -o "Result = PASS"
     echo "CUDA deviceQuery test passed"
     echo "Correctly installed CUDA $cuda_output"
   TESTCUDA

--- a/recipes/torque_install.rb
+++ b/recipes/torque_install.rb
@@ -110,6 +110,7 @@ bash 'copy license stuff' do
   group 'root'
   cwd Chef::Config[:file_cache_path]
   code <<-TORQUEINSTALL
+    set -e
     cd torque-#{node['cfncluster']['torque']['version']}
     cp -v PBS_License.txt #{node['cfncluster']['license_dir']}/torque/PBS_License.txt
     cp -v LICENSE #{node['cfncluster']['license_dir']}/torque/LICENSE


### PR DESCRIPTION
The following fixes have been back-ported:
- Avoid mounting EBS volume when shared_dir is /NONE: #445 
- Fixes for Nvidia drivers and Cuda Toolkit: #447 
- Enable nvidia driver install in kitchen tests with schedulers: #443 
- Fix Kitchen tests for Nvidia drivers and Cuda toolkit: #452 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
