### PR TITLE
Start chrony service for system with init_package=init

### DIFF
--- a/recipes/chrony_config.rb
+++ b/recipes/chrony_config.rb
@@ -15,16 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-if node['init_package'] == 'init'
-  chrony_reload_command = "service #{node['cfncluster']['chrony']['service']} force-reload"
-elsif node['init_package'] == 'systemd'
-  chrony_reload_command = "systemctl force-reload #{node['cfncluster']['chrony']['service']}"
-end
-
 service node['cfncluster']['chrony']['service'] do
   # chrony service supports restart but is not correctly checking if the process is stopped before starting the new one
   supports restart: false
-  supports reload: true
-  reload_command chrony_reload_command
-  action %i[enable reload]
+  action %i[enable start]
 end

--- a/recipes/chrony_install.rb
+++ b/recipes/chrony_install.rb
@@ -28,4 +28,16 @@ end
 append_if_no_line "add configuration to chrony.conf" do
   path node['cfncluster']['chrony']['conf']
   line "server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4"
+  notifies :reload, "service[#{node['cfncluster']['chrony']['service']}]", :immediately
+end
+
+if node['init_package'] == 'init'
+  chrony_reload_command = "service #{node['cfncluster']['chrony']['service']} force-reload"
+elsif node['init_package'] == 'systemd'
+  chrony_reload_command = "systemctl force-reload #{node['cfncluster']['chrony']['service']}"
+end
+
+service node['cfncluster']['chrony']['service'] do
+  reload_command chrony_reload_command
+  action :nothing
 end


### PR DESCRIPTION
In system with init_package=init, chrony service is not started by default.
Regression was introduce by https://github.com/aws/aws-parallelcluster-cookbook/commit/158c8519fd96f250d230ef0b0dd92356217ad365 which is only reloading the service and not making sure it is started

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
