### PR TITLE
Do not force compute fleet to STOPPED state on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 - Upgrade Intel MPI to version U8.
 - Upgrade Intel Parallel Studio XE Runtime to version 2020.2.
+- Do not force compute fleet into STOPPED state when performing a cluster update. This allows to update the queue
+  size without forcing a termination of the existing instances.
 
 2.9.1
 -----

--- a/recipes/update_master_slurm.rb
+++ b/recipes/update_master_slurm.rb
@@ -37,9 +37,8 @@ if not File.exist?(node['cfncluster']['cluster_config_path']) or not FileUtils.i
     action :restart
   end
 
-  execute 'force compute fleet status to STOPPED' do
-    command "#{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws dynamodb put-item --table-name #{node['cfncluster']['cfn_ddb_table']}"\
-          " --item '{\"Id\": {\"S\": \"COMPUTE_FLEET\"}, \"Status\": {\"S\": \"STOPPED\"}}' --region #{node['cfncluster']['cfn_region']}"
+  execute 'reload config for running nodes' do
+    command "/opt/slurm/bin/scontrol reconfigure && sleep 15"
     retries 3
     retry_delay 5
   end


### PR DESCRIPTION
This allows to perform an update of the queue size without having to stop the running compute fleet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
