### PR TITLE
Slurm config optimization

### DIFF
--- a/templates/amazon-2018/slurm/cgroup.conf.erb
+++ b/templates/amazon-2018/slurm/cgroup.conf.erb
@@ -3,3 +3,5 @@
 ###
 CgroupAutomount=yes
 CgroupMountpoint=/cgroup
+TaskAffinity=no
+ConstrainCores=yes

--- a/templates/centos-6/slurm/cgroup.conf.erb
+++ b/templates/centos-6/slurm/cgroup.conf.erb
@@ -3,3 +3,5 @@
 ###
 CgroupAutomount=yes
 CgroupMountpoint=/cgroup
+TaskAffinity=no
+ConstrainCores=yes

--- a/templates/default/slurm/cgroup.conf.erb
+++ b/templates/default/slurm/cgroup.conf.erb
@@ -2,3 +2,5 @@
 # Slurm cgroup support configuration file
 ###
 CgroupAutomount=yes
+TaskAffinity=no
+ConstrainCores=yes

--- a/templates/default/slurm/slurm.conf.erb
+++ b/templates/default/slurm/slurm.conf.erb
@@ -22,14 +22,18 @@ SlurmdPidFile=/var/run/slurmd.pid
 CacheGroups=0
 #
 # CLOUD CONFIGS OPTIONS
+<% if node['cfncluster']['use_private_hostname'] == 'true' or node['cfncluster']['cfn_dns_domain'].nil? or node['cfncluster']['cfn_dns_domain'].empty? -%>
 SlurmctldParameters=idle_on_node_suspend
+TreeWidth=65533
+<% else -%>
+SlurmctldParameters=idle_on_node_suspend,cloud_dns
+<% end -%>
 CommunicationParameters=NoAddrCache
 SuspendProgram=<%= node['cfncluster']['scripts_dir'] %>/slurm/slurm_suspend
 ResumeProgram=<%= node['cfncluster']['scripts_dir'] %>/slurm/slurm_resume
 ResumeFailProgram=<%= node['cfncluster']['scripts_dir'] %>/slurm/slurm_suspend
-SuspendTimeout=1200
-ResumeTimeout=600
-TreeWidth=65533
+SuspendTimeout=120
+ResumeTimeout=3600
 PrivateData=cloud
 ResumeRate=0
 SuspendRate=0
@@ -42,6 +46,7 @@ InactiveLimit=0
 MinJobAge=300
 KillWait=30
 Waittime=0
+MessageTimeout=60
 #
 # SCHEDULING, JOB, AND NODE SETTINGS
 EnforcePartLimits=ALL
@@ -49,6 +54,7 @@ SchedulerType=sched/backfill
 ProctrackType=proctrack/cgroup
 MpiDefault=none
 ReturnToService=1
+TaskPlugin=task/affinity,task/cgroup
 #
 # TRES AND GPU CONFIG OPTIONS
 GresTypes=gpu


### PR DESCRIPTION
* Increase ResumeTimeout to 1 hr, in case nodes have longer pre/post-install scripts
* Enable cloud_dns and removed TreeWidth to reduce pinging between slurmctld and compute nodes
* Change TaskPlugin to task/cgroup to enforce better resource affinity when scheduling jobs

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
