### PR TITLE
Fix torque build for Ubuntu18

### DIFF
--- a/recipes/torque_install.rb
+++ b/recipes/torque_install.rb
@@ -46,6 +46,9 @@ if node['platform'] == 'ubuntu' && node['platform_version'] == "18.04"
     code <<-TORQUE
       set -e
       # Headers needed for compilation
+      # Download all packages matching the pattern 'libicu-dev_55.1-7ubuntu*amd64.deb'
+      # recursively (-r), avoiding to ascend to the parent dir (-np) 
+      # and without creating the hierarchy of directories (-nd)
       wget -r -np -nd http://security.ubuntu.com/ubuntu/pool/main/i/icu/ -A 'libicu-dev_55.1-7ubuntu*amd64.deb'
       dpkg -x libicu-dev_55.1-7ubuntu*amd64.deb extra_libs
     TORQUE

--- a/recipes/torque_install.rb
+++ b/recipes/torque_install.rb
@@ -46,9 +46,8 @@ if node['platform'] == 'ubuntu' && node['platform_version'] == "18.04"
     code <<-TORQUE
       set -e
       # Headers needed for compilation
-      wget http://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu-dev_55.1-7ubuntu0.4_amd64.deb
-      dpkg -x libicu-dev_55.1-7ubuntu0.4_amd64.deb extra_libs
-
+      wget -r -np -nd http://security.ubuntu.com/ubuntu/pool/main/i/icu/ -A 'libicu-dev_55.1-7ubuntu*amd64.deb'
+      dpkg -x libicu-dev_55.1-7ubuntu*amd64.deb extra_libs
     TORQUE
     not_if { ::Dir.exist?("/opt/torque/bin") }
   end


### PR DESCRIPTION
Package libicu-dev_55.1-7ubuntu0.4_amd64.deb is no longer available

Download all packages matching the pattern 'libicu-dev_55.1-7ubuntu*amd64.deb', recursively (-r), avoiding to ascend to the parent dir (-np) and without creating the hierarchy of directories (-nd)

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
