### PR TITLE
CentOS 8: Install python3 version of aws-cfn-bootstrap

### DIFF
--- a/amis/build_ami.sh
+++ b/amis/build_ami.sh
@@ -184,8 +184,8 @@ check_options() {
     esac
 
     # Ensure the specified architecture-OS combination is valid
-    if [ "${_arch}" == "arm64" ] && [[ "${_os}" =~ ^centos[0-9]+ ]]; then
-      echo "Currently there are no CentOS arm64 AMIs available."
+    if [ "${_arch}" == "arm64" ] && [[ "${_os}" =~ ^centos[6-7]$ ]]; then
+      echo "Currently there are no arm64 AMIs available for ${_os}."
       exit 1
     elif [ "${_arch}" == "arm64" ] && [ "${_os}" == "alinux" ]; then
       echo "Currently there are no alinux (AL1) arm64 AMIs available."

--- a/amis/packer_centos8.json
+++ b/amis/packer_centos8.json
@@ -280,9 +280,9 @@
         "region=\"{{user `region`}}\"",
         "bucket=\"s3.amazonaws.com\"",
         "[[ ${region} =~ ^cn- ]] && bucket=\"s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster\"",
-        "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
-        "which pip2",
-        "if [ $? -eq 0 ]; then sudo pip2 install /tmp/aws-cfn-bootstrap-latest.tar.gz; else sudo pip install /tmp/aws-cfn-bootstrap-latest.tar.gz; fi"
+        "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-py3-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz",
+        "sudo dnf install -y python3-pip",
+        "sudo pip3 install /tmp/aws-cfn-bootstrap-py3-latest.tar.gz"
       ]
     },
     {


### PR DESCRIPTION
* Install python3 version of aws-cfn-bootstrap scripts to support CentOS8

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
