### PR TITLE
Implement support for initial_count!=min_count in HIT

### DIFF
--- a/recipes/_master_slurm_finalize.rb
+++ b/recipes/_master_slurm_finalize.rb
@@ -27,6 +27,7 @@ ruby_block "submit dynamic fleet initialization jobs" do
   block do
     require 'json'
     require 'chef/mixin/shell_out'
+    require 'shellwords'
 
     cluster_config = JSON.parse(File.read(node['cfncluster']['cluster_config_path']))
     cluster_config["cluster"]["queue_settings"].each do |queue_name, queue_config|
@@ -34,8 +35,9 @@ ruby_block "submit dynamic fleet initialization jobs" do
         required_dynamic = instance_config.fetch("initial_count", 0) - instance_config.fetch("min_count", 0)
         if required_dynamic.positive?
           # Submitting a job for each instance type that requires an initial_count > min_count
-          shell_out!("/opt/slurm/bin/sbatch --wrap 'sleep infinity' --job-name=parallelcluster-init-cluster "\
-                     "--constraint='[(dynamic&#{instance_config['instance_type']})*#{required_dynamic}]' --partition=#{queue_name}")
+          submit_job_command = Shellwords.escape("/opt/slurm/bin/sbatch --wrap 'sleep infinity' --job-name=parallelcluster-init-cluster "\
+                                                 "--constraint='[(dynamic&#{instance_config['instance_type']})*#{required_dynamic}]' --partition=#{queue_name}")
+          shell_out!("/bin/bash -c #{submit_job_command}")
         end
       end
     end
@@ -45,6 +47,7 @@ end
 ruby_block "wait for static fleet capacity" do
   block do
     require 'chef/mixin/shell_out'
+    require 'shellwords'
 
     # Example output for sinfo
     # $ /opt/slurm/bin/sinfo -N -h -o '%N %t'
@@ -53,7 +56,8 @@ ruby_block "wait for static fleet capacity" do
     # spot-dynamic-c5.xlarge-1 idle~
     # spot-static-t2.large-1 down
     # spot-static-t2.large-2 idle
-    until shell_out!("set -o pipefail && /opt/slurm/bin/sinfo -N -h -o '%N %t' | { grep '\\-static\\-' || true; } | { grep -v -E '(idle|alloc|mix)$' || true; }").stdout.strip.empty?
+    is_fleet_ready_command = Shellwords.escape("set -o pipefail && /opt/slurm/bin/sinfo -N -h -o '%N %t' | { grep '\\-static\\-' || true; } | { grep -v -E '(idle|alloc|mix)$' || true; }")
+    until shell_out!("/bin/bash -c #{is_fleet_ready_command}").stdout.strip.empty?
       Chef::Log.info("Waiting for static fleet capacity provisioning")
       sleep(15)
     end
@@ -64,11 +68,13 @@ end
 ruby_block "wait for dynamic fleet capacity" do
   block do
     require 'chef/mixin/shell_out'
+    require 'shellwords'
 
     # $ /opt/slurm/bin/squeue --name='init-cluster' -O state -h
     # CONFIGURING
     # RUNNING
-    until shell_out!("set -o pipefail && /opt/slurm/bin/squeue --name='init-cluster' -O state -h | { grep -v 'RUNNING' || true; }").stdout.strip.empty?
+    are_jobs_running_command = Shellwords.escape("set -o pipefail && /opt/slurm/bin/squeue --name='init-cluster' -O state -h | { grep -v 'RUNNING' || true; }")
+    until shell_out!("/bin/bash -c #{are_jobs_running_command}").stdout.strip.empty?
       Chef::Log.info("Waiting for dynamic fleet capacity provisioning")
       sleep(15)
     end


### PR DESCRIPTION
When initial_count is greater than min_count it means that the cluster requires part of the dynamic capacity to be up and running when cluster creation completes. In this first iteration we are going to achieve it by performing the following during finalize recipe execution:
1. We submit for each instance type that has initial_count>min_count a dummy Slurm job that runs the `sleep infinity` command
2. We wait for all dummy jobs to be in a `RUNNING` state
3. We cancel all dummy jobs
4 We complete the finalize recipe which will then trigger a notification to inform CloudFormation than the head node is ready


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
