### PR TITLE
Allow pip upgrade

### DIFF
--- a/third-party/pyenv-3.1.1/resources/pip.rb
+++ b/third-party/pyenv-3.1.1/resources/pip.rb
@@ -98,8 +98,10 @@ action_class do
     end
 
     unless new_resource.version
-      Chef::Log.debug("already installed: #{new_resource.package_name} #{current_version}")
-      return false
+      unless new_resource.options.split(/\s+/).include? '--upgrade'
+        Chef::Log.debug("already installed: #{new_resource.package_name} #{current_version}")
+        return false
+      end
     end
 
     if current_version != new_resource.version


### PR DESCRIPTION
Don't skip installation if upgrade flag is provided but version it's not

PR reported in https://github.com/sous-chefs/pyenv/pull/78

Solves https://github.com/aws/aws-parallelcluster/issues/2187

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
