### PR TITLE
CentOS 8: Install Intel HPC packages

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,8 +46,14 @@ default['cfncluster']['cookbook_virtualenv_path'] = "#{node['cfncluster']['syste
 default['cfncluster']['node_virtualenv_path'] = "#{node['cfncluster']['system_pyenv_root']}/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['node_virtualenv']}"
 
 # Intel Packages
-default['cfncluster']['psxe']['version'] = '2019.5'
-default['cfncluster']['intelhpc']['version'] = '2018.0-*.el7'
+default['cfncluster']['psxe']['version'] = '2020.4'
+default['cfncluster']['intelhpc']['platform_name'] = value_for_platform(
+  'centos' => {
+    '~>8' => 'el8',
+    '~>7' => 'el7'
+  }
+)
+default['cfncluster']['intelhpc']['version'] = "2018.0-*.#{node['cfncluster']['intelhpc']['platform_name']}"
 default['cfncluster']['intelpython2']['version'] = '2019.4'
 default['cfncluster']['intelpython3']['version'] = '2019.4'
 

--- a/files/centos-8/intelpython2_modulefile
+++ b/files/centos-8/intelpython2_modulefile
@@ -1,0 +1,2 @@
+#%Modulefile
+prepend-path        PATH                  /opt/intel/intelpython2/bin

--- a/files/centos-8/intelpython3_modulefile
+++ b/files/centos-8/intelpython3_modulefile
@@ -1,0 +1,2 @@
+#%Modulefile
+prepend-path        PATH                  /opt/intel/intelpython3/bin

--- a/recipes/intel_install.rb
+++ b/recipes/intel_install.rb
@@ -20,19 +20,13 @@ return unless node['conditions']['intel_hpc_platform_supported'] && node['cfnclu
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer'
 
-  # Install yum4 needed to handle Intel Packages
-  package 'nextgen-yum4' do
-    retries 3
-    retry_delay 5
-  end
-
-  # Downloads the intel-hpc-platform rpms
-  bash "install intel hpc platform" do
+  # Download intel-hpc-platform rpms to shared /opt/intel/rpms to avoid repetitive download from all nodes
+  bash "download intel hpc platform" do
     cwd node['cfncluster']['sources_dir']
     code <<-INTEL
       set -e
-      yum-config-manager --add-repo https://yum.repos.intel.com/hpc-platform/el7/setup/intel-hpc-platform.repo
-      rpm --import https://yum.repos.intel.com/hpc-platform/el7/setup/PUBLIC_KEY.PUB
+      yum-config-manager --add-repo https://yum.repos.intel.com/hpc-platform/#{node['cfncluster']['intelhpc']['platform_name']}/setup/intel-hpc-platform.repo
+      rpm --import https://yum.repos.intel.com/hpc-platform/#{node['cfncluster']['intelhpc']['platform_name']}/setup/PUBLIC_KEY.PUB
       yum -y install --downloadonly --downloaddir=/opt/intel/rpms intel-hpc-platform-*-#{node['cfncluster']['intelhpc']['version']}
     INTEL
     creates '/opt/intel/rpms'
@@ -40,14 +34,14 @@ when 'MasterServer'
 
   # Parallel Studio is Intel's optimized libraries, this is the runtime (free) version
   # installing version which is not the latest, requires to use yum version 4, see
-  # https://software.intel.com/en-us/articles/installing-intel-parallel-studio-xe-runtime-2019-using-yum-repository
+  # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-parallel-studio-xe-runtime-2020-using-yum-repository.html
   bash "install intel psxe" do
     cwd node['cfncluster']['sources_dir']
     code <<-INTEL
       set -e
-      rpm --import https://yum.repos.intel.com/2019/setup/RPM-GPG-KEY-intel-psxe-runtime-2019
-      yum4 -y install https://yum.repos.intel.com/2019/setup/intel-psxe-runtime-2019-reposetup-1-0.noarch.rpm
-      yum4 -y install intel-psxe-runtime-#{node['cfncluster']['psxe']['version']}
+      rpm --import https://yum.repos.intel.com/2020/setup/RPM-GPG-KEY-intel-psxe-runtime-2020
+      rpm -Uhv https://yum.repos.intel.com/2020/setup/intel-psxe-runtime-2020-reposetup-1-0.noarch.rpm
+      yum -y install intel-psxe-runtime-#{node['cfncluster']['psxe']['version']}
     INTEL
     creates '/opt/intel/psxe_runtime'
   end
@@ -67,12 +61,13 @@ when 'MasterServer'
     code <<-SKIP_UNAVAIL
       set -e
       yum-config-manager --save --setopt=intel-hpc-platform.skip_if_unavailable=True
-      yum-config-manager --save --setopt=intel-psxe-runtime-2019.skip_if_unavailable=True 
+      yum-config-manager --save --setopt=intel-psxe-runtime-2020.skip_if_unavailable=True
       yum-config-manager --save --setopt=intelpython.skip_if_unavailable=True
     SKIP_UNAVAIL
   end
 end
 
+# Installs intel-hpc-platform rpms
 # This rpm installs a file /etc/intel-hpc-platform-release that contains the INTEL_HPC_PLATFORM_VERSION
 bash "install intel hpc platform" do
   cwd node['cfncluster']['sources_dir']


### PR DESCRIPTION
* Enable installation of Intel HPC packages for CentOS 8
* Install Intel PSXE 2020, which does not require yum4 to be used

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
