### PR TITLE
Install debian mysql-dev library to pre-build slurm accounting plugin

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -189,7 +189,7 @@ when 'debian'
                                               apache2 libboost-dev libdb-dev tcsh libssl-dev libncurses5-dev libpam0g-dev libxt-dev
                                               libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev python python-pip
                                               r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev mdadm
-                                              libgcrypt20-dev]
+                                              libgcrypt20-dev libmysqlclient-dev]
   if node['platform_version'] == '18.04'
     default['cfncluster']['base_packages'].delete('libatlas-dev')
     default['cfncluster']['base_packages'].push('libatlas-base-dev', 'libssl1.0-dev', 'libglvnd-dev')

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -234,3 +234,13 @@ if (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
     command "rpm -q intelpython3 | grep #{node['cfncluster']['intelpython3']['version']}"
   end
 end
+
+execute 'check-slurm-accounting-mysql-plugins' do
+  user 'root'
+  command "ls /opt/slurm/lib/slurm/ | grep accounting_storage_mysql"
+end
+
+execute 'check-slurm-jobcomp-mysql-plugins' do
+  user 'root'
+  command "ls /opt/slurm/lib/slurm/ | grep jobcomp_mysql"
+end


### PR DESCRIPTION
* Installing libmysqlclient-dev library for Ubuntu so that slurm accounting mysql plugins are compiled
* Centos and Alinux already has mysql-devel/mariadb-devel installed, no action needed
* Add kitchen test to test that mysql accounting plugins are present

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
