### PR TITLE
Upgrade EFA to 1.10.1 to support Centos8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,23 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **CHANGES**
 
+- Upgrade EFA installer to version 1.10.1
+  - EFA configuration: ``efa-config-1.5`` (from efa-config-1.4)
+  - EFA profile: ``efa-profile-1.1`` (from efa-profile-1.0.0)
+  - EFA kernel module: ``efa-1.10.2`` (from efa-1.6.0)
+  - RDMA core: ``rdma-core-31.amzn0`` (from rdma-core-28.amzn0)
+  - Libfabric: ``libfabric-1.11.1amazon1.1`` (from libfabric-1.10.1amazon1.1)
+  - Open MPI: ``openmpi40-aws-4.0.5`` (from openmpi40-aws-4.0.3)
+  - Unifies installer runtime options across x86 and aarch64
+  - Introduces ``-g/--enable-gdr`` switch to install packages with GPUDirect RDMA support
+  - Updates to OMPI collectives decision file packaging, migrated from efa-config to efa-profile
+  - Introduces CentOS 8 support
 - CentOS 6 is no longer supported.
+- Install python3 version of ``aws-cfn-bootstrap`` scripts
 - Upgrade Intel MPI to version U8.
 - Upgrade Intel Parallel Studio XE Runtime to version 2020.2.
 - Do not force compute fleet into STOPPED state when performing a cluster update. This allows to update the queue
   size without forcing a termination of the existing instances.
-- Upgrade EFA installer to 1.10.0
 - Retrieve FSx Lustre DNS name dynamically.
 
 2.9.1

--- a/attributes/conditions.rb
+++ b/attributes/conditions.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 default['conditions']['lustre_supported'] = platform_supports_lustre_for_architecture?
-default['conditions']['efa_supported'] = platform_supports_efa?
 default['conditions']['intel_mpi_supported'] = !arm_instance?
 default['conditions']['intel_hpc_platform_supported'] = !arm_instance? && platform_supports_intel_hpc_platform?
 default['conditions']['dcv_supported'] = platform_supports_dcv?

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -96,7 +96,7 @@ default['cfncluster']['nvidia']['cuda_version'] = '11.0'
 default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run'
 
 # EFA
-default['cfncluster']['efa']['installer_version'] = '1.10.0'
+default['cfncluster']['efa']['installer_version'] = '1.10.1'
 default['cfncluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cfncluster']['efa']['installer_version']}.tar.gz"
 
 # NICE DCV

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -263,15 +263,6 @@ def arm_instance?
 end
 
 #
-# Check if this is an OS on which EFA is supported
-#
-def platform_supports_efa?
-  [node['platform'] == 'centos' && node['platform_version'].to_i < 8,
-   node['platform'] == 'amazon',
-   node['platform'] == 'ubuntu'].any?
-end
-
-#
 # Check if this platform supports intel's HPC platform
 #
 def platform_supports_intel_hpc_platform?

--- a/recipes/efa_install.rb
+++ b/recipes/efa_install.rb
@@ -15,8 +15,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-return unless node['conditions']['efa_supported']
-
 efa_tarball = "#{node['cfncluster']['sources_dir']}/aws-efa-installer.tar.gz"
 
 # Get EFA Installer

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -253,7 +253,7 @@ end
 ###################
 # EFA - Intel MPI
 ###################
-if node['conditions']['efa_supported'] && node['conditions']['intel_mpi_supported']
+if node['conditions']['intel_mpi_supported']
   case node['cfncluster']['os']
   # TODO add centos8 once EFA package is available
   when 'alinux', 'centos7', 'alinux2'


### PR DESCRIPTION
Add Centos8 as supported OS for EFA.
The `efa_supported` condition is no longer needed because all the OSes are supported.
