### PR TITLE
Skip lustre recipe if unsupported OS platform

### DIFF
--- a/attributes/conditions.rb
+++ b/attributes/conditions.rb
@@ -21,4 +21,7 @@ default['conditions']['efa_supported'] = (node['platform'] == 'centos' && node['
 default['conditions']['intel_mpi_supported'] = (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
   || node['platform'] == 'amazon' || node['platform'] == 'ubuntu'
 
+default['conditions']['lustre_supported'] = (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
+  || node['platform'] == 'amazon' || node['platform'] == 'ubuntu'
+
 default['conditions']['ami_bootstrapped'] = ami_bootstrapped?

--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return unless node['conditions']['lustre_supported']
+
 # Install only on Centos 7.6 and 7.5
 if node['platform'] == 'centos' && (5..6).cover?(node['platform_version'].split('.')[1].to_i)
   lustre_kmod_rpm = "#{node['cfncluster']['sources_dir']}/kmod-lustre-client-#{node['cfncluster']['lustre']['version']}.x86_64.rpm"


### PR DESCRIPTION
This skips Lustre installation on unsupported platforms such as Centos 6

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
