### PR TITLE
CentOS 8: mark as unsupported OS for EFA and enable Intel MPI

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -206,7 +206,8 @@ when 'rhel', 'amazon'
     end
     if node['platform_version'].to_i >= 8
       # gdisk required for FSx
-      default['cfncluster']['base_packages'].push('gdisk')
+      # environment-modules required for IntelMPI
+      default['cfncluster']['base_packages'].push('gdisk', 'environment-modules')
     end
 
     default['cfncluster']['kernel_devel_pkg']['name'] = "kernel-lt-devel" if node['platform'] == 'centos' && node['platform_version'].to_i >= 6 && node['platform_version'].to_i < 7

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -277,7 +277,7 @@ end
 # Check if this is an OS on which EFA is supported
 #
 def platform_supports_efa?
-  [node['platform'] == 'centos' && node['platform_version'].to_i >= 7,
+  [node['platform'] == 'centos' && node['platform_version'].to_i >= 7 && node['platform_version'].to_i < 8,
    node['platform'] == 'amazon',
    node['platform'] == 'ubuntu'].any?
 end


### PR DESCRIPTION
# Mark CentOS 8 as unsupported OS for EFA

Supported AMIs are: Amazon Linux, Amazon Linux 2, RHEL 7.6, RHEL 7.7, RHEL 7.8, CentOS 7, Ubuntu 16.04, and Ubuntu 18.04.

Source: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-working-with.html

With this patch the `efa_install` recipe will be skipped, thanks to `return unless node['conditions']['efa_supported']` condition, on which `default['conditions']['efa_supported'] = platform_supports_efa?`.

NOTE: we already have a validation in the CLI: https://github.com/aws/aws-parallelcluster/blob/v2.9.1/cli/pcluster/config/validators.py#L419




# Add environment-modules requirement to install Intel MPI on CentOS8 

The `environment-modules` package installation automatically creates the `/usr/share/Modules/` folder, required by the intel_mpi recipe.

## Tests
Verified installation:
```
$ rpm -qa | grep intel-mpi
intel-mpi-rt-2019.7-217-2019.7-217.x86_64
intel-mpi-doc-2019-2019.7-217.x86_64
intel-mpi-psxe-2019.7-102-2019.7-102.x86_64
intel-mpi-installer-license-2019.7-217-2019.7-217.x86_64
intel-mpi-sdk-2019.7-217-2019.7-217.x86_64
```

## References
* https://forums.centos.org/viewtopic.php?t=74035