### PR TITLE
Revert "Upgrade to Intel MPI U8"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Introduces CentOS 8 support
 - CentOS 6 is no longer supported.
 - Install python3 version of ``aws-cfn-bootstrap`` scripts
-- Upgrade Intel MPI to version U8.
 - Upgrade Intel Parallel Studio XE Runtime to version 2020.2.
 - Do not force compute fleet into STOPPED state when performing a cluster update. This allows to update the queue
   size without forcing a termination of the existing instances.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,8 +54,8 @@ default['cfncluster']['intelpython2']['version'] = '2019.4'
 default['cfncluster']['intelpython3']['version'] = '2020.2'
 
 # Intel MPI
-default['cfncluster']['intelmpi']['url'] = "https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16814/l_mpi_2019.8.254.tgz"
-default['cfncluster']['intelmpi']['version'] = '2019.8.254'
+default['cfncluster']['intelmpi']['url'] = "https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16546/l_mpi_2019.7.217.tgz"
+default['cfncluster']['intelmpi']['version'] = '2019.7.217'
 default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/impi/#{node['cfncluster']['intelmpi']['version']}/intel64/modulefiles/mpi"
 
 # Python packages

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -296,7 +296,7 @@ if node['conditions']['intel_mpi_supported']
         unset MODULEPATH
         # Must execute this in a bash script because source is a bash built-in function
         source /etc/profile.d/modules.sh
-        module load intelmpi && mpirun --help | grep 'Version 2019 Update 8'
+        module load intelmpi && mpirun --help | grep 'Version 2019 Update 7'
       INTELMPI
       user node['cfncluster']['cfn_cluster_user']
     end


### PR DESCRIPTION
This reverts commit 411191f5ffb6beedb9312c625fcc118059905695. It is
being reverted because of a bug in the RDMA core library that requires a
fix (presumably) to be included in the next EFA installer.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
