### PR TITLE
Fix nfs logic for CentOS 8

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -128,11 +128,10 @@ if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 16.04
   include_recipe "nfs::server"
 end
 if node['platform'] == 'centos' && node['platform_version'].to_i == 8
-  # FIXME: https://github.com/atomic-penguin/cookbook-nfs/issues/116
-  include_recipe "nfs::server"
-else
-  include_recipe "nfs::server4"
+  # Workaround for issue: https://github.com/atomic-penguin/cookbook-nfs/issues/116
+  node.force_override['nfs']['service']['idmap'] = 'nfs-idmapd'
 end
+include_recipe "nfs::server4"
 
 # Put configure-pat.sh onto the host
 cookbook_file 'configure-pat.sh' do


### PR DESCRIPTION
* Fix nfs logic in base_install by calling nfs::server4 recipe and providing correct idmap service name, nfs-idmapd

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
