### PR TITLE
Enable centos7 repo on alinux2 for mpich-devel

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -187,13 +187,12 @@ when 'rhel', 'amazon'
                                                 libffi-devel dkms mysql-devel libedit-devel postgresql-devel postgresql-server
                                                 sendmail cmake byacc libglvnd-devel mdadm libgcrypt-devel]
     if node['platform_version'].to_i == 2
-      # mpich-devel not available on alinux
-      default['cfncluster']['base_packages'].delete('mpich-devel')
       # Swap out some packages for their alinux2 equivalents
       [%w[db4-devel libdb-devel], %w[redhat-lsb system-lsb]].each do |al1, al2equiv|
         default['cfncluster']['base_packages'].delete(al1)
         default['cfncluster']['base_packages'].push(al2equiv)
       end
+
       # Add additional base packages, most of which would be installed as part of `yum groupinstall development`
       default['cfncluster']['base_packages'].concat(%w[libxml2-devel perl-devel dpkg-dev tar gzip bison flex gcc gcc-c++ patch
                                                        rpm-build rpm-sign system-rpm-config cscope ctags diffstat doxygen elfutils

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -20,6 +20,15 @@ when 'rhel', 'amazon'
   include_recipe 'yum'
   if node['platform_family'] == 'amazon' and node['platform_version'].to_i == 2
     alinux_extras_topic 'epel'
+    # The following is required on alinux2 because there is currently no
+    # mpich-devel package in any of the amzn2 or epel repos.
+    # TODO: remove this when mpich-devel is added to a default repo
+    yum_repository 'centos7-base' do
+      baseurl 'http://mirror.centos.org/centos/7/os/$basearch/'
+      gpgcheck true
+      gpgkey 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7'
+      mirrorlist 'http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=os&infra=$infra'
+    end
   else
     include_recipe "yum-epel" if node['platform_version'].to_i < 7
   end


### PR DESCRIPTION
None of the amzn2 or epel yum repos available on alinux2 have
mpich-devel avaiable. This is a package we make available on all of our
other OSes, so to workaround this limitation this commit configures a
yum repo that points at the base repo avaialble in centos7, which does
have a compatible version of mpich-devel.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
