### PR TITLE
Set default domain after setting default region

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -278,9 +278,6 @@ end
 # Munge key
 default['cfncluster']['munge']['munge_key'] = 'YflQEFLjoxsmEK5vQyKklkLKJ#LkjLKDJF@*(#)ajLKQ@hLKN#()FSU(#@KLJH$@HKSASG)*DUJJDksdN'
 
-# AWS domain
-default['cfncluster']['aws_domain'] = aws_domain
-
 # ParallelCluster internal variables (also in /etc/parallelcluster/cfnconfig)
 default['cfncluster']['cfn_region'] = 'us-east-1'
 default['cfncluster']['stack_name'] = nil
@@ -310,3 +307,6 @@ default['cfncluster']['custom_awsbatchcli_package'] = nil
 default['cfncluster']['cfn_raid_parameters'] = 'NONE'
 default['cfncluster']['cfn_raid_vol_ids'] = nil
 default['cfncluster']['skip_install_recipes'] = 'yes'
+
+# AWS domain
+default['cfncluster']['aws_domain'] = aws_domain


### PR DESCRIPTION
This is necessary because the `aws_domain` function uses the value in
`node['cfncluster']['cfn_region']`, which isn't set yet when the
function is first called in the default attributes file.

Signed-off-by: Tim Lane <tilne@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
