### PR TITLE
Fix skip dynamodb call if compute node variables are set

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -259,6 +259,9 @@ suites:
         cfn_shared_dir: <%= ENV['CFN_SHARED_DIR'] %>
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
+        cfn_master: <%= ENV['CFN_MASTER'] %>
+        cfn_master_private_ip: <%= ENV['CFN_MASTER_PRIVATE_IP'] %>
+        slurm_nodename: 'fake-compute'
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'

--- a/recipes/prep_env_slurm.rb
+++ b/recipes/prep_env_slurm.rb
@@ -31,31 +31,33 @@ if node['cfncluster']['cfn_node_type'] == "ComputeFleet"
   ruby_block "retrieve compute node info" do
     block do
       slurm_nodename, master_private_ip, master_private_dns = hit_dynamodb_info
-      node.run_state['slurm_nodename'] = slurm_nodename
-      node.run_state['cfn_master'] = master_private_dns
-      node.run_state['cfn_master_private_ip'] = master_private_ip
+      node.force_default['cfncluster']['slurm_nodename'] = slurm_nodename
+      node.force_default['cfncluster']['cfn_master'] = master_private_dns
+      node.force_default['cfncluster']['cfn_master_private_ip'] = master_private_ip
     end
     retries 5
     retry_delay 3
-    not_if node.run_state['slurm_nodename'] && node.run_state['cfn_master'] && node.run_state['cfn_master_private_ip']
+    not_if { !node['cfncluster']['slurm_nodename'].nil? && !node['cfncluster']['slurm_nodename'].empty? &&
+             !node['cfncluster']['cfn_master'].nil? && !node['cfncluster']['cfn_master'].empty? &&
+             !node['cfncluster']['cfn_master_private_ip'].nil? && !node['cfncluster']['cfn_master_private_ip'].empty? }
   end
 
   file "#{node['cfncluster']['slurm_plugin_dir']}/slurm_nodename" do
-    content(lazy { node.run_state['slurm_nodename'] })
+    content(lazy { node['cfncluster']['slurm_nodename'] })
     mode '0644'
     owner 'root'
     group 'root'
   end
 
   file "#{node['cfncluster']['slurm_plugin_dir']}/master_private_dns" do
-    content(lazy { node.run_state['cfn_master'] })
+    content(lazy { node['cfncluster']['cfn_master'] })
     mode '0644'
     owner 'root'
     group 'root'
   end
 
   file "#{node['cfncluster']['slurm_plugin_dir']}/master_private_ip" do
-    content(lazy { node.run_state['cfn_master_private_ip'] })
+    content(lazy { node['cfncluster']['cfn_master_private_ip'] })
     mode '0644'
     owner 'root'
     group 'root'

--- a/templates/default/cfnconfig.erb
+++ b/templates/default/cfnconfig.erb
@@ -16,6 +16,7 @@ cfn_cluster_user=<%= node['cfncluster']['cfn_cluster_user'] %>
 <% if node['cfncluster']['cfn_node_type'] == 'ComputeFleet' -%>
 cfn_sqs_queue=<%= node['cfncluster']['cfn_sqs_queue'] %>
 cfn_master=<%= node['cfncluster']['cfn_master'] %>
+cfn_master_private_ip=<%= node['cfncluster']['cfn_master_private_ip'] %>
 cfn_scheduler_queue_name=<%= node['cfncluster']['scheduler_queue_name'] %>
 <% end -%>
 <% if node['cfncluster']['cfn_node_type'] == 'MasterServer' -%>


### PR DESCRIPTION
If slurm_nodename, cfn_master and cfn_master_private_ip are set, skip dynamodb call.
Useful during kitchen tests.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
