### PR TITLE
Pin AMI and Kernel Version for Ubuntu 18

### DIFF
--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -32,7 +32,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200323",
           "root-device-type": "ebs"
         },
         "owners": ["099720109477", "513442679011", "837727238323"],

--- a/attributes/conditions.rb
+++ b/attributes/conditions.rb
@@ -21,8 +21,7 @@ default['conditions']['efa_supported'] = (node['platform'] == 'centos' && node['
 default['conditions']['intel_mpi_supported'] = (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
   || node['platform'] == 'amazon' || node['platform'] == 'ubuntu'
 
-# Fsx Lustre temporarily disabled in Ubuntu 18.04 because client is not yet available for new kernel
 default['conditions']['lustre_supported'] = (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) \
-  || node['platform'] == 'amazon' || node['platform'] == 'ubuntu' && node['platform_version'].to_f < 18.04
+  || node['platform'] == 'amazon' || node['platform'] == 'ubuntu'
 
 default['conditions']['ami_bootstrapped'] = ami_bootstrapped?

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -238,6 +238,7 @@ when 'debian'
     default['cfncluster']['base_packages'].delete('libatlas-dev')
     default['cfncluster']['base_packages'].push('libatlas-base-dev', 'libssl-dev', 'libglvnd-dev')
     default['cfncluster']['sge']['version'] = '8.1.9+dfsg-9build1'
+    default['cfncluster']['kernel']['package'] = 'linux-image-4.15.0-1066-aws'
   end
 
   default['cfncluster']['lustre']['public_key'] = 'https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-ubuntu-public-key.asc'

--- a/files/ubuntu-16.04/linux-aws.pref
+++ b/files/ubuntu-16.04/linux-aws.pref
@@ -1,0 +1,1 @@
+# Empty file

--- a/files/ubuntu-18.04/linux-aws.pref
+++ b/files/ubuntu-18.04/linux-aws.pref
@@ -1,0 +1,11 @@
+Package: linux-aws
+Pin: version 5*
+Pin-Priority: -1
+
+Package: linux-image-aws
+Pin: version 5*
+Pin-Priority: -1
+
+Package: linux-headers-aws
+Pin: version 5*
+Pin-Priority: -1

--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -23,7 +23,17 @@ unless node['platform'] == 'centos' && node['platform_version'].to_i < 7
       command "yum -y update && package-cleanup -y --oldkernels --count=1"
     end
   when 'debian'
+    # FIXME: pin Kernel version until Lustre client package version is not aligned with latest
+    cookbook_file 'linux-aws.pref' do
+      path '/etc/apt/preferences.d/linux-aws.pref'
+    end
     apt_update
+    if !node['cfncluster']['kernel']['package'].nil? && !node['cfncluster']['kernel']['package'].empty?
+      package node['cfncluster']['kernel']['package'] do
+        retries 3
+        retry_delay 5
+      end
+    end
     execute 'apt-upgrade' do
       command "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" --with-new-pkgs upgrade && apt-get autoremove -y"
       retries 3


### PR DESCRIPTION
Pin AMI and Kernel Version for Ubuntu 18 until Lustre client package is not aligned with latest version of the kernel

To verify Kernel version available
```
apt-cache policy linux-aws
```
To verify FSx Lustre client version available
```
aws s3 ls fsx-lustre-client-repo/ubuntu/pool/bionic/l/lu/ | grep client
```
Apt documentation
https://manpages.ubuntu.com/manpages/precise/en/man5/apt_preferences.5.html

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
