### PR TITLE
Intel MPI repo is not present anymore since U6

### DIFF
--- a/recipes/intel_mpi.rb
+++ b/recipes/intel_mpi.rb
@@ -53,10 +53,3 @@ bash "create modulefile" do
   MODULEFILE
   creates intelmpi_modulefile
 end
-
-if (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
-  || node['platform'] == 'amazon'
-  execute 'yum-config-manager_skip_if_unavail_intel_mpi' do
-    command "yum-config-manager --save --setopt=intel-mpi.skip_if_unavailable=true"
-  end
-end


### PR DESCRIPTION
Intel MPI repo is not added anymore to yum configuration since U6

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
