### PR TITLE
Restart X server during DCV configuration

### DIFF
--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -22,7 +22,7 @@
 def allow_gpu_acceleration
   # Turn off X
   execute "Turn off X" do
-    command "systemctl set-default multi-user.target"
+    command "systemctl isolate multi-user.target"
   end
 
   # Update the xorg.conf to set up NVIDIA drivers.

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -220,6 +220,11 @@ if node['cfncluster']['cfn_node_type'] == "MasterServer" &&
     command 'dcv version'
     user node['cfncluster']['cfn_cluster_user']
   end
+  if graphic_instance?
+    execute "Ensure local users can access X server" do
+      command %?DISPLAY=:0 XAUTHORITY=$(ps aux | grep "X.*\-auth" | grep -v grep | sed -n 's/.*-auth \([^ ]\+\).*/\1/p') xhost | grep "LOCAL:$"?
+    end
+  end
 end
 
 ###################


### PR DESCRIPTION
The previous version of the DCV configuration recipe was using the
`set-default` unit file command in an attempt to stop the X server. This
sets the target to boot into, but does not stop the X server. This
commit uses the isolate unit command, which stops all units not enabled
in the specified unit (including the X server).

A kitchen test is also added to ensure that local users can access the X
server. This test is recommended in the [DCV admin guide](https://docs.aws.amazon.com/dcv/latest/adminguide/setting-up-installing-linux-checks.html#checks-xserver)
when the DCV GL package has been installed.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
