### PR TITLE
Add guard to fix slurm accounting plugin kitchen test

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -235,12 +235,14 @@ if (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
   end
 end
 
-execute 'check-slurm-accounting-mysql-plugins' do
-  user 'root'
-  command "ls /opt/slurm/lib/slurm/ | grep accounting_storage_mysql"
-end
+if node['cfncluster']['cfn_node_type'] == "MasterServer" and node['cfncluster']['cfn_scheduler'] == 'slurm'
+  execute 'check-slurm-accounting-mysql-plugins' do
+    user 'root'
+    command "ls /opt/slurm/lib/slurm/ | grep accounting_storage_mysql"
+  end
 
-execute 'check-slurm-jobcomp-mysql-plugins' do
-  user 'root'
-  command "ls /opt/slurm/lib/slurm/ | grep jobcomp_mysql"
+  execute 'check-slurm-jobcomp-mysql-plugins' do
+    user 'root'
+    command "ls /opt/slurm/lib/slurm/ | grep jobcomp_mysql"
+  end
 end


### PR DESCRIPTION
* Add guard to only run slurm accounting plugin kitchen test on MasterServer, as Compute are using a fake master setup and does not actually have slurm installed.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
