### PR TITLE
Upgrade Slurm to version 19.05.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ X.X.X
   - Libfabric: libfabric-aws-1.9.0amzn1.0 (updated from libfabric-aws-1.8.1amzn1.3)
   - Open MPI: openmpi40-aws-4.0.2 (no change)
 - Add SHA256 checksum verification to verify integrity of NICE DCV packages
+- Upgrade Slurm to version 19.05.5
 
 2.5.1
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,8 +50,9 @@ default['cfncluster']['sge']['url'] = 'https://arc.liv.ac.uk/downloads/SGE/relea
 default['cfncluster']['torque']['version'] = '6.1.2'
 default['cfncluster']['torque']['url'] = 'https://github.com/adaptivecomputing/torque/archive/6.1.2.tar.gz'
 # Slurm software
-default['cfncluster']['slurm']['version'] = '19-05-3-2'
-default['cfncluster']['slurm']['url'] = 'https://github.com/SchedMD/slurm/archive/slurm-19-05-3-2.tar.gz'
+default['cfncluster']['slurm']['version'] = '19.05.5'
+default['cfncluster']['slurm']['url'] = 'https://download.schedmd.com/slurm/slurm-19.05.5.tar.bz2'
+default['cfncluster']['slurm']['sha1'] = '055adca91e555cc124b1ecac5f3c45e66c17a8ba'
 # Munge
 default['cfncluster']['munge']['munge_version'] = '0.5.13'
 default['cfncluster']['munge']['munge_url'] = "https://github.com/dun/munge/archive/munge-#{node['cfncluster']['munge']['munge_version']}.tar.gz"


### PR DESCRIPTION
- Download url changed from GitHub to official endpoint for stable versions. See https://www.schedmd.com/downloads.php
- Add checksum validation for downloaded archive

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
