### PR TITLE
Start cloudwatch agent in _prep_env

### DIFF
--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -17,6 +17,9 @@
 
 include_recipe 'aws-parallelcluster::base_install'
 
+# Write cloudwatch log config and start it.
+include_recipe "aws-parallelcluster::cloudwatch_agent_config"
+
 if node['platform_family'] == 'amazon' && node['platform_version'] == '2'
   # NOTE: temporary workaround for amazon linux 2 while alternative solutions are evaluated
   execute "hostnamectl set-hostname #{node['ec2']['local_hostname']}"
@@ -37,9 +40,6 @@ end
 
 # Amazon Time Sync
 include_recipe 'aws-parallelcluster::chrony_config'
-
-# Write cloudwatch log config and start it.
-include_recipe "aws-parallelcluster::cloudwatch_agent_config"
 
 # EFA runtime configuration
 include_recipe "aws-parallelcluster::efa_config"


### PR DESCRIPTION
* Start cloudwatch agent at the start of chef run at run time
* This would avoid missing error during early installation stages that would happen before we initiate cloudwatch agent

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
