### PR TITLE
Fix NVIDIA kitchen test

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -325,64 +325,62 @@ end
 ###################
 # NVIDIA - CUDA
 ###################
-if node['cfncluster']['nvidia']['enabled'] == 'yes'
-  bash 'test nvidia driver install' do
-    cwd Chef::Config[:file_cache_path]
-    code <<-TESTNVIDIA
-      has_gpu=$(lspci | grep -o "NVIDIA")
-      if [ -z "$has_gpu" ]; then
-        echo "No GPU detected, no test needed."
-        exit 0
-      fi
+bash 'test nvidia driver install' do
+  cwd Chef::Config[:file_cache_path]
+  code <<-TESTNVIDIA
+    has_gpu=$(lspci | grep -o "NVIDIA")
+    if [ -z "$has_gpu" ]; then
+      echo "No GPU detected, no test needed."
+      exit 0
+    fi
 
-      set -e
-      driver_ver="#{node['cfncluster']['nvidia']['driver_version']}"
-      export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin"
+    set -e
+    driver_ver="#{node['cfncluster']['nvidia']['driver_version']}"
+    export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin"
 
-      # Test NVIDIA Driver installation
-      echo "Testing NVIDIA driver install..."
-      # grep driver version from nvidia-smi output. If driver is not installed nvidia-smi command will fail
-      driver_output=$(nvidia-smi | grep -E -o "Driver Version: [0-9.]+")
-      if [ "$driver_output" != "Driver Version: $driver_ver" ]; then
-        echo "NVIDIA driver installed incorrectly! Installed $driver_output but expected version $driver_ver"
-        exit 1
-      else
-        echo "Correctly installed NVIDIA $driver_output"
-      fi
-    TESTNVIDIA
-  end
+    # Test NVIDIA Driver installation
+    echo "Testing NVIDIA driver install..."
+    # grep driver version from nvidia-smi output. If driver is not installed nvidia-smi command will fail
+    driver_output=$(nvidia-smi | grep -E -o "Driver Version: [0-9.]+")
+    if [ "$driver_output" != "Driver Version: $driver_ver" ]; then
+      echo "NVIDIA driver installed incorrectly! Installed $driver_output but expected version $driver_ver"
+      exit 1
+    else
+      echo "Correctly installed NVIDIA $driver_output"
+    fi
+  TESTNVIDIA
+end
 
-  bash 'test CUDA install' do
-    cwd Chef::Config[:file_cache_path]
-    code <<-TESTCUDA
-      has_gpu=$(lspci | grep -o "NVIDIA")
-      if [ -z "$has_gpu" ]; then
-        echo "No GPU detected, no test needed."
-        exit 0
-      fi
+bash 'test CUDA install' do
+  cwd Chef::Config[:file_cache_path]
+  code <<-TESTCUDA
+    has_gpu=$(lspci | grep -o "NVIDIA")
+    if [ -z "$has_gpu" ]; then
+      echo "No GPU detected, no test needed."
+      exit 0
+    fi
 
-      set -e
-      cuda_ver="#{node['cfncluster']['nvidia']['cuda_version']}"
-      # Test CUDA installation
-      echo "Testing CUDA install with nvcc..."
-      export PATH=/usr/local/cuda-$cuda_ver/bin:$PATH
-      export LD_LIBRARY_PATH=/usr/local/cuda-$cuda_ver/lib64:$LD_LIBRARY_PATH
-      # grep CUDA version from nvcc output. If CUDA is not installed nvcc command will fail
-      cuda_output=$(nvcc -V | grep -E -o "release [0-9]+.[0-9]+")
-      if [ "$cuda_output" != "release $cuda_ver" ]; then
-        echo "CUDA installed incorrectly! Installed $cuda_output but expected $cuda_ver"
-        exit 1
-      else
-        echo "CUDA nvcc test passed, $cuda_output"
-      fi
+    set -e
+    cuda_ver="#{node['cfncluster']['nvidia']['cuda_version']}"
+    # Test CUDA installation
+    echo "Testing CUDA install with nvcc..."
+    export PATH=/usr/local/cuda-$cuda_ver/bin:$PATH
+    export LD_LIBRARY_PATH=/usr/local/cuda-$cuda_ver/lib64:$LD_LIBRARY_PATH
+    # grep CUDA version from nvcc output. If CUDA is not installed nvcc command will fail
+    cuda_output=$(nvcc -V | grep -E -o "release [0-9]+.[0-9]+")
+    if [ "$cuda_output" != "release $cuda_ver" ]; then
+      echo "CUDA installed incorrectly! Installed $cuda_output but expected $cuda_ver"
+      exit 1
+    else
+      echo "CUDA nvcc test passed, $cuda_output"
+    fi
 
-      # Test deviceQuery
-      echo "Testing CUDA install with deviceQuery..."
-      /usr/local/cuda-$cuda_ver/extras/demo_suite/deviceQuery | grep -o "Result = PASS"
-      echo "CUDA deviceQuery test passed"
-      echo "Correctly installed CUDA $cuda_output"
-    TESTCUDA
-  end
+    # Test deviceQuery
+    echo "Testing CUDA install with deviceQuery..."
+    /usr/local/cuda-$cuda_ver/extras/demo_suite/deviceQuery | grep -o "Result = PASS"
+    echo "CUDA deviceQuery test passed"
+    echo "Correctly installed CUDA $cuda_output"
+  TESTCUDA
 end
 
 ###################


### PR DESCRIPTION
The logic to choose whether or not to run the test on NVIDIA/CUDA is inside the test itself, depending on the fact that the instance
where the test is actually running has or not an NVIDIA GPU

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
