### PR TITLE
Remove profile.d script written by pyenv cookbook

### DIFF
--- a/resources/install_pyenv.rb
+++ b/resources/install_pyenv.rb
@@ -15,6 +15,13 @@ action :run do
     global_prefix new_resource.prefix
   end
 
+  # Remove the profile.d script that the pyenv cookbook writes.
+  # This is done in order to avoid exposing the ParallelCluster pyenv installation to customers
+  # on login.
+  file '/etc/profile.d/pyenv.sh' do
+    action :delete
+  end
+
   pyenv_python new_resource.python_version
 
   pyenv_plugin 'virtualenv' do


### PR DESCRIPTION
This is needed because 53038ce removed the code that overwrote this
file. This is a problem for two reasons:
1. The script written by the pyenv cookbook attempts to write to
   directories that the default user does not have permissions for. Thus
   when a customer logs in as the default user they see the error
   message `pyenv: cannot rehash: /opt/parallelcluster/pyenv/shims isn't
   writable`.
2. The point of 53038ce was to avoid exposing the ParallelCluster pyenv
   installation to customers. The profile.d script being present means
   that it is exposed.

The fix is to remove the profile.d script created by the pyenv cookbook.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
