### PR TITLE
Revert "Slurm: upgrade to version 20.02.5"

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -64,9 +64,9 @@ default['cfncluster']['torque']['version'] = '6.1.2'
 default['cfncluster']['torque']['url'] = 'https://github.com/adaptivecomputing/torque/archive/6.1.2.tar.gz'
 # Slurm software
 default['cfncluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
-default['cfncluster']['slurm']['version'] = '20.02.5'
-default['cfncluster']['slurm']['url'] = 'https://download.schedmd.com/slurm/slurm-20.02.5.tar.bz2'
-default['cfncluster']['slurm']['sha1'] = '62d9f66c86e17cbc541328e5f36a1213eaf7789a'
+default['cfncluster']['slurm']['version'] = '20.02.4'
+default['cfncluster']['slurm']['url'] = 'https://download.schedmd.com/slurm/slurm-20.02.4.tar.bz2'
+default['cfncluster']['slurm']['sha1'] = '294de3a2e1410945eb516c40eff5f92087501893'
 # PMIx software
 default['cfncluster']['pmix']['version'] = '3.1.5'
 default['cfncluster']['pmix']['url'] = "https://github.com/openpmix/openpmix/releases/download/v#{node['cfncluster']['pmix']['version']}/pmix-#{node['cfncluster']['pmix']['version']}.tar.gz"


### PR DESCRIPTION
This reverts commit 1d13abebfbc34fcbe67b4d13350793364acaa2c7.

There seems to be a regression in the Slurm --constraint option which
breaks jobs submission.

Signed-off-by: Francesco De Martino <fdm@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
