### PR TITLE
Add .kitchen folder to chefignore

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -93,3 +93,6 @@ Vagrantfile
 # Travis #
 ##########
 .travis.yml
+
+# Kitchen #
+.kitchen


### PR DESCRIPTION
The chefignore file is used to tell knife which cookbook files in the chef-repo should be ignored when uploading data to the Chef Infra Server.
This should solve the error `Failed to complete #converge action: [No such file or directory @ rb_sysopen` as suggested in
https://github.com/test-kitchen/test-kitchen/issues/699 and https://github.com/test-kitchen/test-kitchen/issues/1349

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
