### PR TITLE
Use version-1 superblock format for RAID on Centos8

### DIFF
--- a/recipes/setup_raid_on_master.rb
+++ b/recipes/setup_raid_on_master.rb
@@ -57,9 +57,14 @@ if raid_shared_dir != "NONE"
   raid_dev = "/dev/md0"
 
   # Create RAID device with mdadm
+  raid_superblock_version = value_for_platform(
+    'centos' => { '>=8' => '1.2' },
+    'default' => '0.90'
+  )
   mdadm "MY_RAID" do
     raid_device raid_dev
     level raid_type
+    metadata raid_superblock_version
     devices raid_dev_path
   end
 


### PR DESCRIPTION
Linux raid reserves a bit of space (called a superblock) on each component device.
This space holds metadata about the RAID device and allows correct assembly of the array.

The Linux kernel RAID subsystem recognizes version-0.90 and version-1 Superblock formats.

Old Linux Kernels can only autodetect arrays with superblock version 0.90.
The older version-0.90 used to be the default format until 2009 but it has several limitations
that limit its applicability for use on large arrays or arrays with many component devices.
The newer version-1 is the default as of Kernel v3.1.1. More specifically, 1.2 is used as of v3.1.2.

The default value for the `metadata` property of `mdadm` chef resource is `0.90`
and it causes failures on Centos8. We're changing this value to `1.2`.

## References
* https://raid.wiki.kernel.org/index.php/Superblock
* https://raid.wiki.kernel.org/index.php/RAID_superblock_formats
* https://man7.org/linux/man-pages/man4/md.4.html
* https://docs.chef.io/resources/mdadm/

