### PR TITLE
Amazon linux 2 kitchen test configs

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -89,6 +89,67 @@ platforms:
     transport:
       username: ec2-user
       ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
+  - name: amazon-linux-2-latest
+    driver_plugin: ec2
+    driver_config:
+      image_id: <%= ENV['ALINUX2_IMAGE_ID'] || "ami-062f7200baf2fa504" %>
+      block_device_mappings:
+        - device_name: /dev/xvda
+          ebs:
+            volume_size: <%= ENV['VOLUME_SIZE'] || 25 %>
+            volume_type: gp2
+            delete_on_termination: true
+        - device_name: /dev/xvdba
+          virtual_name: ephemeral0
+        - device_name: /dev/xvdbb
+          virtual_name: ephemeral1
+        - device_name: /dev/xvdbc
+          virtual_name: ephemeral2
+        - device_name: /dev/xvdbd
+          virtual_name: ephemeral3
+        - device_name: /dev/xvdbe
+          virtual_name: ephemeral4
+        - device_name: /dev/xvdbf
+          virtual_name: ephemeral5
+        - device_name: /dev/xvdbg
+          virtual_name: ephemeral6
+        - device_name: /dev/xvdbh
+          virtual_name: ephemeral7
+        - device_name: /dev/xvdbi
+          virtual_name: ephemeral8
+        - device_name: /dev/xvdbj
+          virtual_name: ephemeral9
+        - device_name: /dev/xvdbk
+          virtual_name: ephemeral10
+        - device_name: /dev/xvdbl
+          virtual_name: ephemeral11
+        - device_name: /dev/xvdbm
+          virtual_name: ephemeral12
+        - device_name: /dev/xvdbn
+          virtual_name: ephemeral13
+        - device_name: /dev/xvdbo
+          virtual_name: ephemeral14
+        - device_name: /dev/xvdbp
+          virtual_name: ephemeral15
+        - device_name: /dev/xvdbq
+          virtual_name: ephemeral16
+        - device_name: /dev/xvdbr
+          virtual_name: ephemeral17
+        - device_name: /dev/xvdbs
+          virtual_name: ephemeral18
+        - device_name: /dev/xvdbt
+          virtual_name: ephemeral19
+        - device_name: /dev/xvdbu
+          virtual_name: ephemeral20
+        - device_name: /dev/xvdbv
+          virtual_name: ephemeral21
+        - device_name: /dev/xvdbw
+          virtual_name: ephemeral22
+        - device_name: /dev/xvdbx
+          virtual_name: ephemeral23
+    transport:
+      username: ec2-user
+      ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
   - name: centos-6-minimal
     driver_plugin: ec2
     driver_config:


### PR DESCRIPTION
Add a kitchen test platform config for Amazon Linux 2. This has yet to be tested, but it will be soon after making this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
