### PR TITLE
Disable pyenv rehash

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -28,5 +28,6 @@ depends 'apt', '~> 7.0.0'
 depends 'hostname', '~> 0.4.2'
 depends 'line', '~> 2.4.1'
 depends 'ulimit', '~> 1.0.0'
+# when changing pyenv version, check if pyenv.sh.rb template is still valid
 depends 'pyenv', '~> 3.1.0'
 depends 'kernel_module', '~> 1.1.2'

--- a/recipes/_setup_python.rb
+++ b/recipes/_setup_python.rb
@@ -23,6 +23,13 @@ if node['platform'] == 'centos' && node['platform_version'].to_i < 7
   pyenv_global node['cfncluster']['python-version-centos6']
 end
 
+template "/etc/profile.d/pyenv.sh" do
+  source 'pyenv.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
 activate_virtual_env node['cfncluster']['cookbook_virtualenv'] do
   pyenv_path node['cfncluster']['cookbook_virtualenv_path']
   python_version node['cfncluster']['python-version']

--- a/templates/default/pyenv.sh.erb
+++ b/templates/default/pyenv.sh.erb
@@ -1,0 +1,12 @@
+# Prefer a user pyenv over a system wide install
+if [ -s "${HOME}/.pyenv/bin" ]; then
+    pyenv_root="${HOME}/.pyenv"
+elif [ -s "<%= node['cfncluster']['system_pyenv_root'] %>" ]; then
+    pyenv_root="<%= node['cfncluster']['system_pyenv_root'] %>"
+    export PYENV_ROOT=${pyenv_root}
+fi
+
+if [ -n "$pyenv_root" ]; then
+    export PATH="${pyenv_root}/bin:$PATH"
+    eval "$(pyenv init - --no-rehash)"
+fi


### PR DESCRIPTION
Since changing the contents of pyenv is not needed, disable the rehash to avoid getting the message "pyenv: cannot rehash: /usr/local/pyenv/shims isn't writable"

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
