### PR TITLE
Reduce somaxconn and tcp_max_syn_backlog to 65535

### DIFF
--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -25,11 +25,11 @@ end
 
 # Increase somaxconn and tcp_max_syn_backlog for large scale setting
 execute "increase somaxconn" do
-  command "echo '131072' > /proc/sys/net/core/somaxconn"
+  command "echo '65535' > /proc/sys/net/core/somaxconn"
 end
 
 execute "increase tcp_max_syn_backlog" do
-  command "echo '131072' > /proc/sys/net/ipv4/tcp_max_syn_backlog"
+  command "echo '65535' > /proc/sys/net/ipv4/tcp_max_syn_backlog"
 end
 
 # Amazon Time Sync


### PR DESCRIPTION
For some OSes (e.g. Centos7) this value cannot exceed 65535

Signed-off-by: Francesco De Martino <fdm@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
