### PR TITLE
Start slurmd with nodename/hostname

### DIFF
--- a/files/default/cloudwatch_logs/cloudwatch_log_files.json
+++ b/files/default/cloudwatch_logs/cloudwatch_log_files.json
@@ -91,6 +91,25 @@
       "feature_conditions": []
     },
     {
+      "timestamp_format_key": "month_first",
+      "file_path": "/var/log/cloud-init-output.log",
+      "log_stream_name": "cloud-init-output",
+      "schedulers": [
+        "sge",
+        "slurm",
+        "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet"
+      ],
+      "feature_conditions": []
+    },
+    {
       "timestamp_format_key": "default",
       "file_path": "/var/log/supervisord.log",
       "log_stream_name": "supervisord",

--- a/recipes/_compute_slurm_finalize.rb
+++ b/recipes/_compute_slurm_finalize.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: _compute_slurm_finalize
+#
+# Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+ruby_block 'get_compute_nodename' do
+  block do
+    # Retrieve private ip from Metadata V2
+    require 'mixlib/shellout'
+    node.run_state['compute_ip'] = shell_out!('curl http://169.254.169.254/latest/meta-data/local-ipv4', :user => 'root').stdout.strip
+    # Retrieve NodeName from scontrol
+    node.run_state['slurm_compute_nodename'] = shell_out!("/opt/slurm/bin/scontrol show nodes | awk \"/\\y#{node.run_state['compute_ip']}\\y/\" RS= | grep -oP '^NodeName=\\K(\\S+)'", :user => 'root').stdout.strip
+  end
+  retries 3
+  retry_delay 5
+end
+
+directory '/etc/sysconfig' do
+  user 'root'
+  group 'root'
+  mode '0644'
+end
+
+if node['init_package'] == 'systemd'
+  file '/etc/sysconfig/slurmd' do
+    content(lazy { "SLURMD_OPTIONS='-N #{node.run_state['slurm_compute_nodename']}'" })
+    mode '0644'
+    owner 'root'
+    group 'root'
+  end
+
+  service "slurmd" do
+    supports restart: false
+    action %i[enable start]
+  end
+else
+  file '/etc/sysconfig/slurm' do
+    content(lazy { "SLURMD_OPTIONS='-N #{node.run_state['slurm_compute_nodename']}'" })
+    mode '0644'
+    owner 'root'
+    group 'root'
+  end
+
+  service "slurm" do
+    supports restart: false
+    action %i[enable start]
+  end
+end

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -62,12 +62,14 @@ template '/etc/sudoers.d/99-parallelcluster-user-tty' do
   mode '0600'
 end
 
-# Install parallelcluster specific supervisord config
-template '/etc/parallelcluster/parallelcluster_supervisord.conf' do
-  source 'parallelcluster_supervisord.conf.erb'
-  owner 'root'
-  group 'root'
-  mode '0644'
+unless node['cfncluster']['cfn_scheduler'] == 'slurm'
+  # Install parallelcluster specific supervisord config
+  template '/etc/parallelcluster/parallelcluster_supervisord.conf' do
+    source 'parallelcluster_supervisord.conf.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+  end
 end
 
 # Mount EFS directory with efs_mount recipe

--- a/recipes/finalize.rb
+++ b/recipes/finalize.rb
@@ -21,8 +21,14 @@ service "supervisord" do
   action %i[enable start]
 end
 
-execute "compute_ready" do
-  command "/opt/parallelcluster/scripts/compute_ready"
-  environment('PATH' => '/usr/local/bin:/usr/bin/:$PATH')
-  only_if { node['cfncluster']['cfn_node_type'] == 'ComputeFleet' }
+return unless node['cfncluster']['cfn_node_type'] == 'ComputeFleet'
+
+case node['cfncluster']['cfn_scheduler']
+when 'slurm'
+  include_recipe 'aws-parallelcluster::_compute_slurm_finalize'
+else
+  execute "compute_ready" do
+    command "/opt/parallelcluster/scripts/compute_ready"
+    environment('PATH' => '/usr/local/bin:/usr/bin/:$PATH')
+  end
 end


### PR DESCRIPTION
* Add recipe to finalize compute configuration for slurm and start slurmd with correct nodename/hostname of the compute instance
* Disable supervisord if scheduler is slurm

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
