### PR TITLE
Update slurm daemons service definition and init.d script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
-X.X.X
+2.6.0
 -----
 
 **ENHANCEMENTS**
 - Install NICE DCV on Ubuntu 18.04 (this includes ubuntu-desktop, lightdm, mesa-util packages).
 - Install and setup Amazon Time Sync on Amazon Linux, Centos 6, Centos 7, Ubuntu 16 and Ubuntu 18
 
-**Changes**
+**CHANGES**
 - Upgrade EFA installer to version 1.8.2:
   - Kernel module: efa-1.5.0 (updated from efa-1.4.1)
   - RDMA core: rdma-core-25.0 (distributed only) (no change)
@@ -20,6 +20,9 @@ X.X.X
 - Upgrade Slurm to version 19.05.5
 - Install Python 2.7.17 on CentOS 6 and set it as default through pyenv
 - Install Ganglia from repository on Amazon Linux, Centos 6 and Centos 7
+
+**BUG FIXES**
+- Fix issue with slurmd daemon not being restarted correctly when a compute node is rebooted
 
 2.5.1
 -----

--- a/files/default/slurm-init
+++ b/files/default/slurm-init
@@ -5,10 +5,10 @@
 #              manages exclusive access to a set of compute \
 #              resources and distributes work to those resources.
 #
-# processname: @sbindir@/slurmd
+# processname: /opt/slurm/sbin/slurmd
 # pidfile: /var/run/slurmd.pid
 #
-# processname: @sbindir@/slurmctld
+# processname: /opt/slurm/sbin/slurmctld
 # pidfile: /var/run/slurmctld.pid
 #
 # config: /etc/sysconfig/slurm
@@ -29,10 +29,6 @@ BINDIR="/opt/slurm/bin"
 CONFDIR="/opt/slurm/etc"
 LIBDIR="/opt/slurm/lib"
 SBINDIR="/opt/slurm/sbin"
-
-# On a bluegene system this will be set to '#'.
-# Yes, FALSE is the correct variable to look at in the .in script.
-HAVE_BG="FALSE"
 
 # Source function library.
 if [ -f /etc/rc.status ]; then
@@ -97,14 +93,6 @@ start() {
     shift
     echo -n "starting $prog: "
     unset HOME MAIL USER USERNAME
-
-
-    if [[ $HAVE_BG == "#" ]] && [[ $prog == slurmctld ]]
-    then
-	    # On bluegene systems this need to be set of DB2 can unexpectedly
-	    # crash when the slurmctld is exiting. (Bug 1597)
-	    export DB2NOEXITLIST=ON
-    fi
 
     $STARTPROC $SBINDIR/$prog $*
     rc_status -v

--- a/files/default/slurmctld.service
+++ b/files/default/slurmctld.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Slurm controller daemon
-After=network.target
+After=network.target munge.service
 ConditionPathExists=/opt/slurm/etc/slurm.conf
 
 [Service]
@@ -9,6 +9,7 @@ EnvironmentFile=-/etc/sysconfig/slurmctld
 ExecStart=/opt/slurm/sbin/slurmctld $SLURMCTLD_OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/var/run/slurmctld.pid
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target

--- a/files/default/slurmd.service
+++ b/files/default/slurmd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Slurm node daemon
-After=network.target
+After=munge.service network.target remote-fs.target
 ConditionPathExists=/opt/slurm/etc/slurm.conf
 
 [Service]
@@ -10,9 +10,10 @@ ExecStart=/opt/slurm/sbin/slurmd $SLURMD_OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/var/run/slurmd.pid
 KillMode=process
-LimitNOFILE=51200
+LimitNOFILE=131072
 LimitMEMLOCK=infinity
 LimitSTACK=infinity
+Delegate=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Retrieved latest version of these scripts from the output of Slurm build.
They are the same as in: https://github.com/SchedMD/slurm/tree/slurm-19-05-5-1/etc

Long term we should not hardcode these settings in the cookbook but use the output produced when we build Slurm.

This fixes an issue with slurmd not being restarted after a node is rebooted.
```
root@ip-192-168-127-131:/home/ubuntu# systemctl status slurmd
   slurmd.service - Slurm node daemon
   Loaded: loaded (/etc/systemd/system/slurmd.service; enabled; vendor preset: enabled)
   Active: inactive (dead)
Condition: start condition failed at Fri 2020-01-31 12:30:35 UTC; 6min ago
           ConditionPathExists=/opt/slurm/etc/slurm.conf was not met
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
