### PR TITLE
Move installation of AWS Linux Kernel

### DIFF
--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -26,11 +26,12 @@ unless node['platform'] == 'centos' && node['platform_version'].to_i < 7
     execute 'apt-update' do
       command "apt-get update"
     end
-    execute 'linux-aws' do
-      command "apt install -y linux-aws"
-    end
     execute 'apt-upgrade' do
       command "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" --with-new-pkgs upgrade && apt-get autoremove -y"
+    end
+    package 'linux-aws' do
+      retries 3
+      retry_delay 5
     end
   end
 end


### PR DESCRIPTION
Move the installation of the AWS Linux Kernel after the upgrade.
The upgrade must me done before, and it is already configured to avoid APT to present an interactive ncurses-style menu with options, required by some other packages that could have been triggered if the installation of the AWS Linux kernel was done before the upgrade.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
