### PR TITLE
Move fleet status initialization from finalize to config recipe

### DIFF
--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -76,6 +76,14 @@ execute 'initialize cluster config hash in DynamoDB' do
   not_if { node['cfncluster']['cluster_config_version'].nil? }
 end
 
+execute 'initialize compute fleet status in DynamoDB' do
+  # Initialize the status of the compute fleet in the DynamoDB table. Set it to RUNNING.
+  command "#{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws dynamodb put-item --table-name #{node['cfncluster']['cfn_ddb_table']}"\
+          " --item '{\"Id\": {\"S\": \"COMPUTE_FLEET\"}, \"Status\": {\"S\": \"RUNNING\"}}' --region #{node['cfncluster']['cfn_region']}"
+  retries 3
+  retry_delay 5
+end
+
 # Generate pcluster specific configs
 execute "generate_pcluster_slurm_configs" do
   command "#{node['cfncluster']['cookbook_virtualenv_path']}/bin/python #{node['cfncluster']['scripts_dir']}/slurm/pcluster_slurm_config_generator.py"\

--- a/recipes/_master_slurm_finalize.rb
+++ b/recipes/_master_slurm_finalize.rb
@@ -15,14 +15,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-execute 'initialize compute fleet status' do
-  # Initialize the status of the compute fleet in the DynamoDB table. Set it to RUNNING.
-  command "#{node['cfncluster']['cookbook_virtualenv_path']}/bin/aws dynamodb put-item --table-name #{node['cfncluster']['cfn_ddb_table']}"\
-          " --item '{\"Id\": {\"S\": \"COMPUTE_FLEET\"}, \"Status\": {\"S\": \"RUNNING\"}}' --region #{node['cfncluster']['cfn_region']}"
-  retries 3
-  retry_delay 5
-end
-
 ruby_block "submit dynamic fleet initialization jobs" do
   block do
     require 'json'


### PR DESCRIPTION
This is needed to have the status initialized before daemons are started by supervisord in finalize recipe

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
