### PR TITLE
Cleanup and refactoring of defaults and helpers file

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -32,7 +32,7 @@ platforms:
   - name: amazon-linux-latest
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['ALINUX_IMAGE_ID'] || "ami-55ef662f" %>
+      image_id: <%= ENV['ALINUX_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/xvda
           ebs:
@@ -93,7 +93,7 @@ platforms:
   - name: amazon-linux-2-latest
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['ALINUX2_IMAGE_ID'] || "ami-062f7200baf2fa504" %>
+      image_id: <%= ENV['ALINUX2_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/xvda
           ebs:
@@ -154,7 +154,7 @@ platforms:
   - name: centos-6-minimal
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['CENTOS6_IMAGE_ID'] || "ami-44f1aa3e" %>
+      image_id: <%= ENV['CENTOS6_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
@@ -215,7 +215,7 @@ platforms:
   - name: centos-7-minimal
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['CENTOS7_IMAGE_ID'] || "ami-06fea57c" %>
+      image_id: <%= ENV['CENTOS7_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
@@ -276,7 +276,7 @@ platforms:
   - name: ubuntu-16-04-lts
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['UBUNTU1604_IMAGE_ID'] || "ami-aa2ea6d0" %>
+      image_id: <%= ENV['UBUNTU1604_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
@@ -337,7 +337,7 @@ platforms:
   - name: ubuntu-18-04-lts
     driver_plugin: ec2
     driver_config:
-      image_id: <%= ENV['UBUNTU1804_IMAGE_ID'] || "ami-05ecb1463f8f1ee4b" %>
+      image_id: <%= ENV['UBUNTU1804_IMAGE_ID'] %>
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,11 +21,13 @@ default['cfncluster']['sources_dir'] = "#{node['cfncluster']['base_dir']}/source
 default['cfncluster']['scripts_dir'] = "#{node['cfncluster']['base_dir']}/scripts"
 default['cfncluster']['license_dir'] = "#{node['cfncluster']['base_dir']}/licenses"
 default['cfncluster']['configs_dir'] = "#{node['cfncluster']['base_dir']}/configs"
+
 # Cluster config
 default['cfncluster']['cluster_s3_bucket'] = nil
 default['cfncluster']['cluster_config_s3_key'] = nil
 default['cfncluster']['cluster_config_version'] = nil
 default['cfncluster']['cluster_config_path'] = "#{node['cfncluster']['configs_dir']}/cluster_config.json"
+
 # Python Version
 default['cfncluster']['python-version'] = '3.6.9'
 default['cfncluster']['python-version-centos6'] = '2.7.17'
@@ -42,19 +44,23 @@ default['cfncluster']['node_virtualenv'] = 'node_virtualenv'
 default['cfncluster']['cookbook_virtualenv_path'] = "#{node['cfncluster']['system_pyenv_root']}/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['cookbook_virtualenv']}"
 # Node Virtualenv Path
 default['cfncluster']['node_virtualenv_path'] = "#{node['cfncluster']['system_pyenv_root']}/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['node_virtualenv']}"
+
 # Intel Packages
 default['cfncluster']['psxe']['version'] = '2020.2'
 default['cfncluster']['intelhpc']['version'] = '2018.0-*.el7'
 default['cfncluster']['intelpython2']['version'] = '2019.4'
 default['cfncluster']['intelpython3']['version'] = '2020.2'
+
 # Intel MPI
 default['cfncluster']['intelmpi']['url'] = "https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16814/l_mpi_2019.8.254.tgz"
 default['cfncluster']['intelmpi']['version'] = '2019.8.254'
 default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/impi/#{node['cfncluster']['intelmpi']['version']}/intel64/modulefiles/mpi"
+
 # Python packages
 default['cfncluster']['cfncluster-version'] = '2.9.1'
 default['cfncluster']['cfncluster-cookbook-version'] = '2.9.1'
 default['cfncluster']['cfncluster-node-version'] = '2.9.1'
+
 # URLs to software packages used during install recipes
 # Gridengine software
 default['cfncluster']['sge']['version'] = '8.1.9'
@@ -74,8 +80,12 @@ default['cfncluster']['pmix']['sha1'] = '36bfb962858879cefa7a04a633c1b6984cea03e
 # Munge
 default['cfncluster']['munge']['munge_version'] = '0.5.14'
 default['cfncluster']['munge']['munge_url'] = "https://github.com/dun/munge/archive/munge-#{node['cfncluster']['munge']['munge_version']}.tar.gz"
+# Munge key
+default['cfncluster']['munge']['munge_key'] = 'YflQEFLjoxsmEK5vQyKklkLKJ#LkjLKDJF@*(#)ajLKQ@hLKN#()FSU(#@KLJH$@HKSASG)*DUJJDksdN'
+
 # Ganglia
 default['cfncluster']['ganglia_enabled'] = 'no'
+
 # NVIDIA
 default['cfncluster']['nvidia']['enabled'] = 'no'
 if node['platform'] == 'centos' && node['platform_version'].to_i < 7
@@ -89,51 +99,67 @@ else
   default['cfncluster']['nvidia']['cuda_version'] = '11.0'
   default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run'
 end
+
 # EFA
 default['cfncluster']['efa']['installer_version'] = '1.10.0'
 default['cfncluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cfncluster']['efa']['installer_version']}.tar.gz"
+
 # NICE DCV
 default['cfncluster']['dcv']['installed'] = 'yes'
 default['cfncluster']['dcv']['version'] = '2020.1-9012'
-default['cfncluster']['dcv']['supported_os'] = if arm_instance?
-                                                 %w[ubuntu18 amazon2]
-                                               else
-                                                 %w[centos7 ubuntu18 amazon2]
-                                               end
-default['cfncluster']['dcv']['url_architecture_id'] = if arm_instance?
-                                                        'aarch64'
-                                                      else
-                                                        'x86_64'
-                                                      end
-case "#{node['platform']}#{node['platform_version'].to_i}"
-when 'centos7', 'amazon2'
-  default['cfncluster']['dcv']['package'] = "nice-dcv-#{node['cfncluster']['dcv']['version']}-el7-#{node['cfncluster']['dcv']['url_architecture_id']}"
-  default['cfncluster']['dcv']['server'] = "nice-dcv-server-2020.1.9012-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" # NICE DCV server package
-  default['cfncluster']['dcv']['xdcv'] = "nice-xdcv-2020.1.338-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" # required to create virtual sessions
-  default['cfncluster']['dcv']['gl'] = "nice-dcv-gl-2020.1.840-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" # required to enable GPU sharing
-  default['cfncluster']['dcv']['sha256sum'] = if arm_instance?
-                                                "d590d81360b0e96652cd1ef3a74fff5cb9381f57ff55685a8ddde48d494968e4"
-                                              else
-                                                "c36020cce52ba371a796c041352db6c5d6d55d35acbbfbadafd834e1265aa5bf"
-                                              end
-
-when 'ubuntu18'
-  # Unlike the other supported OSs, the DCV package names for Ubuntu 18.04 use different architecture abbreviations than those used in the download URLs.
-  default['cfncluster']['dcv']['package_architecture_id'] = if arm_instance?
-                                                              'arm64'
-                                                            else
-                                                              'amd64'
-                                                            end
-  default['cfncluster']['dcv']['package'] = "nice-dcv-#{node['cfncluster']['dcv']['version']}-ubuntu1804-#{node['cfncluster']['dcv']['url_architecture_id']}"
-  default['cfncluster']['dcv']['server'] = "nice-dcv-server_2020.1.9012-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb" # NICE DCV server package
-  default['cfncluster']['dcv']['xdcv'] = "nice-xdcv_2020.1.338-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb"  # required to create virtual sessions
-  default['cfncluster']['dcv']['gl'] = "nice-dcv-gl_2020.1.840-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb"  # required to enable GPU sharing
-  default['cfncluster']['dcv']['sha256sum'] = if arm_instance?
-                                                "0cd0512d57808cee0c48d0817a515825f9c512cb9d70e5672fecbb7450b729b3"
-                                              else
-                                                "7569c95465743b512f1ab191e58ea09777353b401c1ec130ee8ea344e00f8900"
-                                              end
+if arm_instance?
+  default['cfncluster']['dcv']['supported_os'] = %w[ubuntu18 amazon2]
+  default['cfncluster']['dcv']['url_architecture_id'] = 'aarch64'
+  default['cfncluster']['dcv']['sha256sum'] = value_for_platform(
+    'centos' => {
+      '~>7' => "d590d81360b0e96652cd1ef3a74fff5cb9381f57ff55685a8ddde48d494968e4"
+    },
+    'amazon' => { '2' => "d590d81360b0e96652cd1ef3a74fff5cb9381f57ff55685a8ddde48d494968e4" },
+    'ubuntu' => { '18.04' => "0cd0512d57808cee0c48d0817a515825f9c512cb9d70e5672fecbb7450b729b3" }
+  )
+else
+  default['cfncluster']['dcv']['supported_os'] = %w[centos7 ubuntu18 amazon2]
+  default['cfncluster']['dcv']['url_architecture_id'] = 'x86_64'
+  default['cfncluster']['dcv']['sha256sum'] = value_for_platform(
+    'centos' => {
+      '~>7' => "c36020cce52ba371a796c041352db6c5d6d55d35acbbfbadafd834e1265aa5bf"
+    },
+    'amazon' => { '2' => "c36020cce52ba371a796c041352db6c5d6d55d35acbbfbadafd834e1265aa5bf" },
+    'ubuntu' => { '18.04' => "7569c95465743b512f1ab191e58ea09777353b401c1ec130ee8ea344e00f8900" }
+  )
 end
+if "#{node['platform']}#{node['platform_version'].to_i}" == 'ubuntu18'
+  # Unlike the other supported OSs, the DCV package names for Ubuntu 18.04 use different architecture abbreviations than those used in the download URLs.
+  default['cfncluster']['dcv']['package_architecture_id'] = arm_instance? ? 'arm64' : 'amd64'
+end
+default['cfncluster']['dcv']['package'] = value_for_platform(
+  'centos' => {
+    '~>7' => "nice-dcv-#{node['cfncluster']['dcv']['version']}-el7-#{node['cfncluster']['dcv']['url_architecture_id']}"
+  },
+  'amazon' => { '2' => "nice-dcv-#{node['cfncluster']['dcv']['version']}-el7-#{node['cfncluster']['dcv']['url_architecture_id']}" },
+  'ubuntu' => { '18.04' => "nice-dcv-#{node['cfncluster']['dcv']['version']}-ubuntu1804-#{node['cfncluster']['dcv']['url_architecture_id']}" }
+)
+default['cfncluster']['dcv']['server'] = value_for_platform( # NICE DCV server package
+  'centos' => {
+    '~>7' => "nice-dcv-server-2020.1.9012-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm"
+  },
+  'amazon' => { '2' => "nice-dcv-server-2020.1.9012-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },
+  'ubuntu' => { '18.04' => "nice-dcv-server_2020.1.9012-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb" }
+)
+default['cfncluster']['dcv']['xdcv'] = value_for_platform( # required to create virtual sessions
+  'centos' => {
+    '~>7' => "nice-xdcv-2020.1.338-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm"
+  },
+  'amazon' => { '2' => "nice-xdcv-2020.1.338-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },
+  'ubuntu' => { '18.04' => "nice-xdcv_2020.1.338-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb" }
+)
+default['cfncluster']['dcv']['gl'] = value_for_platform( # required to enable GPU sharing
+  'centos' => {
+    '~>7' => "nice-dcv-gl-2020.1.840-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm"
+  },
+  'amazon' => { '2' => "nice-dcv-gl-2020.1.840-1.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },
+  'ubuntu' => { '18.04' => "nice-dcv-gl_2020.1.840-1_#{node['cfncluster']['dcv']['package_architecture_id']}.ubuntu1804.deb" }
+)
 default['cfncluster']['dcv']['url'] = "https://d1uj6qtbmh3dt5.cloudfront.net/2020.1/Servers/#{node['cfncluster']['dcv']['package']}.tgz"
 # DCV external authenticator configuration
 default['cfncluster']['dcv']['authenticator']['user'] = "dcvextauth"
@@ -142,6 +168,7 @@ default['cfncluster']['dcv']['authenticator']['certificate'] = "/etc/parallelclu
 default['cfncluster']['dcv']['authenticator']['private_key'] = "/etc/parallelcluster/ext-auth-private-key.pem"
 default['cfncluster']['dcv']['authenticator']['virtualenv'] = "dcv_authenticator_virtualenv"
 default['cfncluster']['dcv']['authenticator']['virtualenv_path'] = "#{node['cfncluster']['system_pyenv_root']}/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['dcv']['authenticator']['virtualenv']}"
+
 # CloudWatch Agent
 default['cfncluster']['cloudwatch']['public_key_url'] = "https://s3.amazonaws.com/amazoncloudwatch-agent/assets/amazon-cloudwatch-agent.gpg"
 default['cfncluster']['cloudwatch']['public_key_local_path'] = "#{node['cfncluster']['sources_dir']}/amazon-cloudwatch-agent.gpg"
@@ -312,12 +339,9 @@ default['cfncluster']['lustre']['kmod_url'] = value_for_platform(
 default['cfncluster']['lustre']['client_url'] = value_for_platform(
   'centos' => {
     '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/lustre-client-2.10.6-1.el7.x86_64.rpm",
-    '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/lustre-client-2.10.5-1.el7.x86_64.rpm",
+    '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/lustre-client-2.10.5-1.el7.x86_64.rpm"
   }
 )
-
-# Munge key
-default['cfncluster']['munge']['munge_key'] = 'YflQEFLjoxsmEK5vQyKklkLKJ#LkjLKDJF@*(#)ajLKQ@hLKN#()FSU(#@KLJH$@HKSASG)*DUJJDksdN'
 
 # ParallelCluster internal variables (also in /etc/parallelcluster/cfnconfig)
 default['cfncluster']['cfn_region'] = 'us-east-1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -198,12 +198,6 @@ when 'rhel', 'amazon'
                                                 blas-devel fftw-devel libffi-devel openssl-devel dkms mysql-devel libedit-devel
                                                 libical-devel postgresql-devel postgresql-server sendmail mdadm python python-pip
                                                 libgcrypt-devel glibc-static]
-
-    # Lustre Drivers for Centos 6
-    default['cfncluster']['lustre']['version'] = '2.10.6'
-    default['cfncluster']['lustre']['kmod_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el6/client/RPMS/x86_64/kmod-lustre-client-2.10.6-1.el6.x86_64.rpm'
-    default['cfncluster']['lustre']['client_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el6/client/RPMS/x86_64/lustre-client-2.10.6-1.el6.x86_64.rpm'
-
     if node['platform_version'].to_i >= 7
       default['cfncluster']['base_packages'] = %w[vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                                   libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
@@ -211,21 +205,6 @@ when 'rhel', 'amazon'
                                                   blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                                   libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel mdadm python python-pip
                                                   libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils]
-      if node['platform_version'].split('.')[1] >= '7'
-        # Lustre Client for Centos >= 7.7
-        default['cfncluster']['lustre']['public_key'] = 'https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc'
-        default['cfncluster']['lustre']['base_url'] = "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7.#{get_rhel_kernel_minor_version}/x86_64/"
-      elsif node['platform_version'].split('.')[1] == '6'
-        # Lustre Drivers for Centos 7.6
-        default['cfncluster']['lustre']['version'] = '2.10.6'
-        default['cfncluster']['lustre']['kmod_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/kmod-lustre-client-2.10.6-1.el7.x86_64.rpm'
-        default['cfncluster']['lustre']['client_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/lustre-client-2.10.6-1.el7.x86_64.rpm'
-      elsif node['platform_version'].split('.')[1] == '5'
-        # Lustre Drivers for Centos 7.5
-        default['cfncluster']['lustre']['version'] = '2.10.5'
-        default['cfncluster']['lustre']['kmod_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/kmod-lustre-client-2.10.5-1.el7.x86_64.rpm'
-        default['cfncluster']['lustre']['client_url'] = 'https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/lustre-client-2.10.5-1.el7.x86_64.rpm'
-      end
     end
     default['cfncluster']['kernel_devel_pkg']['name'] = "kernel-lt-devel" if node['platform'] == 'centos' && node['platform_version'].to_i >= 6 && node['platform_version'].to_i < 7
     default['cfncluster']['rhel']['extra_repo'] = 'rhui-REGION-rhel-server-releases-optional' if node['platform'] == 'redhat' && node['platform_version'].to_i >= 6 && node['platform_version'].to_i < 7
@@ -284,8 +263,6 @@ when 'debian'
     default['cfncluster']['sge']['version'] = '8.1.9+dfsg-9build1'
   end
 
-  default['cfncluster']['lustre']['public_key'] = 'https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-ubuntu-public-key.asc'
-  default['cfncluster']['lustre']['repository_uri'] = 'https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu'
   # Modulefile Directory
   default['cfncluster']['modulefile_dir'] = "/usr/share/modules/modulefiles"
   # MODULESHOME
@@ -307,6 +284,37 @@ when 'debian'
     default['nfs']['service']['idmap'] = 'nfs-idmapd'
   end
 end
+
+# Lustre defaults (for CentOS >=7.7 and Ubuntu)
+default['cfncluster']['lustre']['public_key'] = value_for_platform(
+  'centos' => { '>=7.7' => "https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc" },
+  'ubuntu' => { 'default' => "https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-ubuntu-public-key.asc" }
+)
+default['cfncluster']['lustre']['base_url'] = value_for_platform(
+  'centos' => {
+    '>=7.7' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7.#{get_rhel7_kernel_minor_version}/x86_64/"
+  },
+  'ubuntu' => { 'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu" }
+)
+# Lustre defaults (for CentOS 7.6 and 7.5 only)
+default['cfncluster']['lustre']['version'] = value_for_platform(
+  'centos' => {
+    '7.6' => "2.10.6",
+    '7.5' => "2.10.5"
+  }
+)
+default['cfncluster']['lustre']['kmod_url'] = value_for_platform(
+  'centos' => {
+    '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/kmod-lustre-client-2.10.6-1.el7.x86_64.rpm",
+    '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/kmod-lustre-client-2.10.5-1.el7.x86_64.rpm"
+  }
+)
+default['cfncluster']['lustre']['client_url'] = value_for_platform(
+  'centos' => {
+    '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/lustre-client-2.10.6-1.el7.x86_64.rpm",
+    '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/lustre-client-2.10.5-1.el7.x86_64.rpm",
+  }
+)
 
 # Munge key
 default['cfncluster']['munge']['munge_key'] = 'YflQEFLjoxsmEK5vQyKklkLKJ#LkjLKDJF@*(#)ajLKQ@hLKN#()FSU(#@KLJH$@HKSASG)*DUJJDksdN'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -353,13 +353,18 @@ end
 # following the mapping reported here https://access.redhat.com/articles/3078#RHEL7
 # Method works for minor version >=7
 #
-def get_rhel_kernel_minor_version
-  # kernel release is in the form 3.10.0-1127.8.2.el7.x86_64
-  kernel_patch_version = node['kernel']['release'].match(/^\d+\.\d+\.\d+-(\d+)\..*$/)[1]
+def get_rhel7_kernel_minor_version
   kernel_minor_version = '7'
-  if kernel_patch_version >= '1127'
-    kernel_minor_version = '8'
+
+  if node['platform'] == 'centos'
+    # kernel release is in the form 3.10.0-1127.8.2.el7.x86_64
+    kernel_patch_version = node['kernel']['release'].match(/^\d+\.\d+\.\d+-(\d+)\..*$/)
+    unless kernel_patch_version
+      raise "Unable to retrieve the kernel minor version from #{node['kernel']['release']}."
+    end
+    kernel_minor_version = '8' if kernel_patch_version[1] >= '1127'
   end
+
   kernel_minor_version
 end
 
@@ -370,6 +375,9 @@ def chrony_reload_command
     chrony_reload_command = "service #{node['cfncluster']['chrony']['service']} force-reload"
   elsif node['init_package'] == 'systemd'
     chrony_reload_command = "systemctl force-reload #{node['cfncluster']['chrony']['service']}"
+  else
+    raise "Init package #{node['init_package']} not supported."
   end
+
   chrony_reload_command
 end

--- a/recipes/_lustre_install.rb
+++ b/recipes/_lustre_install.rb
@@ -68,12 +68,15 @@ elsif node['platform'] == 'centos' && node['platform_version'].split('.')[1].to_
   end
 
   kernel_module 'lnet'
+
 elsif node['platform'] == 'centos'
+  # Centos 6
   Chef::Log.warn("Unsupported version of Centos, #{node['platform_version']}, supported versions are >= 7.5")
+
 elsif node['platform'] == 'ubuntu'
 
   apt_repository 'fsxlustreclientrepo' do
-    uri          node['cfncluster']['lustre']['repository_uri']
+    uri          node['cfncluster']['lustre']['base_url']
     components   ['main']
     distribution node['lsb']['codename']
     key          node['cfncluster']['lustre']['public_key']
@@ -94,8 +97,11 @@ elsif node['platform'] == 'ubuntu'
   end
 
   kernel_module 'lnet'
+
 elsif node['platform'] == 'amazon' && node['platform_version'].to_i == 2
+
   alinux_extras_topic 'lustre2.10'
+
 elsif node['platform'] == 'amazon' # Amazon Linux 1
 
   # Install lustre client module

--- a/recipes/dcv_config.rb
+++ b/recipes/dcv_config.rb
@@ -33,9 +33,7 @@ def allow_gpu_acceleration
   # Update the xorg.conf to set up NVIDIA drivers.
   # NOTE: --enable-all-gpus parameter is needed to support servers with more than one NVIDIA GPU.
   nvidia_xconfig_command = "nvidia-xconfig --preserve-busid --enable-all-gpus"
-  if node['ec2']['instance_type'].start_with?("g2.")
-    nvidia_xconfig_command = nvidia_xconfig_command + " --use-display-device=none"
-  end
+  nvidia_xconfig_command += " --use-display-device=none" if node['ec2']['instance_type'].start_with?("g2.")
   execute "Set up Nvidia drivers for X configuration" do
     user 'root'
     command nvidia_xconfig_command

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -85,7 +85,10 @@ if node['conditions']['dcv_supported']
         command 'yum -y install @gnome'
       end
       # Install X Window System (required when using GPU acceleration)
-      package "xorg-x11-server-Xorg"
+      package "xorg-x11-server-Xorg" do
+        retries 3
+        retry_delay 5
+      end
 
       # libvirtd service creates virtual bridge interfaces.
       # It's provided by libvirt-daemon, installed as requirement for gnome-boxes, included in @gnome.


### PR DESCRIPTION
# Remove default AMI IDs from kitchen tests 

The values are old ones, never updated and valid only for `us-east-1`.

The `*_IMAGE_ID` parameter is now mandatory but it's not a breaking change because we're always setting a value when running kitchen tests, retrieving the AMI to use with an `ec2 describe-images` call in the specific region.

# Cleanup FSx Lustre defaults and helpers file

## FSx Lustre defaults Changes

* Moved FSx attributes initialization out from main platform switch case.
* Removed CentOS 6 attributes: this OS is not supported.
* Renamed ubuntu specific `repository_uri` attribute to be aligned with other OSes.
* Refactored attributes initialization by using `value_for_platform` keywork.
* Differentiated attributes according to the version.
   The attributes `version`, `kmod_url` and `client_url` are only used for CentOS 7.5 and 7.6 `public_key` and `base_url` are used for CentOS 7.7 and Ubuntu.
* Renamed `get_rhel_kernel_minor_version` given that it's CentOS 7 specific.

## References
* Value for platform: https://docs.chef.io/dsl_recipe/#value_for_platform
* FSx client installation: https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html

## Improve function to retrieve Centos 7 kernel minor version

The function is in the `value_for_platform` method, so it is called in any case.
If the os was not rhel7 the `.match` method was returning a `nul` value so the `match(...)[1]` was failing.
With this commit we're using '7' as a default and calling the function only if needed.
In any case we're also adding robustness to the function to raise an error if the match fails.

## Improve function to retrieve Chrony reload command

The chrony_reload_command variable could be initialized.
Now we're raising an error if the init package method is an unsupported one.

# Refactor NICE DCV defaults attributes and separate features

Use a global test for ARM instances, to avoid to repeat the check for each variable.
Use value_for_platform to define defaults attributes.

Add newlines between different features

* Move Munge default close to other Munge attributes.
* Add retries to Xorg package installation
* Rubocop fixes

## References:
* https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfUnlessModifier
* https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SelfAssignment