### PR TITLE
Skip *_install recipes if AMI is bootstrapped

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -138,3 +138,18 @@ def graphic_instance?
 
   is_graphic_instance
 end
+
+#
+# Check if the AMI is bootstrapped
+#
+def bootstrapped?
+  version = ''
+  bootstrapped_file = '/opt/parallelcluster/.bootstrapped'
+
+  if ::File.exist?(bootstrapped_file)
+    version = IO.read(bootstrapped_file).chomp
+    Chef::Log.info("Detected bootstrap file #{version}")
+  end
+
+  'aws-parallelcluster-' + node['cfncluster']['cfncluster-version'] == version
+end

--- a/recipes/awsbatch_config.rb
+++ b/recipes/awsbatch_config.rb
@@ -17,7 +17,7 @@
 
 # Use these recipes to add a custom scheduler
 include_recipe 'aws-parallelcluster::base_config'
-include_recipe 'aws-parallelcluster::base_install'
+include_recipe 'aws-parallelcluster::base_install' unless bootstrapped?
 
 # Install aws-parallelcluster-awsbatch-cli.cfg
 awsbatch_cli_config_dir = "/home/#{node['cfncluster']['cfn_cluster_user']}/.parallelcluster/"

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'aws-parallelcluster::base_install'
+include_recipe 'aws-parallelcluster::base_install' unless bootstrapped?
 
 if node['platform_family'] == 'amazon' && node['platform_version'] == '2'
   # NOTE: temporary workaround for amazon linux 2 while alternative solutions are evaluated

--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -78,7 +78,7 @@ end
 if node['cfncluster']['dcv']['supported_os'].include?("#{node['platform']}#{node['platform_version'].to_i}") && node['cfncluster']['cfn_node_type'] == "MasterServer"
 
   # be sure to have DCV packages installed
-  include_recipe "aws-parallelcluster::dcv_install"
+  include_recipe "aws-parallelcluster::dcv_install" unless bootstrapped?
 
   node.default['cfncluster']['dcv']['is_graphic_instance'] = graphic_instance?
 

--- a/recipes/sge_config.rb
+++ b/recipes/sge_config.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 include_recipe 'aws-parallelcluster::base_config'
-include_recipe 'aws-parallelcluster::sge_install'
+include_recipe 'aws-parallelcluster::sge_install' unless bootstrapped?
 
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer'

--- a/recipes/slurm_config.rb
+++ b/recipes/slurm_config.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 include_recipe 'aws-parallelcluster::base_config'
-include_recipe 'aws-parallelcluster::slurm_install'
+include_recipe 'aws-parallelcluster::slurm_install' unless bootstrapped?
 
 # Create the munge key from template
 template "/etc/munge/munge.key" do

--- a/recipes/torque_config.rb
+++ b/recipes/torque_config.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 include_recipe 'aws-parallelcluster::base_config'
-include_recipe 'aws-parallelcluster::torque_install'
+include_recipe 'aws-parallelcluster::torque_install' unless bootstrapped?
 
 # Update ld.conf
 append_if_no_line "add torque libs to ld.so.conf" do


### PR DESCRIPTION
Skip execution of *_install recipes if AMI is already bootstrapped with same version

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
