### PR TITLE
Remove duplicate intelmpi modulefile path

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,7 +36,6 @@ default['cfncluster']['node_virtualenv_path'] = "#{node['cfncluster']['system_py
 # Intel Packages
 default['cfncluster']['psxe']['version'] = '2019.5'
 default['cfncluster']['intelhpc']['version'] = '2018.0-1.el7'
-default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/impi/latest/modulefiles/mpi"
 default['cfncluster']['intelpython2']['version'] = '2019.4'
 default['cfncluster']['intelpython3']['version'] = '2019.4'
 # Intel MPI


### PR DESCRIPTION
This was a leftover from when we switched to the new installer. Same variable is defined a few lines below with the correct path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
