### PR TITLE
Restore know host file management for CentOS6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Add SHA256 checksum verification to verify integrity of NICE DCV packages
 - Upgrade Slurm to version 19.05.5
 - Install Python 2.7.17 on CentOS 6 and set it as default through pyenv
-- Install Ganglia from repository on Amazon Linux, Centos 6 and Centos 7
-- Disable StrictHostKeyChecking for SSH client when target host is inside cluster VPC 
+- Install Ganglia from repository on Amazon Linux, CentOS 6 and CentOS 7
+- Disable StrictHostKeyChecking for SSH client when target host is inside cluster VPC for all OSs except CentOS 6 
 
 **BUG FIXES**
 - Fix issue with slurmd daemon not being restarted correctly when a compute node is rebooted

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -124,12 +124,14 @@ else
   default['openssh']['server']['m_a_cs'] = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256'
 end
 default['openssh']['client']['gssapi_authentication'] = 'yes'
-default['openssh']['client']['match'] = 'exec "ssh_target_checker.sh %h"'
-# Disable StrictHostKeyChecking for target host in the cluster VPC
-default['openssh']['client']['  _strict_host_key_checking'] = 'no'
-# Do not store server key in the know hosts file to avoid scaling clashing
-# that is when an new host gets the same IP of a previously terminated host
-default['openssh']['client']['  _user_known_hosts_file'] = '/dev/null'
+unless node['platform'] == 'centos' && node['platform_version'].to_i < 7
+  default['openssh']['client']['match'] = 'exec "ssh_target_checker.sh %h"'
+  # Disable StrictHostKeyChecking for target host in the cluster VPC
+  default['openssh']['client']['  _strict_host_key_checking'] = 'no'
+  # Do not store server key in the know hosts file to avoid scaling clashing
+  # that is when an new host gets the same IP of a previously terminated host
+  default['openssh']['client']['  _user_known_hosts_file'] = '/dev/null'
+end
 
 # ulimit settings
 default['cfncluster']['filehandle_limit'] = 10_000

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -55,15 +55,18 @@ end
 ###################
 # SSH client conf
 ###################
-execute 'grep ssh_config' do
-  command 'grep -Pz "Match exec \"ssh_target_checker.sh %h\"\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null" /etc/ssh/ssh_config'
+unless node['cfncluster']['os'] == 'centos6'
+  execute 'grep ssh_config' do
+    command 'grep -Pz "Match exec \"ssh_target_checker.sh %h\"\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null" /etc/ssh/ssh_config'
+  end
+
+  execute 'ssh localhost as user' do
+    command "ssh localhost hostname"
+    environment('PATH' => '/usr/local/bin:/usr/bin/:$PATH')
+    user node['cfncluster']['cfn_cluster_user']
+  end
 end
 
-execute 'ssh localhost as user' do
-  command "ssh localhost hostname"
-  environment('PATH' => '/usr/local/bin:/usr/bin/:$PATH')
-  user node['cfncluster']['cfn_cluster_user']
-end
 
 ###################
 # munge


### PR DESCRIPTION
The OpenSSH version in CentOS6 doesn't support the Match directive that allows to conditionally disable the StrictHostKeyChecking parameter

Match directive in ssh_config is available since
OpenSSH 6.5/6.5p1 (2014-01-30)

OpenSSH version of CentOS6 is
OpenSSH 5.3/5.3p1 (2009-10-01)

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
