### PR TITLE
lustre: remove x-systemd.requires=lnet.service from mount options

### DIFF
--- a/recipes/fsx_mount.rb
+++ b/recipes/fsx_mount.rb
@@ -36,7 +36,7 @@ if fsx_shared_dir != "NONE"
 
   mount_options = %w[defaults _netdev flock user_xattr noatime]
 
-  mount_options.push(%w[noauto x-systemd.automount x-systemd.requires=lnet.service]) if node['init_package'] == 'systemd'
+  mount_options.push(%w[noauto x-systemd.automount]) if node['init_package'] == 'systemd'
 
   # Mount FSx over NFS
   mount fsx_shared_dir do


### PR DESCRIPTION
This in order to rely on automatic setup from Lustre

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
