### PR TITLE
Dynamically retrieve master node address when not set in dna.json

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -202,6 +202,7 @@ suites:
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_master: <%= ENV['CFN_MASTER'] %>
+        cfn_master_private_ip: <%= ENV['CFN_MASTER_PRIVATE_IP'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
@@ -230,6 +231,7 @@ suites:
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_master: <%= ENV['CFN_MASTER'] %>
+        cfn_master_private_ip: <%= ENV['CFN_MASTER_PRIVATE_IP'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -257,7 +257,6 @@ suites:
         cfn_shared_dir: <%= ENV['CFN_SHARED_DIR'] %>
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
-        cfn_master: <%= ENV['CFN_MASTER'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -294,6 +294,7 @@ default['cfncluster']['cfn_shared_dir'] = '/shared'
 default['cfncluster']['cfn_efs_shared_dir'] = 'NONE'
 default['cfncluster']['cfn_efs'] = nil
 default['cfncluster']['cfn_master'] = nil
+default['cfncluster']['cfn_master_private_ip'] = nil
 default['cfncluster']['cfn_cluster_user'] = 'ec2-user'
 default['cfncluster']['cfn_fsx_options'] = 'NONE'
 default['cfncluster']['cfn_fsx_fs_id'] = nil

--- a/recipes/_compute_base_config.rb
+++ b/recipes/_compute_base_config.rb
@@ -15,7 +15,17 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-nfs_master = node['cfncluster']['cfn_master']
+# Retrieve master node ip if not set already
+unless node['cfncluster']['cfn_master']
+  ruby_block "retrieve master ip" do
+    block do
+      _, master_private_dns = master_address(node['cfncluster']['cfn_region'], node['cfncluster']['stack_name'])
+      node.force_default['cfncluster']['cfn_master'] = master_private_dns
+    end
+    retries 5
+    retry_delay 3
+  end
+end
 
 # Parse and get RAID shared directory info and turn into an array
 raid_shared_dir = node['cfncluster']['cfn_raid_parameters'].split(',')[0]
@@ -34,7 +44,7 @@ if raid_shared_dir != "NONE"
 
   # Mount RAID directory over NFS
   mount raid_shared_dir do
-    device "#{nfs_master}:#{raid_shared_dir}"
+    device(lazy { "#{node['cfncluster']['cfn_master']}:#{raid_shared_dir}" })
     fstype 'nfs'
     options 'hard,intr,noatime,vers=3,_netdev'
     action %i[mount enable]
@@ -43,7 +53,7 @@ end
 
 # Mount /home over NFS
 mount '/home' do
-  device "#{nfs_master}:/home"
+  device(lazy { "#{node['cfncluster']['cfn_master']}:/home" })
   fstype 'nfs'
   options 'hard,intr,noatime,vers=3,_netdev'
   action %i[mount enable]
@@ -51,7 +61,7 @@ end
 
 # Mount /opt/intel over NFS
 mount '/opt/intel' do
-  device "#{nfs_master}:/opt/intel"
+  device(lazy { "#{node['cfncluster']['cfn_master']}:/opt/intel" })
   fstype 'nfs'
   options 'hard,intr,noatime,vers=3,_netdev'
   action %i[mount enable]
@@ -90,7 +100,7 @@ shared_dir_array.each do |dir|
 
     # Mount shared volume over NFS
     mount dirname do
-      device "#{nfs_master}:#{dirname}"
+      device(lazy { "#{node['cfncluster']['cfn_master']}:#{dirname}" })
       fstype 'nfs'
       options 'hard,intr,noatime,vers=3,_netdev'
       action %i[mount enable]

--- a/recipes/_compute_sge_config.rb
+++ b/recipes/_compute_sge_config.rb
@@ -16,9 +16,8 @@
 # limitations under the License.
 
 # Mount /opt/sge over NFS
-nfs_master = node['cfncluster']['cfn_master']
 mount '/opt/sge' do
-  device "#{nfs_master}:/opt/sge"
+  device(lazy { "#{node['cfncluster']['cfn_master']}:/opt/sge" })
   fstype "nfs"
   options 'hard,intr,noatime,vers=3,_netdev'
   action %i[mount enable]

--- a/recipes/_compute_sge_config.rb
+++ b/recipes/_compute_sge_config.rb
@@ -17,7 +17,7 @@
 
 # Mount /opt/sge over NFS
 mount '/opt/sge' do
-  device(lazy { "#{node['cfncluster']['cfn_master']}:/opt/sge" })
+  device(lazy { "#{node['cfncluster']['cfn_master_private_ip']}:/opt/sge" })
   fstype "nfs"
   options 'hard,intr,noatime,vers=3,_netdev'
   action %i[mount enable]

--- a/recipes/_compute_slurm_config.rb
+++ b/recipes/_compute_slurm_config.rb
@@ -24,7 +24,7 @@ end
 
 # Mount /opt/slurm over NFS
 mount '/opt/slurm' do
-  device(lazy { "#{node['cfncluster']['cfn_master']}:/opt/slurm" })
+  device(lazy { "#{node['cfncluster']['cfn_master_private_ip']}:/opt/slurm" })
   fstype "nfs"
   options 'hard,intr,noatime,vers=3,_netdev'
   action %i[mount enable]

--- a/recipes/_compute_slurm_config.rb
+++ b/recipes/_compute_slurm_config.rb
@@ -23,9 +23,8 @@ directory '/var/spool/slurmd' do
 end
 
 # Mount /opt/slurm over NFS
-nfs_master = node['cfncluster']['cfn_master']
 mount '/opt/slurm' do
-  device "#{nfs_master}:/opt/slurm"
+  device(lazy { "#{node['cfncluster']['cfn_master']}:/opt/slurm" })
   fstype "nfs"
   options 'hard,intr,noatime,vers=3,_netdev'
   action %i[mount enable]

--- a/templates/default/gmond.conf.erb
+++ b/templates/default/gmond.conf.erb
@@ -48,7 +48,7 @@ udp_send_channel {
   host = <%= node['hostname'] %>
 <% end -%>
 <% if node['cfncluster']['cfn_node_type'] == 'ComputeFleet' -%>
-  host = <%= node['cfncluster']['cfn_master'] %>
+  host = <%= node['cfncluster']['cfn_master_private_ip'] %>
 <% end -%>
   port = 8649
   ttl = 1

--- a/templates/ubuntu/gmond.conf.erb
+++ b/templates/ubuntu/gmond.conf.erb
@@ -42,7 +42,7 @@ udp_send_channel {
   host = <%= node['hostname'] %>
 <% end -%>
 <% if node['cfncluster']['cfn_node_type'] == 'ComputeFleet' -%>
-  host = <%= node['cfncluster']['cfn_master'] %>
+  host = <%= node['cfncluster']['cfn_master_private_ip'] %>
 <% end -%>
   port = 8649
   ttl = 1


### PR DESCRIPTION
This allows to decouple the creation of the Master node resource from the creation of the ComputeFleet launch templates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
