### PR TITLE
Install packages in a single package resource

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -51,11 +51,9 @@ build_essential
 include_recipe "aws-parallelcluster::_setup_python"
 
 # Install lots of packages
-node['cfncluster']['base_packages'].each do |p|
-  package p do
-    retries 3
-    retry_delay 5
-  end
+package node['cfncluster']['base_packages'] do
+  retries 10
+  retry_delay 5
 end
 
 case node['platform_family']

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -108,11 +108,9 @@ if node['cfncluster']['dcv']['supported_os'].include?("#{node['platform']}#{node
                            xorg-x11-server-Xorg xorg-x11-fonts-Type1 xorg-x11-drivers
                            gnome-terminal gnu-free-fonts-common gnu-free-mono-fonts
                            gnu-free-sans-fonts gnu-free-serif-fonts glx-utils]
-      prereq_packages.each do |p|
-        package p do
-          retries 3
-          retry_delay 5
-        end
+      package prereq_packages do
+        retries 10
+        retry_delay 5
       end
     end
     disable_lock_screen


### PR DESCRIPTION
* Installing multiple packages one at the time will produce unexpected behavior because some incompatible packages might be uninstalled silently. Switch to installing multiple packages in a single chef package resource so that dependency between all packages is mapped out and any incompatibility will be detected.
* Retry in package resource only applies to the resource. Previously we had 3 retries for every package when installing separately. Now we only have 10 retries in total for installing all base packages at once.

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
