### PR TITLE
Validate OS specified by users is the same as the actual OS of a AMI

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,8 @@ suites:
       - recipe[aws-parallelcluster::_default_pre]
       - recipe[aws-parallelcluster::default]
     attributes:
+      cfncluster:
+        cfn_base_os: <%= ENV['CFN_BASE_OS'] %>
 
   - name: default_gpu
     run_list:
@@ -22,6 +24,7 @@ suites:
       - recipe[aws-parallelcluster::default]
     attributes:
       cfncluster:
+        cfn_base_os: <%= ENV['CFN_BASE_OS'] %>
         nvidia:
           enabled: 'yes'
 
@@ -67,7 +70,10 @@ suites:
         cfn_ephemeral_dir: <%= ENV['CFN_EPHEMERAL_DIR'] %>
         cfn_shared_dir: <%= ENV['CFN_SHARED_DIR'] %>
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
+        # cfn_base_os is one of the base OSs supported by pcluster
+        cfn_base_os: <%= ENV['CFN_BASE_OS'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
+        # os attribute is used in pipeline code. i.e. centos7, centos7-custom
         os: <%= ENV['OS'] %>
 
   - name: sge_config_MasterServer
@@ -90,7 +96,10 @@ suites:
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
+        # cfn_base_os is one of the base OSs supported by pcluster
+        cfn_base_os: <%= ENV['CFN_BASE_OS'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
+        # os attribute is used in pipeline code. i.e. centos7, centos7-custom
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'
@@ -120,7 +129,10 @@ suites:
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
+        # cfn_base_os is one of the base OSs supported by pcluster
+        cfn_base_os: <%= ENV['CFN_BASE_OS'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
+        # os attribute is used in pipeline code. i.e. centos7, centos7-custom
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'
@@ -150,9 +162,12 @@ suites:
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
+        # cfn_base_os is one of the base OSs supported by pcluster
+        cfn_base_os: <%= ENV['CFN_BASE_OS'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
         cluster_s3_bucket: <%= ENV['CLUSTER_CONFIG_S3_BUCKET'] %>
         cluster_config_s3_key: <%= ENV['CLUSTER_CONFIG_S3_KEY'] %>
+        # os attribute is used in pipeline code. i.e. centos7, centos7-custom
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'
@@ -182,7 +197,10 @@ suites:
         cfn_cluster_user: <%= ENV['CFN_CLUSTER_USER'] %>
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_ddb_table: <%= ENV['CFN_DDB_TABLE'] %>
+        # cfn_base_os is one of the base OSs supported by pcluster
+        cfn_base_os: <%= ENV['CFN_BASE_OS'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
+        # os attribute is used in pipeline code. i.e. centos7, centos7-custom
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         custom_awsbatchcli_package: <%= ENV['CUSTOM_AWSBATCHCLI_URL'] %>
@@ -210,7 +228,10 @@ suites:
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_master: <%= ENV['CFN_MASTER'] %>
         cfn_master_private_ip: <%= ENV['CFN_MASTER_PRIVATE_IP'] %>
+        # cfn_base_os is one of the base OSs supported by pcluster
+        cfn_base_os: <%= ENV['CFN_BASE_OS'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
+        # os attribute is used in pipeline code. i.e. centos7, centos7-custom
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'
@@ -240,7 +261,10 @@ suites:
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_master: <%= ENV['CFN_MASTER'] %>
         cfn_master_private_ip: <%= ENV['CFN_MASTER_PRIVATE_IP'] %>
+        # cfn_base_os is one of the base OSs supported by pcluster. i.e. centos7
+        cfn_base_os: <%= ENV['CFN_BASE_OS'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
+        # os attribute is used in pipeline code. i.e. centos7, centos7-custom
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'
@@ -270,8 +294,11 @@ suites:
         cfn_sqs_queue: <%= ENV['CFN_SQS_QUEUE'] %>
         cfn_master: <%= ENV['CFN_MASTER'] %>
         cfn_master_private_ip: <%= ENV['CFN_MASTER_PRIVATE_IP'] %>
+        # cfn_base_os is one of the base OSs supported by pcluster
+        cfn_base_os: <%= ENV['CFN_BASE_OS'] %>
         slurm_nodename: 'fake-dy-compute-1'
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
+        # os attribute is used in pipeline code. i.e. centos7, centos7-custom
         os: <%= ENV['OS'] %>
         ganglia_enabled: 'yes'
         dcv_enabled: 'master'

--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -225,7 +225,8 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
-          "custom_node_package" : "{{user `custom_node_package`}}"
+          "custom_node_package" : "{{user `custom_node_package`}}",
+          "cfn_base_os" : "alinux"
         }
       },
       "remote_cookbook_paths" : [
@@ -243,6 +244,11 @@
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
+      "json" : {
+        "cfncluster" : {
+          "cfn_base_os" : "alinux"
+        }
+      },
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -225,7 +225,8 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
-          "custom_node_package" : "{{user `custom_node_package`}}"
+          "custom_node_package" : "{{user `custom_node_package`}}",
+          "cfn_base_os" : "alinux2"
         }
       },
       "remote_cookbook_paths" : [
@@ -243,6 +244,11 @@
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
+      "json" : {
+        "cfncluster" : {
+          "cfn_base_os" : "alinux2"
+        }
+      },
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [

--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -234,7 +234,8 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
-          "custom_node_package" : "{{user `custom_node_package`}}"
+          "custom_node_package" : "{{user `custom_node_package`}}",
+          "cfn_base_os" : "centos6"
         }
       },
       "remote_cookbook_paths" : [
@@ -252,6 +253,11 @@
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
+      "json" : {
+        "cfncluster" : {
+          "cfn_base_os" : "centos6"
+        }
+      },
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -244,7 +244,8 @@
           "dcv": {
             "installed" : "{{user `dcv_installed`}}"
           },
-          "custom_node_package" : "{{user `custom_node_package`}}"
+          "custom_node_package" : "{{user `custom_node_package`}}",
+          "cfn_base_os" : "centos7"
         }
       },
       "remote_cookbook_paths" : [
@@ -262,6 +263,11 @@
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
+      "json" : {
+        "cfncluster" : {
+          "cfn_base_os" : "centos7"
+        }
+      },
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -246,7 +246,8 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
-          "custom_node_package" : "{{user `custom_node_package`}}"
+          "custom_node_package" : "{{user `custom_node_package`}}",
+          "cfn_base_os" : "ubuntu1604"
         }
       },
       "remote_cookbook_paths" : [
@@ -264,6 +265,11 @@
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
+      "json" : {
+        "cfncluster" : {
+          "cfn_base_os" : "ubuntu1604"
+        }
+      },
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -250,7 +250,8 @@
           "dcv": {
             "installed" : "{{user `dcv_installed`}}"
           },
-          "custom_node_package" : "{{user `custom_node_package`}}"
+          "custom_node_package" : "{{user `custom_node_package`}}",
+          "cfn_base_os" : "ubuntu1804"
         }
       },
       "remote_cookbook_paths" : [
@@ -268,6 +269,11 @@
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
+      "json" : {
+        "cfncluster" : {
+          "cfn_base_os" : "ubuntu1804"
+        }
+      },
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -161,6 +161,39 @@ def ami_bootstrapped?
 end
 
 #
+# Check if OS type specified by the user is the same as the OS identified by Ohai
+#
+def validate_os_type
+  case node['platform']
+  when 'ubuntu'
+    current_os = 'ubuntu'+ node['platform_version'].tr('.','')
+    if node['cfncluster']['cfn_base_os'] != current_os
+      raise_os_not_match(current_os, node['cfncluster']['cfn_base_os'])
+    end
+  when 'amazon'
+    if node['platform_version'].to_i > 2010 && node['cfncluster']['cfn_base_os'] != 'alinux'
+      raise_os_not_match("alinux", node['cfncluster']['cfn_base_os'])
+    elsif node['platform_version'].to_i == 2 && node['cfncluster']['cfn_base_os'] != 'alinux2'
+      raise_os_not_match("alinux2", node['cfncluster']['cfn_base_os'])
+    end
+  when 'centos'
+    current_os = 'centos'+ (node['platform_version'].to_i).to_s
+    if node['cfncluster']['cfn_base_os'] != current_os
+      raise_os_not_match(current_os, node['cfncluster']['cfn_base_os'])
+    end
+  end
+end
+
+#
+# Raise error if OS types do not match
+#
+def raise_os_not_match(current_os, specified_os)
+  raise "The custom AMI you have provided uses the " + current_os + " OS. However, the base_os specified in your" +
+            " config file is " + specified_os +". Please either use an AMI with the " + specified_os +
+            " OS or update the base_os setting in your configuration file to " + current_os + "."
+end
+
+#
 # Retrieve master ip and dns from file (HIT only)
 #
 def hit_master_info

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,6 +15,9 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Validate OS type specified by the user is the same as the OS identified by Ohai
+validate_os_type
+
 include_recipe 'aws-parallelcluster::sge_install'
 include_recipe 'aws-parallelcluster::torque_install'
 include_recipe 'aws-parallelcluster::slurm_install'

--- a/recipes/prep_env.rb
+++ b/recipes/prep_env.rb
@@ -15,6 +15,9 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Validate OS type specified by the user is the same as the OS identified by Ohai
+validate_os_type
+
 # Determine cfn_scheduler_slots settings and update cfn_instance_slots appropriately
 node.default['cfncluster']['cfn_instance_slots'] = if node['cfncluster']['cfn_scheduler_slots'] == 'vcpus'
                                                      node['cpu']['total']


### PR DESCRIPTION
The OS specified by users in config file or command parameter will be compared with the actual OS of a AMI in cluster/AMI creation process. The creation process will fail if the two OSs are not consistent.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
