### PR TITLE
Omit cfn-init-cmd.log and cfn-wire.log from CW Logs integration

### DIFF
--- a/files/default/cloudwatch_logs/cloudwatch_log_files.json
+++ b/files/default/cloudwatch_logs/cloudwatch_log_files.json
@@ -50,50 +50,8 @@
     },
     {
       "timestamp_format_key": "default",
-      "file_path": "/var/log/cfn-init-cmd.log",
-      "log_stream_name": "cfn-init-cmd",
-      "schedulers": [
-        "awsbatch",
-        "sge",
-        "slurm",
-        "torque"
-      ],
-      "platforms": [
-        "amazon",
-        "centos",
-        "ubuntu"
-      ],
-      "node_roles": [
-        "ComputeFleet",
-        "MasterServer"
-      ],
-      "feature_conditions": []
-    },
-    {
-      "timestamp_format_key": "default",
       "file_path": "/var/log/cfn-init.log",
       "log_stream_name": "cfn-init",
-      "schedulers": [
-        "awsbatch",
-        "sge",
-        "slurm",
-        "torque"
-      ],
-      "platforms": [
-        "amazon",
-        "centos",
-        "ubuntu"
-      ],
-      "node_roles": [
-        "ComputeFleet",
-        "MasterServer"
-      ],
-      "feature_conditions": []
-    },
-    {
-      "timestamp_format_key": "default",
-      "file_path": "/var/log/cfn-wire.log",
-      "log_stream_name": "cfn-wire",
       "schedulers": [
         "awsbatch",
         "sge",


### PR DESCRIPTION
In an effort to reduce the cost of enabling the CloudWatch Logs
integration, two of the cfn-* logs are being removed from the config
file used to ultimately instruct the CloudWatch agent which files to
log data for on a cluster's instances.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
