### PR TITLE
Remove "hostname" 3rd-party cookbook dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,6 @@ supports 'centos', '>= 6'
 supports 'ubuntu', '>= 16.04'
 
 depends 'apt', '~> 7.3.0'
-depends 'hostname', '~> 0.4.2'
 depends 'nfs', '~> 2.6.4'
 depends 'line', '~> 2.9.0'
 depends 'openssh', '~> 2.8.1'


### PR DESCRIPTION
Use builtin "hostname" resource https://docs.chef.io/resources/hostname/

No changes are done in the applied configuration
* `hostname -f` return the FQDN e.g. `ip-172-31-10-72.ec2.internal`
* `hostname` return the first part of the FQDN e.g. `ip-172-31-10-72`
* in `/etc/hosts` a new line is added, containing `<private-ip> <fqdn> <short fqdn>` e.g. `172.31.10.72 ip-172-31-10-72.ec2.internal ip-172-31-10-72`

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
