### PR TITLE
Exit with error when failing to retrieve FSx mountpoint

### DIFF
--- a/recipes/fsx_mount.rb
+++ b/recipes/fsx_mount.rb
@@ -32,7 +32,7 @@ if fsx_shared_dir != "NONE"
   end
 
   require 'chef/mixin/shell_out'
-  mountname = shell_out("#{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws fsx --region #{node['cfncluster']['cfn_region']} describe-file-systems --file-system-ids #{node['cfncluster']['cfn_fsx_fs_id']} --query 'FileSystems[0].LustreConfiguration.MountName' --output text", :user=>'root').stdout.strip
+  mountname = shell_out!("#{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws fsx --region #{node['cfncluster']['cfn_region']} describe-file-systems --file-system-ids #{node['cfncluster']['cfn_fsx_fs_id']} --query 'FileSystems[0].LustreConfiguration.MountName' --output text", :user=>'root').stdout.strip
 
   mount_options = %w[defaults _netdev flock user_xattr noatime]
 


### PR DESCRIPTION
Explicitly exit whit error when failing to retrieve the fsx mountpoint with shell_out.

With the current implementation shell_out is simply returning an empty output on failures and the FSx mount is failing right after. Because of this we are unable to identify the root cause behind the failure of the shell_out command. Using shell_out! in order to force failure on errors.

shell_out docs: https://www.rubydoc.info/gems/chef/11.12.4/Chef/Mixin/ShellOut#shell_out!-instance_method

This would have helped debugging the root cause of https://github.com/aws/aws-parallelcluster/issues/1722

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
