### PR TITLE
Use > 8 NFS server kernel threads on instance types with many cores

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -344,6 +344,7 @@ default['cfncluster']['cfn_dns_domain'] = nil
 default['cfncluster']['use_private_hostname'] = 'false'
 default['cfncluster']['skip_install_recipes'] = 'yes'
 default['cfncluster']['scheduler_queue_name'] = nil
+default['cfncluster']['nfs_server_threads'] = [node['cpu']['cores'], 8].max
 
 # AWS domain
 default['cfncluster']['aws_domain'] = aws_domain

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -116,6 +116,7 @@ cookbook_file 'AWS-ParallelCluster-License-README.txt' do
   mode '0644'
 end
 
+node.default['nfs']['threads'] = node['cfncluster']['nfs_server_threads'].to_i
 if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 16.04
   # FIXME: https://github.com/atomic-penguin/cookbook-nfs/issues/93
   include_recipe "nfs::server"


### PR DESCRIPTION
Provide an attribute so that it may be disabled via extra_json.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
