### PR TITLE
Remove previous installation of Slurm and munge

### DIFF
--- a/recipes/munge_install.rb
+++ b/recipes/munge_install.rb
@@ -19,6 +19,10 @@ return if node['conditions']['ami_bootstrapped']
 
 include_recipe 'aws-parallelcluster::base_install'
 
+package %w[munge* libmunge*] do
+  action :purge
+end
+
 munge_tarball = "#{node['cfncluster']['sources_dir']}/munge-#{node['cfncluster']['munge']['munge_version']}.tar.gz"
 
 # Get munge tarball

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -21,6 +21,10 @@ include_recipe 'aws-parallelcluster::base_install'
 include_recipe 'aws-parallelcluster::munge_install'
 include_recipe 'aws-parallelcluster::pmix_install'
 
+package %w[slurm* libslurm*] do
+  action :purge
+end
+
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer', nil
   slurm_tarball = "#{node['cfncluster']['sources_dir']}/slurm-#{node['cfncluster']['slurm']['version']}.tar.gz"


### PR DESCRIPTION
Remove previous installation of Slurm and munge done through OS repositories
This to avoid conflicts with versions installed by PCluster

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
