### PR TITLE
Upgrade EFA to version 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ X.X.X
 - Install NICE DCV on Ubuntu 18.04 (this includes ubuntu-desktop, lightdm, mesa-util packages).
 
 **Changes**
-- Upgrade EFA installer to version 1.8.0:
+- Upgrade EFA installer to version 1.8.1:
   - Kernel module: efa-1.5.0 (updated from efa-1.4.1)
   - RDMA core: rdma-core-27.0 (distributed only) (updated from rdma-core-25.0)
-  - Libfabric: libfabric-aws-1.9.0amzn1.0 (updated from libfabric-aws-1.8.1amzn1.3)
+  - Libfabric: libfabric-aws-1.9.0amzn1.1 (updated from libfabric-aws-1.8.1amzn1.3)
   - Open MPI: openmpi40-aws-4.0.2 (no change)
 - Add SHA256 checksum verification to verify integrity of NICE DCV packages
 - Upgrade Slurm to version 19.05.5

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -74,7 +74,7 @@ else
   default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run'
 end
 # EFA
-default['cfncluster']['efa']['installer_url'] = 'https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.8.0.tar.gz'
+default['cfncluster']['efa']['installer_url'] = 'https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.8.1.tar.gz'
 # ENV2 - tool to capture environment and create modulefiles
 default['cfncluster']['env2']['url'] = 'https://sourceforge.net/projects/env2/files/env2/download'
 # NICE DCV


### PR DESCRIPTION
Contents (vs. 1.8.0):
- Kernel module: efa-1.5.0 (no change)
- RDMA core: rdma-core-27.0 (distributed only) (no change)
- Libfabric: libfabric-aws-1.9.0amzn1.1 (updated from libfabric-aws-1.9.0amzn1.0)
- Open MPI: openmpi40-aws-4.0.2 (no change)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
