### PR TITLE
Fix installation of Lustre client on Centos 7.7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -169,10 +169,10 @@ when 'rhel', 'amazon'
                                                   blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                                   libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel mdadm python python-pip
                                                   libssh2-devel libgcrypt-devel]
-      if node['platform_version'].split('.')[1] == '7'
-        # Lustre Client for Centos 7.7
+      if node['platform_version'].split('.')[1] >= '7'
+        # Lustre Client for Centos >= 7.7
         default['cfncluster']['lustre']['public_key'] = 'https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc'
-        default['cfncluster']['lustre']['base_url'] = 'https://fsx-lustre-client-repo.s3.amazonaws.com/el/7/x86_64/'
+        default['cfncluster']['lustre']['base_url'] = "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7.#{node['platform_version'].split('.')[1]}/x86_64/"
       elsif node['platform_version'].split('.')[1] == '6'
         # Lustre Drivers for Centos 7.6
         default['cfncluster']['lustre']['version'] = '2.10.6'

--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -49,7 +49,7 @@ if node['platform'] == 'centos' && (5..6).cover?(node['platform_version'].split(
   end
 
   kernel_module 'lnet'
-elsif node['platform'] == 'centos' && node['platform_version'].split('.')[1].to_i == 7
+elsif node['platform'] == 'centos' && node['platform_version'].split('.')[1].to_i >= 7
 
   # add fsx lustre repository
   yum_repository "aws-fsx" do
@@ -67,7 +67,7 @@ elsif node['platform'] == 'centos' && node['platform_version'].split('.')[1].to_
 
   kernel_module 'lnet'
 elsif node['platform'] == 'centos'
-  Chef::Log.warn("Unsupported version of Centos, #{node['platform_version']}, supported versions are 7.5, 7.6 and 7.7")
+  Chef::Log.warn("Unsupported version of Centos, #{node['platform_version']}, supported versions are >= 7.5")
 elsif node['platform'] == 'ubuntu'
 
   apt_repository 'fsxlustreclientrepo' do


### PR DESCRIPTION
The newer clients for Centos 7.8 are already available in the same repo.
Without pinning the kernel version we are going to download the latest ones that are not compatible.
Also this should be compatible with Centos 7.8 kernel as soon as it gets released.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
