### PR TITLE
Add support for CentOS 8 in base_install and base_config logic

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -204,6 +204,14 @@ when 'rhel', 'amazon'
                                                   libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel mdadm python python-pip
                                                   libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils]
     end
+    if node['platform_version'].to_i == 8
+      # Install python3 instead of unversioned python
+      default['cfncluster']['base_packages'].delete('python')
+      default['cfncluster']['base_packages'].delete('python-pip')
+      # Install firewalld for iptables used in configure-pat.sh
+      # Install nvme-cli package used to retrieve info about EBS volumes in parallelcluster-ebsnvme-id
+      default['cfncluster']['base_packages'].push(%w[python3 python3-pip firewalld nvme-cli])
+    end
     if node['platform_version'].to_i >= 8
       # gdisk required for FSx
       # environment-modules required for IntelMPI

--- a/files/centos-8/ec2_dev_2_volid.py
+++ b/files/centos-8/ec2_dev_2_volid.py
@@ -1,0 +1,71 @@
+# Same as default/ec2_dev_2_volid.py except call to /usr/local/sbin/parallelcluster-ebsnvme-id
+import requests
+import sys
+import os
+import syslog
+import time
+import boto3
+import configparser
+from botocore.config import Config
+
+
+def main():
+    syslog.syslog("Starting ec2_dev_2_volid.py script")
+    # Get dev
+    try:
+        dev = str(sys.argv[1])
+        syslog.syslog("Input block device is %s" % dev)
+    except IndexError:
+        syslog.syslog(syslog.LOG_ERR, "Provide block device i.e. xvdf")
+
+    # Convert dev to mapping format
+    if 'nvme' in dev:
+        # For newer instances which expose EBS volumes as NVMe devices, translate the
+        # device name so boto can discover it.
+        output = os.popen('sudo /usr/local/sbin/parallelcluster-ebsnvme-id /dev/' + dev).read().split(":")[1].strip()
+        print(output)
+        sys.exit(0)
+    else:
+        dev = dev.replace('xvd', 'sd')
+        dev = '/dev/' + dev
+
+    # Get instance ID
+    instanceId = requests.get("http://169.254.169.254/latest/meta-data/instance-id").text
+
+    # Get region
+    region = requests.get("http://169.254.169.254/latest/meta-data/placement/availability-zone").text
+    region = region[:-1]
+
+    # Parse configuration file to read proxy settings
+    config = configparser.RawConfigParser()
+    config.read('/etc/boto.cfg')
+    proxy_config = Config()
+    if config.has_option('Boto', 'proxy') and config.has_option('Boto', 'proxy_port'):
+        proxy = config.get('Boto', 'proxy')
+        proxy_port = config.get('Boto', 'proxy_port')
+        proxy_config = Config(proxies={'https': "{0}:{1}".format(proxy, proxy_port)})
+
+    # Connect to AWS using boto
+    ec2 = boto3.client('ec2', region_name=region, config=proxy_config)
+
+    # Poll for blockdevicemapping
+    devices = ec2.describe_instance_attribute(InstanceId=instanceId, Attribute='blockDeviceMapping').get('BlockDeviceMappings')
+    devmap = dict((d.get('DeviceName'), d) for d in devices)
+    x = 0
+    while dev not in devmap:
+        if x == 36:
+            syslog.syslog("Dev %s did not appears in 180 seconds." % dev)
+            sys.exit(1)
+        syslog.syslog("Looking for dev %s in devmap %s" % (dev, devmap))
+        time.sleep(5)
+        devices = ec2.describe_instance_attribute(InstanceId=instanceId, Attribute='blockDeviceMapping').get('BlockDeviceMappings')
+        devmap = dict((d.get('DeviceName'), d) for d in devices)
+        x += 1
+
+    # Return volumeId
+    volumeId = devmap.get(dev).get('Ebs').get('VolumeId')
+    print(volumeId)
+
+
+if __name__ == '__main__':
+    main()

--- a/files/centos-8/parallelcluster-ebsnvme-id
+++ b/files/centos-8/parallelcluster-ebsnvme-id
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright (C) 2020 Amazon.com, Inc. or its affiliates.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+# Usage:
+# Read EBS device information and provide information about the volume.
+
+# Sample output: vol067f083a4f6xxxxx
+# Insert '-' after 'vol' so that output looks like vol-067f083a4f6xxxxx
+vol_id=$(sudo nvme id-ctrl -v ${1} | grep -oP "sn\s+:\s\K(.+)" | sed 's/^vol/&-/')
+echo "Volume ID: ${vol_id}"

--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -19,7 +19,7 @@ unless node['platform'] == 'centos' && node['platform_version'].to_i < 7
   # not CentOS6
   case node['platform_family']
   when 'rhel', 'amazon'
-    if node['platform_version'].to_i == 8
+    if node['platform'] == 'centos' && node['platform_version'].to_i == 8
       execute 'dnf-update' do
         command "dnf -y update"
       end

--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -19,8 +19,14 @@ unless node['platform'] == 'centos' && node['platform_version'].to_i < 7
   # not CentOS6
   case node['platform_family']
   when 'rhel', 'amazon'
-    execute 'yum-update' do
-      command "yum -y update && package-cleanup -y --oldkernels --count=1"
+    if node['platform_version'].to_i == 8
+      execute 'dnf-update' do
+        command "dnf -y update"
+      end
+    else
+      execute 'yum-update' do
+        command "yum -y update && package-cleanup -y --oldkernels --count=1"
+      end
     end
   when 'debian'
     apt_update

--- a/recipes/awsbatch_config.rb
+++ b/recipes/awsbatch_config.rb
@@ -46,7 +46,7 @@ if !node['cfncluster']['custom_awsbatchcli_package'].nil? && !node['cfncluster']
       mkdir aws-parallelcluster-custom-cli
       tar -xzf aws-parallelcluster.tgz --directory aws-parallelcluster-custom-cli
       cd aws-parallelcluster-custom-cli/*aws-parallelcluster-*
-      pip install cli/
+      #{node['cfncluster']['cookbook_virtualenv_path']}/bin/pip install cli/
     CLI
   end
 else

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -38,7 +38,6 @@ include_recipe 'aws-parallelcluster::chrony_config'
 # EFA runtime configuration
 include_recipe "aws-parallelcluster::efa_config"
 
-# case node['cfncluster']['cfn_node_type']
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer'
   include_recipe 'aws-parallelcluster::_master_base_config'


### PR DESCRIPTION
This PR enables base_install/base_config to run on a bare CentOS 8 AMI.

The following changes were made:
* Enable PowerTools Repo so *-devel packages can be installed with DNF
* Install Python3 as system python for CentOS 8
* Remove obsolete logic of running nfs::server recipe when Ubuntu, nfs::server4 already includes nfs::server recipe
* Workaround to only run nfs::server instead of nfs::server4 for CentOS 8 due to issue: https://github.com/atomic-penguin/cookbook-nfs/issues/116
* Do not enforce kernel_devel version because kernel_devel package with same version as kernel release version cannot be found
* Modify logic to get EBS device to volume id mapping. Specifically ec2_dev_2_volid.py and parallelcluster-ebsnvme-id are modified for CentOS 8 to use nvme-cli to retrieve volume id for a device following this guide: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#identify-nvme-ebs-device
* Install firewalld so iptables executable becomes available
* Enable EPEL repo by default

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
