### PR TITLE
Revert installing AWSBatch CLI in virtualenv

### DIFF
--- a/recipes/awsbatch_config.rb
+++ b/recipes/awsbatch_config.rb
@@ -46,7 +46,7 @@ if !node['cfncluster']['custom_awsbatchcli_package'].nil? && !node['cfncluster']
       mkdir aws-parallelcluster-custom-cli
       tar -xzf aws-parallelcluster.tgz --directory aws-parallelcluster-custom-cli
       cd aws-parallelcluster-custom-cli/*aws-parallelcluster-*
-      #{node['cfncluster']['cookbook_virtualenv_path']}/bin/pip install cli/
+      pip install cli/
     CLI
   end
 else


### PR DESCRIPTION
* Revert change introduced by this commit 5de2ba587113906731304e0ae06c00a1dbe6f904
* Install AWSBatch with system python instead of virtualenv

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
