### PR TITLE
Disable hyperthreading manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@ build.log
 build-*.log
 
 .tox/
-
-assets/
-report.html

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ build.log
 build-*.log
 
 .tox/
+
+assets/
+report.html

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -320,6 +320,7 @@ default['cfncluster']['cfn_postinstall'] = 'NONE'
 default['cfncluster']['cfn_postinstall_args'] = 'NONE'
 default['cfncluster']['cfn_scheduler'] = 'sge'
 default['cfncluster']['cfn_scheduler_slots'] = 'vcpus'
+default['cfncluster']['cfn_disable_hyperthreading_manually'] = 'false'
 default['cfncluster']['cfn_instance_slots'] = '1'
 default['cfncluster']['cfn_volume'] = nil
 default['cfncluster']['cfn_volume_fs_type'] = 'ext4'

--- a/files/default/disable_hyperthreading_manually.sh
+++ b/files/default/disable_hyperthreading_manually.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# FIXME: persist change for reboot
+for cpunum in $(cat /sys/devices/system/cpu/cpu*/topology/thread_siblings_list | cut -s -d, -f2- | tr ',' '\n' | sort -un)
+do
+    echo 0 > /sys/devices/system/cpu/cpu$cpunum/online
+done

--- a/recipes/disable_hyperthreading.rb
+++ b/recipes/disable_hyperthreading.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: disable_hyperthreading
+#
+# Copyright 2013-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This recipe should only be run when disabling hyperthreading is
+# desired and the instance type doesn't support doing so via CPU
+# options (e.g., *.metal instances).
+return unless node['cfncluster']['cfn_disable_hyperthreading_manually'] == 'true'
+
+script_path = "#{node['cfncluster']['scripts_dir']}/disable_hyperthreading_manually.sh"
+cookbook_file 'disable_hyperthreading_manually.sh' do
+  path script_path
+  owner 'root'
+  group 'root'
+  mode '0744'
+end
+
+execute 'disable hyperthreading manually' do
+  command script_path
+  user 'root'
+end

--- a/recipes/prep_env.rb
+++ b/recipes/prep_env.rb
@@ -23,6 +23,10 @@ node.default['cfncluster']['cfn_instance_slots'] = if node['cfncluster']['cfn_sc
                                                    else
                                                      node['cfncluster']['cfn_scheduler_slots']
                                                    end
+# NOTE: this recipe must be included after cfn_instance_slot because it may alter the values of
+#       node['cpu']['total'], which would break the expected behavior when setting cfn_scheduler_slots
+#       to one of the constants looked for in the above conditionals
+include_recipe "aws-parallelcluster::disable_hyperthreading"
 
 # Setup directories
 directory '/etc/parallelcluster'


### PR DESCRIPTION
Certain instance types (*.metal instances) don't currently support
disabling hyperthreading via a launch template's CpuOptions. For those
instance types, run a script that does the same thing.

Signed-off-by: Tim Lane <tilne@amazon.com>
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
