### PR TITLE
CentOS 8: DNS config and remove firewalld

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -242,9 +242,9 @@ when 'rhel', 'amazon'
       # Install python3 instead of unversioned python
       default['cfncluster']['base_packages'].delete('python')
       default['cfncluster']['base_packages'].delete('python-pip')
-      # Install firewalld for iptables used in configure-pat.sh
+      # Install iptables used in configure-pat.sh
       # Install nvme-cli package used to retrieve info about EBS volumes in parallelcluster-ebsnvme-id
-      default['cfncluster']['base_packages'].push(%w[python3 python3-pip firewalld nvme-cli])
+      default['cfncluster']['base_packages'].push(%w[python3 python3-pip iptables nvme-cli])
     end
     if node['platform_version'].to_i >= 8
       # gdisk required for FSx

--- a/files/centos-8/NetworkManager.conf
+++ b/files/centos-8/NetworkManager.conf
@@ -1,0 +1,51 @@
+# Configuration file for NetworkManager.
+# 
+# See "man 5 NetworkManager.conf" for details.
+#
+# The directories /usr/lib/NetworkManager/conf.d/ and /run/NetworkManager/conf.d/
+# can contain additional configuration snippets installed by packages. These files are
+# read before NetworkManager.conf and have thus lowest priority.
+# The directory /etc/NetworkManager/conf.d/ can contain additional configuration
+# snippets. Those snippets are merged last and overwrite the settings from this main
+# file.
+#
+# The files within one conf.d/ directory are read in asciibetical order.
+#
+# If /etc/NetworkManager/conf.d/ contains a file with the same name as
+# /usr/lib/NetworkManager/conf.d/, the latter file is shadowed and thus ignored.
+# Hence, to disable loading a file from /usr/lib/NetworkManager/conf.d/ you can
+# put an empty file to /etc with the same name. The same applies with respect
+# to the directory /run/NetworkManager/conf.d where files in /run shadow
+# /usr/lib and are themselves shadowed by files under /etc.
+#
+# If two files define the same key, the one that is read afterwards will overwrite
+# the previous one.
+
+[main]
+plugins = ifcfg-rh,
+dhcp = dhclient
+
+
+[logging]
+# When debugging NetworkManager, enabling debug logging is of great help.
+#
+# Logfiles contain no passwords and little sensitive information. But please
+# check before posting the file online. You can also personally hand over the
+# logfile to a NM developer to treat it confidential. Meet us on #nm on freenode.
+# Please post full logfiles except minimal modifications of private data.
+#
+# You can also change the log-level at runtime via
+#   $ nmcli general logging level TRACE domains ALL
+# However, usually it's cleaner to enable debug logging
+# in the configuration and restart NetworkManager so that
+# debug logging is enabled from the start.
+#
+# You will find the logfiles in syslog, for example via
+#   $ journalctl -u NetworkManager
+#
+# Note that debug logging of NetworkManager can be quite verbose. Some messages
+# might be rate-limited by the logging daemon (see RateLimitIntervalSec, RateLimitBurst
+# in man journald.conf). Please disable rate-limiting before collecting debug logs.
+#
+#level=TRACE
+#domains=ALL

--- a/recipes/dns_config.rb
+++ b/recipes/dns_config.rb
@@ -54,6 +54,18 @@ if node['cfncluster']['cfn_scheduler'] == 'slurm' && node['cfncluster']['use_pri
           line "append domain-name \" #{node['cfncluster']['cfn_dns_domain']}\";"
         end
       end
+
+      if platform?('centos') && node['platform_version'].to_i == 8
+        # On CentOS8 dhclient is not enabled by default
+        # Put pcluster version of NetworkManager.conf in place
+        # dhcp = dhclient needs to be added under [main] section to enable dhclient
+        cookbook_file 'NetworkManager.conf' do
+          path '/etc/NetworkManager/NetworkManager.conf'
+          user 'root'
+          group 'root'
+          mode '0644'
+        end
+      end
     end
     restart_network_service
   end


### PR DESCRIPTION
* Configure DNS settings for CentOS 8. Note dhclient is not enabled by default, so need to provide modified NetworkManager config. Afterwards same logic as CentOS 7 can be used
* Remove firewalld, originally installed in order to get iptables packages. When enabled and without proper configuration, firewalld blocks networking traffic. Instead, just install iptables package by itself

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
