### PR TITLE
Fix Lustre client installation for CentOS 7.9

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -325,6 +325,7 @@ def find_rhel7_kernel_minor_version
     raise "Unable to retrieve the kernel minor version from #{node['kernel']['release']}." unless kernel_patch_version
 
     kernel_minor_version = '8' if kernel_patch_version[1] >= '1127'
+    kernel_minor_version = '9' if kernel_patch_version[1] >= '1160'
   end
 
   kernel_minor_version


### PR DESCRIPTION
Add new record to handle mapping between the Lustre repository and the CentOS kernel version, as described in https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html

CentOS 7.9 was released on November 10 2020 (e.g. ami-00e87074e52e6c9f9 in us-east-1)

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
