### PR TITLE
Install PMIx v3.1.5

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,6 +59,10 @@ default['cfncluster']['torque']['url'] = 'https://github.com/adaptivecomputing/t
 default['cfncluster']['slurm']['version'] = '19.05.5'
 default['cfncluster']['slurm']['url'] = 'https://download.schedmd.com/slurm/slurm-19.05.5.tar.bz2'
 default['cfncluster']['slurm']['sha1'] = '055adca91e555cc124b1ecac5f3c45e66c17a8ba'
+# PMIx software
+default['cfncluster']['pmix']['version'] = '3.1.5'
+default['cfncluster']['pmix']['url'] = "https://github.com/openpmix/openpmix/releases/download/v#{node['cfncluster']['pmix']['version']}/pmix-#{node['cfncluster']['pmix']['version']}.tar.gz"
+default['cfncluster']['pmix']['sha1'] = '36bfb962858879cefa7a04a633c1b6984cea03ec'
 # Munge
 default['cfncluster']['munge']['munge_version'] = '0.5.13'
 default['cfncluster']['munge']['munge_url'] = "https://github.com/dun/munge/archive/munge-#{node['cfncluster']['munge']['munge_version']}.tar.gz"
@@ -161,7 +165,7 @@ when 'rhel', 'amazon'
                                                 httpd boost-devel redhat-lsb mlocate mpich-devel openmpi-devel R atlas-devel
                                                 blas-devel fftw-devel libffi-devel openssl-devel dkms mysql-devel libedit-devel
                                                 libical-devel postgresql-devel postgresql-server sendmail mdadm python python-pip
-                                                libgcrypt-devel]
+                                                libgcrypt-devel libevent-devel]
 
     # Lustre Drivers for Centos 6
     default['cfncluster']['lustre']['version'] = '2.10.6'
@@ -174,7 +178,7 @@ when 'rhel', 'amazon'
                                                   httpd boost-devel redhat-lsb mlocate lvm2 mpich-devel R atlas-devel
                                                   blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                                   libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel mdadm python python-pip
-                                                  libssh2-devel libgcrypt-devel]
+                                                  libssh2-devel libgcrypt-devel libevent-devel]
       if node['platform_version'].split('.')[1] >= '7'
         # Lustre Client for Centos >= 7.7
         default['cfncluster']['lustre']['public_key'] = 'https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc'
@@ -200,7 +204,7 @@ when 'rhel', 'amazon'
                                                 libXmu-devel hwloc-devel db4-devel tcl-devel automake autoconf pyparted libtool
                                                 httpd boost-devel redhat-lsb mlocate mpich-devel R atlas-devel fftw-devel
                                                 libffi-devel dkms mysql-devel libedit-devel postgresql-devel postgresql-server
-                                                sendmail cmake byacc libglvnd-devel mdadm libgcrypt-devel]
+                                                sendmail cmake byacc libglvnd-devel mdadm libgcrypt-devel libevent-devel]
     if node['platform_version'].to_i == 2
       # mpich-devel not available on alinux
       default['cfncluster']['base_packages'].delete('mpich-devel')
@@ -240,7 +244,7 @@ when 'debian'
                                               apache2 libboost-dev libdb-dev tcsh libssl-dev libncurses5-dev libpam0g-dev libxt-dev
                                               libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev python python-pip
                                               r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev mdadm
-                                              libgcrypt20-dev libmysqlclient-dev]
+                                              libgcrypt20-dev libmysqlclient-dev libevent-dev]
   if node['platform_version'] == '18.04'
     default['cfncluster']['base_packages'].delete('libatlas-dev')
     default['cfncluster']['base_packages'].push('libatlas-base-dev', 'libssl-dev', 'libglvnd-dev')

--- a/recipes/pmix_install.rb
+++ b/recipes/pmix_install.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: pmix_install
+#
+# Copyright 2013-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+return if node['conditions']['ami_bootstrapped']
+
+pmix_tarball = "#{node['cfncluster']['sources_dir']}/pmix-#{node['cfncluster']['pmix']['version']}.tar.gz"
+
+remote_file pmix_tarball do
+  source node['cfncluster']['pmix']['url']
+  mode '0644'
+  retries 3
+  retry_delay 5
+  not_if { ::File.exist?(pmix_tarball) }
+end
+
+ruby_block "Validate PMIx Tarball Checksum" do
+  block do
+    require 'digest'
+    checksum = Digest::SHA1.file(pmix_tarball).hexdigest
+    raise "Downloaded Tarball Checksum #{checksum} does not match expected checksum #{node['cfncluster']['pmix']['sha1']}" if checksum != node['cfncluster']['pmix']['sha1']
+  end
+end
+
+bash 'Install PMIx' do
+  user 'root'
+  group 'root'
+  cwd Chef::Config[:file_cache_path]
+  code <<-PMIX
+    set -e
+    tar xf #{pmix_tarball}
+    cd pmix-#{node['cfncluster']['pmix']['version']}
+    ./autogen.pl
+    ./configure --prefix=/usr
+    make
+    make install
+  PMIX
+end

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -19,6 +19,7 @@ return if node['conditions']['ami_bootstrapped']
 
 include_recipe 'aws-parallelcluster::base_install'
 include_recipe 'aws-parallelcluster::munge_install'
+include_recipe 'aws-parallelcluster::pmix_install'
 
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer', nil

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -167,6 +167,10 @@ if node['cfncluster']['cfn_scheduler'] == 'slurm'
     execute 'check-slurm-jobcomp-mysql-plugins' do
       command "ls /opt/slurm/lib/slurm/ | grep jobcomp_mysql"
     end
+
+    execute 'check-slurm-pmix-plugins' do
+      command 'ls /opt/slurm/lib/slurm/ | grep pmix'
+    end
   when 'ComputeFleet'
     execute 'ls slurm root' do
       command "ls /opt/slurm"


### PR DESCRIPTION
This enables the slurm be built against it and use it when launching
jobs.

Avoid issues like [this one](https://github.com/aws/aws-parallelcluster/issues/1182) by passing `--mpi=pmix` to `srun`.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
