### PR TITLE
Fix Ganglia installation

### DIFF
--- a/recipes/_ganglia_install.rb
+++ b/recipes/_ganglia_install.rb
@@ -148,7 +148,6 @@ if node['cfncluster']['ganglia_enabled'] == 'yes'
     # Setup ganglia-web.conf apache config
     execute "copy ganglia apache conf" do
       command "cp /etc/ganglia-webfrontend/apache.conf /etc/apache2/sites-enabled/ganglia.conf"
-      notifies :reload, "service[#{node['cfncluster']['ganglia']['httpd_service']}]", :immediately
       not_if "test -f /etc/apache2/sites-enabled/ganglia.conf"
     end
 

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -171,7 +171,7 @@ if node['cfncluster']['ganglia_enabled'] == 'yes'
 
   service node['cfncluster']['ganglia']['httpd_service'] do
     supports restart: true, reload: true
-    action %i[enable start]
+    action %i[enable restart]
   end
 end
 


### PR DESCRIPTION
Apache daemon is normally not running when ganglia is installed, so the
notification sent to it at the end of the installation raised an error.
Fixed by removing the notification. Additionally, the service is now
restarted rather than just started in master_base_config recipe to
cover the case when ganglia is installed with a cluster update.