### PR TITLE
Disallow using AMIs created by other versions of pcluster

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -145,13 +145,19 @@ end
 def ami_bootstrapped?
   version = ''
   bootstrapped_file = '/opt/parallelcluster/.bootstrapped'
+  current_version = 'aws-parallelcluster-' + node['cfncluster']['cfncluster-version']
 
   if ::File.exist?(bootstrapped_file)
     version = IO.read(bootstrapped_file).chomp
     Chef::Log.info("Detected bootstrap file #{version}")
+    if version != current_version
+      raise "This AMI was created with " + version + ", but is trying to be used with " +  current_version +
+                ". Please either use an AMI created with " + current_version + " or change your ParallelCluster to "+
+                version
+    end
   end
 
-  'aws-parallelcluster-' + node['cfncluster']['cfncluster-version'] == version && ( node['cfncluster']['skip_install_recipes'] == 'yes' || node['cfncluster']['skip_install_recipes'] == true )
+  version != '' && ( node['cfncluster']['skip_install_recipes'] == 'yes' || node['cfncluster']['skip_install_recipes'] == true )
 end
 
 #


### PR DESCRIPTION
As a result, a AMI created by other versions of pcluster cannot be used as a BASE_AMI in AMI creation or a custom_AMI in cluster creation.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
