### PR TITLE
Don't build PMIx on CentOS 6

### DIFF
--- a/attributes/conditions.rb
+++ b/attributes/conditions.rb
@@ -21,3 +21,4 @@ default['conditions']['intel_mpi_supported'] = !arm_instance? && platform_suppor
 default['conditions']['intel_hpc_platform_supported'] = !arm_instance? && platform_supports_intel_hpc_platform?
 default['conditions']['dcv_supported'] = !arm_instance? && platform_supports_dcv?
 default['conditions']['ami_bootstrapped'] = ami_bootstrapped?
+default['conditions']['pmix_supported'] = platform_supports_pmix?

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -163,7 +163,7 @@ when 'rhel', 'amazon'
                                                 httpd boost-devel redhat-lsb mlocate mpich-devel openmpi-devel R atlas-devel
                                                 blas-devel fftw-devel libffi-devel openssl-devel dkms mysql-devel libedit-devel
                                                 libical-devel postgresql-devel postgresql-server sendmail mdadm python python-pip
-                                                libgcrypt-devel libevent-devel]
+                                                libgcrypt-devel]
 
     # Lustre Drivers for Centos 6
     default['cfncluster']['lustre']['version'] = '2.10.6'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -224,3 +224,13 @@ def aws_domain
   aws_domain = "#{aws_domain}.cn" if node['cfncluster']['cfn_region'].start_with?("cn-")
   aws_domain
 end
+
+#
+# Chedk if PMIx is supported on this OS. It's not built on CentOS 6
+# because doing so would require installing newer versions of automake,
+# autoconf, libtool, and libevent. This was deemed more effort than it
+# was worth for an OS that will reach EOL soon.
+#
+def platform_supports_pmix?
+  node['platform'] != 'centos' || node['platform_version'].to_i > 6
+end

--- a/recipes/pmix_install.rb
+++ b/recipes/pmix_install.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-return if node['conditions']['ami_bootstrapped']
+return if node['conditions']['ami_bootstrapped'] || !node['conditions']['pmix_supported']
 
 pmix_tarball = "#{node['cfncluster']['sources_dir']}/pmix-#{node['cfncluster']['pmix']['version']}.tar.gz"
 


### PR DESCRIPTION
The changes required for building PMIx on CentOS 6 (see #646) were
deemed more work and risk than they were worth considering the OS
will reach EOL very soon.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
