### PR TITLE
Add check on munge library

### DIFF
--- a/recipes/munge_install.rb
+++ b/recipes/munge_install.rb
@@ -50,9 +50,7 @@ bash 'make install' do
     make -j $CORES
     make install
   MUNGE
-  # TODO: Fix, so it works for upgrade
-  creates '/usr/bin/munge'
-  not_if "/usr/sbin/munged --version | grep -q munge-#{node['cfncluster']['munge']['munge_version']}"
+  not_if "/usr/sbin/munged --version | grep -q munge-#{node['cfncluster']['munge']['munge_version']} && ls #{munge_libdir}/libmunge*"
 end
 
 # Updated munge init script for Amazon Linux


### PR DESCRIPTION
Check is added to verify if munge library are installed. Munge libraries are used later in the process to compile other binaries (e.g. torque)

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
