### PR TITLE
Disable SSH StrictHostKeyChecking for VPC hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Slurm to version 19.05.5
 - Install Python 2.7.17 on CentOS 6 and set it as default through pyenv
 - Install Ganglia from repository on Amazon Linux, Centos 6 and Centos 7
+- Disable StrictHostKeyChecking for SSH client when target host is inside cluster VPC 
 
 **BUG FIXES**
 - Fix issue with slurmd daemon not being restarted correctly when a compute node is rebooted

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -120,7 +120,6 @@ default['openssh']['server']['password_authentication'] = 'no'
 default['openssh']['server']['gssapi_authentication'] = 'yes'
 default['openssh']['server']['gssapi_clean_up_credentials'] = 'yes'
 default['openssh']['server']['subsystem'] = 'sftp /usr/libexec/openssh/sftp-server'
-default['openssh']['client']['gssapi_authentication'] = 'yes'
 if node['platform'] == 'centos' && node['platform_version'].to_i < 7
   default['openssh']['server']['ciphers'] = 'aes128-cbc,aes192-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr'
   default['openssh']['server']['m_a_cs'] = 'hmac-sha2-512,hmac-sha2-256'
@@ -128,6 +127,13 @@ else
   default['openssh']['server']['ciphers'] = 'aes128-cbc,aes192-cbc,aes256-cbc,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com'
   default['openssh']['server']['m_a_cs'] = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256'
 end
+default['openssh']['client']['gssapi_authentication'] = 'yes'
+default['openssh']['client']['match'] = 'exec "ssh_target_checker.sh %h"'
+# Disable StrictHostKeyChecking for target host in the cluster VPC
+default['openssh']['client']['  _strict_host_key_checking'] = 'no'
+# Do not store server key in the know hosts file to avoid scaling clashing
+# that is when an new host gets the same IP of a previously terminated host
+default['openssh']['client']['  _user_known_hosts_file'] = '/dev/null'
 
 # ulimit settings
 default['cfncluster']['filehandle_limit'] = 10_000

--- a/files/default/ssh_target_checker.sh
+++ b/files/default/ssh_target_checker.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Copyright 2013-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o pipefail
+
+log() {
+    echo "$@" | logger -t "pcluster_ssh_target_checker"
+}
+
+retrieve_vpc_cidr_list() {
+    if ! mac=$(curl --retry 3 --retry-delay 0 --silent --fail http://169.254.169.254/latest/meta-data/mac); then
+       log  "Unable to determine MAC address for network interface"
+       exit 1
+    fi
+
+    vpc_cidr_uri="http://169.254.169.254/latest/meta-data/network/interfaces/macs/${mac}/vpc-ipv4-cidr-blocks"
+    if ! mapfile -t vpc_cidr_list < <(curl --retry 3 --retry-delay 0 --silent --fail "${vpc_cidr_uri}"); then
+       log "Unable to retrieve VPC CIDR list from EC2 meta-data"
+       exit 1
+    fi
+
+    echo "${vpc_cidr_list[@]}"
+}
+
+convert_ip_to_decimal() {
+    IFS=./ read -r x y z t mask <<< "${1}"
+    echo -n "$((x<<24|y<<16|z<<8|t))"
+}
+
+convert_mask_to_decimal() {
+    IFS=/ read -r _ mask <<< "${1}"
+    echo -n "$((-1<<(32-mask)))"
+}
+
+check_ip_in_cidr() {
+        target_address=$(convert_ip_to_decimal "${1}")
+        base_address=$(convert_ip_to_decimal "${2}")
+        base_mask=$(convert_mask_to_decimal "${2}")
+
+        if (( (target_address&base_mask) == (base_address&base_mask) )); then
+            return 0
+        fi
+
+        return 1
+}
+
+target_host=$1
+if [[ -z "${target_host}" ]]; then
+   log  "No input target host"
+   exit 1
+fi
+
+if ! resolved_ip=$(getent ahosts "${target_host}" | head -1 | cut -d' ' -f1); then
+   log "Cannot resolve target Host ${target_host}"
+   exit 1
+fi
+
+if [[ "${resolved_ip}" == "127.0.0.1" ]]; then
+   # Special case for localhost
+   log "Target Host ${target_host} is in VPC CIDR"
+   exit 0
+fi
+
+IFS=" " read -r -a vpc_cidr_list <<< "$(retrieve_vpc_cidr_list)"
+
+for vpc_cidr in "${vpc_cidr_list[@]}"
+do
+  check_ip_in_cidr "${resolved_ip}" "${vpc_cidr}"
+  if check_ip_in_cidr "${resolved_ip}" "${vpc_cidr}"; then
+    log "Target Host ${target_host} is in VPC CIDR ${vpc_cidr}"
+    exit 0
+  fi
+done
+
+log  "Target Host ${target_host} is not in any VPC CIDR ${vpc_cidr_list[*]}"
+exit 1

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -81,6 +81,14 @@ end
 # Manage SSH via Chef
 include_recipe "openssh"
 
+# Install SSH target checker
+cookbook_file 'ssh_target_checker.sh' do
+  path "/usr/local/bin/ssh_target_checker.sh"
+  owner "root"
+  group "root"
+  mode "0755"
+end
+
 # Disable selinux
 selinux_state "SELinux Disabled" do
   action :disabled


### PR DESCRIPTION
`StrictHostKeyChecking` configuration will be disabled only when the target host is a host inside the VPC where the cluster is created.

The value of `UserKnownHostsFile` to `/dev/null` is needed to avoid possible clashing due to the fact that, since the cluster scales up and down based on computational needs, a new host could be instantiated with the same IP of a previously terminated host.

Tests
```
Given a VPC with multiple CIDR, 172.31.0.0/16 and 172.33.0.0/16

# /usr/local/bin/ssh_target_checker.sh locahost; echo $?
1
# /usr/local/bin/ssh_target_checker.sh localhost; echo $?
0
# /usr/local/bin/ssh_target_checker.sh 127.0.0.1; echo $?
0
# /usr/local/bin/ssh_target_checker.sh amazon.com; echo $?
1
# /usr/local/bin/ssh_target_checker.sh 172.31.1.1; echo $?
0
# /usr/local/bin/ssh_target_checker.sh 172.32.1.1; echo $?
1
# /usr/local/bin/ssh_target_checker.sh 172.33.1.1; echo $?
0
# /usr/local/bin/ssh_target_checker.sh 172.33.255.255; echo $?
0
# /usr/local/bin/ssh_target_checker.sh 172.33.254.254; echo $?
0
# /usr/local/bin/ssh_target_checker.sh 172.34.254.254; echo $?
1
# /usr/local/bin/ssh_target_checker.sh 172.34.0.0; echo $?
1
```
Log
```
pcluster_ssh_target_checker: Cannot resolve target Host locahost
pcluster_ssh_target_checker: Target Host localhost is in VPC CIDR
pcluster_ssh_target_checker: Target Host 127.0.0.1 is in VPC CIDR
pcluster_ssh_target_checker: Target Host amazon.com is not in any VPC CIDR 172.31.0.0/16 172.33.0.0/16
pcluster_ssh_target_checker: Target Host 172.31.1.1 is in VPC CIDR 172.31.0.0/16
pcluster_ssh_target_checker: Target Host 172.32.1.1 is not in any VPC CIDR 172.31.0.0/16 172.33.0.0/16
pcluster_ssh_target_checker: Target Host 172.33.1.1 is in VPC CIDR 172.33.0.0/16
pcluster_ssh_target_checker: Target Host 172.33.255.255 is in VPC CIDR 172.33.0.0/16
pcluster_ssh_target_checker: Target Host 172.33.254.254 is in VPC CIDR 172.33.0.0/16
pcluster_ssh_target_checker: Target Host 172.34.254.254 is not in any VPC CIDR 172.31.0.0/16 172.33.0.0/16
pcluster_ssh_target_checker: Target Host 172.34.0.0 is not in any VPC CIDR 172.31.0.0/16 172.33.0.0/16
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
