### PR TITLE
Do not use restart command for chrony service

### DIFF
--- a/recipes/chrony_config.rb
+++ b/recipes/chrony_config.rb
@@ -15,8 +15,16 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+if node['init_package'] == 'init'
+  chrony_reload_command = "service #{node['cfncluster']['chrony']['service']} force-reload"
+elsif node['init_package'] == 'systemd'
+  chrony_reload_command = "systemctl force-reload #{node['cfncluster']['chrony']['service']}"
+end
+
 service node['cfncluster']['chrony']['service'] do
   # chrony service supports restart but is not correctly checking if the process is stopped before starting the new one
   supports restart: false
-  action %i[enable restart]
+  supports reload: true
+  reload_command chrony_reload_command
+  action %i[enable reload]
 end


### PR DESCRIPTION
The restart command for chrony service is not correctly checking if the process is stopped before starting the new one, causing the new process to not being able to start. Even Chef restart is not able to handle this case

Replace the restart with a force-reload, (simple reload is not supported)

```
Recipe: aws-parallelcluster::chrony_config
  * service[chrony] action enable (up to date)
  * service[chrony] action reload
    - reload service service[chrony]
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
