### PR TITLE
Retrieve master info from db and use network service for Alinux2

### DIFF
--- a/files/default/slurm/pcluster_slurm_config_generator.py
+++ b/files/default/slurm/pcluster_slurm_config_generator.py
@@ -159,7 +159,11 @@ def main():
             help="JSON file containing info about queues",
         )
         parser.add_argument(
-            "--dryrun", action="store_true", help="dryrun", required=False, default=False,
+            "--dryrun",
+            action="store_true",
+            help="dryrun",
+            required=False,
+            default=False,
         )
         args = parser.parse_args()
         generate_slurm_config_files(args.output_directory, args.template_directory, args.input_file, args.dryrun)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -154,36 +154,37 @@ def ami_bootstrapped?
   'aws-parallelcluster-' + node['cfncluster']['cfncluster-version'] == version && node['cfncluster']['skip_install_recipes'] == 'yes'
 end
 
-def master_address(region, stack_name)
-  require 'chef/mixin/shell_out'
+def hit_master_info
+  master_private_ip_file = "#{node['cfncluster']['slurm_plugin_dir']}/master_private_ip"
+  master_private_dns_file = "#{node['cfncluster']['slurm_plugin_dir']}/master_private_dns"
 
-  output = shell_out!("aws ec2 describe-instances --filters '[{\"Name\":\"tag:Application\", \"Values\": " \
-                      "[\"#{stack_name}\"]},{\"Name\":\"tag:aws-parallelcluster-node-type\", \"Values\": [\"Master\"]},{\"Name\": " \
-                      "\"instance-state-name\", \"Values\": [\"running\"]}]' --region #{region} --query " \
-                      "\"Reservations[0].Instances[0].[PrivateIpAddress,PrivateDnsName]\" --output text").stdout.strip
-
-  raise "Failed when retrieving Master server address: unable to describe EC2 instance" if output == "None"
-
-  master_private_ip, master_private_dns = output.split(/\s+/)
-  Chef::Log.info("Retrieved master private ip: #{master_private_ip}")
-  Chef::Log.info("Retrieved master private dns: #{master_private_dns}")
-
-  [master_private_ip, master_private_dns]
+  [IO.read(master_private_ip_file).chomp, IO.read(master_private_dns_file).chomp]
 end
 
-def compute_hostname
+def hit_slurm_nodename
+  slurm_nodename_file = "#{node['cfncluster']['slurm_plugin_dir']}/slurm_nodename"
+
+  IO.read(slurm_nodename_file).chomp
+end
+
+def hit_dynamodb_info
   require 'chef/mixin/shell_out'
 
-  assigned_hostname = shell_out!("#{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws dynamodb " \
+  output = shell_out!("#{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws dynamodb " \
     "--region #{node['cfncluster']['cfn_region']} query --table-name #{node['cfncluster']['cfn_ddb_table']} " \
     "--index-name InstanceId --key-condition-expression 'InstanceId = :instanceid' " \
     "--expression-attribute-values '{\":instanceid\": {\"S\":\"#{node['ec2']['instance_id']}\"}}' " \
-    "--output text --query 'Items[0].Id.S'", user: 'root').stdout.strip
+    "--projection-expression 'Id,MasterPrivateIp,MasterHostname' " \
+    "--output text --query 'Items[0].[Id.S,MasterPrivateIp.S,MasterHostname.S]'", user: 'root').stdout.strip
 
-  raise "Failed when retrieving Compute hostname from DynamoDB" if assigned_hostname == "None"
+  raise "Failed when retrieving Compute info from DynamoDB" if output == "None"
+  slurm_nodename, master_private_ip, master_private_dns = output.split(/\s+/)
 
-  Chef::Log.info("Assigned_hostname is: #{assigned_hostname}")
-  assigned_hostname
+  Chef::Log.info("Retrieved Slurm nodename is: #{slurm_nodename}")
+  Chef::Log.info("Retrieved master private ip: #{master_private_ip}")
+  Chef::Log.info("Retrieved master private dns: #{master_private_dns}")
+
+  [slurm_nodename, master_private_ip, master_private_dns]
 end
 
 # Utility method to restart network service according to the OS.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -190,16 +190,13 @@ end
 def restart_network_service
   network_service_name = value_for_platform(
     ['centos'] => {
-      '<7.0' => 'network'
-    },
-    ['amazon'] => {
-      '>=2013' => 'network' # Alinux1
+      '>=7.0' => 'NetworkManager'
     },
     %w[ubuntu debian] => {
       '16.04' => 'networking',
       '>=18.04' => 'systemd-resolved'
     },
-    'default' => 'NetworkManager'
+    'default' => 'network'
   )
   Chef::Log.info("Restarting '#{network_service_name}' service, platform #{node['platform']} '#{node['platform_version']}'")
   service network_service_name.to_s do

--- a/recipes/_compute_base_config.rb
+++ b/recipes/_compute_base_config.rb
@@ -15,11 +15,11 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Retrieve master node ip if not set already
-unless node['cfncluster']['cfn_master'] && node['cfncluster']['cfn_master_private_ip']
+# Retrieve master node info
+if node['cfncluster']['cfn_scheduler'] == 'slurm'
   ruby_block "retrieve master ip" do
     block do
-      master_private_ip, master_private_dns = master_address(node['cfncluster']['cfn_region'], node['cfncluster']['stack_name'])
+      master_private_ip, master_private_dns = hit_master_info
       node.force_default['cfncluster']['cfn_master'] = master_private_dns
       node.force_default['cfncluster']['cfn_master_private_ip'] = master_private_ip
     end

--- a/recipes/_compute_slurm_finalize.rb
+++ b/recipes/_compute_slurm_finalize.rb
@@ -17,15 +17,8 @@
 
 ruby_block 'get_compute_nodename' do
   block do
-    # Retrieve private ip from Metadata V2
-    require 'mixlib/shellout'
-    node.run_state['compute_ip'] = shell_out!('curl -s http://169.254.169.254/latest/meta-data/local-ipv4', user: 'root').stdout.strip
-    # Retrieve NodeName from scontrol
-    node.run_state['slurm_compute_nodename'] = shell_out!("/opt/slurm/bin/scontrol show nodes | awk \"/\\y#{node.run_state['compute_ip']}\\y/\" RS="\
-                                                          " | grep -oP '^NodeName=\\K(\\S+)'", user: 'root').stdout.strip
+    node.run_state['slurm_compute_nodename'] = hit_slurm_nodename
   end
-  retries 3
-  retry_delay 5
 end
 
 # Create local file containing slurm nodename of compute node

--- a/recipes/_prep_env.rb
+++ b/recipes/_prep_env.rb
@@ -68,5 +68,50 @@ include_recipe "aws-parallelcluster::_setup_python"
 # Install cloudwatch, write configuration and start it.
 include_recipe "aws-parallelcluster::cloudwatch_agent_config"
 
+# retrieve compute and master node info from dynamodb and save into files
+if node['cfncluster']['cfn_scheduler'] == 'slurm' && node['cfncluster']['cfn_node_type'] == "ComputeFleet"
+
+  # Ensure slurm plugin directory is in place
+  directory "#{node['cfncluster']['slurm_plugin_dir']}" do
+    user 'slurm'
+    group 'slurm'
+    mode '0755'
+    action :create
+    recursive true
+  end
+
+  ruby_block "retrieve compute node info" do
+    block do
+      slurm_nodename, master_private_ip, master_private_dns = hit_dynamodb_info
+      node.run_state['slurm_nodename'] = slurm_nodename
+      node.run_state['cfn_master'] = master_private_dns
+      node.run_state['cfn_master_private_ip'] = master_private_ip
+    end
+    retries 5
+    retry_delay 3
+  end
+
+  file "#{node['cfncluster']['slurm_plugin_dir']}/slurm_nodename" do
+    content(lazy { node.run_state['slurm_nodename'] })
+    mode '0644'
+    owner 'root'
+    group 'root'
+  end
+
+  file "#{node['cfncluster']['slurm_plugin_dir']}/master_private_dns" do
+    content(lazy { node.run_state['cfn_master'] })
+    mode '0644'
+    owner 'root'
+    group 'root'
+  end
+
+  file "#{node['cfncluster']['slurm_plugin_dir']}/master_private_ip" do
+    content(lazy { node.run_state['cfn_master_private_ip'] })
+    mode '0644'
+    owner 'root'
+    group 'root'
+  end
+end
+
 # Configure hostname and DNS
 include_recipe "aws-parallelcluster::dns_config"

--- a/recipes/dns_config.rb
+++ b/recipes/dns_config.rb
@@ -64,7 +64,7 @@ if node['cfncluster']['cfn_scheduler'] == 'slurm' && node['cfncluster']['use_pri
     # - fqdn: $QUEUE-static-$INSTANCE_TYPE_1-[1-$MIN1].$CLUSTER_NAME.pcluster
     ruby_block "retrieve assigned hostname" do
       block do
-        assigned_hostname = compute_hostname
+        assigned_hostname = hit_slurm_nodename
         node.force_default['cfncluster']['assigned_short_hostname'] = assigned_hostname.to_s
 
         if node['cfncluster']['cfn_dns_domain'].nil? || node['cfncluster']['cfn_dns_domain'].empty?

--- a/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -7,3 +7,5 @@ dynamodb_table = <%= node['cfncluster']['cfn_ddb_table'] %>
 hosted_zone = <%= node['cfncluster']['cfn_hosted_zone'] %>
 dns_domain = <%= node['cfncluster']['cfn_dns_domain'] %>
 use_private_hostname = <%= node['cfncluster']['use_private_hostname'] %>
+master_private_ip = <%= node['ec2']['local_ipv4'] %>
+master_hostname = <%= node['ec2']['local_hostname'] %>

--- a/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
+++ b/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
@@ -6,3 +6,5 @@ dynamodb_table = <%= node['cfncluster']['cfn_ddb_table'] %>
 hosted_zone = <%= node['cfncluster']['cfn_hosted_zone'] %>
 dns_domain = <%= node['cfncluster']['cfn_dns_domain'] %>
 use_private_hostname = <%= node['cfncluster']['use_private_hostname'] %>
+master_private_ip = <%= node['ec2']['local_ipv4'] %>
+master_hostname = <%= node['ec2']['local_hostname'] %>


### PR DESCRIPTION
## Use network service as default service to be restarted

Alinux2 should have NetworkManager but in same AMIs it is not available, so it is safer to use the "network" service for both Alinux1 and Alinux2



## Retrieve master info and slurm hostname at prep_env time and save in a file

With this patch we're saving the master_ip and the master_hostname in the configuration file of the daemons.

These values will be saved by the daemons in the DB and we're retrieving them from the compute nodes at runtime.

We're doing a single query call at prep_env time and saving the values in files, to be reused in subsequents calls.