### PR TITLE
Extend retry of DCV session existence check

### DIFF
--- a/files/default/dcv/pcluster_dcv_authenticator.py
+++ b/files/default/dcv/pcluster_dcv_authenticator.py
@@ -369,7 +369,7 @@ class DCVAuthenticator(BaseHTTPRequestHandler):
 
     @staticmethod
     def _verify_session_existence(user, session_id):
-        retry(DCVAuthenticator._is_session_valid, func_args=[user, session_id], attempts=5, wait=1)
+        retry(DCVAuthenticator._is_session_valid, func_args=[user, session_id], attempts=20, wait=1)
 
     @staticmethod
     def check_dcv_process(row, user, session_id):


### PR DESCRIPTION
I'm extending the retry to 20 seconds because sometimes 5 seconds are not enough to start the session.

