### PR TITLE
Upgrade EFA to version 1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Install and setup Amazon Time Sync on Amazon Linux, Centos 6, Centos 7, Ubuntu 16 and Ubuntu 18
 
 **CHANGES**
-- Upgrade EFA installer to version 1.8.2:
-  - Kernel module: efa-1.5.0 (updated from efa-1.4.1)
+- Upgrade EFA installer to version 1.8.3:
+  - Kernel module: efa-1.5.1 (updated from efa-1.4.1)
   - RDMA core: rdma-core-25.0 (distributed only) (no change)
   - Libfabric: libfabric-aws-1.9.0amzn1.1 (updated from libfabric-aws-1.8.1amzn1.3)
   - Open MPI: openmpi40-aws-4.0.2 (no change)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -72,7 +72,7 @@ default['cfncluster']['nvidia']['cuda_url'] = if node['platform'] == 'centos' &&
                                                 'https://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run'
                                               end
 # EFA
-default['cfncluster']['efa']['installer_url'] = 'https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.8.2.tar.gz'
+default['cfncluster']['efa']['installer_url'] = 'https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.8.3.tar.gz'
 # ENV2 - tool to capture environment and create modulefiles
 default['cfncluster']['env2']['url'] = 'https://sourceforge.net/projects/env2/files/env2/download'
 # NICE DCV


### PR DESCRIPTION
Upgrade EFA installer to version 1.8.3:
*  Kernel module: efa-1.5.1 (updated from efa-1.4.1)
*  RDMA core: rdma-core-25.0 (distributed only) (no change)
*  Libfabric: libfabric-aws-1.9.0amzn1.1 (updated from libfabric-aws-1.8.1amzn1.3)
* Open MPI: openmpi40-aws-4.0.2 (no change)

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
