### PR TITLE
Add kitchen tests for CentOS 8 and remove default AMI IDs for all the OSes

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -273,6 +273,67 @@ platforms:
     transport:
       username: centos
       ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
+  - name: centos-8-minimal
+    driver_plugin: ec2
+    driver_config:
+      image_id: <%= ENV['CENTOS8_IMAGE_ID'] %>
+      block_device_mappings:
+        - device_name: /dev/sda1
+          ebs:
+            volume_size: <%= ENV['VOLUME_SIZE'] || 25 %>
+            volume_type: gp2
+            delete_on_termination: true
+        - device_name: /dev/xvdba
+          virtual_name: ephemeral0
+        - device_name: /dev/xvdbb
+          virtual_name: ephemeral1
+        - device_name: /dev/xvdbc
+          virtual_name: ephemeral2
+        - device_name: /dev/xvdbd
+          virtual_name: ephemeral3
+        - device_name: /dev/xvdbe
+          virtual_name: ephemeral4
+        - device_name: /dev/xvdbf
+          virtual_name: ephemeral5
+        - device_name: /dev/xvdbg
+          virtual_name: ephemeral6
+        - device_name: /dev/xvdbh
+          virtual_name: ephemeral7
+        - device_name: /dev/xvdbi
+          virtual_name: ephemeral8
+        - device_name: /dev/xvdbj
+          virtual_name: ephemeral9
+        - device_name: /dev/xvdbk
+          virtual_name: ephemeral10
+        - device_name: /dev/xvdbl
+          virtual_name: ephemeral11
+        - device_name: /dev/xvdbm
+          virtual_name: ephemeral12
+        - device_name: /dev/xvdbn
+          virtual_name: ephemeral13
+        - device_name: /dev/xvdbo
+          virtual_name: ephemeral14
+        - device_name: /dev/xvdbp
+          virtual_name: ephemeral15
+        - device_name: /dev/xvdbq
+          virtual_name: ephemeral16
+        - device_name: /dev/xvdbr
+          virtual_name: ephemeral17
+        - device_name: /dev/xvdbs
+          virtual_name: ephemeral18
+        - device_name: /dev/xvdbt
+          virtual_name: ephemeral19
+        - device_name: /dev/xvdbu
+          virtual_name: ephemeral20
+        - device_name: /dev/xvdbv
+          virtual_name: ephemeral21
+        - device_name: /dev/xvdbw
+          virtual_name: ephemeral22
+        - device_name: /dev/xvdbx
+          virtual_name: ephemeral23
+    transport:
+      username: centos
+      ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
   - name: ubuntu-16-04-lts
     driver_plugin: ec2
     driver_config:

--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -32,7 +32,7 @@ platforms:
   - name: amazon-linux-latest
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['ALINUX_IMAGE_ID'] || "ami-55ef662f" %>
+      image_id: <%= ENV['ALINUX_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/xvda
           ebs:
@@ -93,7 +93,7 @@ platforms:
   - name: amazon-linux-2-latest
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['ALINUX2_IMAGE_ID'] || "ami-062f7200baf2fa504" %>
+      image_id: <%= ENV['ALINUX2_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/xvda
           ebs:
@@ -154,7 +154,7 @@ platforms:
   - name: centos-6-minimal
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['CENTOS6_IMAGE_ID'] || "ami-44f1aa3e" %>
+      image_id: <%= ENV['CENTOS6_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
@@ -215,7 +215,7 @@ platforms:
   - name: centos-7-minimal
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['CENTOS7_IMAGE_ID'] || "ami-06fea57c" %>
+      image_id: <%= ENV['CENTOS7_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
@@ -276,7 +276,7 @@ platforms:
   - name: ubuntu-16-04-lts
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['UBUNTU1604_IMAGE_ID'] || "ami-aa2ea6d0" %>
+      image_id: <%= ENV['UBUNTU1604_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
@@ -337,7 +337,7 @@ platforms:
   - name: ubuntu-18-04-lts
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['UBUNTU1804_IMAGE_ID'] || "ami-05ecb1463f8f1ee4b" %>
+      image_id: <%= ENV['UBUNTU1804_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:


### PR DESCRIPTION
The values are old ones, never updated and valid only for `us-east-1`.

The `*_IMAGE_ID` parameter is now mandatory but it's not a breaking change because we're always setting a value when running kitchen tests, retrieving the AMI to use with an `ec2 describe-images` call in the specific region.