### PR TITLE
Setup Nvidia Driver for G2 instance type

### DIFF
--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -32,9 +32,13 @@ def allow_gpu_acceleration
 
   # Update the xorg.conf to set up NVIDIA drivers.
   # NOTE: --enable-all-gpus parameter is needed to support servers with more than one NVIDIA GPU.
+  nvidia_xconfig_command = "nvidia-xconfig --preserve-busid --enable-all-gpus"
+  if node['ec2']['instance_type'].start_with?("g2.")
+    nvidia_xconfig_command = nvidia_xconfig_command + " --use-display-device=none"
+  end
   execute "Set up Nvidia drivers for X configuration" do
     user 'root'
-    command "nvidia-xconfig --preserve-busid --enable-all-gpus"
+    command nvidia_xconfig_command
   end
 
   # dcvgl package must be installed after NVIDIA and before starting up X


### PR DESCRIPTION
Setup Nvidia Driver to work with G2 instance type when DCV is enabled

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
