### PR TITLE
Provide default dcv_port in kitchen test

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -94,6 +94,7 @@ suites:
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'
+        dcv_port: '8443'
         enable_intel_hpc_platform: 'true'
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
@@ -121,6 +122,7 @@ suites:
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'
+        dcv_port: '8443'
         enable_intel_hpc_platform: 'true'
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
@@ -148,6 +150,7 @@ suites:
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'
+        dcv_port: '8443'
         enable_intel_hpc_platform: 'true'
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
@@ -175,6 +178,7 @@ suites:
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'
+        dcv_port: '8443'
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
@@ -201,6 +205,7 @@ suites:
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'
+        dcv_port: '8443'
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
 
@@ -227,5 +232,6 @@ suites:
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'
+        dcv_port: '8443'
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>


### PR DESCRIPTION
* Added default dcv_port to avoid kitchen test failure

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
