### PR TITLE
Fix installation of custom pcluster cli

### DIFF
--- a/recipes/awsbatch_config.rb
+++ b/recipes/awsbatch_config.rb
@@ -42,9 +42,10 @@ if !node['cfncluster']['custom_awsbatchcli_package'].nil? && !node['cfncluster']
     cwd Chef::Config[:file_cache_path]
     code <<-CLI
       set -e
-      curl --retry 3 -v -L -o aws-parallelcluster.tgz #{node['cfncluster']['custom_awsbatchcli_package']}
-      tar -xzf aws-parallelcluster.tgz
-      cd *aws-parallelcluster-*
+      curl --retry 3 -L -o aws-parallelcluster.tgz #{node['cfncluster']['custom_awsbatchcli_package']}
+      mkdir aws-parallelcluster-custom-cli
+      tar -xzf aws-parallelcluster.tgz --directory aws-parallelcluster-custom-cli
+      cd aws-parallelcluster-custom-cli/*aws-parallelcluster-*
       pip install cli/
     CLI
   end

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -153,9 +153,10 @@ if !node['cfncluster']['custom_node_package'].nil? && !node['cfncluster']['custo
       echo "PATH is $PATH"
       source #{node['cfncluster']['node_virtualenv_path']}/bin/activate
       pip uninstall --yes aws-parallelcluster-node
-      curl --retry 3 -v -L -o aws-parallelcluster-node.tgz #{node['cfncluster']['custom_node_package']}
-      tar -xzf aws-parallelcluster-node.tgz
-      cd *aws-parallelcluster-node-*
+      curl --retry 3 -L -o aws-parallelcluster-node.tgz #{node['cfncluster']['custom_node_package']}
+      mkdir aws-parallelcluster-custom-node
+      tar -xzf aws-parallelcluster-node.tgz --directory aws-parallelcluster-custom-node
+      cd aws-parallelcluster-custom-node/*aws-parallelcluster-node-*
       pip install .
       deactivate
     NODE


### PR DESCRIPTION
The logic was incompatible with the concurrent custom installation of node package because when executing `cd *aws-parallelcluster-*` it was entering the node directory and not the cli one. Because of this `pip install cli/` was failing.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
