### PR TITLE
Add missing clustermgtd conf params and add possibility to use private hostnames

### DIFF
--- a/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -4,3 +4,6 @@ region = <%= node['cfncluster']['cfn_region'] %>
 proxy = <%= node['cfncluster']['cfn_proxy'] %>
 heartbeat_file_path = /opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat
 dynamodb_table = <%= node['cfncluster']['cfn_ddb_table'] %>
+hosted_zone = <%= node['cfncluster']['cfn_hosted_zone'] %>
+dns_domain = <%= node['cfncluster']['cfn_dns_domain'] %>
+use_private_hostname = <%= node['cfncluster']['use_private_hostname'] %>

--- a/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
+++ b/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
@@ -5,3 +5,4 @@ proxy = <%= node['cfncluster']['cfn_proxy'] %>
 dynamodb_table = <%= node['cfncluster']['cfn_ddb_table'] %>
 hosted_zone = <%= node['cfncluster']['cfn_hosted_zone'] %>
 dns_domain = <%= node['cfncluster']['cfn_dns_domain'] %>
+use_private_hostname = <%= node['cfncluster']['use_private_hostname'] %>


### PR DESCRIPTION
Now it is possible to restore the SIT behaviour by setting the use_private_hostname = yes as extra_json parameter.

This parameter is now propagated on both clustermgtd and slurm_resume configuration files

If the Route53 custom domain is not created we're setting `assigned_hostname.dhcp_domain` as hostname.


