### PR TITLE
Move disable pyenv rehash inside install_pyenv custom resource

### DIFF
--- a/recipes/_setup_python.rb
+++ b/recipes/_setup_python.rb
@@ -23,13 +23,6 @@ if node['platform'] == 'centos' && node['platform_version'].to_i < 7
   pyenv_global node['cfncluster']['python-version-centos6']
 end
 
-template "/etc/profile.d/pyenv.sh" do
-  source 'pyenv.sh.erb'
-  owner 'root'
-  group 'root'
-  mode '0755'
-end
-
 activate_virtual_env node['cfncluster']['cookbook_virtualenv'] do
   pyenv_path node['cfncluster']['cookbook_virtualenv_path']
   python_version node['cfncluster']['python-version']

--- a/resources/install_pyenv.rb
+++ b/resources/install_pyenv.rb
@@ -17,4 +17,11 @@ action :run do
   pyenv_plugin 'virtualenv' do
     git_url 'https://github.com/pyenv/pyenv-virtualenv'
   end
+
+  template "/etc/profile.d/pyenv.sh" do
+    source 'pyenv.sh.erb'
+    owner 'root'
+    group 'root'
+    mode '0755'
+  end
 end


### PR DESCRIPTION
Since the install_pyenv custom resource could be called from anywhere (e.g. from dcv_install), move the disable of pyenv rehash contextual to the pyenv creation.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
