### PR TITLE
Install newer version of Python in CentOS 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ X.X.X
   - Open MPI: openmpi40-aws-4.0.2 (no change)
 - Add SHA256 checksum verification to verify integrity of NICE DCV packages
 - Upgrade Slurm to version 19.05.5
+- Install Python 2.7.17 on CentOS 6 and set it as default through pyenv
 
 2.5.1
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,7 @@ default['cfncluster']['scripts_dir'] = "#{node['cfncluster']['base_dir']}/script
 default['cfncluster']['license_dir'] = "#{node['cfncluster']['base_dir']}/licenses"
 # Python Version
 default['cfncluster']['python-version'] = '3.6.9'
+default['cfncluster']['python-version-centos6'] = '2.7.17'
 # Virtualenv Cookbook Name
 default['cfncluster']['cookbook_virtualenv'] = 'cookbook_virtualenv'
 # Virtualenv Node Name

--- a/recipes/_setup_python.rb
+++ b/recipes/_setup_python.rb
@@ -18,6 +18,13 @@ install_pyenv "root" do
   python_version node['cfncluster']['python-version']
 end
 
+if node['platform'] == 'centos' && node['platform_version'].to_i < 7
+  # CentOS 6 - install a newer version of Python using pyenv and make it globally available
+  pyenv_system_install node['cfncluster']['python-version-centos6']
+  pyenv_python node['cfncluster']['python-version-centos6']
+  pyenv_global node['cfncluster']['python-version-centos6']
+end
+
 activate_virtual_env node['cfncluster']['cookbook_virtualenv'] do
   pyenv_path node['cfncluster']['cookbook_virtualenv_path']
   pyenv_user "root"


### PR DESCRIPTION
Python 2.7.17 is installed through pyenv and made globally available for all the users.
This is done to permit the installation of the recent versions of AWS CLI that have dropped support for Python 2.6
https://aws.amazon.com/it/blogs/developer/deprecation-of-python-2-6-and-python-3-3-in-botocore-boto3-and-the-aws-cli

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
