### PR TITLE
Remove Ridley gem dependency

### DIFF
--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -4,7 +4,6 @@
     "parallelcluster_cookbook_version" : "",
     "chef_version" : "",
     "chef_custom_install_url" : "{{env `CHEF_CUSTOM_INSTALL_URL`}}",
-    "ridley_version" : "",
     "berkshelf_version" : "",
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
@@ -186,7 +185,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/cinc/embedded/bin/gem install --no-document ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+        "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -4,7 +4,6 @@
     "parallelcluster_cookbook_version" : "",
     "chef_version" : "",
     "chef_custom_install_url" : "{{env `CHEF_CUSTOM_INSTALL_URL`}}",
-    "ridley_version" : "",
     "berkshelf_version" : "",
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
@@ -186,7 +185,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/cinc/embedded/bin/gem install --no-document ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+        "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {

--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -4,7 +4,6 @@
     "parallelcluster_cookbook_version" : "",
     "chef_version" : "",
     "chef_custom_install_url" : "{{env `CHEF_CUSTOM_INSTALL_URL`}}",
-    "ridley_version" : "",
     "berkshelf_version" : "",
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
@@ -193,7 +192,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/cinc/embedded/bin/gem install --no-document ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+        "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -4,7 +4,6 @@
     "parallelcluster_cookbook_version" : "",
     "chef_version" : "",
     "chef_custom_install_url" : "{{env `CHEF_CUSTOM_INSTALL_URL`}}",
-    "ridley_version" : "",
     "berkshelf_version" : "",
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
@@ -202,7 +201,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/cinc/embedded/bin/gem install --no-document ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+        "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -4,7 +4,6 @@
     "parallelcluster_cookbook_version" : "",
     "chef_version" : "",
     "chef_custom_install_url" : "{{env `CHEF_CUSTOM_INSTALL_URL`}}",
-    "ridley_version" : "",
     "berkshelf_version" : "",
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
@@ -207,7 +206,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/cinc/embedded/bin/gem install --no-document ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+        "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -4,7 +4,6 @@
     "parallelcluster_cookbook_version" : "",
     "chef_version" : "",
     "chef_custom_install_url" : "{{env `CHEF_CUSTOM_INSTALL_URL`}}",
-    "ridley_version" : "",
     "berkshelf_version" : "",
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
@@ -208,7 +207,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo /opt/cinc/embedded/bin/gem install --no-document ridley:{{user `ridley_version`}} berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
+        "sudo /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{user `berkshelf_version`}} ffi-libarchive"
       ]
     },
     {

--- a/amis/packer_variables.json
+++ b/amis/packer_variables.json
@@ -2,6 +2,5 @@
   "parallelcluster_version": "2.7.0",
   "parallelcluster_cookbook_version": "2.7.0",
   "chef_version": "15.11.8",
-  "ridley_version": "5.1.1",
   "berkshelf_version": "7.0.4"
 }


### PR DESCRIPTION
Ridley was a runtime Berkshelf dependencies removed since Berkshelf version 6.3.1, see https://github.com/berkshelf/berkshelf/blob/master/CHANGELOG.md#v631-2017-08-22

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
