### PR TITLE
Install and setup Amazon Time Syn on all supported OSs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ X.X.X
 
 **ENHANCEMENTS**
 - Install NICE DCV on Ubuntu 18.04 (this includes ubuntu-desktop, lightdm, mesa-util packages).
+- Install and setup Amazon Time Sync on Amazon Linux, Centos 6, Centos 7, Ubuntu 16 and Ubuntu 18
 
 **Changes**
 - Upgrade EFA installer to version 1.8.2:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -194,6 +194,8 @@ when 'rhel', 'amazon'
 
   default['cfncluster']['ganglia']['gmond_service'] = 'gmond'
   default['cfncluster']['ganglia']['httpd_service'] = 'httpd'
+  default['cfncluster']['chrony']['service'] = "chronyd"
+  default['cfncluster']['chrony']['conf'] = "/etc/chrony.conf"
   default['cfncluster']['torque']['trqauthd_source'] = 'file:///opt/torque/contrib/init.d/trqauthd'
   default['cfncluster']['torque']['pbs_mom_source'] = 'file:///opt/torque/contrib/init.d/pbs_mom'
   default['cfncluster']['torque']['pbs_sched_source'] = 'file:///opt/torque/contrib/init.d/pbs_sched'
@@ -220,6 +222,8 @@ when 'debian'
   default['cfncluster']['kernel_generic_pkg'] = "linux-generic"
   default['cfncluster']['ganglia']['gmond_service'] = 'ganglia-monitor'
   default['cfncluster']['ganglia']['httpd_service'] = 'apache2'
+  default['cfncluster']['chrony']['service'] = "chrony"
+  default['cfncluster']['chrony']['conf'] = "/etc/chrony/chrony.conf"
   default['cfncluster']['torque']['trqauthd_source'] = 'file:///opt/torque/contrib/init.d/debian.trqauthd'
   default['cfncluster']['torque']['pbs_mom_source'] = 'file:///opt/torque/contrib/init.d/debian.pbs_mom'
   default['cfncluster']['torque']['pbs_sched_source'] = 'file:///opt/torque/contrib/init.d/debian.pbs_sched'

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -29,6 +29,9 @@ execute 'setup ephemeral' do
   creates '/scratch'
 end
 
+# Amazon Time Sync
+include_recipe 'aws-parallelcluster::chrony_config'
+
 # Write cloudwatch log config and start it.
 include_recipe "aws-parallelcluster::cloudwatch_agent_config"
 

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -212,3 +212,6 @@ end
 
 # Install the AWS cloudwatch agent
 include_recipe "aws-parallelcluster::cloudwatch_agent_install"
+
+# Install Amazon Time Sync
+include_recipe "aws-parallelcluster::chrony_install"

--- a/recipes/chrony_config.rb
+++ b/recipes/chrony_config.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: chrony_config
+#
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+service node['cfncluster']['chrony']['service'] do
+  supports restart: true
+  action %i[enable restart]
+end

--- a/recipes/chrony_install.rb
+++ b/recipes/chrony_install.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: chrony_install
+#
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install Amazon Time Sync
+package %w[ntp ntpdate ntp*] do
+  action :remove
+end
+
+package %w[chrony] do
+  retries 3
+  retry_delay 5
+end
+
+append_if_no_line "add configuration to chrony.conf" do
+  path node['cfncluster']['chrony']['conf']
+  line "server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4"
+end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -174,6 +174,14 @@ when 'ComputeFleet'
 end
 
 ###################
+# Amazon Time Sync
+###################
+execute 'check chrony' do
+  command "chronyc tracking | grep -i reference | grep 169.254.169.123"
+  user node['cfncluster']['cfn_cluster_user']
+end
+
+###################
 # DCV
 ###################
 if node['cfncluster']['cfn_node_type'] == "MasterServer" &&


### PR DESCRIPTION
Setup chrony package following the guide https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html

Kitchen Test added

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
