### PR TITLE
Fix condition to avoid failure when partition changes require a reboot

### DIFF
--- a/files/default/setup-ephemeral-drives.sh
+++ b/files/default/setup-ephemeral-drives.sh
@@ -24,9 +24,11 @@ function error_exit () {
 function exec_command() {
   _command_output=$($@ 2>&1)
   _exit_code=$?
+  echo "${_command_output}" | grep -vi "you should reboot now" >& /dev/null
+  _grep_exit_code=$?
 
   # Do not set RC=1 if error says that changes have been written but a reboot is required to inform the kernel
-  [[ $_exit_code -ne 0 && $(echo "${_command_output}" | grep -i "you should reboot now") ]] && RC=1
+  [[ ${_exit_code} -ne 0 && ${_grep_exit_code} -eq 0 ]] && RC=1
 }
 
 # LVM stripe, format, mount ephemeral drives


### PR DESCRIPTION
The patch will let the script continue also when the following error is returned by the parted command: "Error: Partition(s) Y on /dev/XXX have been written, but we have been unable to inform the kernel of the change, probably because it/they are in use. As a result, the old partition(s) will remain in use. You should reboot now before making further changes."

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
