### PR TITLE
Pin AMI and Kernel Version for Ubuntu 18

### DIFF
--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -32,7 +32,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200408",
           "root-device-type": "ebs"
         },
         "owners": ["099720109477", "513442679011", "837727238323"],

--- a/attributes/conditions.rb
+++ b/attributes/conditions.rb
@@ -21,8 +21,7 @@ default['conditions']['efa_supported'] = (node['platform'] == 'centos' && node['
 default['conditions']['intel_mpi_supported'] = (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
   || node['platform'] == 'amazon' || node['platform'] == 'ubuntu'
 
-# Fsx Lustre temporarily disabled in Ubuntu 18.04 because client is not yet available for new kernel
 default['conditions']['lustre_supported'] = (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
-  || node['platform'] == 'amazon' || node['platform'] == 'ubuntu' && node['platform_version'].to_f < 18.04
+  || node['platform'] == 'amazon' || node['platform'] == 'ubuntu'
 
 default['conditions']['ami_bootstrapped'] = ami_bootstrapped?

--- a/files/ubuntu-16.04/linux-aws.pref
+++ b/files/ubuntu-16.04/linux-aws.pref
@@ -1,0 +1,1 @@
+# Empty file

--- a/files/ubuntu-18.04/linux-aws.pref
+++ b/files/ubuntu-18.04/linux-aws.pref
@@ -1,0 +1,3 @@
+Package: linux-aws
+Pin: version 4.15*
+Pin-Priority: 1001

--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -23,6 +23,10 @@ unless node['platform'] == 'centos' && node['platform_version'].to_i < 7
       command "yum -y update && package-cleanup -y --oldkernels --count=1"
     end
   when 'debian'
+    # FIXME: pin Kernel version until Lustre client package version is not aligned with latest
+    cookbook_file 'linux-aws.pref' do
+      path '/etc/apt/preferences.d/linux-aws.pref'
+    end
     apt_update
     execute 'apt-upgrade' do
       command "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" --with-new-pkgs upgrade && apt-get autoremove -y"


### PR DESCRIPTION
Pin AMI and Kernel Version for Ubuntu 18 until Lustre client package is not aligned with latest version of the kernel

To verify Kernel version available
```
apt-cache policy linux-aws
```
To verify FSx Lustre client version available
```
aws s3 ls fsx-lustre-client-repo/ubuntu/pool/bionic/l/lu/ | grep client
```
Apt documentation
https://manpages.ubuntu.com/manpages/precise/en/man5/apt_preferences.5.html

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
