### PR TITLE
Revert "Upgrade intelpython2 to 2019.5"

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,7 +45,7 @@ default['cfncluster']['node_virtualenv_path'] = "#{node['cfncluster']['system_py
 # Intel Packages
 default['cfncluster']['psxe']['version'] = '2020.2'
 default['cfncluster']['intelhpc']['version'] = '2018.0-*.el7'
-default['cfncluster']['intelpython2']['version'] = '2019.5'
+default['cfncluster']['intelpython2']['version'] = '2019.4'
 default['cfncluster']['intelpython3']['version'] = '2020.2'
 # Intel MPI
 default['cfncluster']['intelmpi']['url'] = "https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16814/l_mpi_2019.8.254.tgz"

--- a/recipes/intel_install.rb
+++ b/recipes/intel_install.rb
@@ -58,7 +58,8 @@ when 'MasterServer'
     code <<-INTEL
       set -e
       yum-config-manager --add-repo https://yum.repos.intel.com/intelpython/setup/intelpython.repo
-      yum -y install intelpython2-#{node['cfncluster']['intelpython2']['version']} intelpython3-#{node['cfncluster']['intelpython3']['version']}
+      yum -y install intelpython2-#{node['cfncluster']['intelpython2']['version']}
+      yum -y install intelpython3-#{node['cfncluster']['intelpython3']['version']}
     INTEL
     creates '/opt/intel/intelpython2'
   end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -400,13 +400,15 @@ end
 ###################
 # Intel Python Libraries
 if node['conditions']['intel_hpc_platform_supported'] && node['cfncluster']['enable_intel_hpc_platform'] == 'true'
-  execute "check-intel-python2" do
-    # Output code will be 1 if version is different
-    command "rpm -q intelpython2 | grep #{node['cfncluster']['intelpython2']['version']}"
-  end
-  execute "check-intel-python3" do
-    # Output code will be 1 if version is different
-    command "rpm -q intelpython3 | grep #{node['cfncluster']['intelpython3']['version']}"
+  %w[2 3].each do |python_version|
+    intel_package_version = node['cfncluster']["intelpython#{python_version}"]['version']
+    execute "check-intel-python#{python_version}-rpm" do
+      # Output code will be 1 if version is different
+      command "rpm -q intelpython#{python_version} | grep #{intel_package_version}"
+    end
+    execute "check-intel-python#{python_version}-executable" do
+      command "/opt/intel/intelpython#{python_version}/bin/python -V"
+    end
   end
 end
 


### PR DESCRIPTION
This reverts commit d303398ca0add92f4fd092092c26e4fab715c449.

This is necessary because the most recent version of Intel's intelpython2 package apparently isn't available via their yum repo.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
