### PR TITLE
Fix cfn_scheduler_slots in pcluster update

### DIFF
--- a/recipes/prep_env.rb
+++ b/recipes/prep_env.rb
@@ -22,7 +22,7 @@ validate_os_type
 node.default['cfncluster']['cfn_instance_slots'] = if node['cfncluster']['cfn_scheduler_slots'] == 'vcpus'
                                                      node['cpu']['total']
                                                    elsif node['cfncluster']['cfn_scheduler_slots'] == 'cores'
-                                                     node['cpu']['total'].fdiv(2).ceil
+                                                     node['cpu']['cores']
                                                    else
                                                      node['cfncluster']['cfn_scheduler_slots']
                                                    end


### PR DESCRIPTION
Replace node['cpu']['total']/2 with node['cpu']['cores'], because value of node['cpu']['cores'] won't change by CpuOption and disable_hyperthreading.

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
