### PR TITLE
Remove pyenv shims from PATH

### DIFF
--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -47,6 +47,18 @@ when 'MasterServer', nil
     cwd Chef::Config[:file_cache_path]
     code <<-SLURM
       set -e
+
+      NEW_PATH=""
+      _OLD_IFS=${IFS}
+      IFS=':'
+      for p in ${PATH}
+      do
+        [[ ! ${p} =~ \.pyenv ]] && NEW_PATH="${p}:${NEW_PATH}"
+      done
+      IFS=${_OLD_IFS}
+      export PATH=${NEW_PATH}
+
+      env
       tar xf #{slurm_tarball}
       cd slurm-#{node['cfncluster']['slurm']['version']}
       ./configure --prefix=/opt/slurm


### PR DESCRIPTION
This commit is a temporary workaround for an issue where the two pyenv
shims prepended to PATH invoke each other in an endless loop.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
