### PR TITLE
kitchen tests: disable Lustre test on Centos6

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -341,13 +341,13 @@ end
 ###################
 # FSx Lustre
 ###################
-case node['platform']
-when 'amazon', 'centos'
+case node['cfncluster']['os']
+when 'alinux', 'centos7'
   execute 'check for lustre libraries' do
     command "rpm -qa | grep lustre-client"
     user node['cfncluster']['cfn_cluster_user']
   end
-when 'ubuntu'
+when 'ubuntu1604', 'ubuntu1804'
   execute 'check for lustre libraries' do
     command "dpkg -l | grep lustre"
     user node['cfncluster']['cfn_cluster_user']


### PR DESCRIPTION
FSx Lustre is not supported on Centos6

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
