### PR TITLE
Update to current official CentOS 7 base AMI

### DIFF
--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -33,11 +33,11 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "CentOS Linux 7 * HVM EBS ENA *",
+          "name": "CentOS 7.* *",
           "root-device-type": "ebs",
           "architecture": "{{user `ami_arch`}}"
         },
-        "owners": ["410186602215"],
+        "owners": ["125523088429"],
         "most_recent": true
       },
       "ami_regions" : "{{user `build_for`}}",


### PR DESCRIPTION
Update to the current official CentOS 7 Public Image, as listed here https://wiki.centos.org/Cloud/AWS/#Official_CentOS_Linux_:_Public_Images

* AMI Owner ID changed from `410186602215` to `125523088429`
* AMI name format changed from `CentOS Linux 7 x86_64 HVM EBS ENA 1805_01` to `CentOS 7.8.2003 x86_64`

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
