### PR TITLE
Revert "Pin cfn-bootstrap on Centos 6"

### DIFF
--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -257,8 +257,8 @@
         "region=\"{{user `region`}}\"",
         "bucket=\"s3.amazonaws.com\"",
         "[[ ${region} =~ ^cn- ]] && bucket=\"s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster\"",
-        "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-1.4-31.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-1.4-31.tar.gz",
-        "sudo pip install /tmp/aws-cfn-bootstrap-1.4-31.tar.gz"
+        "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
+        "sudo pip install /tmp/aws-cfn-bootstrap-latest.tar.gz"
       ]
     },
     {


### PR DESCRIPTION
This reverts commit 15fa434b
Cfn-bootstrap scripts compatibility with python 2.6 has been restored.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
