### PR TITLE
Remove intel mpi installer after install

### DIFF
--- a/recipes/intel_mpi.rb
+++ b/recipes/intel_mpi.rb
@@ -36,6 +36,9 @@ bash "install intel mpi" do
     tar -xf l_mpi_#{node['cfncluster']['intelmpi']['version']}.tgz
     cd l_mpi_#{node['cfncluster']['intelmpi']['version']}/
     ./install.sh -s silent.cfg --accept_eula
+    mv rpm/EULA.txt /opt/intel/impi/#{node['cfncluster']['intelmpi']['version']}
+    cd ..
+    rm -rf l_mpi_#{node['cfncluster']['intelmpi']['version']}*
   INTELMPI
   creates "/opt/intel/impi/#{node['cfncluster']['intelmpi']['version']}"
 end


### PR DESCRIPTION
Removes the installer source but keeps `EULA.txt` in the `/opt/intel/impi` directory.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
