### PR TITLE
Torque: fix issue with job scheduling

### DIFF
--- a/templates/default/torque.server_name.erb
+++ b/templates/default/torque.server_name.erb
@@ -1,5 +1,5 @@
 <% if node['cfncluster']['cfn_node_type'] == 'MasterServer' -%>
-<%= node['hostname'] %>
+<%= node['ec2']['local_hostname'] %>
 <% end -%>
 <% if node['cfncluster']['cfn_node_type'] == 'ComputeFleet' -%>
 <%= node['cfncluster']['cfn_master'] %>

--- a/templates/default/torque.setup.erb
+++ b/templates/default/torque.setup.erb
@@ -70,6 +70,13 @@ echo set server managers += "${USER}@${HOSTNAME}" | qmgr
 qmgr -c 'set server scheduling = true'
 qmgr -c 'set server keep_completed = 300'
 qmgr -c 'set server mom_job_sync = true'
+# resources_max.nodect enforces the max size of the cluster
+qmgr -c 'set server resources_max.nodect = <%= node['cfncluster']['cfn_max_queue_size'] %>'
+# resources_available.nodect enforces the max number of usable slots. Setting this to max_queue_size causes
+# torque not to use all slots available to the cluster and the scheduler erroneously limits the number of concurrent
+# running jobs so that the total number of required nodes is equal to max_queue_size. This is not correct because a node
+# can be shared across multiple jobs if free slots are available.
+# This value is updated by sqswatcher to be equal to max_queue_size*node_slots
 qmgr -c 'set server resources_available.nodect = <%= node['cfncluster']['cfn_max_queue_size'] %>'
 qmgr -c 'set server node_check_rate = 120'
 qmgr -c 'set server node_ping_rate = 60'
@@ -84,6 +91,7 @@ qmgr -c 'set queue batch started = true'
 qmgr -c 'set queue batch enabled = true'
 qmgr -c 'set queue batch resources_default.walltime = 1:00:00'
 qmgr -c 'set queue batch resources_default.nodes = 1'
+qmgr -c 'set queue batch resources_max.nodect = <%= node['cfncluster']['cfn_max_queue_size'] %>'
 qmgr -c 'set queue batch resources_available.nodect = <%= node['cfncluster']['cfn_max_queue_size'] %>'
 
 qmgr -c 'set server default_queue = batch'


### PR DESCRIPTION
### The problem

`resources_available.nodect = N` torque config parameter, that is used by ParallelCluster to set the max size that the cluster can assume, is not behaving exactly as documented [here](http://docs.adaptivecomputing.com/torque/6-1-2/adminGuide/torque.htm#topics/torque/13-appendices/nQueueAttributes/queueAttribReference.htm#queueResourceLimits), but it's limiting the number of jobs that can run concurrently by limiting the total number of nodes to N even if a node has free slots to be allocated.

### Reproducing the issue
ParallelCluster version 2.5.1 (same applies to older versions)

Create a cluster with the following config
```
...
[cluster default]
base_os = centos7
scheduler = torque
master_instance_type = c5.xlarge
compute_instance_type = c5.xlarge
initial_queue_size = 2
max_queue_size = 2
maintain_initial_size = true
...
```

Since max_queue_size is set to 2 the following values are configured in Torque:
```
qmgr -c 'p s'
#
# Create queues and set their attributes.
#
#
# Create and define queue batch
#
create queue batch
set queue batch queue_type = Execution
set queue batch resources_max.ncpus = 4
set queue batch resources_default.walltime = 01:00:00
set queue batch resources_default.nodes = 1
set queue batch resources_available.nodect = 2
set queue batch enabled = True
set queue batch started = True
#
# Set server attributes.
#
set server scheduling = True
set server acl_hosts = ip-192-168-47-81
set server managers = root@ip-192-168-47-81.eu-west-1.compute.internal
set server operators = root@*
set server default_queue = batch
set server log_events = 2047
set server mail_from = adm
set server query_other_jobs = True
set server resources_available.nodect = 2
set server node_ping_rate = 60
set server node_check_rate = 120
set server tcp_timeout = 300
set server job_stat_rate = 300
set server poll_jobs = True
set server down_on_error = True
set server mom_job_sync = True
set server keep_completed = 300
set server moab_array_compatible = True
set server nppcu = 1
set server timeout_for_job_delete = 30
set server timeout_for_job_requeue = 30
set server note_append_on_error = True
```

Now if we submit the following jobs:
```
[centos@ip-192-168-47-81 ~]$ echo "sleep 10000" | qsub -l nodes=1
0.ip-192-168-47-81.eu-west-1.compute.internal
[centos@ip-192-168-47-81 ~]$ echo "sleep 10000" | qsub -l nodes=1
1.ip-192-168-47-81.eu-west-1.compute.internal
[centos@ip-192-168-47-81 ~]$ echo "sleep 10000" | qsub -l nodes=1
2.ip-192-168-47-81.eu-west-1.compute.internal
```

Here is what happens:
```
[centos@ip-192-168-47-81 ~]$ qstat -ans

ip-192-168-47-81.eu-west-1.compute.internal:
                                                                                  Req'd       Req'd       Elap
Job ID                  Username    Queue    Jobname          SessID  NDS   TSK   Memory      Time    S   Time
----------------------- ----------- -------- ---------------- ------ ----- ------ --------- --------- - ---------
0.ip-192-168-47-81.eu-  centos      batch    STDIN              8948     1      1       --   01:00:00 R  00:00:04
   ip-192-168-70-209/0
   Job started on Tue Jan 07 at 15:14
1.ip-192-168-47-81.eu-  centos      batch    STDIN              8976     1      1       --   01:00:00 R  00:00:04
   ip-192-168-70-209/1
   Job started on Tue Jan 07 at 15:14
2.ip-192-168-47-81.eu-  centos      batch    STDIN               --      1      1       --   01:00:00 Q       --
    --
   Not Running: Not enough nodes available
```

And as you can see 1 node has still 2 free slots and another one is fully free:
```
[centos@ip-192-168-47-81 ~]$ pbsnodes
ip-192-168-47-81
     state = down,offline
     power_state = Running
     np = 1
     ntype = cluster
     note = MasterServer
     mom_service_port = 15002
     mom_manager_port = 15003

ip-192-168-70-209
     state = free
     power_state = Running
     np = 4
     ntype = cluster
     jobs = 0/0.ip-192-168-47-81.eu-west-1.compute.internal,1/1.ip-192-168-47-81.eu-west-1.compute.internal
     status = opsys=linux,uname=Linux ip-192-168-70-209 3.10.0-1062.9.1.el7.x86_64 #1 SMP Fri Dec 6 15:49:49 UTC 2019 x86_64,sessions=8948 8976 11225,nsessions=3,nusers=2,idletime=5119,totmem=7648368kb,availmem=7068040kb,physmem=7648368kb,ncpus=4,loadave=0.00,gres=,netload=3429685,state=free,varattr= ,cpuclock=Fixed,macaddr=06:96:07:cd:1d:3a,version=6.1.2,rectime=1578410609,jobs=0.ip-192-168-47-81.eu-west-1.compute.internal 1.ip-192-168-47-81.eu-west-1.compute.internal
     mom_service_port = 15002
     mom_manager_port = 15003

ip-192-168-119-210
     state = free
     power_state = Running
     np = 4
     ntype = cluster
     status = opsys=linux,uname=Linux ip-192-168-119-210 3.10.0-1062.9.1.el7.x86_64 #1 SMP Fri Dec 6 15:49:49 UTC 2019 x86_64,sessions=11222,nsessions=1,nusers=1,idletime=5118,totmem=7648368kb,availmem=7071008kb,physmem=7648368kb,ncpus=4,loadave=0.00,gres=,netload=3480891,state=free,varattr= ,cpuclock=Fixed,macaddr=06:0b:75:c2:48:c0,version=6.1.2,rectime=1578410608,jobs=
     mom_service_port = 15002
     mom_manager_port = 15003
```

### Workaround
`resources_available.nodect = N` serves two different causes:
1. Enables torque to accept jobs that request a number of nodes greater than the ones available to the cluster (nodes that the scaling daemons will launch)
2. Prevents the submission of jobs that exceed the max size of the cluster

The workaround for the following issue consists in setting `resources_max.nodect = max_queue_size`, so that no jobs are accepted if max_queue_size is exceeded, and change `resources_available.nodect = max_queue_size*node_slots` so that torque will correctly use all available slots in the cluster.

### Tests
https://github.com/aws/aws-parallelcluster/pull/1584

***
Also set server_name to fqdn on master node. This is to align the configuration with compute nodes and fix errors caused by pbs_server unable to locate jobs
```
12/31/2019 10:14:34.609;128;PBS_Server.3961;Job;2.ip-10-0-127-143;Unknown Job Id Error
12/31/2019 10:14:34.609;128;PBS_Server.3961;Req;req_reject;Reject reply code=15001(Unknown Job Id Error MSG=cannot locate job), aux=0, type=DeleteJob, from root@ip-10-0-127-
143.eu-west-1.compute.internal
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
