### PR TITLE
Install whoopsie before ubuntu-desktop

### DIFF
--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -94,6 +94,7 @@ if node['cfncluster']['dcv']['supported_os'].include?("#{node['platform']}#{node
         cwd Chef::Config[:file_cache_path]
         code <<-PREREQ
           set -e
+          apt -y install whoopsie
           apt -y install ubuntu-desktop
           apt -y purge ifupdown
           DEBIAN_FRONTEND=noninteractive apt -y install lightdm


### PR DESCRIPTION
When `whoopsie` is installed as part of the installation of
`ubuntu-desktop` it crashes and results in a popup that says "System
program problem detected" when a user first connects to the first DCV
session. When it's already installed this does not to happen.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
