### PR TITLE
Vendor PCluster cookbook in Packer instance

### DIFF
--- a/amis/build_ami.sh
+++ b/amis/build_ami.sh
@@ -38,13 +38,6 @@ requirements_check() {
       echo "Please visit https://www.packer.io/downloads.html for instruction on how to download and install"
       exit 1
     fi
-
-    berks vendor --help >/dev/null 2>&1
-    if [ $? -ne 0 ] ; then
-      echo "berks command not found. Is berkshelf installed?"
-      echo "Please visit https://github.com/berkshelf/berkshelf for instruction on how to download and install"
-      exit 1
-    fi
 }
 
 
@@ -125,7 +118,7 @@ check_options() {
     available_os="centos6 centos7 alinux ubuntu1604 ${available_arm_os}"
     cwd="$(dirname $0)"
     tmp_dir=$(mktemp -d)
-    export VENDOR_PATH="${tmp_dir}/vendor/cookbooks"
+    export COOKBOOK_PATH="${tmp_dir}/cookbook"
 
     if [ "${_custom}" == "true" ]; then
         only=custom-${_os}
@@ -210,8 +203,8 @@ check_options() {
 do_command() {
     RC=0
 
-    rm -rf "${VENDOR_PATH}" || RC=1
-    berks vendor "${VENDOR_PATH}" --berksfile "${cwd}/../Berksfile" || RC=1
+    mkdir -p "${COOKBOOK_PATH}"
+    cp -R ${cwd}/../* "${COOKBOOK_PATH}"
     if [ "x${_build_date}" == "x" ]; then
       export BUILD_DATE=$(date +%Y%m%d%H%M)
     else

--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -8,7 +8,7 @@
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
-    "vendor_path" : "{{env `VENDOR_PATH`}}",
+    "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
@@ -156,21 +156,9 @@
       ]
     },
     {
-      "type" : "shell",
-      "inline" : [
-        "sudo mkdir -p /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
-    },
-    {
       "type" : "file",
-      "source" : "{{user `vendor_path`}}",
-      "destination" : "/tmp/cookbooks"
-    },
-    {
-      "type" : "shell",
-      "inline" : [
-        "sudo cp -pr /tmp/cookbooks /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
+      "source" : "{{user `cookbook_path`}}",
+      "destination" : "/tmp/cookbook"
     },
     {
       "type" : "shell",
@@ -186,6 +174,14 @@
       "type" : "shell",
       "inline" : [
         "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "set -x",
+        "sudo /opt/cinc/embedded/bin/berks vendor /etc/chef/cookbooks --berksfile /tmp/cookbook/Berksfile",
+        "sudo chown -R root:root /etc/chef"
       ]
     },
     {

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -8,7 +8,7 @@
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
-    "vendor_path" : "{{env `VENDOR_PATH`}}",
+    "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
@@ -156,21 +156,9 @@
       ]
     },
     {
-      "type" : "shell",
-      "inline" : [
-        "sudo mkdir -p /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
-    },
-    {
       "type" : "file",
-      "source" : "{{user `vendor_path`}}",
-      "destination" : "/tmp/cookbooks"
-    },
-    {
-      "type" : "shell",
-      "inline" : [
-        "sudo cp -pr /tmp/cookbooks /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
+      "source" : "{{user `cookbook_path`}}",
+      "destination" : "/tmp/cookbook"
     },
     {
       "type" : "shell",
@@ -186,6 +174,14 @@
       "type" : "shell",
       "inline" : [
         "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "set -x",
+        "sudo /opt/cinc/embedded/bin/berks vendor /etc/chef/cookbooks --berksfile /tmp/cookbook/Berksfile",
+        "sudo chown -R root:root /etc/chef"
       ]
     },
     {

--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -8,7 +8,7 @@
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
-    "vendor_path" : "{{env `VENDOR_PATH`}}",
+    "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
@@ -163,21 +163,9 @@
       ]
     },
     {
-      "type" : "shell",
-      "inline" : [
-        "sudo mkdir -p /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
-    },
-    {
       "type" : "file",
-      "source" : "{{user `vendor_path`}}",
-      "destination" : "/tmp/cookbooks"
-    },
-    {
-      "type" : "shell",
-      "inline" : [
-        "sudo cp -pr /tmp/cookbooks /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
+      "source" : "{{user `cookbook_path`}}",
+      "destination" : "/tmp/cookbook"
     },
     {
       "type" : "shell",
@@ -193,6 +181,14 @@
       "type" : "shell",
       "inline" : [
         "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "set -x",
+        "sudo /opt/cinc/embedded/bin/berks vendor /etc/chef/cookbooks --berksfile /tmp/cookbook/Berksfile",
+        "sudo chown -R root:root /etc/chef"
       ]
     },
     {

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -8,7 +8,7 @@
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
-    "vendor_path" : "{{env `VENDOR_PATH`}}",
+    "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "dcv_installed": "{{env `DCV_INSTALLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
@@ -172,21 +172,9 @@
       ]
     },
     {
-      "type" : "shell",
-      "inline" : [
-        "sudo mkdir -p /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
-    },
-    {
       "type" : "file",
-      "source" : "{{user `vendor_path`}}",
-      "destination" : "/tmp/cookbooks"
-    },
-    {
-      "type" : "shell",
-      "inline" : [
-        "sudo cp -pr /tmp/cookbooks /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
+      "source" : "{{user `cookbook_path`}}",
+      "destination" : "/tmp/cookbook"
     },
     {
       "type" : "shell",
@@ -202,6 +190,14 @@
       "type" : "shell",
       "inline" : [
         "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "set -x",
+        "sudo /opt/cinc/embedded/bin/berks vendor /etc/chef/cookbooks --berksfile /tmp/cookbook/Berksfile",
+        "sudo chown -R root:root /etc/chef"
       ]
     },
     {

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -8,7 +8,7 @@
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
-    "vendor_path" : "{{env `VENDOR_PATH`}}",
+    "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
@@ -176,21 +176,9 @@
       ]
     },
     {
-      "type" : "shell",
-      "inline" : [
-        "sudo mkdir -p /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
-    },
-    {
       "type" : "file",
-      "source" : "{{user `vendor_path`}}",
-      "destination" : "/tmp/cookbooks"
-    },
-    {
-      "type" : "shell",
-      "inline" : [
-        "sudo cp -pr /tmp/cookbooks /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
+      "source" : "{{user `cookbook_path`}}",
+      "destination" : "/tmp/cookbook"
     },
     {
       "type" : "shell",
@@ -207,6 +195,14 @@
       "type" : "shell",
       "inline" : [
         "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "set -x",
+        "sudo /opt/cinc/embedded/bin/berks vendor /etc/chef/cookbooks --berksfile /tmp/cookbook/Berksfile",
+        "sudo chown -R root:root /etc/chef"
       ]
     },
     {

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -8,7 +8,7 @@
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
-    "vendor_path" : "{{env `VENDOR_PATH`}}",
+    "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "dcv_installed": "{{env `DCV_INSTALLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
@@ -177,21 +177,9 @@
       ]
     },
     {
-      "type" : "shell",
-      "inline" : [
-        "sudo mkdir -p /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
-    },
-    {
       "type" : "file",
-      "source" : "{{user `vendor_path`}}",
-      "destination" : "/tmp/cookbooks"
-    },
-    {
-      "type" : "shell",
-      "inline" : [
-        "sudo cp -pr /tmp/cookbooks /etc/chef && sudo chown -R root:root /etc/chef"
-      ]
+      "source" : "{{user `cookbook_path`}}",
+      "destination" : "/tmp/cookbook"
     },
     {
       "type" : "shell",
@@ -208,6 +196,14 @@
       "type" : "shell",
       "inline" : [
         "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "set -x",
+        "sudo /opt/cinc/embedded/bin/berks vendor /etc/chef/cookbooks --berksfile /tmp/cookbook/Berksfile",
+        "sudo chown -R root:root /etc/chef"
       ]
     },
     {

--- a/amis/packer_variables.json
+++ b/amis/packer_variables.json
@@ -2,5 +2,5 @@
   "parallelcluster_version": "2.7.0",
   "parallelcluster_cookbook_version": "2.7.0",
   "chef_version": "15.11.8",
-  "berkshelf_version": "7.0.4"
+  "berkshelf_version": "7.0.10"
 }


### PR DESCRIPTION
Vendor the aws-parallelcluster cookbook during Packer bootstrap and not client side

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
