### PR TITLE
Fix upgrade Lustre client modules on system upgrade on Ubuntu

### DIFF
--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -83,7 +83,12 @@ elsif node['platform'] == 'ubuntu'
 
   apt_update
 
-  apt_package "lustre-client-modules-#{node['kernel']['release']} lustre-client-modules-aws" do
+  apt_package "lustre-client-modules-#{node['kernel']['release']}" do
+    retries 3
+    retry_delay 5
+  end
+
+  apt_package "lustre-client-modules-aws" do
     retries 3
     retry_delay 5
   end


### PR DESCRIPTION
Fix https://github.com/aws/aws-parallelcluster-cookbook/commit/7d55769f597d6a39cd74ebb638968dcc56b23722

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
