### PR TITLE
Check pip version greater than 19.3

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -464,3 +464,22 @@ unless node['cfncluster']['os'].end_with?("-custom")
     user node['cfncluster']['cfn_cluster_user']
   end
 end
+
+###################
+# PIP
+###################
+require 'chef/mixin/shell_out'
+
+virtual_envs = ["#{node['cfncluster']['node_virtualenv_path']}", "#{node['cfncluster']['cookbook_virtualenv_path']}"]
+for virtual_env in virtual_envs
+  pip_version = nil
+  pip_show = shell_out!("#{virtual_env}/bin/pip show pip").stdout.strip
+  pip_show.split(/\n+/).each do |line|
+    pip_version = line.split(/\s+/)[1] if line.start_with?('Version:')
+  end
+  Chef::Log.debug("pip version in virtualenv #{virtual_env} is #{pip_version}")
+  if !pip_version || pip_version.to_f < 19.3
+    # pip versions >= 19.3 is required to enable installation of python wheel binaries on Graviton
+    raise "pip version in virtualenv #{virtual_env} must be greater than 19.3"
+  end
+end


### PR DESCRIPTION
pip versions >= 19.3 is required to enable installation of python wheel binaries on Graviton, reference https://github.com/aws/aws-graviton-getting-started

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
