### PR TITLE
Revert "Remove pyenv shims from PATH"

### DIFF
--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -50,20 +50,9 @@ when 'MasterServer', nil
     code <<-SLURM
       set -e
 
-      NEW_PATH=""
-      _OLD_IFS=${IFS}
-      IFS=':'
-      for p in ${PATH}
-      do
-        [[ ! ${p} =~ \.pyenv ]] && NEW_PATH="${p}:${NEW_PATH}"
-      done
-      IFS=${_OLD_IFS}
-      export PATH=${NEW_PATH}
-
       # python3 is required to build slurm >= 20.02
       source #{node['cfncluster']['cookbook_virtualenv_path']}/bin/activate
 
-      env
       tar xf #{slurm_tarball}
       cd slurm-#{node['cfncluster']['slurm']['version']}
       ./configure --prefix=/opt/slurm


### PR DESCRIPTION
Not needed anymore since we are now sourcing the virtualenv explicitly before compiling.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
