### PR TITLE
Setup for Resume and Suspend scripts

### DIFF
--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -113,6 +113,13 @@ file "/var/log/parallelcluster/slurm_resume.log" do
   mode '0644'
 end
 
+template "#{node['cfncluster']['configs_dir']}/slurm/parallelcluster_slurm_resume.conf" do
+  source 'slurm/parallelcluster_slurm_resume.conf.erb'
+  owner 'slurm'
+  group 'slurm'
+  mode '0644'
+end
+
 template "#{node['cfncluster']['scripts_dir']}/slurm/slurm_suspend" do
   source 'slurm/suspend_program.erb'
   owner 'slurm'
@@ -126,8 +133,8 @@ file "/var/log/parallelcluster/slurm_suspend.log" do
   mode '0644'
 end
 
-template "#{node['cfncluster']['configs_dir']}/parallelcluster_slurm_cloudbursting.conf" do
-  source 'slurm/parallelcluster_slurm_cloudbursting.conf.erb'
+template "#{node['cfncluster']['configs_dir']}/slurm/parallelcluster_slurm_suspend.conf" do
+  source 'slurm/parallelcluster_slurm_suspend.conf.erb'
   owner 'slurm'
   group 'slurm'
   mode '0644'

--- a/templates/default/slurm/parallelcluster_slurm_cloudbursting.conf.erb
+++ b/templates/default/slurm/parallelcluster_slurm_cloudbursting.conf.erb
@@ -1,0 +1,9 @@
+[slurm_resume]
+cluster_name = <%= node['cfncluster']['stack_name'].sub("parallelcluster-", "") %>
+region = <%= node['cfncluster']['cfn_region'] %>
+proxy = <%= node['cfncluster']['cfn_proxy'] %>
+
+[slurm_suspend]
+cluster_name = <%= node['cfncluster']['stack_name'].sub("parallelcluster-", "") %>
+region = <%= node['cfncluster']['cfn_region'] %>
+proxy = <%= node['cfncluster']['cfn_proxy'] %>

--- a/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
+++ b/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
@@ -1,0 +1,4 @@
+[slurm_resume]
+cluster_name = <%= node['cfncluster']['stack_name'].sub("parallelcluster-", "") %>
+region = <%= node['cfncluster']['cfn_region'] %>
+proxy = <%= node['cfncluster']['cfn_proxy'] %>

--- a/templates/default/slurm/parallelcluster_slurm_suspend.conf.erb
+++ b/templates/default/slurm/parallelcluster_slurm_suspend.conf.erb
@@ -1,8 +1,3 @@
-[slurm_resume]
-cluster_name = <%= node['cfncluster']['stack_name'].sub("parallelcluster-", "") %>
-region = <%= node['cfncluster']['cfn_region'] %>
-proxy = <%= node['cfncluster']['cfn_proxy'] %>
-
 [slurm_suspend]
 cluster_name = <%= node['cfncluster']['stack_name'].sub("parallelcluster-", "") %>
 region = <%= node['cfncluster']['cfn_region'] %>


### PR DESCRIPTION
* Setup permissions correctly for resume and suspend scripts. The directory containing scripts needs to have 0755, the scripts have 0744, and logs for scripts have 0644.
* Add `parallelcluster_slurm_cloudbursting.conf` to provide configuration for resume/suspend scripts

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
