### PR TITLE
Revert "Add temporary workaround to install Nvidia driver using dkms"

### DIFF
--- a/recipes/_nvidia_install.rb
+++ b/recipes/_nvidia_install.rb
@@ -28,13 +28,6 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
     not_if { ::File.exist?('/usr/bin/nvidia-smi') }
   end
 
-
-  nvidia_install_command = "./nvidia.run --silent --dkms"
-  if node['platform'] == 'ubuntu' && node['platform_version'] == "18.04"
-    # temporary workaround to install Nvidia drier using dkms until this
-    # https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1868169 get fixed
-    nvidia_install_command = "#{nvidia_install_command} --no-cc-version-check"
-  end
   # Install NVIDIA driver
   bash 'nvidia.run advanced' do
     user 'root'
@@ -42,7 +35,7 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
     cwd '/tmp'
     code <<-NVIDIA
       set -e
-      #{nvidia_install_command}
+      ./nvidia.run --silent --dkms
       rm -f /tmp/nvidia.run
     NVIDIA
     creates '/usr/bin/nvidia-smi'


### PR DESCRIPTION
Reverts aws/aws-parallelcluster-cookbook#571

Kernel gcc version is aligned again with gcc version

```
$ uname -a
Linux ip-172-31-5-176 4.15.0-1065-aws #69-Ubuntu SMP Thu Mar 26 02:17:29 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ cat /proc/version
Linux version 4.15.0-1065-aws (buildd@lgw01-amd64-035) (gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04)) #69-Ubuntu SMP Thu Mar 26 02:17:29 UTC 2020

$ gcc --version
gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

before it was

```
$ uname -a
Linux ip-172-31-14-235 4.15.0-1063-aws #67-Ubuntu SMP Mon Mar 2 07:24:29 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ cat /proc/version
Linux version 4.15.0-1063-aws (buildd@lcy01-amd64-026) (gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)) #67-Ubuntu SMP Mon Mar 2 07:24:29 UTC 2020

$ gcc --version
gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```