### PR TITLE
Set ulimits for slurmd on alinux and centos6

### DIFF
--- a/recipes/_compute_slurm_finalize.rb
+++ b/recipes/_compute_slurm_finalize.rb
@@ -33,11 +33,11 @@ else
   slurm_service_binary = "slurm"
 end
 
-file "/etc/sysconfig/#{slurm_service_binary}" do
-  content(lazy { "SLURMD_OPTIONS='-N #{node.run_state['slurm_compute_nodename']}'" })
-  mode '0644'
-  owner 'root'
+template "/etc/sysconfig/#{slurm_service_binary}" do
+  source 'slurm/slurm.sysconfig.erb'
+  user 'root'
   group 'root'
+  mode '0644'
 end
 
 service slurm_service_binary do

--- a/templates/amazon-2018/slurm/slurm.sysconfig.erb
+++ b/templates/amazon-2018/slurm/slurm.sysconfig.erb
@@ -1,0 +1,4 @@
+SLURMD_OPTIONS='-N <%= node.run_state['slurm_compute_nodename'] %>'
+ulimit -SHn 131072  # the maximum number of open file descriptors
+ulimit -SHl unlimited  # the maximum size a process may lock into memory
+ulimit -SHs unlimited  # the maximum stack size

--- a/templates/centos-6/slurm/slurm.sysconfig.erb
+++ b/templates/centos-6/slurm/slurm.sysconfig.erb
@@ -1,0 +1,4 @@
+SLURMD_OPTIONS='-N <%= node.run_state['slurm_compute_nodename'] %>'
+ulimit -SHn 131072  # the maximum number of open file descriptors
+ulimit -SHl unlimited  # the maximum size a process may lock into memory
+ulimit -SHs unlimited  # the maximum stack size

--- a/templates/default/slurm/slurm.sysconfig.erb
+++ b/templates/default/slurm/slurm.sysconfig.erb
@@ -1,0 +1,1 @@
+SLURMD_OPTIONS='-N <%= node.run_state['slurm_compute_nodename'] %>'


### PR DESCRIPTION
For init.d based services limits are not set at boot even though they are configured in /etc/security/limits.conf or in files under /etc/security/limits.d. On top of that jobs executed by slurm cannot have ulimits that are bigger than the one set for the  `slurmd` daemon (see https://slurm.schedmd.com/faq.html#rlimit). Since on `alinux` and `centos6` we are starting slurm as an `init.d` ulimits were not configured correctly. Mirroring the same limits used for slurm when this is started with systemd.

Tested on alinux with custom cookbook:
```
[ec2-user@ip-10-0-0-237 ~]$ cat limits-with-patch
core file size          (blocks, -c) 0
data seg size           (kbytes, -d) unlimited
scheduling priority             (-e) 0
file size               (blocks, -f) unlimited
pending signals                 (-i) 756534
max locked memory       (kbytes, -l) unlimited
max memory size         (kbytes, -m) unlimited
core file size          (blocks, -c) 0
open files                      (-n) 8192
pipe size            (512 bytes, -p) 8
POSIX message queues     (bytes, -q) 819200
real-time priority              (-r) 0
stack size              (kbytes, -s) 8192
cpu time               (seconds, -t) unlimited
max user processes              (-u) 30646
virtual memory          (kbytes, -v) unlimited
file locks                      (-x) unlimited
[ec2-user@ip-10-0-0-237 ~]$ cat limits-before-patch
core file size          (blocks, -c) 0
data seg size           (kbytes, -d) unlimited
scheduling priority             (-e) 0
file size               (blocks, -f) unlimited
pending signals                 (-i) 756534
max locked memory       (kbytes, -l) 64
max memory size         (kbytes, -m) unlimited
open files                      (-n) 4096
pipe size            (512 bytes, -p) 8
POSIX message queues     (bytes, -q) 819200
real-time priority              (-r) 0
stack size              (kbytes, -s) 8192
cpu time               (seconds, -t) unlimited
max user processes              (-u) 30422
virtual memory          (kbytes, -v) unlimited
file locks                      (-x) unlimited
[ec2-user@ip-10-0-0-237 ~]$ cat limits-alinux2
core file size          (blocks, -c) 0
data seg size           (kbytes, -d) unlimited
scheduling priority             (-e) 0
file size               (blocks, -f) unlimited
pending signals                 (-i) 756466
max locked memory       (kbytes, -l) unlimited
max memory size         (kbytes, -m) unlimited
open files                      (-n) 8192
pipe size            (512 bytes, -p) 8
POSIX message queues     (bytes, -q) 819200
real-time priority              (-r) 0
stack size              (kbytes, -s) 8192
cpu time               (seconds, -t) unlimited
max user processes              (-u) 4096
virtual memory          (kbytes, -v) unlimited
file locks                      (-x) unlimited
[ec2-user@ip-10-0-0-237 ~]$ diff -wbB limits-alinux2 limits-with-patch
5c5
< pending signals                 (-i) 756466
---
> pending signals                 (-i) 756534
14c14
< max user processes              (-u) 4096
---
> max user processes              (-u) 30646
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
