### PR TITLE
CentOS 8: Add support for lustre and cw log agent to Centos8+ARM

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -338,7 +338,7 @@ default['cfncluster']['lustre']['public_key'] = value_for_platform(
 )
 default['cfncluster']['lustre']['base_url'] = value_for_platform(
   'centos' => {
-    # Get architecture if centos8, node['kernel']['machine'] should be 'x86_64' or 'aarch64'
+    # node['kernel']['machine'] contains the architecture: 'x86_64' or 'aarch64'
     '>=8' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8/#{node['kernel']['machine']}/",
     'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7.#{get_rhel7_kernel_minor_version}/x86_64/"
   },

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -338,7 +338,8 @@ default['cfncluster']['lustre']['public_key'] = value_for_platform(
 )
 default['cfncluster']['lustre']['base_url'] = value_for_platform(
   'centos' => {
-    '>=8' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8/x86_64/",
+    # Get architecture if centos8, node['kernel']['machine'] should be 'x86_64' or 'aarch64'
+    '>=8' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8/#{node['kernel']['machine']}/",
     'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7.#{get_rhel7_kernel_minor_version}/x86_64/"
   },
   'ubuntu' => { 'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu" }

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -327,7 +327,8 @@ end
 #
 def platform_supports_lustre_on_arm?
   [node['platform'] == 'ubuntu' && node['platform_version'].to_i == 18,
-   node['platform'] == 'amazon' && node['platform_version'].to_i == 2].any?
+   node['platform'] == 'amazon' && node['platform_version'].to_i == 2,
+   node['platform'] == 'centos' && node['platform_version'].to_i == 8].any?
 end
 
 def aws_domain

--- a/recipes/cloudwatch_agent_install.rb
+++ b/recipes/cloudwatch_agent_install.rb
@@ -32,7 +32,13 @@ s3_domain = "https://s3.#{node['cfncluster']['cfn_region']}.#{node['cfncluster']
 # Set URLs used to download the package and expected signature based on platform
 package_url_prefix = "#{s3_domain}/amazoncloudwatch-agent-#{node['cfncluster']['cfn_region']}"
 arch_url_component = arm_instance? ? 'arm64' : 'amd64'
-platform_url_component = node['platform'] == 'amazon' ? 'amazon_linux' : node['platform']
+platform_url_component = value_for_platform(
+  # No CW Agent for CentOS 8 ARM, using RHEL package
+  'centos' => { '>=8.0' => arm_instance? ? 'redhat' : node['platform'] },
+  'amazon' => { 'default' => 'amazon_linux' },
+  'default' => node['platform']
+)
+Chef::Log.info("Platform for cloudwatch is #{platform_url_component}")
 package_extension = node['platform'] == 'ubuntu' ? 'deb' : 'rpm'
 package_url = [
   package_url_prefix,


### PR DESCRIPTION
* Extend lustre install recipe to CentOS8+ARM
* Add support for cloudwatch logging on Centos8+ARM by using RedHat ARM agent

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
