### PR TITLE
Install libssl-dev instead of libssl1.0-dev

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -233,7 +233,7 @@ when 'debian'
                                               libgcrypt20-dev libmysqlclient-dev]
   if node['platform_version'] == '18.04'
     default['cfncluster']['base_packages'].delete('libatlas-dev')
-    default['cfncluster']['base_packages'].push('libatlas-base-dev', 'libssl1.0-dev', 'libglvnd-dev')
+    default['cfncluster']['base_packages'].push('libatlas-base-dev', 'libssl-dev', 'libglvnd-dev')
     default['cfncluster']['sge']['version'] = '8.1.9+dfsg-9build1'
   end
 


### PR DESCRIPTION
* libssl1.0-dev is incompatible with libmysqlclient-dev, installing libssl1.0-dev after libmysqlclient-dev will uninstall libmysqlclient-dev. Switching to installing libssl-dev.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
