### PR TITLE
Add support for computemgtd

### DIFF
--- a/recipes/_compute_slurm_config.rb
+++ b/recipes/_compute_slurm_config.rb
@@ -23,6 +23,7 @@ directory '/var/spool/slurmd' do
 end
 
 # Mount /opt/slurm over NFS
+# Computemgtd config is under /opt/slurm/etc/pcluster; all compute nodes share a config
 mount '/opt/slurm' do
   device(lazy { "#{node['cfncluster']['cfn_master_private_ip']}:/opt/slurm" })
   fstype "nfs"
@@ -30,6 +31,15 @@ mount '/opt/slurm' do
   action %i[mount enable]
   retries 3
   retry_delay 5
+end
+
+# Ensure slurm config directory is in place, directory will contain slurm_nodename file used to identify current compute node in computemgtd
+directory "#{node['cfncluster']['configs_dir']}/slurm" do
+  user 'slurm'
+  group 'slurm'
+  mode '0755'
+  action :create
+  recursive true
 end
 
 # Check to see if there is GPU on the instance, only execute run_nvidiasmi if there is GPU

--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -147,13 +147,21 @@ template "#{node['cfncluster']['configs_dir']}/slurm/parallelcluster_clustermgtd
   mode '0644'
 end
 
-# Create directory used to store clustermgtd heartbeat
-directory "/home/#{node['cfncluster']['cfn_cluster_user']}/.parallelcluster/.slurm_plugin" do
+# Create shared directory used to store clustermgtd heartbeat and computemgtd config
+directory "/opt/slurm/etc/pcluster/.slurm_plugin" do
   user 'root'
   group 'root'
   mode '0644'
   action :create
   recursive true
+end
+
+# Put computemgtd config under /opt/slurm/etc/pcluster/.slurm_plugin so all compute nodes share a config
+template "/opt/slurm/etc/pcluster/.slurm_plugin/parallelcluster_computemgtd.conf" do
+  source 'slurm/parallelcluster_computemgtd.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
 end
 
 cookbook_file '/etc/systemd/system/slurmctld.service' do

--- a/templates/default/parallelcluster_supervisord.conf.erb
+++ b/templates/default/parallelcluster_supervisord.conf.erb
@@ -33,7 +33,12 @@ environment = HOME="<%= node['cfncluster']['dcv']['authenticator']['user_home'] 
 
 <%# ComputeFleet -%>
 <% when 'ComputeFleet' -%>
-<% if node['cfncluster']['cfn_scheduler'] != 'slurm' -%>
+<% if node['cfncluster']['cfn_scheduler'] == 'slurm' -%>
+[program:computemgtd]
+command = <%= node['cfncluster']['node_virtualenv_path'] %>/bin/computemgtd
+redirect_stderr = true
+stdout_logfile = /var/log/parallelcluster/computemgtd
+<% else -%>
 [program:nodewatcher]
 command = <%= node['cfncluster']['node_virtualenv_path'] %>/bin/nodewatcher
 redirect_stderr = true

--- a/templates/default/slurm/parallelcluster_computemgtd.conf.erb
+++ b/templates/default/slurm/parallelcluster_computemgtd.conf.erb
@@ -1,5 +1,5 @@
-[clustermgtd]
+[computemgtd]
 cluster_name = <%= node['cfncluster']['stack_name'].sub("parallelcluster-", "") %>
 region = <%= node['cfncluster']['cfn_region'] %>
 proxy = <%= node['cfncluster']['cfn_proxy'] %>
-heartbeat_file_path = /opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat
+clustermgtd_heartbeat_file_path = /opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat


### PR DESCRIPTION
* Add computemgtd specific configs, start computemgtd on slurm compute nodes
* Mount /opt/parallelcluster to all computes
* Use /opt/parallelcluster/slurm/clustermgtd_heartbeat for clustermgtd heartbeat

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
