### PR TITLE
Avoid dpkg lock during Packer provisioner shell execution

### DIFF
--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -158,7 +158,7 @@
     {
       "type": "shell",
       "inline": [
-        "sudo flock $(apt-config shell StateDir Dir::State/d | sed -r \"s/.*'(.*)\\/?'$/\\1/\")/daily_lock systemctl stop apt-daily.timer apt-daily.service"
+        "sudo flock $(apt-config shell StateDir Dir::State/d | sed -r \"s/.*'(.*)\\/?'$/\\1/\")/daily_lock systemctl stop apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service"
       ]
     },
     {

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -159,7 +159,7 @@
     {
       "type": "shell",
       "inline": [
-        "sudo flock $(apt-config shell StateDir Dir::State/d | sed -r \"s/.*'(.*)\\/?'$/\\1/\")/daily_lock systemctl stop apt-daily.timer apt-daily.service"
+        "sudo flock $(apt-config shell StateDir Dir::State/d | sed -r \"s/.*'(.*)\\/?'$/\\1/\")/daily_lock systemctl stop apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service"
       ]
     },
     {


### PR DESCRIPTION
There are other two services (apt-daily-upgrade.timer and apt-daily-upgrade.service) that are executing unattended upgrades. Fix is to add them to the list of services to stop after the dpkg lock is freed.

This solves https://github.com/aws/aws-parallelcluster/issues/1904

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
