### PR TITLE
Fix error with apt autoremove

### DIFF
--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -27,7 +27,7 @@ unless node['platform'] == 'centos' && node['platform_version'].to_i < 7
       command "apt-get update"
     end
     execute 'apt-upgrade' do
-      command "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" --with-new-pkgs upgrade && apt-get autoremove"
+      command "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" --with-new-pkgs upgrade && apt-get autoremove -y"
     end
   end
 end


### PR DESCRIPTION
The command apt-get autoremove in _update_packages.rb was launched
without the "-y" parameter, leading to an interactive prompt which
was breaking the build.
