### PR TITLE
Modify permissions on /opt/parallelcluster/scripts/slurm dir

### DIFF
--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -53,7 +53,7 @@ end
 # Copy pcluster config generator and templates
 remote_directory "#{node['cfncluster']['scripts_dir']}/slurm" do
   source 'slurm'
-  mode '0700'
+  mode '0755'
   action :create
   recursive true
 end


### PR DESCRIPTION
The dir is owned by root and we need slurm user to execute some of the files in this dir


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
