### PR TITLE
Fix setting for custom omnibus installation url

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -16,10 +16,9 @@ driver_config:
 
 provisioner:
   name: chef_zero
-  product_name: cinc
-  product_version: 15.11.8
-  # use custom chef install URL to cope with issue https://github.com/chef/bento/issues/609
+  require_chef_omnibus: 15.11.8
   chef_omnibus_url: https://raw.githubusercontent.com/aws/aws-parallelcluster-cookbook/develop/util/cinc-install.sh
+  chef_omnibus_root: /opt/cinc
   retry_on_exit_code:
     - 35 # 35 is the exit code signaling that the node is rebooting
   max_retries: 1


### PR DESCRIPTION
According to doc https://docs.chef.io/workstation/config_yml_kitchen/
`product_name` and `product_version` are the new params that work in conjunction with `download_url`, but `download_url` can only point to an executable to be installed directly (it cannot be an omnibus installation script).

For now switch back in using the deprecated parameters `require_chef_omnibus` and `chef_omnibus_url`, that is the only combination that allows to specify a custom omnibus installation url.

`chef_omnibus_root` is required since the cinc client is installed in place of chef one, and root installation folder is different for this case.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
