### PR TITLE
Capture AWS CLI regions kitchen test output

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -43,7 +43,7 @@ bash 'check awscli regions' do
     regions=($(#{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws ec2 describe-regions --region #{node['cfncluster']['cfn_region']} --query "Regions[].{Name:RegionName}" --output text))
     for region in "${regions[@]}"
     do
-      #{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws ec2 describe-regions --region "${region}" >/dev/null 2>&1
+      #{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws ec2 describe-regions --region "${region}"
     done
   AWSREGIONS
 end


### PR DESCRIPTION
The kitchen test that verifies `aws ec2 describe-regions` can be called
successfully has been failing sporadically. It's difficult to debug
these failures without output that indicates the nature of the error.
This commit enables capturing that output.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
