### PR TITLE
Download Chef client from our s3 buckets

### DIFF
--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -173,7 +173,8 @@
     {
       "type" : "shell",
       "inline" : [
-        "curl --retry 3 -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v {{user `chef_version`}}"
+        "region=\"{{user `region`}}\"",
+        "curl --retry 3 -L https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\")/archives/chef/chef-install.sh | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -173,7 +173,8 @@
     {
       "type" : "shell",
       "inline" : [
-        "curl --retry 3 -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v {{user `chef_version`}}"
+        "region=\"{{user `region`}}\"",
+        "curl --retry 3 -L https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\")/archives/chef/chef-install.sh | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {

--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -180,7 +180,8 @@
     {
       "type" : "shell",
       "inline" : [
-        "curl --retry 3 -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v {{user `chef_version`}}"
+        "region=\"{{user `region`}}\"",
+        "curl --retry 3 -L https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\")/archives/chef/chef-install.sh | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -189,7 +189,8 @@
     {
       "type" : "shell",
       "inline" : [
-        "curl --retry 3 -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v {{user `chef_version`}}"
+        "region=\"{{user `region`}}\"",
+        "curl --retry 3 -L https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\")/archives/chef/chef-install.sh | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -189,8 +189,10 @@
     },
     {
       "type" : "shell",
+      "inline_shebang": "/bin/bash -e",
       "inline" : [
-        "curl --retry 3 -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v {{user `chef_version`}}"
+        "region=\"{{user `region`}}\"",
+        "curl --retry 3 -L https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\")/archives/chef/chef-install.sh | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -190,8 +190,10 @@
     },
     {
       "type" : "shell",
+      "inline_shebang": "/bin/bash -e",
       "inline" : [
-        "curl --retry 3 -L https://www.chef.io/chef/install.sh | sudo bash -s -- -v {{user `chef_version`}}"
+        "region=\"{{user `region`}}\"",
+        "curl --retry 3 -L https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\")/archives/chef/chef-install.sh | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {


### PR DESCRIPTION
This patch moves the download of Chef client from Chef website to our s3
buckets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
