### PR TITLE
Slurm: do not limit the rate of burstable capacity

### DIFF
--- a/templates/default/slurm/slurm.conf.erb
+++ b/templates/default/slurm/slurm.conf.erb
@@ -31,6 +31,7 @@ SuspendTimeout=1200
 ResumeTimeout=600
 TreeWidth=65533
 PrivateData=cloud
+ResumeRate=0
 #
 # TIMERS
 SlurmctldTimeout=300


### PR DESCRIPTION
>ResumeRate
The rate at which nodes in power save mode are returned to normal operation by ResumeProgram. The value is number of nodes per minute and it can be used to prevent power surges if a large number of nodes in power save mode are assigned work at the same time (e.g. a large job starts). A value of zero results in no limits being imposed.

Disabling any rate limiting for bursted capacity in Slurm


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
