### PR TITLE
Blacklist new Kernel Version in Ubuntu 16/18

### DIFF
--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -31,7 +31,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-2019*",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-2020011*",
           "root-device-type": "ebs"
         },
         "owners": ["099720109477", "513442679011", "837727238323"],

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -32,7 +32,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-2019*",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-202001*",
           "root-device-type": "ebs"
         },
         "owners": ["099720109477", "513442679011", "837727238323"],

--- a/files/ubuntu-16.04/linux-aws.pref
+++ b/files/ubuntu-16.04/linux-aws.pref
@@ -1,3 +1,3 @@
 Package: linux-aws
-Pin: version 4.4.0.1100.104
-Pin-Priority: 1001
+Pin: version 4.4.0.1101.105
+Pin-Priority: -1

--- a/files/ubuntu-18.04/linux-aws.pref
+++ b/files/ubuntu-18.04/linux-aws.pref
@@ -1,3 +1,3 @@
 Package: linux-aws
-Pin: version 4.15.0.1057
-Pin-Priority: 1001
+Pin: version 4.15.0.1058.59
+Pin-Priority: -1

--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -23,7 +23,7 @@ unless node['platform'] == 'centos' && node['platform_version'].to_i < 7
       command "yum -y update && package-cleanup -y --oldkernels --count=1"
     end
   when 'debian'
-    # FIXME: pin Kernel version until Lustre client package version is not aligned with latest
+    # FIXME: blacklist new Kernel version until Lustre client package version is not aligned with latest
     cookbook_file 'linux-aws.pref' do
       path '/etc/apt/preferences.d/linux-aws.pref'
     end


### PR DESCRIPTION
Blacklist new Kernel Version in Ubuntu 16/18 until Lustre client package is not aligned with latest version of the kernel

To verify Kernel version available
 apt-cache policy linux-aws
To verify FSx Lustre client version available
 aws s3 ls fsx-lustre-client-repo/ubuntu/pool/xenial/l/lu/ | grep client
and
 aws s3 ls fsx-lustre-client-repo/ubuntu/pool/bionic/l/lu/ | grep client

Apt documentation
 https://manpages.ubuntu.com/manpages/precise/en/man5/apt_preferences.5.html

WARNING This is a temporary change that will be reverted once new FSx Lustre client will be available.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
