### PR TITLE
DCV: Disable locking screen at all

### DIFF
--- a/files/default/dcv/10_org.gnome.desktop.screensaver.gschema.override
+++ b/files/default/dcv/10_org.gnome.desktop.screensaver.gschema.override
@@ -1,2 +1,5 @@
 [org.gnome.desktop.screensaver]
 lock-enabled = false
+
+[org.gnome.desktop.lockdown]
+disable-lock-screen = true

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -252,6 +252,12 @@ if node['cfncluster']['cfn_node_type'] == "MasterServer" &&
   execute 'check DCV external authenticator python version' do
     command %(#{node['cfncluster']['dcv']['authenticator']['virtualenv_path']}/bin/python -V | grep "Python #{node['cfncluster']['python-version']}")
   end
+  execute 'check screensaver screen lock disabled' do
+    command 'gsettings get org.gnome.desktop.screensaver lock-enabled | grep false'
+  end
+  execute 'check non-screensaver screen lock disabled' do
+    command 'gsettings get org.gnome.desktop.lockdown disable-lock-screen | grep true'
+  end
 end
 
 ###################


### PR DESCRIPTION
Previously only screen locking via the screensaver was being disabled.
Disable locking the screen for any reason.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
