### PR TITLE
Fix incorrect string interpolation

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -231,7 +231,7 @@ if node['cfncluster']['cfn_node_type'] == "MasterServer" &&
     end
   end
   execute 'check DCV external authenticator python version' do
-    command %(#{default['cfncluster']['dcv']['authenticator']['virtualenv_path']}/bin/python -V | grep "Python #{node['cfncluster']['python-version']}")
+    command %(#{node['cfncluster']['dcv']['authenticator']['virtualenv_path']}/bin/python -V | grep "Python #{node['cfncluster']['python-version']}")
   end
 end
 


### PR DESCRIPTION
`default` -> `node`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
