### PR TITLE
Fix Intel MPI test for custom AMI

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -280,6 +280,8 @@ if node['cfncluster']['cfn_node_type'] == 'MasterServer'
       code <<-INTELMPI
         set -e
         # Initialize module
+        # Unset MODULEPATH to force search path reinitialization when loading profile 
+        unset MODULEPATH  
         # Must execute this in a bash script because source is a bash built-in function
         source /etc/profile.d/modules.sh
         module load intelmpi && mpirun --help | grep 'Version 2019 Update 7'


### PR DESCRIPTION
Unset MODULEPATH to force search path reinitialization when loading profile.

This is needed to do a reinitialization when "modules" search path is modified and search path need to be re-read without a logout/login action.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
