### PR TITLE
Export Master Private IP in dna.json and use it for NFS mount

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -202,6 +202,7 @@ suites:
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_master: <%= ENV['CFN_MASTER'] %>
+        cfn_master_privateip: <%= ENV['CFN_MASTER_PRIVATEIP'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
@@ -230,6 +231,7 @@ suites:
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_master: <%= ENV['CFN_MASTER'] %>
+        cfn_master_privateip: <%= ENV['CFN_MASTER_PRIVATEIP'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
@@ -258,6 +260,7 @@ suites:
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_master: <%= ENV['CFN_MASTER'] %>
+        cfn_master_privateip: <%= ENV['CFN_MASTER_PRIVATEIP'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -290,6 +290,7 @@ default['cfncluster']['cfn_shared_dir'] = '/shared'
 default['cfncluster']['cfn_efs_shared_dir'] = 'NONE'
 default['cfncluster']['cfn_efs'] = nil
 default['cfncluster']['cfn_master'] = nil
+default['cfncluster']['cfn_master_privateip'] = nil
 default['cfncluster']['cfn_cluster_user'] = 'ec2-user'
 default['cfncluster']['cfn_fsx_options'] = 'NONE'
 default['cfncluster']['cfn_fsx_fs_id'] = nil

--- a/recipes/_compute_base_config.rb
+++ b/recipes/_compute_base_config.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-nfs_master = node['cfncluster']['cfn_master']
+nfs_master = node['cfncluster']['cfn_master_privateip']
 
 # Parse and get RAID shared directory info and turn into an array
 raid_shared_dir = node['cfncluster']['cfn_raid_parameters'].split(',')[0]

--- a/recipes/_compute_sge_config.rb
+++ b/recipes/_compute_sge_config.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Mount /opt/sge over NFS
-nfs_master = node['cfncluster']['cfn_master']
+nfs_master = node['cfncluster']['cfn_master_privateip']
 mount '/opt/sge' do
   device "#{nfs_master}:/opt/sge"
   fstype "nfs"

--- a/recipes/_compute_slurm_config.rb
+++ b/recipes/_compute_slurm_config.rb
@@ -23,7 +23,7 @@ directory '/var/spool/slurmd' do
 end
 
 # Mount /opt/slurm over NFS
-nfs_master = node['cfncluster']['cfn_master']
+nfs_master = node['cfncluster']['cfn_master_privateip']
 mount '/opt/slurm' do
   device "#{nfs_master}:/opt/slurm"
   fstype "nfs"

--- a/templates/default/cfnconfig.erb
+++ b/templates/default/cfnconfig.erb
@@ -17,6 +17,7 @@ cfn_cluster_user=<%= node['cfncluster']['cfn_cluster_user'] %>
 cfn_sqs_queue=<%= node['cfncluster']['cfn_sqs_queue'] %>
 cfn_health_sqs_queue=<%= node['cfncluster']['cfn_health_sqs_queue'] %>
 cfn_master=<%= node['cfncluster']['cfn_master'] %>
+cfn_master_privateip=<%= node['cfncluster']['cfn_master_privateip'] %>
 <% end -%>
 <% if node['cfncluster']['cfn_node_type'] == 'MasterServer' -%>
 cfn_volume=<%= node['cfncluster']['cfn_volume'] %>


### PR DESCRIPTION
Compute node will mount NFS share from master using private IP instead of private DNS name

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
