### PR TITLE
Move torque setup configuration in config recipe

### DIFF
--- a/recipes/_master_torque_config.rb
+++ b/recipes/_master_torque_config.rb
@@ -15,6 +15,15 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Modified torque.setup
+template 'torque.setup' do
+  source 'torque.setup.erb'
+  path '/opt/torque/bin/torque.setup'
+  user 'root'
+  group 'root'
+  mode '0755'
+end
+
 # Run torque.setup
 bash "run-torque-setup" do
   code <<-SETUPTORQUE

--- a/recipes/torque_install.rb
+++ b/recipes/torque_install.rb
@@ -101,15 +101,6 @@ directory '/var/spool/torque' do
   recursive true
 end
 
-# Modified torque.setup
-template 'torque.setup' do
-  source 'torque.setup.erb'
-  path '/opt/torque/bin/torque.setup'
-  user 'root'
-  group 'root'
-  mode '0755'
-end
-
 # Copy required licensing files
 directory "#{node['cfncluster']['license_dir']}/torque"
 


### PR DESCRIPTION
torque.setup script must be configured during "config recipe" execution and not during "install recipe" execution.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
