### PR TITLE
Purge pending packages before installing new ones

### DIFF
--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -160,6 +160,8 @@
         "sudo sed -i 's/APT::Periodic::Update-Package-Lists \"1\"/APT::Periodic::Update-Package-Lists \"0\"/' /etc/apt/apt.conf.d/20auto-upgrades",
         "sudo sed -i 's/APT::Periodic::Update-Package-Lists \"1\"/APT::Periodic::Update-Package-Lists \"0\"/' /etc/apt/apt.conf.d/10periodic",
         "sudo sed -i 's/APT::Periodic::Unattended-Upgrade \"1\"/APT::Periodic::Unattended-Upgrade \"0\"/' /etc/apt/apt.conf.d/20auto-upgrades",
+        "sudo dpkg --purge --pending",
+        "sudo DEBIAN_FRONTEND=noninteractive apt-get -fy install",
         "sudo apt-cache search build-essential",
         "sudo apt-get clean",
         "sudo apt-get update"


### PR DESCRIPTION
`apt-get install` was failing when provisioning an AMI that had
pending, uninstalled packages. Avoid this by purging pending packages
prior to installing new ones.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
