### PR TITLE
Add groupship to munge required directories

### DIFF
--- a/recipes/munge_install.rb
+++ b/recipes/munge_install.rb
@@ -79,5 +79,6 @@ dirs.each do |dir|
   directory dir do
     action :create
     owner "munge"
+    group "munge"
   end
 end


### PR DESCRIPTION
See https://github.com/dun/munge/wiki/Installation-Guide#securing-the-installation

This solve the issue preventing munge 0.5.14 to start when baking at runtime 

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
