### PR TITLE
Install Ganglia from package repositories for ALinux, Centos6/7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ X.X.X
 - Add SHA256 checksum verification to verify integrity of NICE DCV packages
 - Upgrade Slurm to version 19.05.5
 - Install Python 2.7.17 on CentOS 6 and set it as default through pyenv
-- Install Ganglia from repository on Amazon Linux
+- Install Ganglia from repository on Amazon Linux, Centos 6 and Centos 7
 
 2.5.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ X.X.X
 - Add SHA256 checksum verification to verify integrity of NICE DCV packages
 - Upgrade Slurm to version 19.05.5
 - Install Python 2.7.17 on CentOS 6 and set it as default through pyenv
+- Install Ganglia from repository on Amazon Linux
 
 2.5.1
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,10 +60,6 @@ default['cfncluster']['munge']['munge_version'] = '0.5.13'
 default['cfncluster']['munge']['munge_url'] = "https://github.com/dun/munge/archive/munge-#{node['cfncluster']['munge']['munge_version']}.tar.gz"
 # Ganglia
 default['cfncluster']['ganglia_enabled'] = 'no'
-default['cfncluster']['ganglia']['version'] = '3.7.2'
-default['cfncluster']['ganglia']['url'] = 'https://github.com/ganglia/monitor-core/archive/3.7.2.tar.gz'
-default['cfncluster']['ganglia']['web_version'] = '3.7.2'
-default['cfncluster']['ganglia']['web_url'] = 'https://github.com/ganglia/ganglia-web/archive/3.7.2.tar.gz'
 # NVIDIA
 default['cfncluster']['nvidia']['enabled'] = 'no'
 # domain has dynamic DNS resolution, will resolve to a server in Tokyo when called from China
@@ -196,7 +192,6 @@ when 'rhel', 'amazon'
                                                 sendmail cmake byacc libglvnd-devel mdadm libgcrypt-devel]
   end
 
-  default['cfncluster']['ganglia']['apache_user'] = 'apache'
   default['cfncluster']['ganglia']['gmond_service'] = 'gmond'
   default['cfncluster']['ganglia']['httpd_service'] = 'httpd'
   default['cfncluster']['torque']['trqauthd_source'] = 'file:///opt/torque/contrib/init.d/trqauthd'
@@ -223,7 +218,6 @@ when 'debian'
   # Modulefile Directory
   default['cfncluster']['modulefile_dir'] = "/usr/share/modules/modulefiles"
   default['cfncluster']['kernel_generic_pkg'] = "linux-generic"
-  default['cfncluster']['ganglia']['apache_user'] = 'www-data'
   default['cfncluster']['ganglia']['gmond_service'] = 'ganglia-monitor'
   default['cfncluster']['ganglia']['httpd_service'] = 'apache2'
   default['cfncluster']['torque']['trqauthd_source'] = 'file:///opt/torque/contrib/init.d/debian.trqauthd'

--- a/files/amazon/ganglia.conf
+++ b/files/amazon/ganglia.conf
@@ -1,0 +1,8 @@
+Alias /ganglia /usr/share/ganglia
+
+<Directory "/usr/share/ganglia">
+	AllowOverride All
+	Order allow,deny
+	Allow from all
+	Deny from none
+</Directory>

--- a/files/amazon/ganglia.conf
+++ b/files/amazon/ganglia.conf
@@ -1,8 +1,0 @@
-Alias /ganglia /usr/share/ganglia
-
-<Directory "/usr/share/ganglia">
-	AllowOverride All
-	Order allow,deny
-	Allow from all
-	Deny from none
-</Directory>

--- a/files/centos-7/ganglia-webfrontend.conf
+++ b/files/centos-7/ganglia-webfrontend.conf
@@ -1,6 +1,6 @@
-Alias /ganglia /usr/share/ganglia-webfrontend
+Alias /ganglia /usr/share/ganglia
 
-<Directory "/usr/share/ganglia-webfrontend">
+<Directory "/usr/share/ganglia">
 	AllowOverride All
         Require all granted
 </Directory>

--- a/files/default/AWS-ParallelCluster-License-README.txt
+++ b/files/default/AWS-ParallelCluster-License-README.txt
@@ -3,7 +3,6 @@ AWS ParallelCluster is licensed under the Apache License 2.0 (http://aws.amazon.
 AWS ParallelCluster AMIs ship with the following independent packages, which are offered
 under separate terms.
 
-ganglia
 sge
 slurm
 torque

--- a/files/default/ganglia-webfrontend.conf
+++ b/files/default/ganglia-webfrontend.conf
@@ -1,6 +1,6 @@
-Alias /ganglia /usr/share/ganglia-webfrontend
+Alias /ganglia /usr/share/ganglia
 
-<Directory "/usr/share/ganglia-webfrontend">
+<Directory "/usr/share/ganglia">
 	AllowOverride All
 	Order allow,deny
 	Allow from all

--- a/recipes/_ganglia_install.rb
+++ b/recipes/_ganglia_install.rb
@@ -17,7 +17,7 @@
 
 if node['cfncluster']['ganglia_enabled'] == 'yes'
   case node['platform']
-  when "redhat", "centos", "amazon", "scientific" # ~FC024
+  when "redhat", "centos", "scientific" # ~FC024
 
     package %w[httpd apr-devel libconfuse-devel expat-devel rrdtool-devel pcre-devel php php-gd] do
       retries 3
@@ -138,6 +138,26 @@ if node['cfncluster']['ganglia_enabled'] == 'yes'
       creates "#{node['cfncluster']['license_dir']}/ganglia/COPYING"
     end
 
+  when  "amazon"
+    package %w[ganglia ganglia-gmond ganglia-gmetad ganglia-web php php-gd rrdtool] do
+      retries 3
+      retry_delay 5
+    end
+
+    cookbook_file 'ganglia.conf' do
+      path '/etc/httpd/conf.d/ganglia.conf'
+      user 'root'
+      group 'root'
+      mode '0644'
+    end
+
+    directory '/var/lib/ganglia/rrds' do
+      owner 'nobody'
+      group 'nobody'
+      mode 0755
+      recursive true
+      action :create
+    end
   when "ubuntu"
 
     package %w[ganglia-monitor rrdtool gmetad ganglia-webfrontend] do

--- a/templates/default/gmetad.conf.erb
+++ b/templates/default/gmetad.conf.erb
@@ -4,27 +4,27 @@
 #
 #-------------------------------------------------------------------------------
 # Setting the debug_level to 1 will keep daemon in the forground and
-# show only error messages. Setting this value higher than 1 will make 
+# show only error messages. Setting this value higher than 1 will make
 # gmetad output debugging information and stay in the foreground.
 # default: 0
 # debug_level 10
 #
 #-------------------------------------------------------------------------------
-# What to monitor. The most important section of this file. 
+# What to monitor. The most important section of this file.
 #
 # The data_source tag specifies either a cluster or a grid to
 # monitor. If we detect the source is a cluster, we will maintain a complete
-# set of RRD databases for it, which can be used to create historical 
+# set of RRD databases for it, which can be used to create historical
 # graphs of the metrics. If the source is a grid (it comes from another gmetad),
 # we will only maintain summary RRDs for it.
 #
-# Format: 
+# Format:
 # data_source "my cluster" [polling interval] address1:port addreses2:port ...
-# 
+#
 # The keyword 'data_source' must immediately be followed by a unique
-# string which identifies the source, then an optional polling interval in 
-# seconds. The source will be polled at this interval on average. 
-# If the polling interval is omitted, 15sec is asssumed. 
+# string which identifies the source, then an optional polling interval in
+# seconds. The source will be polled at this interval on average.
+# If the polling interval is omitted, 15sec is asssumed.
 #
 # If you choose to set the polling interval to something other than the default,
 # note that the web frontend determines a host as down if its TN value is less
@@ -32,7 +32,7 @@
 # to something around or greater than 80sec, this will cause the frontend to
 # incorrectly display hosts as down even though they are not.
 #
-# A list of machines which service the data source follows, in the 
+# A list of machines which service the data source follows, in the
 # format ip:port, or name:port. If a port is not specified then 8649
 # (the default gmond port) is assumed.
 # default: There is no default value
@@ -69,7 +69,7 @@ data_source "<%= node['cfncluster']['stack_name'] %>" localhost
 # The name of this Grid. All the data sources above will be wrapped in a GRID
 # tag with this name.
 # default: unspecified
-#gridname ""
+# gridname "MyGrid"
 #
 #-------------------------------------------------------------------------------
 # The authority URL for this grid. Used by other gmetads to locate graphs
@@ -81,7 +81,7 @@ data_source "<%= node['cfncluster']['stack_name'] %>" localhost
 #
 #-------------------------------------------------------------------------------
 # List of machines this gmetad will share XML with. Localhost
-# is always trusted. 
+# is always trusted.
 # default: There is no default value
 # trusted_hosts 127.0.0.1 169.229.50.165 my.gmetad.org
 #
@@ -99,7 +99,7 @@ data_source "<%= node['cfncluster']['stack_name'] %>" localhost
 #-------------------------------------------------------------------------------
 # User gmetad will setuid to (defaults to "nobody")
 # default: "nobody"
-# setuid_username "nobody"
+setuid_username ganglia
 #
 #-------------------------------------------------------------------------------
 # Umask to apply to created rrd files and grid directory structure
@@ -133,6 +133,11 @@ data_source "<%= node['cfncluster']['stack_name'] %>" localhost
 # unsummarized_metrics diskstat CPU
 #
 #-------------------------------------------------------------------------------
+# Prevent gmetad from generating summaries for sFlow VM metrics
+# default: off
+# unsummarized_sflow_vm_metrics on
+#
+#-------------------------------------------------------------------------------
 # In earlier versions of gmetad, hostnames were handled in a case
 # sensitive manner
 # If your hostname directories have been renamed to lower case,
@@ -144,23 +149,91 @@ case_sensitive_hostnames 0
 
 #-------------------------------------------------------------------------------
 # It is now possible to export all the metrics collected by gmetad directly to
-# graphite by setting the following attributes. 
+# graphite by setting the following attributes.
 #
 # The hostname or IP address of the Graphite server
 # default: unspecified
 # carbon_server "my.graphite.box"
 #
-# The port on which Graphite is listening
+# The port and protocol on which Graphite is listening
 # default: 2003
 # carbon_port 2003
 #
-# A prefix to prepend to the metric names exported by gmetad. Graphite uses dot-
-# separated paths to organize and refer to metrics. 
+# default: tcp
+# carbon_protocol udp
+#
+# **Deprecated in favor of graphite_path** A prefix to prepend to the
+# metric names exported by gmetad. Graphite uses dot-
+# separated paths to organize and refer to metrics.
 # default: unspecified
 # graphite_prefix "datacenter1.gmetad"
 #
-# Number of milliseconds gmetad will wait for a response from the graphite server 
+# A user-definable graphite path. Graphite uses dot-
+# separated paths to organize and refer to metrics.
+# For reverse compatibility graphite_prefix will be prepended to this
+# path, but this behavior should be considered deprecated.
+# This path may include 3 variables that will be replaced accordingly:
+# %s -> source (cluster name)
+# %h -> host (host name)
+# %m -> metric (metric name)
+# default: graphite_prefix.%s.%h.%m
+# graphite_path "datacenter1.gmetad.%s.%h.%m
+
+# Number of milliseconds gmetad will wait for a response from the graphite server
 # default: 500
 # carbon_timeout 500
-#
 
+#-------------------------------------------------------------------------------
+# Memcached configuration (if it has been compiled in)
+# Format documentation at http://docs.libmemcached.org/libmemcached_configuration.html
+# default: ""
+# memcached_parameters "--SERVER=127.0.0.1 --POOL-MIN=10 --POOL-MAX=32"
+#
+# Metrics will be stored in memcached as follows HOST/METRIC_NAME. If you
+# want to include cluster name e.g. CLUSTER/HOST/METRIC_NAME set below value
+# to 1
+# default: 0
+# memcached_include_cluster_in_key 0
+
+#-------------------------------------------------------------------------------
+# Riemann configuration (if enabled during build)
+# Metrics can be forwarded to a Riemann event stream processor for real-time
+# thresholding and alerting. See http://riemann.io/
+#
+# +-------------------+----------------+
+# |  Ganglia          |  Riemann       |
+# |-------------------|----------------|
+# |  grid             |  grid          |
+# |  cluster          |  cluster       |
+# |  host             |  host*         |
+# |  ip               |  ip            |
+# |  metric           |  service*      |
+# |  value(int,float) |  metric*       |
+# |  type             |  (internal)    |
+# |  units            |  description*  |
+# |  value(string)    |  state*        |
+# |  reported         |  time*         |
+# |  tags(comma-sep)  |  tags*         |
+# |  location         |  location      |
+# |  tmax             |  ttl*          |
+# +-------------------+----------------+
+#
+# Note: attributes with a star (*) are standard Riemann fields
+#
+# The hostname or IP address of the Riemann server
+# default: unspecified
+# riemann_server "my.riemann.box"
+#
+# The port and protocol on which Riemann is listening
+# default: 5555
+# riemann_port 5555
+#
+# default: udp
+# riemann_protocol tcp
+#
+# List of arbitrary key-value pairs to be used as event attributes in
+# addition to those listed above.
+#
+# default: undefined
+# riemann_attributes "key=val[,...]"
+# riemann_attributes "customer=Acme Corp,environment=PROD"

--- a/templates/default/gmond.conf.erb
+++ b/templates/default/gmond.conf.erb
@@ -3,7 +3,7 @@
 globals {
   daemonize = yes
   setuid = yes
-  user = nobody
+  user = ganglia
   debug_level = 0
   max_udp_msg_len = 1472
   mute = no
@@ -13,7 +13,13 @@ globals {
   host_tmax = 20 /*secs */
   cleanup_threshold = 300 /*secs */
   gexec = no
+  # By default gmond will use reverse DNS resolution when displaying your hostname
+  # Uncommeting following value will override that value.
+  # override_hostname = "mywebserver.domain.com"
+  # If you are not using multicast this value should be set to something other than 0.
+  # Otherwise if you restart aggregator gmond you will get empty graphs. 60 seconds is reasonable
   send_metadata_interval = 0 /*secs */
+
 }
 
 /*
@@ -33,11 +39,11 @@ host {
    used to only support having a single channel */
 udp_send_channel {
   bind_hostname = yes # Highly recommended, soon to be default.
-                       # This option tells gmond to use a source address
-                       # that resolves to the machine's hostname.  Without
-                       # this, the metrics may appear to come from any
-                       # interface and the DNS names associated with
-                       # those IPs will be used to create the RRDs.
+                      # This option tells gmond to use a source address
+                      # that resolves to the machine's hostname.  Without
+                      # this, the metrics may appear to come from any
+                      # interface and the DNS names associated with
+                      # those IPs will be used to create the RRDs.
 <% if node['cfncluster']['cfn_node_type'] == 'MasterServer' -%>
   host = <%= node['hostname'] %>
 <% end -%>
@@ -50,13 +56,21 @@ udp_send_channel {
 
 /* You can specify as many udp_recv_channels as you like as well. */
 udp_recv_channel {
+  # mcast_join = 239.2.11.71
   port = 8649
+  # bind = 239.2.11.71
+  # retry_bind = true
+  # Size of the UDP buffer. If you are handling lots of metrics you really
+  # should bump it up to e.g. 10MB or even higher.
+  # buffer = 10485760
 }
 
 /* You can specify as many tcp_accept_channels as you like to share
    an xml description of the state of the cluster */
 tcp_accept_channel {
   port = 8649
+  # If you want to gzip XML output
+  gzip_output = no
 }
 
 /* Channel to receive sFlow datagrams */
@@ -149,7 +163,6 @@ collection_group {
     name = "mem_total"
     title = "Memory Total"
   }
-  /* Should this be here? Swap can be added/removed between reboots. */
   metric {
     name = "swap_total"
     title = "Swap Space Total"
@@ -225,6 +238,11 @@ collection_group {
     name = "cpu_wio"
     value_threshold = "1.0"
     title = "CPU wio"
+  }
+  metric {
+    name = "cpu_steal"
+    value_threshold = "1.0"
+    title = "CPU steal"
   }
   /* The next two metrics are optional if you want more detail...
      ... since they are accounted for in cpu_system.


### PR DESCRIPTION
For ALinux, CentOS6 and CentOS7 install Ganglia from package repositories instead of installing it from source.
This avoid compilation issues that could raise errors when using a custom AMI.

Tested manually creating an AMI starting from both the default AMI and a custom one like DeepLearning ALinux AMI and enabling ganglia at cluster creation time.

Ganglia version installed from repositories is 3.7.2 for ALinux, CentOS6 and CentOS7, which is the same as the one previously downloaded frm GitHub.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
