### PR TITLE
Install libswitch-perl package for torque-slurm wrapper

### DIFF
--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -101,6 +101,20 @@ when 'MasterServer', nil
     # TODO: Fix, so it works for upgrade
     creates "#{node['cfncluster']['license_dir']}/slurm/README.rst"
   end
+
+  # Install PerlSwitch
+  if node['platform'] == 'ubuntu'
+    package 'libswitch-perl' do
+      retries 3
+      retry_delay 5
+    end
+  elsif node['platform'] == 'centos' && node['platform_version'].to_i >= 7 || node['platform'] == 'amazon'
+    package 'perl-Switch' do
+      retries 3
+      retry_delay 5
+    end
+  end
+
 when 'ComputeFleet'
   # Created Slurm shared mount point
   directory "/opt/slurm" do


### PR DESCRIPTION
* Install libswitch-perl package on ubuntu1604, ubuntu1804 && install perl-Switch package on alinux, alinux2 and centos7. Centos6 already supports pbs.
* The purpose is to support Torque commands in slurm pcluster. [Here is the offical doc](https://slurm.schedmd.com/faq.html#torque)
* After package installed, pcluster supports some basic scheduler commands:
  * qsub -- sbatch: create a job is to submit an executable script to a batch server.
  * qdel -- scancel: delete jobs in the order in which their job identifiers are presented to the command.
  * qstat -- squeue: show status of pbs batch jobs.
  * qhold -- scontrol hold: request that a server place one or more holds on a job.
  * qrls -- scontrol release: remove or release holds which exist on batch jobs.
  * pbsnodes -- sinfo -N or scontrol show nodes: show node details.
  * qstat -q -- sinfo: show queue info.

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
