### PR TITLE
Add chrony wait to ensure instance is synced before check

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -206,7 +206,7 @@ execute 'check chrony running' do
 end
 
 execute 'check chrony conf' do
-  command "chronyc tracking | grep -i reference | grep 169.254.169.123"
+  command "chronyc waitsync 30; chronyc tracking | grep -i reference | grep 169.254.169.123"
   user node['cfncluster']['cfn_cluster_user']
 end
 


### PR DESCRIPTION
Add chronyc waitsync 30 before calling chronyc tracking to ensure the instance is synced before the check
(waits up to 5m for synchronization, checking every 10s)

Doc https://chrony.tuxfamily.org/doc/3.1/chronyc.html

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
