### PR TITLE
Upgrade Slurm to version 20.02

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,9 +53,9 @@ default['cfncluster']['sge']['url'] = 'https://arc.liv.ac.uk/downloads/SGE/relea
 default['cfncluster']['torque']['version'] = '6.1.2'
 default['cfncluster']['torque']['url'] = 'https://github.com/adaptivecomputing/torque/archive/6.1.2.tar.gz'
 # Slurm software
-default['cfncluster']['slurm']['version'] = '19.05.5'
-default['cfncluster']['slurm']['url'] = 'https://download.schedmd.com/slurm/slurm-19.05.5.tar.bz2'
-default['cfncluster']['slurm']['sha1'] = '055adca91e555cc124b1ecac5f3c45e66c17a8ba'
+default['cfncluster']['slurm']['version'] = '20.02.1'
+default['cfncluster']['slurm']['url'] = 'https://download.schedmd.com/slurm/slurm-20.02.1.tar.bz2'
+default['cfncluster']['slurm']['sha1'] = '91704d8c73bf1a6eab64ccde3f3d03b85188672a'
 # Munge
 default['cfncluster']['munge']['munge_version'] = '0.5.13'
 default['cfncluster']['munge']['munge_url'] = "https://github.com/dun/munge/archive/munge-#{node['cfncluster']['munge']['munge_version']}.tar.gz"

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -60,6 +60,9 @@ when 'MasterServer', nil
       IFS=${_OLD_IFS}
       export PATH=${NEW_PATH}
 
+      # python3 is required to build slurm >= 20.02
+      source #{node['cfncluster']['cookbook_virtualenv_path']}/bin/activate
+
       env
       tar xf #{slurm_tarball}
       cd slurm-#{node['cfncluster']['slurm']['version']}
@@ -68,6 +71,7 @@ when 'MasterServer', nil
       make -j $CORES
       make install
       make install-contrib
+      deactivate
     SLURM
     # TODO: Fix, so it works for upgrade
     creates '/opt/slurm/bin/srun'


### PR DESCRIPTION
Upgrade Slurm to version 20.02

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
