### PR TITLE
FSx Lustre on Centos 7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -167,7 +167,11 @@ when 'rhel', 'amazon'
                                                   blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                                   libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel mdadm python python-pip
                                                   libssh2-devel libgcrypt-devel]
-      if node['platform_version'].split('.')[1] == '6'
+      if node['platform_version'].split('.')[1] == '7'
+        # Lustre Client for Centos 7.7
+        default['cfncluster']['lustre']['public_key'] = 'https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc'
+        default['cfncluster']['lustre']['base_url'] = 'https://fsx-lustre-client-repo.s3.amazonaws.com/el/7/x86_64/'
+      elsif node['platform_version'].split('.')[1] == '6'
         # Lustre Drivers for Centos 7.6
         default['cfncluster']['lustre']['version'] = '2.10.6'
         default['cfncluster']['lustre']['kmod_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/kmod-lustre-client-2.10.6-1.el7.x86_64.rpm'

--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -51,42 +51,18 @@ if node['platform'] == 'centos' && (5..6).cover?(node['platform_version'].split(
   kernel_module 'lnet'
 elsif node['platform'] == 'centos' && node['platform_version'].split('.')[1].to_i == 7
 
-  # Install build dependencies
-  package %w[libselinux-devel libyaml-devel rpm-build gcc git make] do
+  # add fsx lustre repository
+  yum_repository "aws-fsx" do
+    description "AWS FSx Packages  - $basearch"
+    baseurl node['cfncluster']['lustre']['base_url']
+    gpgkey node['cfncluster']['lustre']['public_key']
     retries 3
     retry_delay 5
   end
 
-  # grab lustre source
-  bash "clone github repo" do
-    cwd node['cfncluster']['sources_dir']
-    code <<-LUSTRECLONE
-      set -e
-      git clone git://git.whamcloud.com/fs/lustre-release.git --depth 2 -b 2.10.8
-    LUSTRECLONE
-    not_if { ::Dir.exist?("#{node['cfncluster']['sources_dir']}/lustre-release") }
-  end
-
-  # Make RPMS
-  bash "make rpms" do
-    cwd "#{node['cfncluster']['sources_dir']}/lustre-release"
-    code <<-LUSTREBUILD
-      set -e
-      sh ./autogen.sh
-      ./configure --disable-server --with-o2ib=no
-      make rpms
-    LUSTREBUILD
-    not_if { ::File.exist?("#{node['cfncluster']['sources_dir']}/lustre-release/kmod-lustre-client-2.10.8-1.el7.x86_64.rpm") }
-  end
-
-  # Install lustre mount drivers
-  yum_package 'lustre_kmod' do
-    source "#{node['cfncluster']['sources_dir']}/lustre-release/kmod-lustre-client-2.10.8-1.el7.x86_64.rpm"
-  end
-
-  # Install lustre mount drivers
-  yum_package 'lustre_client' do
-    source "#{node['cfncluster']['sources_dir']}/lustre-release/lustre-client-2.10.8-1.el7.x86_64.rpm"
+  yum_package %w(kmod-lustre-client lustre-client) do
+    retries 3
+    retry_delay 5
   end
 
   kernel_module 'lnet'


### PR DESCRIPTION
This changes the lustre client install from compiling from source to using the pre-built
rpms from the FSx Lustre team.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
