### PR TITLE
Set custom CLI package URL for Batch kitchen tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -179,6 +179,7 @@ suites:
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
+        custom_awsbatchcli_package: <%= ENV['CUSTOM_AWSBATCHCLI_URL'] %>
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
 


### PR DESCRIPTION
Enable a URL of a custom pcluster CLI to be specified via an
environment variable when running kitchen tests for the MastserServer
using Batch as the scheduler. This is useful for the release process,
where unless the version to use is overridden, the awsbatch_config
recipe will attempt to install a version of the CLI that has not been
released.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
