### PR TITLE
Install kernel headers

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -216,7 +216,6 @@ when 'debian'
   # Modulefile Directory
   default['cfncluster']['modulefile_dir'] = "/usr/share/modules/modulefiles"
   default['cfncluster']['kernel_generic_pkg'] = "linux-generic"
-  default['cfncluster']['kernel_extra_pkg'] = "linux-image-extra-#{node['kernel']['release']}"
   default['cfncluster']['ganglia']['apache_user'] = 'www-data'
   default['cfncluster']['ganglia']['gmond_service'] = 'ganglia-monitor'
   default['cfncluster']['ganglia']['httpd_service'] = 'apache2'

--- a/recipes/_nvidia_install.rb
+++ b/recipes/_nvidia_install.rb
@@ -18,26 +18,6 @@
 # Only run if node['cfncluster']['nvidia']['enabled'] = 'yes'
 if node['cfncluster']['nvidia']['enabled'] == 'yes'
 
-  case node['platform_family']
-  when 'rhel', 'amazon'
-    yum_package node['cfncluster']['kernel_devel_pkg']['name'] do
-      retries 3
-      retry_delay 5
-    end
-  when 'debian'
-    # Needed for new kernel version
-    apt_package node['cfncluster']['kernel_generic_pkg'] do
-      retries 3
-      retry_delay 5
-    end
-    # Needed for old kernel version
-    apt_package node['cfncluster']['kernel_extra_pkg'] do
-      retries 3
-      retry_delay 5
-      ignore_failure true
-    end
-  end
-
   # Get NVIDIA run file
   nvidia_tmp_runfile = "/tmp/nvidia.run"
   remote_file nvidia_tmp_runfile do

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -53,6 +53,20 @@ node['cfncluster']['base_packages'].each do |p|
   end
 end
 
+case node['platform_family']
+when 'rhel', 'amazon'
+  yum_package node['cfncluster']['kernel_devel_pkg']['name'] do
+    version node['cfncluster']['kernel_devel_pkg']['version']
+    retries 3
+    retry_delay 5
+  end
+when 'debian'
+  apt_package node['cfncluster']['kernel_generic_pkg'] do
+    retries 3
+    retry_delay 5
+  end
+end
+
 bash "install awscli" do
   cwd Chef::Config[:file_cache_path]
   code <<-CLI


### PR DESCRIPTION
The resource to install the kernel headers has been moved outside of the nvidia_install recipe because there could be other dependencies
that require headers during installation (e.g. EFA driver)

The kernel_extra_pkg has been removed because was used in Ubuntu 14 (not supported anymore)
Installation based on version is required only for platform family rhel and amazon
For platform family debian, the linux-generic metapackage will take care of the version
```
> apt-cache depends linux-generic
linux-generic
  Depends: linux-image-generic
  Depends: linux-headers-generic
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

Tested manually, creating AMI for alinux and ubuntu1604


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
