### PR TITLE
Improve function to retrieve Centos 7 kernel minor version

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -375,6 +375,9 @@ def chrony_reload_command
     chrony_reload_command = "service #{node['cfncluster']['chrony']['service']} force-reload"
   elsif node['init_package'] == 'systemd'
     chrony_reload_command = "systemctl force-reload #{node['cfncluster']['chrony']['service']}"
+  else
+    raise "Init package #{node['init_package']} not supported."
   end
+
   chrony_reload_command
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -354,12 +354,17 @@ end
 # Method works for minor version >=7
 #
 def get_rhel7_kernel_minor_version
-  # kernel release is in the form 3.10.0-1127.8.2.el7.x86_64
-  kernel_patch_version = node['kernel']['release'].match(/^\d+\.\d+\.\d+-(\d+)\..*$/)[1]
   kernel_minor_version = '7'
-  if kernel_patch_version >= '1127'
-    kernel_minor_version = '8'
+
+  if node['platform'] == 'centos'
+    # kernel release is in the form 3.10.0-1127.8.2.el7.x86_64
+    kernel_patch_version = node['kernel']['release'].match(/^\d+\.\d+\.\d+-(\d+)\..*$/)
+    unless kernel_patch_version
+      raise "Unable to retrieve the kernel minor version from #{node['kernel']['release']}."
+    end
+    kernel_minor_version = '8' if kernel_patch_version[1] >= '1127'
   end
+
   kernel_minor_version
 end
 


### PR DESCRIPTION
The function was in the `value_for_platform` method, so it was called in any case.

If the os was not rhel7 the `.match` method was returning a `nul` value so the `match(...)[1]` was failing.

With this commit we're adding a default for all the oses in the `value_for_platform` selector and then calling the function only if needed.

In any case we're also adding robustness to the function to avoid to fail if the match is failing.
