### PR TITLE
Add timeout to retry operation when installing through dpkg

### DIFF
--- a/util/chef-install.sh
+++ b/util/chef-install.sh
@@ -275,10 +275,12 @@ install_file() {
       ;;
     "deb")
       echo "installing with dpkg..."
-      until dpkg -i "$2"; do
+      next_wait=0
+      until dpkg -i "$2" || [ ${next_wait} -ge 10 ] ; do
         echo "Retrying dpkg -i $2 ..."
-        sleep 1
+        sleep $((next_wait=next_wait+1))
       done
+      [ ${next_wait} -lt 10 ]
       ;;
     "bff")
       echo "installing with installp..."


### PR DESCRIPTION
Timeout added in order to avoid retrying indefinitely

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
