### PR TITLE
Add support for Amazon Linux 2

### DIFF
--- a/amis/build_ami.sh
+++ b/amis/build_ami.sh
@@ -101,7 +101,7 @@ parse_options() {
 check_options() {
     set -e
 
-    available_os="centos6 centos7 alinux ubuntu1604 ubuntu1804"
+    available_os="centos6 centos7 alinux ubuntu1604 ubuntu1804 alinux2"
     cwd="$(dirname $0)"
     tmp_dir=$(mktemp -d)
     export VENDOR_PATH="${tmp_dir}/vendor/cookbooks"
@@ -171,7 +171,7 @@ do_command() {
           RC=$?
         done
         ;;
-      centos6|centos7|alinux|ubuntu1604|ubuntu1804)
+      centos6|centos7|alinux|ubuntu1604|ubuntu1804|alinux2)
         packer build -color=false -var-file="${cwd}/packer_variables.json" -only=${only} "${cwd}/packer_${_os}.json"
         RC=$?
         ;;

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -1,0 +1,258 @@
+{
+  "variables" : {
+    "parallelcluster_version" : "",
+    "parallelcluster_cookbook_version" : "",
+    "chef_version" : "",
+    "ridley_version" : "",
+    "berkshelf_version" : "",
+    "build_for" : "{{env `BUILD_FOR`}}",
+    "ami_perms" : "{{env `AMI_PERMS`}}",
+    "build_date" : "{{env `BUILD_DATE`}}",
+    "vendor_path" : "{{env `VENDOR_PATH`}}",
+    "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
+    "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
+    "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
+    "security_group_id" : "{{env `AWS_SECURITY_GROUP_ID`}}",
+    "vpc_id" : "{{env `AWS_VPC_ID`}}",
+    "associate_public_ip" : "{{env `ASSOCIATE_PUBLIC_IP`}}",
+    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}",
+    "region" : "{{env `AWS_REGION`}}",
+    "custom_ami_id" : "{{env `CUSTOM_AMI_ID`}}",
+    "custom_node_package" : "{{env `PARALLELCLUSTER_NODE_URL`}}",
+    "parallelcluster_ref" : "{{env `PARALLELCLUSTER_REF`}}",
+    "parallelcluster_cookbook_ref" : "{{env `PARALLELCLUSTER_COOKBOOK_REF`}}",
+    "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}"
+  },
+  "builders" : [
+    {
+      "name" : "alinux2",
+      "type" : "amazon-ebs",
+      "region" : "{{user `region`}}",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name": "amzn2-ami-hvm-*.*.*.*-x86_64-gp2",
+          "root-device-type": "ebs"
+        },
+        "owners": ["amazon"],
+        "most_recent": true
+      },
+      "ami_regions" : "{{user `build_for`}}",
+      "ami_groups" : "{{user `ami_perms`}}",
+      "instance_type" : "{{user `instance_type`}}",
+      "ssh_username" : "ec2-user",
+      "ssh_pty" : true,
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-amzn2-hvm-{{user `build_date`}}",
+      "subnet_id" : "{{user `subnet_id`}}",
+      "vpc_id" : "{{user `vpc_id`}}",
+      "security_group_id" : "{{user `security_group_id`}}",
+      "skip_region_validation" : true,
+      "associate_public_ip_address" : "{{user `associate_public_ip`}}",
+      "sriov_support" : true,
+      "ena_support" : true,
+      "shutdown_behavior" : "terminate",
+      "tags" : {
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
+        "build_date" : "{{user `build_date`}}",
+        "parallelcluster_ref" : "{{user `parallelcluster_ref`}}",
+        "parallelcluster_cookbook_ref" : "{{user `parallelcluster_cookbook_ref`}}",
+        "parallelcluster_node_ref" : "{{user `parallelcluster_node_ref`}}"
+      },
+      "run_tags" : {
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
+        "build_date" : "{{user `build_date`}}",
+        "parallelcluster_ref" : "{{user `parallelcluster_ref`}}",
+        "parallelcluster_cookbook_ref" : "{{user `parallelcluster_cookbook_ref`}}",
+        "parallelcluster_node_ref" : "{{user `parallelcluster_node_ref`}}"
+      },
+      "launch_block_device_mappings" : [
+        {
+          "device_name" : "/dev/xvda",
+          "volume_size" : "25",
+          "volume_type" : "gp2",
+          "delete_on_termination" : true
+        },
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ],
+      "ami_block_device_mappings" : [
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ]
+    },
+    {
+      "name" : "custom-alinux2",
+      "type" : "amazon-ebs",
+      "region" : "{{user `region`}}",
+      "source_ami": "{{user `custom_ami_id`}}",
+      "ami_regions" : "{{user `build_for`}}",
+      "ami_groups" : "{{user `ami_perms`}}",
+      "instance_type" : "{{user `instance_type`}}",
+      "ssh_username" : "ec2-user",
+      "ssh_pty" : true,
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}aws-parallelcluster-{{user `parallelcluster_version`}}-amzn2-hvm-{{user `build_date`}}",
+      "subnet_id" : "{{user `subnet_id`}}",
+      "vpc_id" : "{{user `vpc_id`}}",
+      "skip_region_validation" : true,
+      "associate_public_ip_address" : "{{user `associate_public_ip`}}",
+      "sriov_support" : true,
+      "ena_support" : true,
+      "shutdown_behavior" : "terminate",
+      "tags" : {
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "run_tags" : {
+        "Name": "Packer Builder {{user `custom_ami_id`}}",
+        "parallelcluster_version" : "aws-parallelcluster-{{user `parallelcluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "launch_block_device_mappings" : [
+        {
+          "device_name" : "/dev/xvda",
+          "volume_type" : "gp2",
+          "delete_on_termination" : true
+        },
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ],
+      "ami_block_device_mappings" : [
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ]
+    }
+  ],
+  "provisioners" : [
+    {
+      "type" : "shell",
+      "inline" : [
+        "sudo yum -y groupinstall development && sudo yum -y install curl wget jq"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "sudo mkdir -p /etc/chef && sudo chown -R root:root /etc/chef"
+      ]
+    },
+    {
+      "type" : "file",
+      "source" : "{{user `vendor_path`}}",
+      "destination" : "/tmp/cookbooks"
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "sudo cp -pr /tmp/cookbooks /etc/chef && sudo chown -R root:root /etc/chef"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "curl --retry 3 -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v {{user `chef_version`}}"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "sudo /opt/chef/embedded/bin/gem install --no-rdoc --no-ri ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "only": ["alinux2"],
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "json" : {
+        "cfncluster" : {
+          "default_pre_reboot" : "false"
+        }
+      },
+      "run_list" : [
+        "aws-parallelcluster::_default_pre"
+      ]
+    },
+    {
+      "type" : "shell",
+      "only": ["alinux2"],
+      "expect_disconnect" : "true",
+      "inline" : [
+        "sudo reboot"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "only": ["alinux2"],
+      "pause_before": "2m",
+      "json" : {
+        "cfncluster" : {
+          "cfn_region": "{{user `region`}}",
+          "nvidia" : {
+            "enabled" : "{{user `nvidia_enabled`}}"
+          },
+          "custom_node_package" : "{{user `custom_node_package`}}"
+        }
+      },
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "aws-parallelcluster::default"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "only": ["custom-alinux2"],
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "aws-parallelcluster::default"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
+        "echo aws-parallelcluster-{{user `parallelcluster_version`}} | sudo tee /opt/parallelcluster/.bootstrapped"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "sudo /usr/local/sbin/ami_cleanup.sh"
+      ]
+    }
+  ]
+}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -78,24 +78,20 @@ default['cfncluster']['env2']['url'] = 'https://sourceforge.net/projects/env2/fi
 # NICE DCV
 default['cfncluster']['dcv']['installed'] = 'yes'
 default['cfncluster']['dcv']['version'] = '2019.1-7644'
-default['cfncluster']['dcv']['supported_os'] = %w[centos7 ubuntu18]
-case node['platform']
-when 'centos'
-  if node['platform_version'].to_i == 7
-    default['cfncluster']['dcv']['package'] = "nice-dcv-#{node['cfncluster']['dcv']['version']}-el7"
-    default['cfncluster']['dcv']['server'] = "nice-dcv-server-2019.1.7644-1.el7.x86_64.rpm" # NICE DCV server package
-    default['cfncluster']['dcv']['xdcv'] = "nice-xdcv-2019.1.226-1.el7.x86_64.rpm" # required to create virtual sessions
-    default['cfncluster']['dcv']['gl'] = "nice-dcv-gl-2019.1.544-1.el7.x86_64.rpm" # required to enable GPU sharing
-    default['cfncluster']['dcv']['sha256sum'] = "ab50323c92b3584ac88f697fd45e68b98da0b1b334a3e1f7eef6343df3aa4d91"
-  end
-when 'ubuntu'
-  if node['platform_version'] == '18.04'
-    default['cfncluster']['dcv']['package'] = "nice-dcv-#{node['cfncluster']['dcv']['version']}-ubuntu1804"
-    default['cfncluster']['dcv']['server'] = "nice-dcv-server_2019.1.7644-1_amd64.ubuntu1804.deb" # NICE DCV server package
-    default['cfncluster']['dcv']['xdcv'] = "nice-xdcv_2019.1.226-1_amd64.ubuntu1804.deb"  # required to create virtual sessions
-    default['cfncluster']['dcv']['gl'] = "nice-dcv-gl_2019.1.544-1_amd64.ubuntu1804.deb"  # required to enable GPU sharing
-    default['cfncluster']['dcv']['sha256sum'] = "41a0b4112c435b3a57de3ae46cfe8cdf90c33a216f488e3bfab944f034f6067f"
-  end
+default['cfncluster']['dcv']['supported_os'] = %w[centos7 ubuntu18 amazon2]
+case "#{node['platform']}#{node['platform_version'].to_i}"
+when 'centos7', 'amazon2'
+  default['cfncluster']['dcv']['package'] = "nice-dcv-#{node['cfncluster']['dcv']['version']}-el7"
+  default['cfncluster']['dcv']['server'] = "nice-dcv-server-2019.1.7644-1.el7.x86_64.rpm" # NICE DCV server package
+  default['cfncluster']['dcv']['xdcv'] = "nice-xdcv-2019.1.226-1.el7.x86_64.rpm" # required to create virtual sessions
+  default['cfncluster']['dcv']['gl'] = "nice-dcv-gl-2019.1.544-1.el7.x86_64.rpm" # required to enable GPU sharing
+  default['cfncluster']['dcv']['sha256sum'] = "ab50323c92b3584ac88f697fd45e68b98da0b1b334a3e1f7eef6343df3aa4d91"
+when 'ubuntu18'
+  default['cfncluster']['dcv']['package'] = "nice-dcv-#{node['cfncluster']['dcv']['version']}-ubuntu1804"
+  default['cfncluster']['dcv']['server'] = "nice-dcv-server_2019.1.7644-1_amd64.ubuntu1804.deb" # NICE DCV server package
+  default['cfncluster']['dcv']['xdcv'] = "nice-xdcv_2019.1.226-1_amd64.ubuntu1804.deb"  # required to create virtual sessions
+  default['cfncluster']['dcv']['gl'] = "nice-dcv-gl_2019.1.544-1_amd64.ubuntu1804.deb"  # required to enable GPU sharing
+  default['cfncluster']['dcv']['sha256sum'] = "41a0b4112c435b3a57de3ae46cfe8cdf90c33a216f488e3bfab944f034f6067f"
 end
 default['cfncluster']['dcv']['url'] = "https://d1uj6qtbmh3dt5.cloudfront.net/2019.1/Servers/#{node['cfncluster']['dcv']['package']}.tgz"
 # DCV external authenticator configuration
@@ -190,6 +186,24 @@ when 'rhel', 'amazon'
                                                 httpd boost-devel redhat-lsb mlocate mpich-devel R atlas-devel fftw-devel
                                                 libffi-devel dkms mysql-devel libedit-devel postgresql-devel postgresql-server
                                                 sendmail cmake byacc libglvnd-devel mdadm libgcrypt-devel]
+    if node['platform_version'].to_i == 2
+      # mpich-devel not available on alinux
+      default['cfncluster']['base_packages'].delete('mpich-devel')
+      # Swap out some packages for their alinux2 equivalents
+      [%w[db4-devel libdb-devel], %w[redhat-lsb system-lsb]].each do |al1, al2equiv|
+        default['cfncluster']['base_packages'].delete(al1)
+        default['cfncluster']['base_packages'].push(al2equiv)
+      end
+      # Add additional base packages, most of which would be installed as part of `yum groupinstall development`
+      default['cfncluster']['base_packages'].concat(%w[libxml2-devel perl-devel dpkg-dev tar gzip bison flex gcc gcc-c++ patch
+                                                       rpm-build rpm-sign system-rpm-config cscope ctags diffstat doxygen elfutils
+                                                       gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl
+                                                       jq wget python-pip])
+      # Download from debian repo (https://packages.debian.org/source/buster/gridengine)
+      # because it contains fixes for known build issues
+      default['cfncluster']['sge']['url'] = 'http://deb.debian.org/debian/pool/main/g/gridengine/gridengine_8.1.9+dfsg.orig.tar.gz'
+      default['cfncluster']['sge']['version'] = '8.1.9+dfsg-9'
+    end
   end
 
   default['cfncluster']['ganglia']['gmond_service'] = 'gmond'

--- a/files/amazon-2/sge_preinstall.sh
+++ b/files/amazon-2/sge_preinstall.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+url_base_file() {
+  local url=$1
+  if [ -z "$url" ]; then
+    echo Must pass URL
+    exit 1
+  fi
+  echo "${url##*/}"
+}
+
+# Following is the URL under which are stored the sources and binaries
+DEB_SGE_URL_BASE=http://deb.debian.org/debian/pool/main/g/gridengine
+
+# Download source archive
+SRC_ARCHIVE_OUTFILE=`url_base_file $TARBALL_URL`
+curl -o $SRC_ARCHIVE_OUTFILE $TARBALL_URL
+
+# Download file containing changes to make to the original source
+MODS_OUTFILE=gridengine_${VERSION}.debian.tar.xz
+curl -o $MODS_OUTFILE $DEB_SGE_URL_BASE/$MODS_OUTFILE
+
+# Download Debian source control file used to apply the required changes to the original source
+DSC_OUTFILE=gridengine_${VERSION}.dsc
+curl -o $DSC_OUTFILE $DEB_SGE_URL_BASE/$DSC_OUTFILE
+
+# Use dpkg-source to extract the source and apply the changes to original source
+# Import key used to sign the package for purposes of verification.
+# Import to the keyring that debian packages examine by default
+gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyring.debian.org --recv-keys 3AF9DDC1
+SRC_DIR=`pwd`/$TARBALL_ROOT_DIR
+dpkg-source -x --require-valid-signature --require-strong-checksums $DSC_OUTFILE $SRC_DIR
+
+
+tar cvzf $TARBALL_PATH $TARBALL_ROOT_DIR

--- a/files/default/cloudwatch_logs/cloudwatch_log_configs_util.py
+++ b/files/default/cloudwatch_logs/cloudwatch_log_configs_util.py
@@ -22,7 +22,7 @@ import jsonschema
 
 
 DEFAULT_SCHEMA_PATH = os.path.realpath(os.path.join(os.path.curdir, "cloudwatch_log_files_schema.json"))
-SCHEMA_PATH = os.environ.get("CW_LOGS_CONFIGS_PATH", DEFAULT_SCHEMA_PATH)
+SCHEMA_PATH = os.environ.get("CW_LOGS_CONFIGS_SCHEMA_PATH", DEFAULT_SCHEMA_PATH)
 DEFAULT_LOG_CONFIGS_PATH = os.path.realpath(os.path.join(os.path.curdir, "cloudwatch_log_files.json"))
 LOG_CONFIGS_PATH = os.environ.get("CW_LOGS_CONFIGS_PATH", DEFAULT_LOG_CONFIGS_PATH)
 LOG_CONFIGS_BAK_PATH = "{}.bak".format(LOG_CONFIGS_PATH)

--- a/files/default/cloudwatch_logs/cloudwatch_log_files.json
+++ b/files/default/cloudwatch_logs/cloudwatch_log_files.json
@@ -324,7 +324,8 @@
       ],
       "platforms": [
         "centos",
-        "ubuntu"
+        "ubuntu",
+        "amazon"
       ],
       "node_roles": [
         "MasterServer"
@@ -348,7 +349,8 @@
       ],
       "platforms": [
         "centos",
-        "ubuntu"
+        "ubuntu",
+        "amazon"
       ],
       "node_roles": [
         "MasterServer"
@@ -372,7 +374,8 @@
       ],
       "platforms": [
         "centos",
-        "ubuntu"
+        "ubuntu",
+        "amazon"
       ],
       "node_roles": [
         "MasterServer"
@@ -396,7 +399,8 @@
       ],
       "platforms": [
         "centos",
-        "ubuntu"
+        "ubuntu",
+        "amazon"
       ],
       "node_roles": [
         "MasterServer"
@@ -420,7 +424,8 @@
       ],
       "platforms": [
         "centos",
-        "ubuntu"
+        "ubuntu",
+        "amazon"
       ],
       "node_roles": [
         "MasterServer"
@@ -444,7 +449,8 @@
       ],
       "platforms": [
         "centos",
-        "ubuntu"
+        "ubuntu",
+        "amazon"
       ],
       "node_roles": [
         "MasterServer"
@@ -468,7 +474,8 @@
       ],
       "platforms": [
         "centos",
-        "ubuntu"
+        "ubuntu",
+        "amazon"
       ],
       "node_roles": [
         "MasterServer"

--- a/files/default/dcv/pcluster_dcv_connect.sh
+++ b/files/default/dcv/pcluster_dcv_connect.sh
@@ -112,7 +112,7 @@ main() {
     os=$(< /etc/chef/dna.json jq -r .cfncluster.cfn_base_os)
     _log "Input parameters: user: ${user}, OS: ${os}, shared_folder_path: ${shared_folder_path}."
 
-    if [[ ${os} != "centos7" ]] && [[ ${os} != "ubuntu1804" ]]; then
+    if [[ ${os} != "centos7" ]] && [[ ${os} != "ubuntu1804" ]] && [[ ${os} != "alinux2" ]]; then
         _fail "OS not supported."
     fi
 

--- a/files/default/setup-ephemeral-drives.sh
+++ b/files/default/setup-ephemeral-drives.sh
@@ -36,7 +36,7 @@ function setup_ephemeral_drives () {
   chmod 1777 ${cfn_ephemeral_dir} || RC=1
   if ls /dev/nvme* >& /dev/null; then
     IS_NVME=1
-    MAPPING=$(realpath --relative-to=/dev/ -P  /dev/disk/by-id/nvme*Instance_Storage*)
+    MAPPING=$(realpath --relative-to=/dev/ -P  /dev/disk/by-id/nvme*Instance_Storage* | uniq)
   else
     IS_NVME=0
     MAPPING=$(/usr/bin/ec2-metadata -b | grep ephemeral | awk '{print $2}' | sed 's/sd/xvd/')

--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -87,7 +87,9 @@ elsif node['platform'] == 'ubuntu'
   end
 
   kernel_module 'lnet'
-elsif node['platform'] == 'amazon'
+elsif node['platform'] == 'amazon' && node['platform_version'].to_i == 2
+  alinux_extras_topic 'lustre2.10'
+elsif node['platform'] == 'amazon' # Amazon Linux 1
 
   # Install lustre client module
   package 'lustre-client' do

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -17,11 +17,17 @@
 
 include_recipe 'aws-parallelcluster::base_install'
 
-# Setup hostnames to be short
-node.default['set_fqdn'] = node['ec2']['local_hostname']
-node.default['hostname_cookbook']['hostsfile_ip'] = node['ec2']['local_ipv4']
-include_recipe 'hostname::default'
-ignore_failure 'service[network]' if node['platform_family'] == 'rhel'
+if node['platform_family'] == 'amazon' and node['platform_version'] == '2'
+  # NOTE: temporary workaround for amazon linux 2 while alternative solutions are evaluated
+  execute "hostnamectl set-hostname #{node['ec2']['local_hostname']}"
+  short_hostname = node['ec2']['local_hostname'].split('.')[0]
+  execute "hostname #{short_hostname}"
+else
+  node.default['set_fqdn'] = node['ec2']['local_hostname']
+  node.default['hostname_cookbook']['hostsfile_ip'] = node['ec2']['local_ipv4']
+  include_recipe 'hostname::default'
+  ignore_failure 'service[network]' if node['platform_family'] == 'rhel'
+end
 
 # Setup ephemeral drives
 execute 'setup ephemeral' do

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -18,7 +18,12 @@
 case node['platform_family']
 when 'rhel', 'amazon'
   include_recipe 'yum'
-  include_recipe "yum-epel" if node['platform_version'].to_i < 7
+  if node['platform_family'] == 'amazon' and node['platform_version'].to_i == 2
+    alinux_extras_topic 'epel'
+  else
+    include_recipe "yum-epel" if node['platform_version'].to_i < 7
+  end
+
 
   unless node['platform_version'].to_i < 7
     execute 'yum-config-manager_skip_if_unavail' do

--- a/recipes/cloudwatch_agent_config.rb
+++ b/recipes/cloudwatch_agent_config.rb
@@ -57,7 +57,7 @@ end
 execute "cloudwatch-config-validation" do
   user 'root'
   environment(
-    'CW_LOGS_SCHEMA_PATH' => config_schema_path,
+    'CW_LOGS_CONFIGS_SCHEMA_PATH' => config_schema_path,
     'CW_LOGS_CONFIGS_PATH' => config_data_path
   )
   command "#{node.default['cfncluster']['cookbook_virtualenv_path']}/bin/python #{validator_script_path}"

--- a/recipes/cloudwatch_agent_config.rb
+++ b/recipes/cloudwatch_agent_config.rb
@@ -81,7 +81,7 @@ execute "cloudwatch-agent-start" do
   user 'root'
   command "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
   not_if do
-    system("[[ $(/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | jq --raw-output .status) = running ]]") ||
+    system("[ $(/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | jq --raw-output .status) = running ]") ||
       node['cfncluster']['cfn_cluster_cw_logging_enabled'] != 'true'
   end
 end

--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -36,7 +36,7 @@ def allow_gpu_acceleration
   # DO NOT install dcv-gl on non-GPU instances, or will run into a black screen issue
   dcv_gl = "#{node['cfncluster']['sources_dir']}/#{node['cfncluster']['dcv']['package']}/#{node['cfncluster']['dcv']['gl']}"
   case node['platform']
-  when 'centos'
+  when 'centos', 'amazon'
     package dcv_gl do
       action :install
       source dcv_gl
@@ -95,6 +95,12 @@ if node['cfncluster']['dcv']['supported_os'].include?("#{node['platform']}#{node
     mode '0700'
   end
   execute "certificate generation" do
+    # args to the script represent:
+    # * path to certificate
+    # * path to private key
+    # * user to make owner of the two files
+    # * group to make owner of the two files
+    # NOTE: the last arg is hardcoded to be 'dcv' so that the dcvserver can read the files when authenticating
     command "/etc/parallelcluster/generate_certificate.sh \"#{node['cfncluster']['dcv']['authenticator']['certificate']}\" \"#{node['cfncluster']['dcv']['authenticator']['private_key']}\" #{node['cfncluster']['dcv']['authenticator']['user']} dcv"
     user 'root'
   end

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -19,7 +19,7 @@
 def install_package_list(packages)
   packages.each do |package_name|
     case node['platform']
-    when 'centos'
+    when 'centos', 'amazon'
       package package_name do
         action :install
         source package_name
@@ -101,6 +101,17 @@ if node['cfncluster']['dcv']['supported_os'].include?("#{node['platform']}#{node
           wget https://d1uj6qtbmh3dt5.cloudfront.net/NICE-GPG-KEY
           gpg --import NICE-GPG-KEY
         PREREQ
+      end
+    when 'amazon'
+      prereq_packages = %W[gdm gnome-session gnome-classic-session gnome-session-xsession
+                           xorg-x11-server-Xorg xorg-x11-fonts-Type1 xorg-x11-drivers
+                           gnome-terminal gnu-free-fonts-common gnu-free-mono-fonts
+                           gnu-free-sans-fonts gnu-free-serif-fonts glx-utils]
+      prereq_packages.each do |p|
+        package p do
+          retries 3
+          retry_delay 5
+        end
       end
     end
     disable_lock_screen

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -197,7 +197,7 @@ end
 # EFA - Intel MPI
 ###################
 case node['cfncluster']['os']
-when 'alinux', 'centos7'
+when 'alinux', 'centos7', 'alinux2'
   execute 'check efa rpm installed' do
     command "rpm -qa | grep libfabric && rpm -qa | grep efa-"
     user node['cfncluster']['cfn_cluster_user']

--- a/recipes/torque_install.rb
+++ b/recipes/torque_install.rb
@@ -52,6 +52,12 @@ if node['platform'] == 'ubuntu' && node['platform_version'] == "18.04"
   end
 end
 
+if node['platform'] == 'amazon' && node['platform_version'].to_i == 2
+  cxx_flags = "-std=c++03"
+  c_flags = "-fpermissive"
+  configure_flags = "--disable-gcc-warnings"
+end
+
 # Install Torque
 bash 'make install' do
   user 'root'

--- a/resources/alinux_extras_topic.rb
+++ b/resources/alinux_extras_topic.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+resource_name :alinux_extras_topic
+provides :alinux_extras_topic
+
+# Resource to install a package via the Amazon Linux Extras package manager,
+# available starting in Amazon Linux 2.
+
+property :topic, String, name_property: true
+
+default_action :install
+
+action :install do
+  execute "amazon-linux-extras install -y #{new_resource.topic}" do
+    user 'root'
+    retries 3
+    retry_delay 5
+    not_if "amazon-linux-extras | grep #{new_resource.topic} | grep enabled"
+  end
+end


### PR DESCRIPTION
This PR contains the changes required to support on amazon linux 2 all of the features for which we have integration tests (with the exception of the intel HPC suite which is only supported for centos 7).

Testing:
* Running all of the integration tests (except for the scaling and benchmark tests) locally

A couple of notes:
* There is a workaround for an issue in setting hostnames in the base_config recipe. The hostname cookbook we use for the other OSes doesn't work the same on alinux2. Specifically, it sets the hostname to the fqdn, which breaks some things (torque, for example).
* The changes required for the kitchen tests are (probably) not all in this PR. My plan is to make those when attempting to get the kitchen tests running.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.