### PR TITLE
Disable libvirtd service in CentOS7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+
+X.X.X
+-----
+
+**CHANGES**
+
+- Disable libvirtd service on Centos 7. Virtual bridge interfaces are incorrectly detected by Open MPI and
+  cause MPI applications to hang, see https://www.open-mpi.org/faq/?category=tcp#tcp-selection for details 
+
 2.7.0
 -----
 

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -85,6 +85,16 @@ if node['cfncluster']['dcv']['supported_os'].include?("#{node['platform']}#{node
       # Install X Window System (required when using GPU acceleration)
       package "xorg-x11-server-Xorg"
 
+      # libvirtd service creates virtual bridge interfaces.
+      # It's provided by libvirt-daemon, installed as requirement for gnome-boxes, included in @gnome.
+      # Open MPI does not ignore other local-only devices other than loopback:
+      # if virtual bridge interface is up, Open MPI assumes that that network is usable for MPI communications.
+      # This is incorrect and it led to MPI applications hanging when they tried to send or receive MPI messages
+      # see https://www.open-mpi.org/faq/?category=tcp#tcp-selection for details
+      service 'libvirtd' do
+        action %i[disable stop]
+      end
+
     when 'ubuntu'
       apt_update
       # Must install whoopsie separately before installing ubuntu-desktop to avoid whoopsie crash pop-up

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -409,3 +409,18 @@ when 'ubuntu1604', 'ubuntu1804'
     user node['cfncluster']['cfn_cluster_user']
   end
 end
+
+###################
+# Bridge Network Interface
+###################
+if node['platform'] == 'centos' && node['platform_version'].to_i >= 7
+  bash 'test bridge network interface presence' do
+    code <<-TESTBRIDGE
+      set -e
+      # brctl show
+      # bridge name bridge id STP enabled interfaces
+      # virbr0 8000.525400e6e4f9 yes virbr0-nic
+      [ $(brctl show | awk 'FNR == 2 {print $1}') ] && exit 1 || exit 0
+    TESTBRIDGE
+  end
+end


### PR DESCRIPTION
libvirtd service creates virtual bridge interfaces.
It's provided by libvirt-daemon, installed as requirement for gnome-boxes, included in group 'gnome' (CentOS7).
Open MPI does not ignore other local-only devices other than loopback:
if virtual bridge interface is up, Open MPI assumes that that network is usable for MPI communications.
This is incorrect and it led to MPI applications hanging when they tried to send or receive MPI messages
see https://www.open-mpi.org/faq/?category=tcp#tcp-selection for details

Temporary workaround before the patch get released is to create a post install script with the following commands:
```
sudo systemctl stop libvirtd
sudo ip link set $(brctl show | awk 'FNR == 2 {print $1}') down
sudo brctl delbr $(brctl show | awk 'FNR == 2 {print $1}')
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
