### PR TITLE
Fix cfn_scheduler_slots issue when updating computing instance type

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -323,6 +323,7 @@ default['cfncluster']['cfn_postinstall'] = 'NONE'
 default['cfncluster']['cfn_postinstall_args'] = 'NONE'
 default['cfncluster']['cfn_scheduler'] = 'sge'
 default['cfncluster']['cfn_scheduler_slots'] = 'vcpus'
+default['cfncluster']['cfn_scheduler_slots_type'] = 'vcpus'
 default['cfncluster']['cfn_disable_hyperthreading_manually'] = 'false'
 default['cfncluster']['cfn_instance_slots'] = '1'
 default['cfncluster']['cfn_volume'] = nil

--- a/recipes/prep_env.rb
+++ b/recipes/prep_env.rb
@@ -26,6 +26,16 @@ node.default['cfncluster']['cfn_instance_slots'] = if node['cfncluster']['cfn_sc
                                                    else
                                                      node['cfncluster']['cfn_scheduler_slots']
                                                    end
+
+# Set cfn_scheduler_slots_type to vcpus/cores based on disable_hyperthreading = false/true
+# Set cfn_scheduler_slots_type to vcpus/cores/integer based on extra json {'cfn_scheduler_slots' = 'vcpus'/'cores'/integer}
+node.default['cfncluster']['cfn_scheduler_slots_type'] = if node['cfncluster']['cfn_scheduler_slots'] == 'vcpus'
+                                                           'vcpus'
+                                                         elsif node['cfncluster']['cfn_scheduler_slots'] == 'cores' || node['cfncluster']['cfn_scheduler_slots'].to_i == node['cpu']['cores']
+                                                           'cores'
+                                                         else
+                                                           node['cfncluster']['cfn_scheduler_slots']
+                                                         end
 # NOTE: this recipe must be included after cfn_instance_slot because it may alter the values of
 #       node['cpu']['total'], which would break the expected behavior when setting cfn_scheduler_slots
 #       to one of the constants looked for in the above conditionals

--- a/templates/default/cfnconfig.erb
+++ b/templates/default/cfnconfig.erb
@@ -5,7 +5,7 @@ cfn_postinstall=<%= node['cfncluster']['cfn_postinstall'] %>
 cfn_postinstall_args=<%= node['cfncluster']['cfn_postinstall_args'] %>
 cfn_region=<%= node['cfncluster']['cfn_region'] %>
 cfn_scheduler=<%= node['cfncluster']['cfn_scheduler'] %>
-cfn_scheduler_slots=<%= node['cfncluster']['cfn_scheduler_slots'] %>
+cfn_scheduler_slots_type=<%= node['cfncluster']['cfn_scheduler_slots_type'] %>
 cfn_instance_slots=<%= node['cfncluster']['cfn_instance_slots'] %>
 cfn_encrypted_ephemeral=<%= node['cfncluster']['cfn_encrypted_ephemeral'] %>
 cfn_ephemeral_dir=<%= node['cfncluster']['cfn_ephemeral_dir'] %>


### PR DESCRIPTION
* Add a new attribute `cfn_scheduler_slots_type` for cfnconfig and delete attribute `cfn_scheduler_slots `in cfnconfig file
* If `cfn_scheduler_slots` is `'cores'` or `vcpus//2`, `cfn_scheduler_slots_type` is `'cores'.` else `cfn_scheduler_slots_type` is 'vcpus'
* [node repo link](https://github.com/aws/aws-parallelcluster-node/pull/258) and [integration test link](https://github.com/aws/aws-parallelcluster/pull/2114)

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
