### PR TITLE
More robust downloading of SGE archive signing key

### DIFF
--- a/files/amazon-2/sge_preinstall.sh
+++ b/files/amazon-2/sge_preinstall.sh
@@ -1,5 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [ -z ${TARBALL_URL} ]; then
+  echo "TARBALL_URL must be set"
+  exit 1
+elif [ -z ${TARBALL_ROOT_DIR} ]; then
+  echo "TARBALL_ROOT_DIR must be set"
+  exit 1
+elif [ -z ${TARBALL_PATH} ]; then
+  echo "TARBALL_PATH must be set"
+  exit 1
+elif [ -z ${VERSION} ]; then
+  echo "VERSION must be set"
+  exit 1
+fi
 
 url_base_file() {
   local url=$1
@@ -10,25 +24,28 @@ url_base_file() {
   echo "${url##*/}"
 }
 
+# Import the public key of Afif Elghraoui, the Debian developer whose public key
+# was used to sign the .dsc file that will be used.
+# Import to the keyring that debian packages examine by default
+curl --retry 3 --retry-delay 5 -o afif.key "https://db.debian.org/fetchkey.cgi?fingerprint=8EBD460CB464A67530FF39FBCEAE6AD3AFE826FB"
+gpg --no-default-keyring --keyring trustedkeys.gpg --import afif.key
+
 # Following is the URL under which are stored the sources and binaries
 DEB_SGE_URL_BASE=http://deb.debian.org/debian/pool/main/g/gridengine
 
 # Download source archive
 SRC_ARCHIVE_OUTFILE=`url_base_file $TARBALL_URL`
-curl -o $SRC_ARCHIVE_OUTFILE $TARBALL_URL
+curl --retry 3 --retry-delay 5 -o $SRC_ARCHIVE_OUTFILE $TARBALL_URL
 
 # Download file containing changes to make to the original source
 MODS_OUTFILE=gridengine_${VERSION}.debian.tar.xz
-curl -o $MODS_OUTFILE $DEB_SGE_URL_BASE/$MODS_OUTFILE
+curl --retry 3 --retry-delay 5 -o $MODS_OUTFILE $DEB_SGE_URL_BASE/$MODS_OUTFILE
 
 # Download Debian source control file used to apply the required changes to the original source
 DSC_OUTFILE=gridengine_${VERSION}.dsc
-curl -o $DSC_OUTFILE $DEB_SGE_URL_BASE/$DSC_OUTFILE
+curl --retry 3 --retry-delay 5 -o $DSC_OUTFILE $DEB_SGE_URL_BASE/$DSC_OUTFILE
 
 # Use dpkg-source to extract the source and apply the changes to original source
-# Import key used to sign the package for purposes of verification.
-# Import to the keyring that debian packages examine by default
-gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyring.debian.org --recv-keys 3AF9DDC1
 SRC_DIR=`pwd`/$TARBALL_ROOT_DIR
 dpkg-source -x --require-valid-signature --require-strong-checksums $DSC_OUTFILE $SRC_DIR
 


### PR DESCRIPTION
The builds for alinux2 AMIs in China are consistently failing while
building SGE. They are failing when trying to import the public key used
to sign the debian archive that is used. This change uses a (hopefully)
more reliable method of importing the public key.

I didn't use a remote_file resource because this only needs to be done
for alinux2. Doing this via a shell command allows me to keep it out of
the general-purpose recipe used for all of the other OSes.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
