### PR TITLE
Override action reload for chrony service

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -362,3 +362,14 @@ def get_rhel_kernel_minor_version
   end
   kernel_minor_version
 end
+
+# Return chrony service reload command
+# Chrony doesn't support reload but only force-reload command
+def chrony_reload_command
+  if node['init_package'] == 'init'
+    chrony_reload_command = "service #{node['cfncluster']['chrony']['service']} force-reload"
+  elsif node['init_package'] == 'systemd'
+    chrony_reload_command = "systemctl force-reload #{node['cfncluster']['chrony']['service']}"
+  end
+  chrony_reload_command
+end

--- a/recipes/chrony_config.rb
+++ b/recipes/chrony_config.rb
@@ -18,5 +18,6 @@
 service node['cfncluster']['chrony']['service'] do
   # chrony service supports restart but is not correctly checking if the process is stopped before starting the new one
   supports restart: false
+  reload_command chrony_reload_command
   action %i[enable start]
 end

--- a/recipes/chrony_install.rb
+++ b/recipes/chrony_install.rb
@@ -31,12 +31,6 @@ append_if_no_line "add configuration to chrony.conf" do
   notifies :reload, "service[#{node['cfncluster']['chrony']['service']}]", :immediately
 end
 
-if node['init_package'] == 'init'
-  chrony_reload_command = "service #{node['cfncluster']['chrony']['service']} force-reload"
-elsif node['init_package'] == 'systemd'
-  chrony_reload_command = "systemctl force-reload #{node['cfncluster']['chrony']['service']}"
-end
-
 service node['cfncluster']['chrony']['service'] do
   reload_command chrony_reload_command
   action :nothing


### PR DESCRIPTION
Override action reload for chrony service with force-reload, since reload is not supported

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
