### PR TITLE
Add retry when downloading DCV GPG key

### DIFF
--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -124,6 +124,8 @@ if node['conditions']['dcv_supported']
           wget https://d1uj6qtbmh3dt5.cloudfront.net/NICE-GPG-KEY
           gpg --import NICE-GPG-KEY
         PREREQ
+        retries 3
+        retry_delay 5
       end
 
     when 'amazon'


### PR DESCRIPTION
This makes it more reliable in case of transient networking issues.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
