### PR TITLE
Use Gnome standard in alinux2 instead of Gnome-classic

### DIFF
--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -120,6 +120,16 @@ if node['cfncluster']['dcv']['supported_os'].include?("#{node['platform']}#{node
         retries 10
         retry_delay 5
       end
+
+      # Use Gnome in place of Gnome-classic
+      file "Setup Gnome standard" do
+        content "PREFERRED=/usr/bin/gnome-session"
+        owner "root"
+        group "root"
+        mode "0755"
+        path "/etc/sysconfig/desktop"
+      end
+
     end
     disable_lock_screen
 


### PR DESCRIPTION
Signed-off-by: ddeidda <ddeidda@amazon.com>

Tests done:

- Created AMI with Patch and used as custom_ami to spin up a new cluster.
- Tested connection with ``pcluster dcv connect`` command.
- Checked screen not being locked after a period (> 30 min) of inactivity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
