### PR TITLE
Arm performance library support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade NICE DCV to version 2020.2-9662
 - Use inclusive language in recipe names and internal naming convention.
 - Download Intel MPI and HPC packages from S3 rather than Intel yum repos.
+- Install Arm Performance Library 20.2.1 on ARM AMI(CentOS8, Alinux2, Ubuntu1804)
 
 **BUG FIXES**
 - Fix installation of Intel PSXE package on CentOS 7 by using yum4.

--- a/attributes/conditions.rb
+++ b/attributes/conditions.rb
@@ -21,3 +21,4 @@ default['conditions']['intel_hpc_platform_supported'] = !arm_instance? && platfo
 default['conditions']['dcv_supported'] = platform_supports_dcv?
 default['conditions']['ami_bootstrapped'] = ami_bootstrapped?
 default['conditions']['overwrite_nfs_template'] = overwrite_nfs_template?
+default['conditions']['arm_pl_supported'] = arm_instance?

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -68,6 +68,23 @@ default['cfncluster']['intelmpi']['version'] = '2019.7.217'
 default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/impi/#{node['cfncluster']['intelmpi']['version']}/intel64/modulefiles/mpi"
 default['cfncluster']['intelmpi']['kitchen_test_string'] = 'Version 2019 Update 7'
 
+# Arm Performance Library
+default['cfncluster']['armpl']['version'] = '20.2.1'
+default['cfncluster']['armpl']['gcc']['major_minor_version'] = '9.3'
+default['cfncluster']['armpl']['gcc']['patch_version'] = '0'
+default['cfncluster']['armpl']['gcc']['url'] = "https://ftp.gnu.org/gnu/gcc/gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.#{node['cfncluster']['armpl']['gcc']['patch_version']}/gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.#{node['cfncluster']['armpl']['gcc']['patch_version']}.tar.gz"
+default['cfncluster']['armpl']['platform'] = value_for_platform(
+    'centos' => { '~>8' => 'RHEL-8' },
+    'amazon' => { '2' => 'RHEL-8' },
+    'ubuntu' => { '18.04' => 'Ubuntu-16.04' }
+)
+
+default['cfncluster']['armpl']['url'] = value_for_platform(
+    'centos' => { '~>8' => "https://aws-parallelcluster-dev-commercial-dev.s3.amazonaws.com/archives/armpl/RHEL-8/arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.tar" },
+    'amazon' => { '2' => "https://aws-parallelcluster-dev-commercial-dev.s3.amazonaws.com/archives/armpl/RHEL-8/arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.tar" },
+    'ubuntu' => { '18.04' => "https://aws-parallelcluster-dev-commercial-dev.s3.amazonaws.com/archives/armpl/Ubuntu-16.04/arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.tar" }
+)
+
 # Python packages
 default['cfncluster']['cfncluster-version'] = '2.10.1'
 default['cfncluster']['cfncluster-cookbook-version'] = '2.10.1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -78,11 +78,10 @@ default['cfncluster']['armpl']['platform'] = value_for_platform(
     'amazon' => { '2' => 'RHEL-8' },
     'ubuntu' => { '18.04' => 'Ubuntu-16.04' }
 )
-
 default['cfncluster']['armpl']['url'] = value_for_platform(
-    'centos' => { '~>8' => "https://aws-parallelcluster-dev-commercial-dev.s3.amazonaws.com/archives/armpl/RHEL-8/arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.tar" },
-    'amazon' => { '2' => "https://aws-parallelcluster-dev-commercial-dev.s3.amazonaws.com/archives/armpl/RHEL-8/arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.tar" },
-    'ubuntu' => { '18.04' => "https://aws-parallelcluster-dev-commercial-dev.s3.amazonaws.com/archives/armpl/Ubuntu-16.04/arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.tar" }
+    'centos' => { '~>8' => "https://#{node['cfncluster']['cfn_region']}-aws-parallelcluster.s3.#{node['cfncluster']['cfn_region']}.#{aws_domain}/archives/armpl/RHEL-8/arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.tar" },
+    'amazon' => { '2' => "https://#{node['cfncluster']['cfn_region']}-aws-parallelcluster.s3.#{node['cfncluster']['cfn_region']}.#{aws_domain}/archives/armpl/RHEL-8/arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.tar" },
+    'ubuntu' => { '18.04' => "https://#{node['cfncluster']['cfn_region']}-aws-parallelcluster.s3.#{node['cfncluster']['cfn_region']}.#{aws_domain}/archives/armpl/Ubuntu-16.04/arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.tar" }
 )
 
 # Python packages

--- a/recipes/arm_pl_install.rb
+++ b/recipes/arm_pl_install.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: arm_pl_install
+#
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+return unless node['conditions']['arm_pl_supported']
+
+armpl_installer = "#{node['cfncluster']['sources_dir']}/arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.tar"
+
+# fetch armpl installer script
+remote_file armpl_installer do
+  source node['cfncluster']['armpl']['url']
+  mode '0644'
+  retries 3
+  retry_delay 5
+  not_if { ::File.exist?("/opt/arm/armpl/#{node['cfncluster']['armpl']['version']}") }
+end
+
+bash "install arm performance library" do
+  cwd node['cfncluster']['sources_dir']
+  code <<-ARMPL
+    set -e
+    tar -xf arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.tar
+    cd arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}/
+    ./arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}.sh --accept --install-to /opt/arm/armpl/#{node['cfncluster']['armpl']['version']}
+    cd ..
+    rm -rf arm-performance-libraries_#{node['cfncluster']['armpl']['version']}_#{node['cfncluster']['armpl']['platform']}*
+  ARMPL
+  creates "/opt/arm/armpl/#{node['cfncluster']['armpl']['version']}"
+end
+
+# create armpl module directory
+directory "#{node['cfncluster']['modulefile_dir']}/armpl"
+
+# arm performance library modulefile configuration
+template "#{node['cfncluster']['modulefile_dir']}/armpl/#{node['cfncluster']['armpl']['version']}" do
+  source 'armpl_modulefile.erb'
+  user 'root'
+  group 'root'
+  mode '0755'
+end
+
+gcc_tarball = "#{node['cfncluster']['sources_dir']}/gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.#{node['cfncluster']['armpl']['gcc']['patch_version']}.tar.gz"
+
+# Get gcc tarball
+remote_file gcc_tarball do
+  source node['cfncluster']['armpl']['gcc']['url']
+  mode '0644'
+  retries 3
+  retry_delay 5
+  not_if { ::File.exist?(gcc_tarball) }
+end
+
+# Install gcc
+bash 'make install' do
+  user 'root'
+  group 'root'
+  cwd node['cfncluster']['sources_dir']
+  code <<-GCC
+      set -e
+
+      tar -xf #{gcc_tarball}
+      cd gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.#{node['cfncluster']['armpl']['gcc']['patch_version']}
+      ./contrib/download_prerequisites
+      mkdir build && cd build
+      ../configure --prefix=/opt/arm/armpl/gcc/#{node['cfncluster']['armpl']['gcc']['major_minor_version']}.#{node['cfncluster']['armpl']['gcc']['patch_version']} --disable-bootstrap --enable-checking=release --enable-languages=c,c++,fortran --disable-multilib
+      CORES=$(grep processor /proc/cpuinfo | wc -l)
+      make -j $CORES
+      make install
+  GCC
+  creates '/opt/arm/armpl/gcc'
+end
+
+gcc_modulefile = "/opt/arm/armpl/#{node['cfncluster']['armpl']['version']}/modulefiles/armpl/gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}"
+
+# gcc modulefile configuration
+template gcc_modulefile do
+  source 'gcc_modulefile.erb'
+  user 'root'
+  group 'root'
+  mode '0755'
+end

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -223,3 +223,6 @@ include_recipe "aws-parallelcluster::cloudwatch_agent_install"
 
 # Install Amazon Time Sync
 include_recipe "aws-parallelcluster::chrony_install"
+
+# Install ARM Performance Library
+include_recipe "aws-parallelcluster::arm_pl_install"

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -527,3 +527,24 @@ for virtual_env in virtual_envs
     end
   end
 end
+
+###################
+# ARM - PL
+###################
+if node['conditions']['arm_pl_supported']
+  bash 'check gcc version and module loaded' do
+    cwd Chef::Config[:file_cache_path]
+    code <<-ARMPL
+      set -e
+      # Initialize module
+      unset MODULEPATH
+      source /etc/profile.d/modules.sh
+      (module avail)2>&1 | grep armpl/#{node['cfncluster']['armpl']['version']}
+      module load armpl/#{node['cfncluster']['armpl']['version']}
+      gcc --version | grep #{node['cfncluster']['armpl']['gcc']['major_minor_version']}
+      (module list)2>&1 | grep armpl/#{node['cfncluster']['armpl']['version']}_gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}
+      (module list)2>&1 | grep armpl/gcc-#{node['cfncluster']['armpl']['gcc']['major_minor_version']}
+    ARMPL
+    user node['cfncluster']['cfn_cluster_user']
+  end
+end

--- a/templates/default/armpl_modulefile.erb
+++ b/templates/default/armpl_modulefile.erb
@@ -1,0 +1,47 @@
+#%Module1.0
+
+## Required internal variables
+set category arm
+set name     armpl
+set version  <%= node['cfncluster']['armpl']['version'] %>
+set gcc_version <%= node['cfncluster']['armpl']['gcc']['major_minor_version'] %>
+set root     /opt/$category/$name/$version
+
+## Set resource definition
+set fullname "Arm Performance Libraries"
+set externalurl https://developer.arm.com
+
+## Required for "module help ..."
+
+proc ModulesHelp { } {
+puts stderr "Use ARMpl with GCC like this:"
+puts stderr "At compile time add '-I<armpl_include>' and at link time"
+  puts stderr "add  '-l<armpl_library> -lgfortran -lamath -lm -lastring'"
+  puts stderr ""
+  puts stderr "Description                     <armpl_include>             <armpl_library>"
+  puts stderr "32-bit integers                 ARMPL_INCLUDES              armpl_lp64"
+  puts stderr "64-bit integers                 ARMPL_INCLUDES_ILP64        armpl_ilp64"
+  puts stderr "single-threaded library         ARMPL_INCLUDES              armpl_lp64"
+  puts stderr "OpenMP multi-threaded library  ARMPL_INCLUDES_LP64_MP       armpl_lp64_mp"
+  puts stderr "64-bit integers & OpenMP       ARMPL_INCLUDES_ILP64_MP      armpl_ilp64_mp"
+  }
+
+  # Add license path
+  setenv ARM_LICENSE_DIR $root/arm-performance-libraries_${version}_gcc-${gcc_version}/license_terms
+
+  # Load the pre-installed gcc module
+  module load $root/modulefiles/armpl/gcc-${gcc_version}
+
+  # Get full version
+  set full_version ${version}
+  if {[llength [split ${version} .]] < 3} {
+    set full_version ${version}.0
+  }
+
+  # Load the pre-installed armpl module
+  module load $root/modulefiles/armpl/${full_version}_gcc-${gcc_version}
+
+  # EULA
+  if [ module-info mode load ] {
+    puts stderr "Use of the free of charge version of Arm Performance Libraries is subject to the terms and conditions of the Arm Performance Libraries (free version) -  End User License Agreement (EULA). A copy of the EULA can be found in the '$root/arm-performance-libraries_${version}_gcc-${gcc_version}/license_terms' folder"
+  }

--- a/templates/default/gcc_modulefile.erb
+++ b/templates/default/gcc_modulefile.erb
@@ -1,0 +1,44 @@
+#%Module1.0
+
+## Required internal variables
+set name     gcc
+set version  <%= node['cfncluster']['armpl']['gcc']['major_minor_version'] %>.<%= node['cfncluster']['armpl']['gcc']['patch_version'] %>
+set category arm
+set library armpl
+set root     /opt/$category/$library/$name/$version
+
+
+## Set resource definition
+set fullname "GNU compiler collection"
+set externalurl http://www.gcc.gnu.org
+set description "GNU compiler collection"
+
+## Required for "module help ..."
+
+proc ModulesHelp { } {
+global description externalurl
+puts stderr "Description - $description"
+puts stderr "Other Docs  - $externalurl"
+}
+
+## Required for "module display ..." and SWDB
+
+module-whatis                   "$description"
+
+## Software-specific settings exported to user environment
+
+if { [ file readable $root/lib ] }  {
+prepend-path    LD_LIBRARY_PATH $root/lib
+}
+if { [ file readable $root/lib64 ] }  {
+prepend-path    LD_LIBRARY_PATH $root/lib64
+}
+if { [ file readable $root/share/man ] }  {
+prepend-path    MANPATH         $root/share/man
+}
+if { [ file readable $root/bin ] }  {
+prepend-path    PATH            $root/bin
+}
+if { [ file readable $root/include ] }  {
+prepend-path    INCLUDE            $root/include
+}


### PR DESCRIPTION
**Changes**
* Add arm performance library installation and module configuration
* Add gcc-9.3 module configuration and create modulefile
* Currently support alinux2, ubuntu1804 and centos8 arm instance
* Arm performance library kitchen test

**Version Update**
we could simply set  `default['cfncluster']['armpl']['version']`(e.g. 20.2.1 or 20.3), `default['cfncluster']['armpl']['gcc']['major_minor_version']` values to new version, then the value will propagate.

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
