### PR TITLE
Fix matching for chefignore file

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -95,4 +95,4 @@ Vagrantfile
 .travis.yml
 
 # Kitchen #
-.kitchen
+.kitchen/*


### PR DESCRIPTION
chefignore file uses Ruby’s File.fnmatch
Files to be ignored are under the .kitchen folder, e.g.

BEFORE PR
```
irb(main):013:0> File.fnmatch('.kitchen', '.kitchen/sge-config-MasterServer-centos-6-minimal.yml')
=> false
```

AFTER PR
```
irb(main):015:0> File.fnmatch('.kitchen/*', '.kitchen/sge-config-MasterServer-centos-6-minimal.yml')
=> true
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
