### PR TITLE
Add a new option post_install_script to createami CLI

### DIFF
--- a/amis/build_ami.sh
+++ b/amis/build_ami.sh
@@ -117,8 +117,8 @@ check_options() {
     available_arm_os="ubuntu1804 alinux2"  # subset of supported OSes for which ARM AMIs are available
     available_os="centos6 centos7 alinux ubuntu1604 ${available_arm_os}"
     cwd="$(dirname $0)"
-    tmp_dir=$(mktemp -d)
-    export COOKBOOK_PATH="${tmp_dir}/cookbook"
+    export COOKBOOK_PATH="$(cd ${cwd}/..; pwd)"
+    export SCRIPT_PATH="${cwd}/../../script"
 
     if [ "${_custom}" == "true" ]; then
         only=custom-${_os}
@@ -203,8 +203,8 @@ check_options() {
 do_command() {
     RC=0
 
-    mkdir -p "${COOKBOOK_PATH}"
-    cp -R ${cwd}/../* "${COOKBOOK_PATH}"
+    mkdir -p "${SCRIPT_PATH}"
+
     if [ "x${_build_date}" == "x" ]; then
       export BUILD_DATE=$(date +%Y%m%d%H%M)
     else

--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -9,6 +9,7 @@
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
     "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
+    "script_path": "{{env `SCRIPT_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
@@ -167,6 +168,11 @@
       "destination" : "/tmp/cookbook"
     },
     {
+      "type": "file",
+      "source": "{{user `script_path`}}",
+      "destination": "/tmp/createami_scripts"
+    },
+    {
       "type" : "shell",
       "inline" : [
         "set -x",
@@ -253,6 +259,14 @@
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "set -x",
+        "script_name=$(ls /tmp/createami_scripts)",
+        "[[ -n ${script_name} ]] && (sudo chmod +x /tmp/createami_scripts/${script_name} && sudo /tmp/createami_scripts/${script_name} && sudo mkdir -p /opt/parallelcluster/createami_scripts && sudo mv /tmp/createami_scripts/${script_name} /opt/parallelcluster/createami_scripts) || echo 'No post install script'"
       ]
     },
     {

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -9,6 +9,7 @@
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
     "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
+    "script_path": "{{env `SCRIPT_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
@@ -167,6 +168,11 @@
       "destination" : "/tmp/cookbook"
     },
     {
+      "type": "file",
+      "source": "{{user `script_path`}}",
+      "destination": "/tmp/createami_scripts"
+    },
+    {
       "type" : "shell",
       "inline" : [
         "set -x",
@@ -253,6 +259,14 @@
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "set -x",
+        "script_name=$(ls /tmp/createami_scripts)",
+        "[[ -n ${script_name} ]] && (sudo chmod +x /tmp/createami_scripts/${script_name} && sudo /tmp/createami_scripts/${script_name} && sudo mkdir -p /opt/parallelcluster/createami_scripts && sudo mv /tmp/createami_scripts/${script_name} /opt/parallelcluster/createami_scripts) || echo 'No post install script'"
       ]
     },
     {

--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -9,6 +9,7 @@
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
     "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
+    "script_path": "{{env `SCRIPT_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
@@ -174,6 +175,11 @@
       "destination" : "/tmp/cookbook"
     },
     {
+      "type": "file",
+      "source": "{{user `script_path`}}",
+      "destination": "/tmp/createami_scripts"
+    },
+    {
       "type" : "shell",
       "inline" : [
         "set -x",
@@ -272,6 +278,14 @@
         "[[ ${region} =~ ^cn- ]] && bucket=\"s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster\"",
         "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
         "sudo pip install /tmp/aws-cfn-bootstrap-latest.tar.gz"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "set -x",
+        "script_name=$(ls /tmp/createami_scripts)",
+        "[[ -n ${script_name} ]] && (sudo chmod +x /tmp/createami_scripts/${script_name} && sudo /tmp/createami_scripts/${script_name} && sudo mkdir -p /opt/parallelcluster/createami_scripts && sudo mv /tmp/createami_scripts/${script_name} /opt/parallelcluster/createami_scripts) || echo 'No post install script'"
       ]
     },
     {

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -9,6 +9,7 @@
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
     "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
+    "script_path": "{{env `SCRIPT_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "dcv_installed": "{{env `DCV_INSTALLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
@@ -183,6 +184,11 @@
       "destination" : "/tmp/cookbook"
     },
     {
+      "type": "file",
+      "source": "{{user `script_path`}}",
+      "destination": "/tmp/createami_scripts"
+    },
+    {
       "type" : "shell",
       "inline" : [
         "set -x",
@@ -283,6 +289,14 @@
         "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
         "which pip2",
         "if [ $? -eq 0 ]; then sudo pip2 install /tmp/aws-cfn-bootstrap-latest.tar.gz; else sudo pip install /tmp/aws-cfn-bootstrap-latest.tar.gz; fi"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "set -x",
+        "script_name=$(ls /tmp/createami_scripts)",
+        "[[ -n ${script_name} ]] && (sudo chmod +x /tmp/createami_scripts/${script_name} && sudo /tmp/createami_scripts/${script_name} && sudo mkdir -p /opt/parallelcluster/createami_scripts && sudo mv /tmp/createami_scripts/${script_name} /opt/parallelcluster/createami_scripts) || echo 'No post install script'"
       ]
     },
     {

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -9,6 +9,7 @@
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
     "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
+    "script_path": "{{env `SCRIPT_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
@@ -187,6 +188,11 @@
       "destination" : "/tmp/cookbook"
     },
     {
+      "type": "file",
+      "source": "{{user `script_path`}}",
+      "destination": "/tmp/createami_scripts"
+    },
+    {
       "type" : "shell",
       "inline_shebang": "/bin/bash -e",
       "inline" : [
@@ -285,6 +291,15 @@
         "[[ ${region} =~ ^cn- ]] && bucket=\"s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster\"",
         "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
         "sudo pip install /tmp/aws-cfn-bootstrap-latest.tar.gz"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline_shebang" : "/bin/bash -e",
+      "inline": [
+        "set -x",
+        "script_name=$(ls /tmp/createami_scripts)",
+        "[[ -n ${script_name} ]] && (sudo chmod +x /tmp/createami_scripts/${script_name} && sudo /tmp/createami_scripts/${script_name} && sudo mkdir -p /opt/parallelcluster/createami_scripts && sudo mv /tmp/createami_scripts/${script_name} /opt/parallelcluster/createami_scripts) || echo 'No post install script'"
       ]
     },
     {

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -9,6 +9,7 @@
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}",
     "cookbook_path" : "{{env `COOKBOOK_PATH`}}",
+    "script_path": "{{env `SCRIPT_PATH`}}",
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "dcv_installed": "{{env `DCV_INSTALLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
@@ -188,6 +189,11 @@
       "destination" : "/tmp/cookbook"
     },
     {
+      "type": "file",
+      "source": "{{user `script_path`}}",
+      "destination": "/tmp/createami_scripts"
+    },
+    {
       "type" : "shell",
       "inline_shebang": "/bin/bash -e",
       "inline" : [
@@ -289,6 +295,15 @@
         "[[ ${region} =~ ^cn- ]] && bucket=\"s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster\"",
         "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
         "sudo pip install /tmp/aws-cfn-bootstrap-latest.tar.gz"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline_shebang" : "/bin/bash -e",
+      "inline": [
+        "set -x",
+        "script_name=$(ls /tmp/createami_scripts)",
+        "[[ -n ${script_name} ]] && (sudo chmod +x /tmp/createami_scripts/${script_name} && sudo /tmp/createami_scripts/${script_name} && sudo mkdir -p /opt/parallelcluster/createami_scripts && sudo mv /tmp/createami_scripts/${script_name} /opt/parallelcluster/createami_scripts) || echo 'No post install script'"
       ]
     },
     {


### PR DESCRIPTION
* Upload script folder with createami post install script to packer instance.
* Execute the script if the script is specified.
* Move the script to `/opt/parallelcluster/createami_scripts` folder.
* [CLI PR](https://github.com/aws/aws-parallelcluster/pull/2039) and [tests performance](https://jenkins.yuleiwan.ds9.nice.aws.a2z.com/job/02_integration_test/39/testReport/)

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
