### PR TITLE
Fix CloudWatch agent status check

### DIFF
--- a/recipes/cloudwatch_agent_config.rb
+++ b/recipes/cloudwatch_agent_config.rb
@@ -81,7 +81,7 @@ execute "cloudwatch-agent-start" do
   user 'root'
   command "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
   not_if do
-    system("[[ $(/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | jq --raw-output .status) = running ]]") ||
+    system("[ $(/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | jq --raw-output .status) = running ]") ||
       node['cfncluster']['cfn_cluster_cw_logging_enabled'] != 'true'
   end
 end


### PR DESCRIPTION
The call to `system` in the `not_if` guard of the resource that starts
the CloudWatch agent uses `[[` instead of `[`, which might break on
OSes where the default shell does not support it (namely ubuntu). This
fixes that.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
