### PR TITLE
Increase somaxconn and tcp_max_syn_backlog persistently

### DIFF
--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -24,12 +24,12 @@ execute 'setup ephemeral' do
 end
 
 # Increase somaxconn and tcp_max_syn_backlog for large scale setting
-execute "increase somaxconn" do
-  command "echo '65535' > /proc/sys/net/core/somaxconn"
+sysctl 'net.core.somaxconn' do
+  value 65535
 end
 
-execute "increase tcp_max_syn_backlog" do
-  command "echo '65535' > /proc/sys/net/ipv4/tcp_max_syn_backlog"
+sysctl 'net.ipv4.tcp_max_syn_backlog' do
+  value 65535
 end
 
 # Amazon Time Sync


### PR DESCRIPTION
sysctl chef resource https://docs.chef.io/resources/sysctl/ is used to set and persist the settings

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
