### PR TITLE
Permit to build amis in a region other then us-east-1

### DIFF
--- a/amis/build_ami.sh
+++ b/amis/build_ami.sh
@@ -17,7 +17,7 @@
 # Usage: build_ami.sh --os <os> --region <region> --partition <partition> [--public] [--custom]
 #                     [--build-date <build-date>] [--arch <arch>]
 #   os: the os to build (supported values: all|centos6|centos7|centos8|alinux|alinux2|ubuntu1604|ubuntu1804)
-#   partition: partition to build in (supported values: commercial|govcloud|china)
+#   partition: partition to build in (supported values: commercial|govcloud|china|region)
 #   region: region to copy ami too (supported values: all|us-east-1|us-gov-west-1|...)
 #   custom: specifies to create the AMI from a custom AMI-id, which must be specified by variable CUSTOM_AMI_ID in the environment (optional)
 #   public: specifies AMIs visibility (optional, default is private)
@@ -142,11 +142,11 @@ check_options() {
     fi
 
     if [ "${_partition}" == "commercial" ]; then
-      export AWS_REGION="us-east-1"
+      export AWS_REGION=${AWS_REGION-us-east-1}
     elif [ "${_partition}" == "govcloud" ]; then
-      export AWS_REGION="us-gov-west-1"
+      export AWS_REGION=${AWS_REGION-us-gov-west-1}
     elif [ "${_partition}" == "china" ]; then
-      export AWS_REGION="cn-north-1"
+      export AWS_REGION=${AWS_REGION-cn-north-1}
     elif [ "${_partition}" == "region" ]; then
       export AWS_REGION="${_region}"
     else


### PR DESCRIPTION
From now the script will use the `AWS_REGION` env variable, if already set.
```
export AWS_REGION=eu-west-1
build_ami.sh --partition "commercial" --region "all"
```
