### PR TITLE
CloudWatch: remove cfn-init log from ComputeFleet

### DIFF
--- a/files/default/cloudwatch_logs/cloudwatch_log_files.json
+++ b/files/default/cloudwatch_logs/cloudwatch_log_files.json
@@ -64,7 +64,6 @@
         "ubuntu"
       ],
       "node_roles": [
-        "ComputeFleet",
         "MasterServer"
       ],
       "feature_conditions": []


### PR DESCRIPTION
Not needed since now using cloud-init

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
