### PR TITLE
Pin Intel Python2/3 versions

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,8 @@ default['cfncluster']['intelmpi']['version'] = '2019.5'
 default['cfncluster']['psxe']['version'] = '2019.5'
 default['cfncluster']['intelhpc']['version'] = '2018.0-1.el7'
 default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/impi/latest/modulefiles/mpi"
+default['cfncluster']['intelpython2']['version'] = '2019.4'
+default['cfncluster']['intelpython3']['version'] = '2019.4'
 # Python packages
 default['cfncluster']['cfncluster-version'] = '2.5.1'
 default['cfncluster']['cfncluster-node-version'] = '2.5.1'

--- a/recipes/intel_install.rb
+++ b/recipes/intel_install.rb
@@ -51,7 +51,7 @@ when 'MasterServer'
       set -e
       yum-config-manager --add-repo https://yum.repos.intel.com/intelpython/setup/intelpython.repo
       yum-config-manager --save --setopt=intelpython.skip_if_unavailable=true
-      yum -y install intelpython2 intelpython3
+      yum -y install intelpython2-#{node['cfncluster']['intelpython2']['version']} intelpython3-#{node['cfncluster']['intelpython3']['version']}
     INTEL
     creates '/opt/intel/intelpython2'
   end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -221,3 +221,16 @@ execute 'cloudwatch-agent-status' do
   user 'root'
   command "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | grep status | grep stopped"
 end
+
+# Intel Python Libraries
+if (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
+  && (node['cfncluster']['enable_intel_hpc_platform'] == 'true')
+  execute "check-intel-python2" do
+    # Output code will be 1 if version is different
+    command "rpm -q intelpython2 | grep #{node['cfncluster']['intelpython2']['version']}"
+  end
+  execute "check-intel-python3" do
+    # Output code will be 1 if version is different
+    command "rpm -q intelpython3 | grep #{node['cfncluster']['intelpython3']['version']}"
+  end
+end


### PR DESCRIPTION
The latest release (2020.0-014) of Intel Python 3 was breaking
integration tests as clck was not recognizing it as valid. This fix pins
the python3 version to the previous one 2019.4-088.