### PR TITLE
Add HIT logs to CloudWatch

### DIFF
--- a/files/default/cloudwatch_logs/cloudwatch_log_files.json
+++ b/files/default/cloudwatch_logs/cloudwatch_log_files.json
@@ -136,7 +136,6 @@
       "log_stream_name": "nodewatcher",
       "schedulers": [
         "sge",
-        "slurm",
         "torque"
       ],
       "platforms": [
@@ -155,7 +154,6 @@
       "log_stream_name": "jobwatcher",
       "schedulers": [
         "sge",
-        "slurm",
         "torque"
       ],
       "platforms": [
@@ -174,8 +172,75 @@
       "log_stream_name": "sqswatcher",
       "schedulers": [
         "sge",
-        "slurm",
         "torque"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "MasterServer"
+      ],
+      "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/parallelcluster/clustermgtd",
+      "log_stream_name": "clustermgtd",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "MasterServer"
+      ],
+      "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/parallelcluster/computemgtd",
+      "log_stream_name": "computemgtd",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet"
+      ],
+      "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/parallelcluster/slurm_resume.log",
+      "log_stream_name": "slurm_resume",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "MasterServer"
+      ],
+      "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/parallelcluster/slurm_suspend.log",
+      "log_stream_name": "slurm_suspend",
+      "schedulers": [
+        "slurm"
       ],
       "platforms": [
         "amazon",


### PR DESCRIPTION
Added the following log files when scheduler is Slurm:
- /var/log/parallelcluster/clustermgtd
- /var/log/parallelcluster/computemgtd
- /var/log/parallelcluster/slurm_resume.log
- /var/log/parallelcluster/slurm_suspend.log

Also removed sqswatcher, nodewatcher and jobwatcher logs when scheduler is Slurm


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
