### PR TITLE
Slurm: enable cloud_dns option when DNS is configured

### DIFF
--- a/templates/default/slurm/slurm.conf.erb
+++ b/templates/default/slurm/slurm.conf.erb
@@ -23,13 +23,17 @@ CacheGroups=0
 #
 # CLOUD CONFIGS OPTIONS
 SlurmctldParameters=idle_on_node_suspend
+<% if node['cfncluster']['use_private_hostname'] == 'true' or node['cfncluster']['cfn_dns_domain'].nil? or node['cfncluster']['cfn_dns_domain'].empty? -%>
 CommunicationParameters=NoAddrCache
+TreeWidth=65533
+<% else -%>
+CommunicationParameters=NoAddrCache,cloud_dns
+<% end -%>
 SuspendProgram=<%= node['cfncluster']['scripts_dir'] %>/slurm/slurm_suspend
 ResumeProgram=<%= node['cfncluster']['scripts_dir'] %>/slurm/slurm_resume
 ResumeFailProgram=<%= node['cfncluster']['scripts_dir'] %>/slurm/slurm_suspend
 SuspendTimeout=1200
 ResumeTimeout=600
-TreeWidth=65533
 PrivateData=cloud
 ResumeRate=0
 SuspendRate=0


### PR DESCRIPTION
Since all nodes are resolvable over DNS we can enable cloud_dns option and leave TreeWidth to its default (50). This can improve improve communications when jobs request lots of nodes and when there are a lot of active nodes in
the system. With TreeWidth=65533, that means that slurmctld will ping every node individually. With TreeWidth=50, slurmctld only needs to ping 50 of them and it will fan it out to the other nodes.

Tested a slurm restart and scontrol reconfigure to check if nodeaddr and nodehostname are preserved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
