### PR TITLE
Unpin Intel HPC release number

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,7 +38,7 @@ default['cfncluster']['cookbook_virtualenv_path'] = "#{node['cfncluster']['syste
 default['cfncluster']['node_virtualenv_path'] = "#{node['cfncluster']['system_pyenv_root']}/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['node_virtualenv']}"
 # Intel Packages
 default['cfncluster']['psxe']['version'] = '2019.5'
-default['cfncluster']['intelhpc']['version'] = '2018.0-1.el7'
+default['cfncluster']['intelhpc']['version'] = '2018.0-*.el7'
 default['cfncluster']['intelpython2']['version'] = '2019.4'
 default['cfncluster']['intelpython3']['version'] = '2019.4'
 # Intel MPI


### PR DESCRIPTION
Release number can change when new build is uploaded into the repository.
Version has not changed and still pinned to 2018.0

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
