### PR TITLE
Disable health check if health queue is not created

### DIFF
--- a/templates/default/sqswatcher.cfg.erb
+++ b/templates/default/sqswatcher.cfg.erb
@@ -7,3 +7,4 @@ scheduler = <%= node['cfncluster']['cfn_scheduler'] %>
 cluster_user = <%= node['cfncluster']['cfn_cluster_user'] %>
 proxy = <%= node['cfncluster']['cfn_proxy'] %>
 stack_name = <%= node['cfncluster']['stack_name'] %>
+<%= if node['cfncluster']['cfn_health_sqs_queue'].nil? || node['cfncluster']['cfn_health_sqs_queue'].empty? then "disable_health_check = True" end %>


### PR DESCRIPTION
* Disable health check if health SQS queue is not created, for example, when using AWSBatch as scheduler

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
