### PR TITLE
Fix Chef::Mount error on rerunning the recipes.

### DIFF
--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -90,6 +90,15 @@ vol_array.each_with_index do |volumeid, index|
     subscribes :run, "ruby_block[sleeping_for_volume_#{index}]", :immediately
   end
 
+  # If an update is performed by re-running all recipes, the mount shared_dir_array
+  # block will fail because dev_uuids does not get set.
+  ruby_block "get_uuids_#{index}" do
+    block do
+      dev_uuids[index] = get_uuid(dev_path[index])
+    end
+    action :run
+  end
+
   # Create the shared directories
   directory shared_dir_array[index] do
     owner 'root'


### PR DESCRIPTION
*Description of changes:* 

When trying to re-run Chef in order to update the configuration of the master, I stumbled onto an error with the `mount shared_dir_array` block. Because the `ruby_block "setup_disk_#{index}` does not run on a second execution, `dev_uuids` is not never set, so the device in the mount block is `nil`. 

Here, I manually run the `get_uuid` to fill the `dev_uuids` array. This fixes the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
