### PR TITLE
Pin AMI ID to be used as base for Ubuntu 16/18

### DIFF
--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -31,7 +31,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-2019*",
           "root-device-type": "ebs"
         },
         "owners": ["099720109477", "513442679011", "837727238323"],

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -32,7 +32,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-2019*",
           "root-device-type": "ebs"
         },
         "owners": ["099720109477", "513442679011", "837727238323"],


### PR DESCRIPTION
Pin AMI ID to be used as base for Ubuntu 16/18 until Lustre client package is not aligned with latest version of the kernel

Latest AMI contains a new kernel version that cannot be downgraded, see also
https://github.com/aws/aws-parallelcluster-cookbook/pull/511

This is a temporary commit that will be removed once new FSx Lustre client will be available.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
