### PR TITLE
Add CentOS 8 support for NICE DCV and attributes cleanup 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,11 +21,13 @@ default['cfncluster']['sources_dir'] = "#{node['cfncluster']['base_dir']}/source
 default['cfncluster']['scripts_dir'] = "#{node['cfncluster']['base_dir']}/scripts"
 default['cfncluster']['license_dir'] = "#{node['cfncluster']['base_dir']}/licenses"
 default['cfncluster']['configs_dir'] = "#{node['cfncluster']['base_dir']}/configs"
+
 # Cluster config
 default['cfncluster']['cluster_s3_bucket'] = nil
 default['cfncluster']['cluster_config_s3_key'] = nil
 default['cfncluster']['cluster_config_version'] = nil
 default['cfncluster']['cluster_config_path'] = "#{node['cfncluster']['configs_dir']}/cluster_config.json"
+
 # Python Version
 default['cfncluster']['python-version'] = '3.6.9'
 default['cfncluster']['python-version-centos6'] = '2.7.17'
@@ -42,18 +44,22 @@ default['cfncluster']['node_virtualenv'] = 'node_virtualenv'
 default['cfncluster']['cookbook_virtualenv_path'] = "#{node['cfncluster']['system_pyenv_root']}/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['cookbook_virtualenv']}"
 # Node Virtualenv Path
 default['cfncluster']['node_virtualenv_path'] = "#{node['cfncluster']['system_pyenv_root']}/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['node_virtualenv']}"
+
 # Intel Packages
 default['cfncluster']['psxe']['version'] = '2019.5'
 default['cfncluster']['intelhpc']['version'] = '2018.0-*.el7'
 default['cfncluster']['intelpython2']['version'] = '2019.4'
 default['cfncluster']['intelpython3']['version'] = '2019.4'
+
 # Intel MPI
 default['cfncluster']['intelmpi']['url'] = "https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16546/l_mpi_2019.7.217.tgz"
 default['cfncluster']['intelmpi']['version'] = '2019.7.217'
 default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/impi/#{node['cfncluster']['intelmpi']['version']}/intel64/modulefiles/mpi"
+
 # Python packages
 default['cfncluster']['cfncluster-version'] = '2.9.1'
 default['cfncluster']['cfncluster-node-version'] = '2.9.1'
+
 # URLs to software packages used during install recipes
 # Gridengine software
 default['cfncluster']['sge']['version'] = '8.1.9'
@@ -73,8 +79,12 @@ default['cfncluster']['pmix']['sha1'] = '36bfb962858879cefa7a04a633c1b6984cea03e
 # Munge
 default['cfncluster']['munge']['munge_version'] = '0.5.13'
 default['cfncluster']['munge']['munge_url'] = "https://github.com/dun/munge/archive/munge-#{node['cfncluster']['munge']['munge_version']}.tar.gz"
+# Munge key
+default['cfncluster']['munge']['munge_key'] = 'YflQEFLjoxsmEK5vQyKklkLKJ#LkjLKDJF@*(#)ajLKQ@hLKN#()FSU(#@KLJH$@HKSASG)*DUJJDksdN'
+
 # Ganglia
 default['cfncluster']['ganglia_enabled'] = 'no'
+
 # NVIDIA
 default['cfncluster']['nvidia']['enabled'] = 'no'
 if node['platform'] == 'centos' && node['platform_version'].to_i < 7
@@ -88,8 +98,10 @@ else
   default['cfncluster']['nvidia']['cuda_version'] = '11.0'
   default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run'
 end
+
 # EFA
 default['cfncluster']['efa']['installer_url'] = 'https://efa-installer.amazonaws.com/aws-efa-installer-1.9.5.tar.gz'
+
 # NICE DCV
 default['cfncluster']['dcv']['installed'] = 'yes'
 default['cfncluster']['dcv']['version'] = '2020.1-9012'
@@ -154,6 +166,7 @@ default['cfncluster']['dcv']['authenticator']['certificate'] = "/etc/parallelclu
 default['cfncluster']['dcv']['authenticator']['private_key'] = "/etc/parallelcluster/ext-auth-private-key.pem"
 default['cfncluster']['dcv']['authenticator']['virtualenv'] = "dcv_authenticator_virtualenv"
 default['cfncluster']['dcv']['authenticator']['virtualenv_path'] = "#{node['cfncluster']['system_pyenv_root']}/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['dcv']['authenticator']['virtualenv']}"
+
 # CloudWatch Agent
 default['cfncluster']['cloudwatch']['public_key_url'] = "https://s3.amazonaws.com/amazoncloudwatch-agent/assets/amazon-cloudwatch-agent.gpg"
 default['cfncluster']['cloudwatch']['public_key_local_path'] = "#{node['cfncluster']['sources_dir']}/amazon-cloudwatch-agent.gpg"
@@ -339,12 +352,9 @@ default['cfncluster']['lustre']['kmod_url'] = value_for_platform(
 default['cfncluster']['lustre']['client_url'] = value_for_platform(
   'centos' => {
     '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/lustre-client-2.10.6-1.el7.x86_64.rpm",
-    '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/lustre-client-2.10.5-1.el7.x86_64.rpm",
+    '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/lustre-client-2.10.5-1.el7.x86_64.rpm"
   }
 )
-
-# Munge key
-default['cfncluster']['munge']['munge_key'] = 'YflQEFLjoxsmEK5vQyKklkLKJ#LkjLKDJF@*(#)ajLKQ@hLKN#()FSU(#@KLJH$@HKSASG)*DUJJDksdN'
 
 # ParallelCluster internal variables (also in /etc/parallelcluster/cfnconfig)
 default['cfncluster']['cfn_region'] = 'us-east-1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -103,23 +103,26 @@ end
 default['cfncluster']['efa']['installer_url'] = 'https://efa-installer.amazonaws.com/aws-efa-installer-1.9.5.tar.gz'
 
 # NICE DCV
+default['cfncluster']['dcv_port'] = 8443
 default['cfncluster']['dcv']['installed'] = 'yes'
 default['cfncluster']['dcv']['version'] = '2020.1-9012'
 if arm_instance?
-  default['cfncluster']['dcv']['supported_os'] = %w[ubuntu18 amazon2]
+  default['cfncluster']['dcv']['supported_os'] = %w[centos8 ubuntu18 amazon2]
   default['cfncluster']['dcv']['url_architecture_id'] = 'aarch64'
   default['cfncluster']['dcv']['sha256sum'] = value_for_platform(
     'centos' => {
+      '~>8' => "eca626c10a6fe8b8770b1809555e6c1747a8ab7b6991e25e370d8d0c19902f4e",
       '~>7' => "d590d81360b0e96652cd1ef3a74fff5cb9381f57ff55685a8ddde48d494968e4"
     },
     'amazon' => { '2' => "d590d81360b0e96652cd1ef3a74fff5cb9381f57ff55685a8ddde48d494968e4" },
     'ubuntu' => { '18.04' => "0cd0512d57808cee0c48d0817a515825f9c512cb9d70e5672fecbb7450b729b3" }
   )
 else
-  default['cfncluster']['dcv']['supported_os'] = %w[centos7 ubuntu18 amazon2]
+  default['cfncluster']['dcv']['supported_os'] = %w[centos8 centos7 ubuntu18 amazon2]
   default['cfncluster']['dcv']['url_architecture_id'] = 'x86_64'
   default['cfncluster']['dcv']['sha256sum'] = value_for_platform(
     'centos' => {
+      '~>8' => "ecaed9e711630c26b25b8ea2a21db4bf93795cb7d6186a6a1dde8a7a9f37d54a",
       '~>7' => "c36020cce52ba371a796c041352db6c5d6d55d35acbbfbadafd834e1265aa5bf"
     },
     'amazon' => { '2' => "c36020cce52ba371a796c041352db6c5d6d55d35acbbfbadafd834e1265aa5bf" },
@@ -132,6 +135,7 @@ if "#{node['platform']}#{node['platform_version'].to_i}" == 'ubuntu18'
 end
 default['cfncluster']['dcv']['package'] = value_for_platform(
   'centos' => {
+    '~>8' => "nice-dcv-#{node['cfncluster']['dcv']['version']}-el8-#{node['cfncluster']['dcv']['url_architecture_id']}",
     '~>7' => "nice-dcv-#{node['cfncluster']['dcv']['version']}-el7-#{node['cfncluster']['dcv']['url_architecture_id']}"
   },
   'amazon' => { '2' => "nice-dcv-#{node['cfncluster']['dcv']['version']}-el7-#{node['cfncluster']['dcv']['url_architecture_id']}" },
@@ -139,6 +143,7 @@ default['cfncluster']['dcv']['package'] = value_for_platform(
 )
 default['cfncluster']['dcv']['server'] = value_for_platform( # NICE DCV server package
   'centos' => {
+    '~>8' => "nice-dcv-server-2020.1.9012-1.el8.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm",
     '~>7' => "nice-dcv-server-2020.1.9012-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm"
   },
   'amazon' => { '2' => "nice-dcv-server-2020.1.9012-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },
@@ -146,6 +151,7 @@ default['cfncluster']['dcv']['server'] = value_for_platform( # NICE DCV server p
 )
 default['cfncluster']['dcv']['xdcv'] = value_for_platform( # required to create virtual sessions
   'centos' => {
+    '~>8' => "nice-xdcv-2020.1.338-1.el8.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm",
     '~>7' => "nice-xdcv-2020.1.338-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm"
   },
   'amazon' => { '2' => "nice-xdcv-2020.1.338-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },
@@ -153,6 +159,7 @@ default['cfncluster']['dcv']['xdcv'] = value_for_platform( # required to create 
 )
 default['cfncluster']['dcv']['gl'] = value_for_platform( # required to enable GPU sharing
   'centos' => {
+    '~>8' => "nice-dcv-gl-2020.1.840-1.el8.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm",
     '~>7' => "nice-dcv-gl-2020.1.840-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm"
   },
   'amazon' => { '2' => "nice-dcv-gl-2020.1.840-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -93,45 +93,59 @@ default['cfncluster']['efa']['installer_url'] = 'https://efa-installer.amazonaws
 # NICE DCV
 default['cfncluster']['dcv']['installed'] = 'yes'
 default['cfncluster']['dcv']['version'] = '2020.1-9012'
-default['cfncluster']['dcv']['supported_os'] = if arm_instance?
-                                                 %w[ubuntu18 amazon2]
-                                               else
-                                                 %w[centos7 ubuntu18 amazon2]
-                                               end
-default['cfncluster']['dcv']['url_architecture_id'] = if arm_instance?
-                                                        'aarch64'
-                                                      else
-                                                        'x86_64'
-                                                      end
-case "#{node['platform']}#{node['platform_version'].to_i}"
-when 'centos7', 'amazon2'
-  default['cfncluster']['dcv']['package'] = "nice-dcv-#{node['cfncluster']['dcv']['version']}-el7-#{node['cfncluster']['dcv']['url_architecture_id']}"
-  default['cfncluster']['dcv']['server'] = "nice-dcv-server-2020.1.9012-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" # NICE DCV server package
-  default['cfncluster']['dcv']['xdcv'] = "nice-xdcv-2020.1.338-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" # required to create virtual sessions
-  default['cfncluster']['dcv']['gl'] = "nice-dcv-gl-2020.1.840-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" # required to enable GPU sharing
-  default['cfncluster']['dcv']['sha256sum'] = if arm_instance?
-                                                "d590d81360b0e96652cd1ef3a74fff5cb9381f57ff55685a8ddde48d494968e4"
-                                              else
-                                                "c36020cce52ba371a796c041352db6c5d6d55d35acbbfbadafd834e1265aa5bf"
-                                              end
-
-when 'ubuntu18'
-  # Unlike the other supported OSs, the DCV package names for Ubuntu 18.04 use different architecture abbreviations than those used in the download URLs.
-  default['cfncluster']['dcv']['package_architecture_id'] = if arm_instance?
-                                                              'arm64'
-                                                            else
-                                                              'amd64'
-                                                            end
-  default['cfncluster']['dcv']['package'] = "nice-dcv-#{node['cfncluster']['dcv']['version']}-ubuntu1804-#{node['cfncluster']['dcv']['url_architecture_id']}"
-  default['cfncluster']['dcv']['server'] = "nice-dcv-server_2020.1.9012-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb" # NICE DCV server package
-  default['cfncluster']['dcv']['xdcv'] = "nice-xdcv_2020.1.338-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb"  # required to create virtual sessions
-  default['cfncluster']['dcv']['gl'] = "nice-dcv-gl_2020.1.840-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb"  # required to enable GPU sharing
-  default['cfncluster']['dcv']['sha256sum'] = if arm_instance?
-                                                "0cd0512d57808cee0c48d0817a515825f9c512cb9d70e5672fecbb7450b729b3"
-                                              else
-                                                "7569c95465743b512f1ab191e58ea09777353b401c1ec130ee8ea344e00f8900"
-                                              end
+if arm_instance?
+  default['cfncluster']['dcv']['supported_os'] = %w[ubuntu18 amazon2]
+  default['cfncluster']['dcv']['url_architecture_id'] = 'aarch64'
+  default['cfncluster']['dcv']['sha256sum'] = value_for_platform(
+    'centos' => {
+      '~>7' => "d590d81360b0e96652cd1ef3a74fff5cb9381f57ff55685a8ddde48d494968e4"
+    },
+    'amazon' => { '2' => "d590d81360b0e96652cd1ef3a74fff5cb9381f57ff55685a8ddde48d494968e4" },
+    'ubuntu' => { '18.04' => "0cd0512d57808cee0c48d0817a515825f9c512cb9d70e5672fecbb7450b729b3" }
+  )
+else
+  default['cfncluster']['dcv']['supported_os'] = %w[centos7 ubuntu18 amazon2]
+  default['cfncluster']['dcv']['url_architecture_id'] = 'x86_64'
+  default['cfncluster']['dcv']['sha256sum'] = value_for_platform(
+    'centos' => {
+      '~>7' => "c36020cce52ba371a796c041352db6c5d6d55d35acbbfbadafd834e1265aa5bf"
+    },
+    'amazon' => { '2' => "c36020cce52ba371a796c041352db6c5d6d55d35acbbfbadafd834e1265aa5bf" },
+    'ubuntu' => { '18.04' => "7569c95465743b512f1ab191e58ea09777353b401c1ec130ee8ea344e00f8900" }
+  )
 end
+if "#{node['platform']}#{node['platform_version'].to_i}" == 'ubuntu18'
+  # Unlike the other supported OSs, the DCV package names for Ubuntu 18.04 use different architecture abbreviations than those used in the download URLs.
+  default['cfncluster']['dcv']['package_architecture_id'] = arm_instance? ? 'arm64' : 'amd64'
+end
+default['cfncluster']['dcv']['package'] = value_for_platform(
+  'centos' => {
+    '~>7' => "nice-dcv-#{node['cfncluster']['dcv']['version']}-el7-#{node['cfncluster']['dcv']['url_architecture_id']}"
+  },
+  'amazon' => { '2' => "nice-dcv-#{node['cfncluster']['dcv']['version']}-el7-#{node['cfncluster']['dcv']['url_architecture_id']}" },
+  'ubuntu' => { '18.04' => "nice-dcv-#{node['cfncluster']['dcv']['version']}-ubuntu1804-#{node['cfncluster']['dcv']['url_architecture_id']}" }
+)
+default['cfncluster']['dcv']['server'] = value_for_platform( # NICE DCV server package
+  'centos' => {
+    '~>7' => "nice-dcv-server-2020.1.9012-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm"
+  },
+  'amazon' => { '2' => "nice-dcv-server-2020.1.9012-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },
+  'ubuntu' => { '18.04' => "nice-dcv-server_2020.1.9012-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb" }
+)
+default['cfncluster']['dcv']['xdcv'] = value_for_platform( # required to create virtual sessions
+  'centos' => {
+    '~>7' => "nice-xdcv-2020.1.338-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm"
+  },
+  'amazon' => { '2' => "nice-xdcv-2020.1.338-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },
+  'ubuntu' => { '18.04' => "nice-xdcv_2020.1.338-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb" }
+)
+default['cfncluster']['dcv']['gl'] = value_for_platform( # required to enable GPU sharing
+  'centos' => {
+    '~>7' => "nice-dcv-gl-2020.1.840-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm"
+  },
+  'amazon' => { '2' => "nice-dcv-gl-2020.1.840-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },
+  'ubuntu' => { '18.04' => "nice-dcv-gl_2020.1.840-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb" }
+)
 default['cfncluster']['dcv']['url'] = "https://d1uj6qtbmh3dt5.cloudfront.net/2020.1/Servers/#{node['cfncluster']['dcv']['package']}.tgz"
 # DCV external authenticator configuration
 default['cfncluster']['dcv']['authenticator']['user'] = "dcvextauth"

--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -20,10 +20,10 @@
 
 # Configure the system to enable NICE DCV to have direct access to the Linux server's GPU and enable GPU sharing.
 def allow_gpu_acceleration
-  # On CentOS 7 fix circular dependency multi-user.target -> cloud-init-> isolate multi-user.target.
+  # On CentOS >=7 fix circular dependency multi-user.target -> cloud-init-> isolate multi-user.target.
   # multi-user.target doesn't start until cloud-init run is finished. So isolate multi-user.target
   # is stuck into starting, which keep hanging chef until the 3600s timeout.
-  unless node['platform'] == 'centos' && node['platform_version'].to_i == 7
+  unless node['platform'] == 'centos' && node['platform_version'].to_i >= 7
     # Turn off X
     execute "Turn off X" do
       command "systemctl isolate multi-user.target"
@@ -91,6 +91,17 @@ if node['conditions']['dcv_supported'] && node['cfncluster']['cfn_node_type'] ==
     execute 'No RND' do
       user 'root'
       command "sed --in-place '/RANDFILE/d' /etc/ssl/openssl.cnf"
+    end
+  when 'centos'
+    if node['platform_version'].to_i >= 8
+      # Wayland, the default GNOME Display Manager for CentOS 8, is not supported by DCV
+      Chef::Log.info("Disabling Wayland and force login screen to use Xorg")
+      replace_or_add "Disable Wayland in /etc/gdm/custom.conf" do
+        path "/etc/gdm/custom.conf"
+        pattern ".*WaylandEnable.*"
+        line "WaylandEnable=false"
+        replace_only true
+      end
     end
   end
 

--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -33,9 +33,7 @@ def allow_gpu_acceleration
   # Update the xorg.conf to set up NVIDIA drivers.
   # NOTE: --enable-all-gpus parameter is needed to support servers with more than one NVIDIA GPU.
   nvidia_xconfig_command = "nvidia-xconfig --preserve-busid --enable-all-gpus"
-  if node['ec2']['instance_type'].start_with?("g2.")
-    nvidia_xconfig_command = nvidia_xconfig_command + " --use-display-device=none"
-  end
+  nvidia_xconfig_command += " --use-display-device=none" if node['ec2']['instance_type'].start_with?("g2.")
   execute "Set up Nvidia drivers for X configuration" do
     user 'root'
     command nvidia_xconfig_command

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -85,7 +85,10 @@ if node['conditions']['dcv_supported']
         command 'yum -y install @gnome'
       end
       # Install X Window System (required when using GPU acceleration)
-      package "xorg-x11-server-Xorg"
+      package "xorg-x11-server-Xorg" do
+        retries 3
+        retry_delay 5
+      end
 
       # libvirtd service creates virtual bridge interfaces.
       # It's provided by libvirt-daemon, installed as requirement for gnome-boxes, included in @gnome.


### PR DESCRIPTION
# Add CentOS 8 support for NICE DCV
* Disable Wayland, the default GNOME Display Manager for  CentOS 8, that is not supported by DCV
* Add default value for dcv_port

## Selinux notes
Default SELinux policies in RHEL8 can lead to failures in `xdm` processes using NVIDIA drivers/libraries,
thus for example the `gnome-shell` and the `dcv` system agent (being children of `gdm`) can be impacted.
By default SELinux is disabled so it doesn't impact our installation.
If SELinux is re-enabled, custom policies must be defined to grant `xdm_t` processes the permissions they need.

## Tests
* Verified gdm configuration file
* Started session and listed

## References
DCV guide: https://docs.aws.amazon.com/dcv/latest/adminguide/setting-up-installing-linux-server.html

# Refactor NICE DCV defaults attributes
* Use a global test for ARM instances, to avoid to repeat the check for each variable.
* Use value_for_platform to define defaults attributes.

# Add newlines between different features
* Move Munge default close to other Munge attributes.
* Add retries to Xorg package installation
* Rubocop fixes

## References:
* https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfUnlessModifier
* https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SelfAssignment