### PR TITLE
Fix EFA installation on Alinux2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -274,7 +274,7 @@ when 'rhel', 'amazon'
       default['cfncluster']['base_packages'].concat(%w[libxml2-devel perl-devel dpkg-dev tar gzip bison flex gcc gcc-c++ patch
                                                        rpm-build rpm-sign system-rpm-config cscope ctags diffstat doxygen elfutils
                                                        gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl
-                                                       jq wget python-pip NetworkManager-config-routing-rules])
+                                                       jq wget python-pip NetworkManager-config-routing-rules libibverbs-utils librdmacm-utils])
       # Download from debian repo (https://packages.debian.org/source/buster/gridengine)
       # because it contains fixes for known build issues
       default['cfncluster']['sge']['url'] = 'https://deb.debian.org/debian/pool/main/g/gridengine/gridengine_8.1.9+dfsg.orig.tar.gz'


### PR DESCRIPTION
There is a conflicts between `libibverbs` and `librdmacm` packages provided by EFA bundle and
same packages coming from OS repository.
`libibverbs` and `librdmacm` are installed as dependencies of the `hwloc-devel` package
`libibverbs` and `librdmacm` are installed as dependencies of `libibverbs-utils` and `librdmacm-util`

Workaround is to install first the newer packages (and dependencies) coming from the OS,
then install EFA

`hwloc-devel` is needed for SGE compilaton (at least)

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
