### PR TITLE
Do not use restart command for chrony service

### DIFF
--- a/recipes/chrony_config.rb
+++ b/recipes/chrony_config.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 service node['cfncluster']['chrony']['service'] do
-  supports restart: true
+  # chrony service supports restart but is not correctly checking if the process is stopped before starting the new one
+  supports restart: false
   action %i[enable restart]
 end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -183,8 +183,10 @@ if node['init_package'] == 'init'
   gmond_check_command = "service #{node['cfncluster']['ganglia']['gmond_service']} status | grep -i running"
   gmetad_check_command = "service gmetad status | grep -i running"
 elsif node['init_package'] == 'systemd'
-  gmond_check_command = "systemctl status #{node['cfncluster']['ganglia']['gmond_service']} | grep -i running"
-  gmetad_check_command = "systemctl status gmetad | grep -i running"
+  # $ systemctl show -p SubState <service>
+  # SubState=Running
+  gmond_check_command = "systemctl show -p SubState #{node['cfncluster']['ganglia']['gmond_service']} | grep -i running"
+  gmetad_check_command = "systemctl show -p SubState gmetad | grep -i running"
 end
 
 case node['cfncluster']['cfn_node_type']
@@ -212,7 +214,9 @@ end
 if node['init_package'] == 'init'
   chrony_check_command = "service #{node['cfncluster']['chrony']['service']} status | grep -i running"
 elsif node['init_package'] == 'systemd'
-  chrony_check_command = "systemctl status #{node['cfncluster']['chrony']['service']} | grep -i running"
+  # $ systemctl show -p SubState <service>
+  # SubState=Running
+  chrony_check_command = "systemctl show -p SubState #{node['cfncluster']['chrony']['service']} | grep -i running"
 end
 
 execute 'check chrony running' do


### PR DESCRIPTION
The restart command for chrony service is not correctly checking if the process is stopped before starting the new one, causing the new process to not being able to start
e.g.

```
chrony[2359]: chronyd is running and online.
systemd[1]: Started LSB: Controls chronyd NTP time daemon.
chronyd[2463]: Selected source 50.205.244.25
chronyd[2463]: Selected source 169.254.169.123
chrony[4195]: Stopped /usr/sbin/chronyd (pid 2463).
chronyd[2463]: chronyd exiting
systemd[1]: Stopped LSB: Controls chronyd NTP time daemon.
systemd[1]: Starting LSB: Controls chronyd NTP time daemon...
chrony[4203]: /usr/sbin/chronyd already running
```

Replace the restart with a stop/start sequence handled by chef

Fix also the check to see if a service is running when systemctl is used
```
# systemctl show -p SubState chrony
SubState=exited
```
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
