### PR TITLE
Cleanup initialization of FSx Lustre defaults and add CentOS 8 support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -196,12 +196,6 @@ when 'rhel', 'amazon'
                                                 blas-devel fftw-devel libffi-devel openssl-devel dkms mysql-devel libedit-devel
                                                 libical-devel postgresql-devel postgresql-server sendmail mdadm python python-pip
                                                 libgcrypt-devel glibc-static]
-
-    # Lustre Drivers for Centos 6
-    default['cfncluster']['lustre']['version'] = '2.10.6'
-    default['cfncluster']['lustre']['kmod_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el6/client/RPMS/x86_64/kmod-lustre-client-2.10.6-1.el6.x86_64.rpm'
-    default['cfncluster']['lustre']['client_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el6/client/RPMS/x86_64/lustre-client-2.10.6-1.el6.x86_64.rpm'
-
     if node['platform_version'].to_i >= 7
       default['cfncluster']['base_packages'] = %w[vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                                   libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
@@ -209,21 +203,6 @@ when 'rhel', 'amazon'
                                                   blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                                   libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel mdadm python python-pip
                                                   libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils]
-      if node['platform_version'].split('.')[1] >= '7'
-        # Lustre Client for Centos >= 7.7
-        default['cfncluster']['lustre']['public_key'] = 'https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc'
-        default['cfncluster']['lustre']['base_url'] = "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7.#{get_rhel_kernel_minor_version}/x86_64/"
-      elsif node['platform_version'].split('.')[1] == '6'
-        # Lustre Drivers for Centos 7.6
-        default['cfncluster']['lustre']['version'] = '2.10.6'
-        default['cfncluster']['lustre']['kmod_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/kmod-lustre-client-2.10.6-1.el7.x86_64.rpm'
-        default['cfncluster']['lustre']['client_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/lustre-client-2.10.6-1.el7.x86_64.rpm'
-      elsif node['platform_version'].split('.')[1] == '5'
-        # Lustre Drivers for Centos 7.5
-        default['cfncluster']['lustre']['version'] = '2.10.5'
-        default['cfncluster']['lustre']['kmod_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/kmod-lustre-client-2.10.5-1.el7.x86_64.rpm'
-        default['cfncluster']['lustre']['client_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/lustre-client-2.10.5-1.el7.x86_64.rpm'
-      end
     end
     default['cfncluster']['kernel_devel_pkg']['name'] = "kernel-lt-devel" if node['platform'] == 'centos' && node['platform_version'].to_i >= 6 && node['platform_version'].to_i < 7
     default['cfncluster']['rhel']['extra_repo'] = 'rhui-REGION-rhel-server-releases-optional' if node['platform'] == 'redhat' && node['platform_version'].to_i >= 6 && node['platform_version'].to_i < 7
@@ -282,8 +261,6 @@ when 'debian'
     default['cfncluster']['sge']['version'] = '8.1.9+dfsg-9build1'
   end
 
-  default['cfncluster']['lustre']['public_key'] = 'https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-ubuntu-public-key.asc'
-  default['cfncluster']['lustre']['repository_uri'] = 'https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu'
   # Modulefile Directory
   default['cfncluster']['modulefile_dir'] = "/usr/share/modules/modulefiles"
   # MODULESHOME
@@ -305,6 +282,37 @@ when 'debian'
     default['nfs']['service']['idmap'] = 'nfs-idmapd'
   end
 end
+
+# Lustre defaults (for CentOS >=7.7 and Ubuntu)
+default['cfncluster']['lustre']['public_key'] = value_for_platform(
+  'centos' => { '>=7.7' => "https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc" },
+  'ubuntu' => { 'default' => "https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-ubuntu-public-key.asc" }
+)
+default['cfncluster']['lustre']['base_url'] = value_for_platform(
+  'centos' => {
+    '>=7.7' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7.#{get_rhel7_kernel_minor_version}/x86_64/"
+  },
+  'ubuntu' => { 'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu" }
+)
+# Lustre defaults (for CentOS 7.6 and 7.5 only)
+default['cfncluster']['lustre']['version'] = value_for_platform(
+  'centos' => {
+    '7.6' => "2.10.6",
+    '7.5' => "2.10.5"
+  }
+)
+default['cfncluster']['lustre']['kmod_url'] = value_for_platform(
+  'centos' => {
+    '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/kmod-lustre-client-2.10.6-1.el7.x86_64.rpm",
+    '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/kmod-lustre-client-2.10.5-1.el7.x86_64.rpm"
+  }
+)
+default['cfncluster']['lustre']['client_url'] = value_for_platform(
+  'centos' => {
+    '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/lustre-client-2.10.6-1.el7.x86_64.rpm",
+    '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/lustre-client-2.10.5-1.el7.x86_64.rpm",
+  }
+)
 
 # Munge key
 default['cfncluster']['munge']['munge_key'] = 'YflQEFLjoxsmEK5vQyKklkLKJ#LkjLKDJF@*(#)ajLKQ@hLKN#()FSU(#@KLJH$@HKSASG)*DUJJDksdN'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -204,6 +204,11 @@ when 'rhel', 'amazon'
                                                   libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel mdadm python python-pip
                                                   libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils]
     end
+    if node['platform_version'].to_i >= 8
+      # gdisk required for FSx
+      default['cfncluster']['base_packages'].push('gdisk')
+    end
+
     default['cfncluster']['kernel_devel_pkg']['name'] = "kernel-lt-devel" if node['platform'] == 'centos' && node['platform_version'].to_i >= 6 && node['platform_version'].to_i < 7
     default['cfncluster']['rhel']['extra_repo'] = 'rhui-REGION-rhel-server-releases-optional' if node['platform'] == 'redhat' && node['platform_version'].to_i >= 6 && node['platform_version'].to_i < 7
     default['cfncluster']['rhel']['extra_repo'] = 'rhui-REGION-rhel-server-optional' if node['platform'] == 'redhat' && node['platform_version'].to_i >= 7
@@ -290,7 +295,8 @@ default['cfncluster']['lustre']['public_key'] = value_for_platform(
 )
 default['cfncluster']['lustre']['base_url'] = value_for_platform(
   'centos' => {
-    '>=7.7' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7.#{get_rhel7_kernel_minor_version}/x86_64/"
+    '>=8' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8/x86_64/",
+    'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7.#{get_rhel7_kernel_minor_version}/x86_64/"
   },
   'ubuntu' => { 'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu" }
 )

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -353,7 +353,7 @@ end
 # following the mapping reported here https://access.redhat.com/articles/3078#RHEL7
 # Method works for minor version >=7
 #
-def get_rhel_kernel_minor_version
+def get_rhel7_kernel_minor_version
   # kernel release is in the form 3.10.0-1127.8.2.el7.x86_64
   kernel_patch_version = node['kernel']['release'].match(/^\d+\.\d+\.\d+-(\d+)\..*$/)[1]
   kernel_minor_version = '7'

--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -17,8 +17,9 @@
 
 return unless node['conditions']['lustre_supported']
 
-# Install only on Centos 7.6 and 7.5
-if node['platform'] == 'centos' && (5..6).cover?(node['platform_version'].split('.')[1].to_i)
+if node['platform'] == 'centos' && %w[7.5 7.6].include?(node['platform_version'].to_f)
+  # Centos 7.6 and 7.5
+
   lustre_kmod_rpm = "#{node['cfncluster']['sources_dir']}/kmod-lustre-client-#{node['cfncluster']['lustre']['version']}.x86_64.rpm"
   lustre_client_rpm = "#{node['cfncluster']['sources_dir']}/lustre-client-#{node['cfncluster']['lustre']['version']}.x86_64.rpm"
 
@@ -41,28 +42,30 @@ if node['platform'] == 'centos' && (5..6).cover?(node['platform_version'].split(
   end
 
   # Install lustre mount drivers
-  yum_package 'lustre_kmod' do
+  package 'lustre_kmod' do
     source lustre_kmod_rpm
   end
 
   # Install lustre mount drivers
-  yum_package 'lustre_client' do
+  package 'lustre_client' do
     source lustre_client_rpm
   end
 
   kernel_module 'lnet'
-elsif node['platform'] == 'centos' && node['platform_version'].split('.')[1].to_i >= 7
+
+elsif node['platform'] == 'centos' && node['platform_version'].to_f >= 7.7
+  # Centos 8 and >= 7.7
 
   # add fsx lustre repository
   yum_repository "aws-fsx" do
-    description "AWS FSx Packages  - $basearch"
+    description "AWS FSx Packages - $basearch"
     baseurl node['cfncluster']['lustre']['base_url']
     gpgkey node['cfncluster']['lustre']['public_key']
     retries 3
     retry_delay 5
   end
 
-  yum_package %w[kmod-lustre-client lustre-client] do
+  package %w[kmod-lustre-client lustre-client] do
     retries 3
     retry_delay 5
   end
@@ -86,12 +89,12 @@ elsif node['platform'] == 'ubuntu'
 
   apt_update
 
-  apt_package "lustre-client-modules-#{node['kernel']['release']}" do
+  package "lustre-client-modules-#{node['kernel']['release']}" do
     retries 3
     retry_delay 5
   end
 
-  apt_package "lustre-client-modules-aws" do
+  package "lustre-client-modules-aws" do
     retries 3
     retry_delay 5
   end

--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -68,12 +68,15 @@ elsif node['platform'] == 'centos' && node['platform_version'].split('.')[1].to_
   end
 
   kernel_module 'lnet'
+
 elsif node['platform'] == 'centos'
+  # Centos 6
   Chef::Log.warn("Unsupported version of Centos, #{node['platform_version']}, supported versions are >= 7.5")
+
 elsif node['platform'] == 'ubuntu'
 
   apt_repository 'fsxlustreclientrepo' do
-    uri          node['cfncluster']['lustre']['repository_uri']
+    uri          node['cfncluster']['lustre']['base_url']
     components   ['main']
     distribution node['lsb']['codename']
     key          node['cfncluster']['lustre']['public_key']
@@ -94,8 +97,11 @@ elsif node['platform'] == 'ubuntu'
   end
 
   kernel_module 'lnet'
+
 elsif node['platform'] == 'amazon' && node['platform_version'].to_i == 2
+
   alinux_extras_topic 'lustre2.10'
+
 elsif node['platform'] == 'amazon' # Amazon Linux 1
 
   # Install lustre client module


### PR DESCRIPTION
# Cleanup initialization of FSx Lustre default

## Changes

* Moved FSx attributes initialization out from main platform switch case.
* Removed CentOS 6 attributes: this OS is not supported.
* Renamed ubuntu specific `repository_uri` attribute to be aligned with other OSes.
* Refactored attributes initialization by using `value_for_platform` keywork.
* Differentiated attributes according to the version.
   The attributes `version`, `kmod_url` and `client_url` are only used for CentOS 7.5 and 7.6
   `public_key` and `base_url` are used for CentOS 7.7 and Ubuntu.
* Renamed `get_rhel_kernel_minor_version` given that it's CentOS 7 specific.

## References
* Value for platform: https://docs.chef.io/dsl_recipe/#value_for_platform

# Add FSx support for CentOS 8

* Use `package` in place of `yum_package` to support `dnf`.
* Added `gdisk` package, required by `update initramfs` action, called by `kernel_module 'lnet'` resource.
* Use `['platform_version'].to_f`  to compare minor version of the OS in place of `['platform_version'].split('.')[1].to_i`
  to be compatible with multiple major OS values.
* Explicitly added `x86_64` at the end of the `base_url` parameter, like we have for CentOS 7.

## Other changes
* Improved check for CentOS 7.5. and 7.6.
* Use `package` in place of `apt_package` to be aligned to other OSes.

## Tests
Verified installation:
```
$ rpm -qa | grep lustre-client
lustre-client-2.10.8-1.fsx6.el8.x86_64
kmod-lustre-client-2.10.8-1.fsx6.el8.x86_64
```

## References
* Lustre installation guide: https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html
* gdisk issue: https://www.spinics.net/lists/centos-devel/msg18766.html
* package resource: https://docs.chef.io/resources/package/

