### PR TITLE
Fix EFA installation on Alinux2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -254,7 +254,7 @@ when 'rhel', 'amazon'
 
   when 'amazon'
     default['cfncluster']['base_packages'] = %w[vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
-                                                libXmu-devel hwloc-devel db4-devel tcl-devel automake autoconf pyparted libtool
+                                                libXmu-devel db4-devel tcl-devel automake autoconf pyparted libtool
                                                 httpd boost-devel redhat-lsb mlocate mpich-devel R atlas-devel fftw-devel
                                                 libffi-devel dkms mysql-devel libedit-devel postgresql-devel postgresql-server
                                                 sendmail cmake byacc libglvnd-devel mdadm libgcrypt-devel libevent-devel

--- a/recipes/efa_install.rb
+++ b/recipes/efa_install.rb
@@ -57,3 +57,12 @@ bash "install efa" do
   EFAINSTALL
   not_if { ::Dir.exist?('/opt/amazon/efa') && !efa_gdr_enabled?}
 end
+
+if node['platform'] == 'amazon'
+  # FIXME libibverbs and librdmacm are dependencies of hwloc-devel and EFA
+  # the version on the OS repo conflicts against the one provided by EFA installer
+  package 'hwloc-devel' do
+    retries 3
+    retry_delay 5
+  end
+end


### PR DESCRIPTION
There is a conflicts between `libibverbs` and `librdmacm` packages provided by EFA bundle and
same packages coming from OS repository.
`libibverbs` and `librdmacm` are installed as dependencies of the `hwloc-devel` package

Workaround is to install first the packages coming from EFA and then the `hwloc-devel` package

`hwloc-devel` is needed for SGE compilaton (at least)

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
