### PR TITLE
Add retry delay to sge preinstall script

### DIFF
--- a/files/default/sge_preinstall.sh
+++ b/files/default/sge_preinstall.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -e
-curl --retry 3 -v -L -o $TARBALL_PATH $TARBALL_URL
+curl --retry 3 --retry-delay 5 -v -L -o $TARBALL_PATH $TARBALL_URL


### PR DESCRIPTION
* Adding retry-delay flag to avoid random errors while downloading sge package

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
