### PR TITLE
Skip *_install recipes if AMI is bootstrapped

### DIFF
--- a/attributes/conditions.rb
+++ b/attributes/conditions.rb
@@ -20,3 +20,5 @@ default['conditions']['efa_supported'] = (node['platform'] == 'centos' && node['
 
 default['conditions']['intel_mpi_supported'] = (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
   || node['platform'] == 'amazon' || node['platform'] == 'ubuntu'
+
+default['conditions']['ami_bootstrapped'] = ami_bootstrapped?

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -292,3 +292,4 @@ default['cfncluster']['custom_node_package'] = nil
 default['cfncluster']['custom_awsbatchcli_package'] = nil
 default['cfncluster']['cfn_raid_parameters'] = 'NONE'
 default['cfncluster']['cfn_raid_vol_ids'] = nil
+default['cfncluster']['skip_install_recipes'] = 'yes'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -138,3 +138,18 @@ def graphic_instance?
 
   is_graphic_instance
 end
+
+#
+# Check if the AMI is bootstrapped
+#
+def ami_bootstrapped?
+  version = ''
+  bootstrapped_file = '/opt/parallelcluster/.bootstrapped'
+
+  if ::File.exist?(bootstrapped_file)
+    version = IO.read(bootstrapped_file).chomp
+    Chef::Log.info("Detected bootstrap file #{version}")
+  end
+
+  'aws-parallelcluster-' + node['cfncluster']['cfncluster-version'] == version && node['cfncluster']['skip_install_recipes'] == 'yes'
+end

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return if node['conditions']['ami_bootstrapped']
+
 case node['platform_family']
 when 'rhel', 'amazon'
   include_recipe 'yum'

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -15,6 +15,8 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+return if node['conditions']['ami_bootstrapped']
+
 # Utility function to install a list of packages
 def install_package_list(packages)
   packages.each do |package_name|

--- a/recipes/munge_install.rb
+++ b/recipes/munge_install.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return if node['conditions']['ami_bootstrapped']
+
 include_recipe 'aws-parallelcluster::base_install'
 
 munge_tarball = "#{node['cfncluster']['sources_dir']}/munge-#{node['cfncluster']['munge']['munge_version']}.tar.gz"

--- a/recipes/sge_install.rb
+++ b/recipes/sge_install.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return if node['conditions']['ami_bootstrapped']
+
 include_recipe 'aws-parallelcluster::base_install'
 
 case node['cfncluster']['cfn_node_type']

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return if node['conditions']['ami_bootstrapped']
+
 include_recipe 'aws-parallelcluster::base_install'
 include_recipe 'aws-parallelcluster::munge_install'
 

--- a/recipes/torque_install.rb
+++ b/recipes/torque_install.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return if node['conditions']['ami_bootstrapped']
+
 include_recipe 'aws-parallelcluster::base_install'
 include_recipe 'aws-parallelcluster::munge_install'
 


### PR DESCRIPTION
Skip execution of *_install recipes if AMI is already bootstrapped with same version.
The old behaviour can be restored setting the property "skip_install_recipes" to "no" through extra_json.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
