### PR TITLE
Change location for ssh_target_checker.sh

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -86,7 +86,7 @@ include_recipe "openssh"
 
 # Install SSH target checker
 cookbook_file 'ssh_target_checker.sh' do
-  path "/usr/local/bin/ssh_target_checker.sh"
+  path "/usr/bin/ssh_target_checker.sh"
   owner "root"
   group "root"
   mode "0755"


### PR DESCRIPTION
Default PATH for pbs_mom (torque) is PATH=/sbin:/usr/sbin:/bin:/usr/bin pbs_mon
and it was failing when pushing back to the master node the output and error files of the job

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
