### PR TITLE
Remove dpkg check for intel-mpi

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -223,10 +223,6 @@ when 'ubuntu1604', 'ubuntu1804'
     command "dpkg -l | grep libfabric && dpkg -l | grep 'efa '"
     user node['cfncluster']['cfn_cluster_user']
   end
-  execute 'check intel mpi installed' do
-    command "dpkg -l | grep intel-mpi"
-    user node['cfncluster']['cfn_cluster_user']
-  end
 end
 
 # Test only on MasterServer since on compute nodes we mount an empty /opt/intel drive in kitchen tests that


### PR DESCRIPTION
* When using official installer script to install, intel-mpi no longer shows up in dpkg list
* Still checking that intel-mpi is correctly installed with `mpirun` check

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
