### PR TITLE
Pin Kernel Version in Ubuntu 16/18

### DIFF
--- a/files/ubuntu-16.04/linux-aws.pref
+++ b/files/ubuntu-16.04/linux-aws.pref
@@ -1,0 +1,3 @@
+Package: linux-aws
+Pin: version 4.4.0.1100.104
+Pin-Priority: 1001

--- a/files/ubuntu-18.04/linux-aws.pref
+++ b/files/ubuntu-18.04/linux-aws.pref
@@ -1,0 +1,3 @@
+Package: linux-aws
+Pin: version 4.15.0.1057
+Pin-Priority: 1001

--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -23,6 +23,10 @@ unless node['platform'] == 'centos' && node['platform_version'].to_i < 7
       command "yum -y update && package-cleanup -y --oldkernels --count=1"
     end
   when 'debian'
+    # FIXME: pin Kernel version until Lustre client package version is not aligned with latest
+    cookbook_file 'linux-aws.pref' do
+      path '/etc/apt/preferences.d/linux-aws.pref'
+    end
     execute 'apt-update' do
       command "apt-get update"
     end


### PR DESCRIPTION
Pin Kernel Version in Ubuntu 16/18 until Lustre client package is not aligned with latest version of the kernel

To verify Kernel version available
 apt-cache policy linux-aws
To verify FSx Lustre client version available
 aws s3 ls fsx-lustre-client-repo/ubuntu/pool/xenial/l/lu/ | grep client
and
 aws s3 ls fsx-lustre-client-repo/ubuntu/pool/bionic/l/lu/ | grep client

Apt documentation
 https://manpages.ubuntu.com/manpages/precise/en/man5/apt_preferences.5.html

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
