### PR TITLE
Add support for P4d instance type.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -105,6 +105,7 @@ suites:
         dcv_port: '8443'
         enable_intel_hpc_platform: 'true'
         enable_efa: 'compute'
+        efa_gdr_enabled: 'compute'
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 - Add support for CentOS 8 in all Commercial and GovCloud regions.
 - Enable FSx Lustre on China regions.
+- Add support for instance types with multiple network cards like P4d
 
 **CHANGES**
 
@@ -24,11 +25,14 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Introduces ``-g/--enable-gdr`` switch to install packages with GPUDirect RDMA support
   - Updates to OMPI collectives decision file packaging, migrated from efa-config to efa-profile
   - Introduces CentOS 8 support
+  
 - CentOS 6 is no longer supported.
 - Install python3 version of ``aws-cfn-bootstrap`` scripts
 - Upgrade Intel Parallel Studio XE Runtime to version 2020.2.
 - Do not force compute fleet into STOPPED state when performing a cluster update. This allows to update the queue
   size without forcing a termination of the existing instances.
+- Upgrade NVIDIA driver to version 450.80.02
+- Install NVIDIA Fabric manager to enable NVIDIA NVSwitch on supported platforms
 - Retrieve FSx Lustre DNS name dynamically.
 
 2.9.1

--- a/files/centos-8/configure_nw_interface.sh
+++ b/files/centos-8/configure_nw_interface.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Configure a specific Network Interface according to the OS
+# The configuration involves 3 aspects:
+# - Main configuration (IP address, protocol and gateway)
+# - A specific routing table, so that all traffic coming to a network interface leaves the instance using the same
+#   interface
+# - A routing rule to make the OS use the specific routing table for this network interface
+
+# RedHat 8 official documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/configuring-policy-based-routing-to-define-alternative-routes_configuring-and-managing-networking
+
+set -e
+
+if
+  [ -z "${DEVICE_NAME}" ] ||          # name of the device
+  [ -z "${DEVICE_NUMBER}" ] ||        # number of the device
+  [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
+  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
+  [ -z "${CIDR_PREFIX_LENGTH}" ]      # the prefix length of the device IP cidr block
+then
+  echo 'One or more environment variables missing'
+  exit 1
+fi
+
+con_name="System ${DEVICE_NAME}"
+route_table="100${DEVICE_NUMBER}"
+priority="100${DEVICE_NUMBER}"
+metric="100${DEVICE_NUMBER}"
+
+# Rename connection
+original_con_name=`nmcli -t -f GENERAL.CONNECTION device show ${DEVICE_NAME} | cut -f2 -d':'`
+nmcli connection modify "${original_con_name}" con-name "${con_name}" ifname ${DEVICE_NAME}
+
+configured_ip=`nmcli -t -f IP4.ADDRESS device show ${DEVICE_NAME} | cut -f2 -d':'`
+if [ -z "${configured_ip}" ]; then
+  # Setup connection method to "manual", configure ip address and gateway, only if not already configured.
+  sudo nmcli connection modify "${con_name}" ipv4.method manual ipv4.addresses ${DEVICE_IP_ADDRESS}/${CIDR_PREFIX_LENGTH} ipv4.gateway ${GW_IP_ADDRESS}
+fi
+
+# Setup routes
+# This command uses the ipv4.routes parameter to add a static route to the routing table with ID ${route_table}.
+# This static route for 0.0.0.0/0 uses the IP of the gateway as next hop.
+nmcli connection modify "${con_name}" ipv4.routes "0.0.0.0/0 ${GW_IP_ADDRESS} ${metric} table=${route_table}"
+
+# Setup routing rules
+# The command uses the ipv4.routing-rules parameter to add a routing rule with priority ${priority} that routes
+# traffic from ${DEVICE_IP_ADDRESS} to table ${route_table}. Low values have a high priority.
+# The syntax in the ipv4.routing-rules parameter is the same as in an "ip rule add" command,
+# except that ipv4.routing-rules always requires specifying a priority.
+nmcli connection modify "${con_name}" ipv4.routing-rules "priority ${priority} from ${DEVICE_IP_ADDRESS} table ${route_table}"
+
+# Reapply previous connection modification.
+nmcli device reapply ${DEVICE_NAME}

--- a/files/default/configure_nw_interface.sh
+++ b/files/default/configure_nw_interface.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Configure a specific Network Interface according to the OS
+# The configuration involves 3 aspects:
+# - Main configuration (IP address, protocol and gateway)
+# - A specific routing table, so that all traffic coming to a network interface leaves the instance using the same
+#   interface
+# - A routing rule to make the OS use the specific routing table for this network interface
+
+set -e
+
+if
+  [ -z "${DEVICE_NAME}" ] ||          # name of the device
+  [ -z "${DEVICE_NUMBER}" ] ||        # number of the device
+  [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
+  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
+  [ -z "${CIDR_PREFIX_LENGTH}" ] ||   # the prefix length of the device IP cidr block
+  [ -z "${NETMASK}" ]                 # netmask to apply to device ip address
+then
+  echo 'One or more environment variables missing'
+  exit 1
+fi
+
+ROUTE_TABLE="100${DEVICE_NUMBER}"
+
+# config file
+FILE="/etc/sysconfig/network-scripts/ifcfg-${DEVICE_NAME}"
+if [ ! -f "$FILE" ]; then
+/bin/cat <<EOF >${FILE}
+DEVICE=${DEVICE_NAME}
+TYPE=Ethernet
+ONBOOT=yes
+BOOTPROTO=none
+IPADDR=${DEVICE_IP_ADDRESS}
+PREFIX=${CIDR_PREFIX_LENGTH}
+GATEWAY=${GW_IP_ADDRESS}
+IPV4_FAILURE_FATAL=yes
+NAME="System ${DEVICE_NAME}"
+EOF
+fi
+
+# route file
+FILE="/etc/sysconfig/network-scripts/route-${DEVICE_NAME}"
+if [ ! -f "$FILE" ]; then
+/bin/cat <<EOF >${FILE}
+default via ${GW_IP_ADDRESS} dev ${DEVICE_NAME} table ${ROUTE_TABLE}
+default via ${GW_IP_ADDRESS} dev ${DEVICE_NAME} metric ${ROUTE_TABLE}
+${DEVICE_IP_ADDRESS} dev ${DEVICE_NAME} table ${ROUTE_TABLE}
+EOF
+fi
+
+# rule file
+FILE="/etc/sysconfig/network-scripts/rule-${DEVICE_NAME}"
+if [ ! -f "$FILE" ]; then
+/bin/cat <<EOF >${FILE}
+from ${DEVICE_IP_ADDRESS} lookup ${ROUTE_TABLE}
+EOF
+fi

--- a/files/ubuntu-16.04/configure_nw_interface.sh
+++ b/files/ubuntu-16.04/configure_nw_interface.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Configure a specific Network Interface according to the OS
+# The configuration involves 3 aspects:
+# - Main configuration (IP address, protocol and gateway)
+# - A specific routing table, so that all traffic coming to a network interface leaves the instance using the same
+#   interface
+# - A routing rule to make the OS use the specific routing table for this network interface
+
+set -e
+
+if
+  [ -z "${DEVICE_NAME}" ] ||          # name of the device
+  [ -z "${DEVICE_NUMBER}" ] ||        # number of the device
+  [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
+  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
+  [ -z "${CIDR_PREFIX_LENGTH}" ] ||   # the prefix length of the device IP cidr block
+  [ -z "${NETMASK}" ]                 # netmask to apply to device ip address
+then
+  echo 'One or more environment variables missing'
+  exit 1
+fi
+
+if [ "${DEVICE_NUMBER}" = "0" ]
+  then
+    echo "Device 0 is already configured in Ubuntu 16.04"
+    exit 0
+fi
+
+FILE="/etc/network/interfaces.d/${DEVICE_NAME}.cfg"
+ROUTE_TABLE="100${DEVICE_NUMBER}"
+
+/bin/cat <<EOF >${FILE}
+auto ${DEVICE_NAME}
+iface ${DEVICE_NAME} inet static
+address ${DEVICE_IP_ADDRESS}
+netmask ${NETMASK}
+
+# Gateway configuration
+up ip route add default via ${GW_IP_ADDRESS} dev ${DEVICE_NAME} table ${ROUTE_TABLE}
+up ip route add default via ${GW_IP_ADDRESS} dev ${DEVICE_NAME} metric ${ROUTE_TABLE}
+
+# Routes and rules
+up ip route add ${DEVICE_IP_ADDRESS} dev ${DEVICE_NAME} table ${ROUTE_TABLE}
+up ip rule add from ${DEVICE_IP_ADDRESS} lookup ${ROUTE_TABLE}
+EOF

--- a/files/ubuntu-18.04/configure_nw_interface.sh
+++ b/files/ubuntu-18.04/configure_nw_interface.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Configure a specific Network Interface according to the OS
+# The configuration involves 3 aspects:
+# - Main configuration (IP address, protocol and gateway)
+# - A specific routing table, so that all traffic coming to a network interface leaves the instance using the same
+#   interface
+# - A routing rule to make the OS use the specific routing table for this network interface
+
+set -e
+
+if
+  [ -z "${DEVICE_NAME}" ] ||          # name of the device
+  [ -z "${DEVICE_NUMBER}" ] ||        # number of the device
+  [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
+  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
+  [ -z "${CIDR_PREFIX_LENGTH}" ] ||   # the prefix length of the device IP cidr block
+  [ -z "${NETMASK}" ]                 # netmask to apply to device ip address
+then
+  echo 'One or more environment variables missing'
+  exit 1
+fi
+
+STATIC_IP_CONFIG=$(cat<<END
+      addresses:
+       - ${DEVICE_IP_ADDRESS}/${CIDR_PREFIX_LENGTH}
+      dhcp4: no
+END
+)
+
+if [ "${DEVICE_NUMBER}" = "0" ]
+  then
+    echo "Device 0 is dhcp managed in Ubuntu 18.04"
+    STATIC_IP_CONFIG=""
+fi
+
+FILE="/etc/netplan/${DEVICE_NAME}.yaml"
+ROUTE_TABLE="100${DEVICE_NUMBER}"
+
+/bin/cat <<EOF >${FILE}
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    ${DEVICE_NAME}:
+$STATIC_IP_CONFIG
+      routes:
+       - to: 0.0.0.0/0
+         via: ${GW_IP_ADDRESS} # Default gateway
+         table: ${ROUTE_TABLE}
+       - to: 0.0.0.0/0
+         via: ${GW_IP_ADDRESS} # Default gateway
+         metric: ${ROUTE_TABLE}
+       - to: ${DEVICE_IP_ADDRESS}
+         via: 0.0.0.0
+         scope: link
+         table: ${ROUTE_TABLE}
+      routing-policy:
+        - from: ${DEVICE_IP_ADDRESS}
+          table: ${ROUTE_TABLE}
+EOF

--- a/recipes/_nvidia_config.rb
+++ b/recipes/_nvidia_config.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: _nvidia_config
+#
+# Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start nvidia fabric manager on NVSwitch enabled systems
+# (not available on alinux)
+unless node['cfncluster']['cfn_base_os'] == 'alinux'
+  if get_nvswitches > 1
+    service 'nvidia-fabricmanager' do
+      action [:start, :enable]
+      supports status: true
+    end
+  end
+end

--- a/recipes/_nvidia_install.rb
+++ b/recipes/_nvidia_install.rb
@@ -77,4 +77,20 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes' || node['cfncluster']['nvidi
     end
   end
 
+  # Install NVIDIA Fabric Manager (not available on alinux)
+  unless node['cfncluster']['cfn_base_os'] == 'alinux'
+    add_package_repository(
+      "nvidia-fm-repo",
+      node['cfncluster']['nvidia']['fabricmanager']['repository_uri'],
+      "#{node['cfncluster']['nvidia']['fabricmanager']['repository_uri']}/#{node['cfncluster']['nvidia']['fabricmanager']['repository_key']}",
+      "/"
+    )
+
+    package node['cfncluster']['nvidia']['fabricmanager']['package'] do
+      version node['cfncluster']['nvidia']['fabricmanager']['version']
+    end
+
+    remove_package_repository("nvidia-fm-repo")
+  end
+
 end

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -35,6 +35,9 @@ end
 # Amazon Time Sync
 include_recipe 'aws-parallelcluster::chrony_config'
 
+# NVIDIA services (fabric manager)
+include_recipe "aws-parallelcluster::_nvidia_config"
+
 # EFA runtime configuration
 include_recipe "aws-parallelcluster::efa_config"
 

--- a/recipes/efa_config.rb
+++ b/recipes/efa_config.rb
@@ -15,6 +15,9 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Installation recipe must be re-executed at runtime to enable GDR
+include_recipe "aws-parallelcluster::efa_install"
+
 if node['platform'] == 'ubuntu'
   if node['cfncluster']['enable_efa'] == 'compute' && node['cfncluster']['cfn_node_type'] == 'ComputeFleet'
     # Disabling ptrace protection is needed for EFA in order to use SHA transfer for intra-node communication.

--- a/recipes/efa_install.rb
+++ b/recipes/efa_install.rb
@@ -42,10 +42,11 @@ when 'debian'
 end
 
 installer_options = "-y"
-if arm_instance?
-  # efa-kmod currently unavailable for ARM instances
-  installer_options += " -k"
-end
+# efa-kmod currently unavailable for ARM instances
+installer_options += " -k" if arm_instance?
+# enable gpudirect support
+installer_options += " -g" if efa_gdr_enabled?
+
 bash "install efa" do
   cwd node['cfncluster']['sources_dir']
   code <<-EFAINSTALL
@@ -54,5 +55,5 @@ bash "install efa" do
     cd aws-efa-installer
     ./efa_installer.sh #{installer_options}
   EFAINSTALL
-  not_if { ::Dir.exist?('/opt/amazon/efa') }
+  not_if { ::Dir.exist?('/opt/amazon/efa') && !efa_gdr_enabled?}
 end

--- a/recipes/network_interfaces_config.rb
+++ b/recipes/network_interfaces_config.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: network_interfaces_config
+#
+# Copyright 2013-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+def network_interface_macs
+  uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs")
+  res = Net::HTTP.get_response(uri)
+  macs = res.body.delete("/").split("\n")
+  macs
+end
+
+def device_name(mac)
+  cmd = Mixlib::ShellOut.new("ip -o link | grep #{mac} | awk '{print substr($2, 1, length($2) -1)}'")
+  cmd.run_command
+  cmd.stdout.delete("\n")
+end
+
+def device_number(mac)
+  uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{mac}/device-number")
+  res = Net::HTTP.get_response(uri)
+  res.body
+end
+
+def device_ip(mac)
+  uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{mac}/local-ipv4s")
+  res = Net::HTTP.get_response(uri)
+  res.body
+end
+
+def gateway_address
+  cmd = Mixlib::ShellOut.new("ip r | grep default | head -n 1 | awk '{print $3}'")
+  cmd.run_command
+  cmd.stdout.delete("\n")
+end
+
+def cidr_prefix_length(mac)
+  uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{mac}/subnet-ipv4-cidr-block")
+  res = Net::HTTP.get_response(uri)
+  res.body.split("/")[1]
+end
+
+def cidr_to_netmask(cidr)
+  require 'ipaddr'
+  IPAddr.new('255.255.255.255').mask(cidr).to_s
+end
+
+macs = network_interface_macs
+log "macs: #{macs}"
+
+if macs.length > 1
+
+  cookbook_file 'configure_nw_interface.sh' do
+    path '/tmp/configure_nw_interface.sh'
+    user 'root'
+    group 'root'
+    mode '0644'
+  end
+
+  # Configure nw interfaces
+  macs.each do |mac|
+    device_name = device_name(mac)
+    device_number = device_number(mac)
+    gw_ip_address = gateway_address
+    device_ip_address = device_ip(mac)
+    cidr_prefix_length = cidr_prefix_length(mac)
+    netmask = cidr_to_netmask(cidr_prefix_length)
+
+    execute 'configure_nw_interface' do
+      user 'root'
+      group 'root'
+      cwd "/tmp"
+      environment(
+        'DEVICE_NAME' => device_name,
+        'DEVICE_NUMBER' => device_number,
+        'GW_IP_ADDRESS' => gw_ip_address,
+        'DEVICE_IP_ADDRESS' => device_ip_address,
+        'CIDR_PREFIX_LENGTH' => cidr_prefix_length,
+        'NETMASK' => netmask
+      )
+
+      command 'sh /tmp/configure_nw_interface.sh'
+    end
+  end
+
+
+  # Apply configuration
+  reload_network_config
+end

--- a/recipes/prep_env.rb
+++ b/recipes/prep_env.rb
@@ -76,6 +76,9 @@ include_recipe "aws-parallelcluster::_setup_python"
 # Install cloudwatch, write configuration and start it.
 include_recipe "aws-parallelcluster::cloudwatch_agent_config"
 
+# Configure additional Networking Interfaces (if present)
+include_recipe "aws-parallelcluster::network_interfaces_config"
+
 if node['cfncluster']['cfn_scheduler'] == 'slurm'
   include_recipe "aws-parallelcluster::prep_env_slurm"
 end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -304,6 +304,16 @@ if node['conditions']['intel_mpi_supported']
 end
 
 ###################
+# EFA - GDR (GPUDirect RDMA)
+###################
+if node['conditions']['efa_supported'] && efa_gdr_enabled?
+  execute 'check efa gdr installed' do
+    command "modinfo efa | grep 'gdr:\ *Y'"
+    user node['cfncluster']['cfn_cluster_user']
+  end
+end
+
+###################
 # jq
 ###################
 unless node['cfncluster']['os'].end_with?("-custom")
@@ -379,6 +389,22 @@ bash 'test CUDA install' do
     echo "CUDA deviceQuery test passed"
     echo "Correctly installed CUDA $cuda_output"
   TESTCUDA
+end
+
+###################
+# FabricManager
+###################
+unless node['cfncluster']['cfn_base_os'] == 'alinux'
+  if get_nvswitches > 1
+    bash 'test fabric-manager daemon' do
+      cwd Chef::Config[:file_cache_path]
+      code <<-TESTFM
+        set -e
+        systemctl show -p SubState nvidia-fabricmanager | grep -i running
+        echo "NVIDIA Fabric Manager service correctly started"
+      TESTFM
+    end
+  end
 end
 
 ###################


### PR DESCRIPTION
This commit introduces the support for the new P4d instance type. The changes introduced by this commit involve:
- Support for Multiple Network Interfaces
- Support for GPUDirect on EFA driver (EFA GDR)
- NVIDIA Fabric Manager to enable NVIDIA NVSwitch
- NVIDIA driver updated to version 450.80.02

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
