### PR TITLE
Improve Lustre client installation for CentOS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -335,8 +335,8 @@ default['cfncluster']['lustre']['public_key'] = value_for_platform(
 default['cfncluster']['lustre']['base_url'] = value_for_platform(
   'centos' => {
     # node['kernel']['machine'] contains the architecture: 'x86_64' or 'aarch64'
-    '>=8' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8/#{node['kernel']['machine']}/",
-    'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7.#{find_rhel7_kernel_minor_version}/x86_64/"
+    '>=8' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8#{find_rhel_minor_version}/#{node['kernel']['machine']}/",
+    'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7#{find_rhel_minor_version}/x86_64/"
   },
   'ubuntu' => { 'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu" }
 )

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -311,23 +311,34 @@ def aws_domain
 end
 
 #
-# Retrieve RHEL kernel minor version from running kernel
-# The minor version is retrieved from the patch version of the running kernel
+# Retrieve RHEL OS minor version from running kernel version
+# The OS minor version is retrieved from the patch version of the running kernel
 # following the mapping reported here https://access.redhat.com/articles/3078#RHEL7
-# Method works for minor version >=7
+# Method works for CentOS8 minor version >=2 and CentOS7 minor version >=7
 #
-def find_rhel7_kernel_minor_version
-  kernel_minor_version = '7'
+def find_rhel_minor_version
+  os_minor_version = ''
 
   if node['platform'] == 'centos'
     # kernel release is in the form 3.10.0-1127.8.2.el7.x86_64
     kernel_patch_version = node['kernel']['release'].match(/^\d+\.\d+\.\d+-(\d+)\..*$/)
-    raise "Unable to retrieve the kernel minor version from #{node['kernel']['release']}." unless kernel_patch_version
+    raise "Unable to retrieve the kernel patch version from #{node['kernel']['release']}." unless kernel_patch_version
 
-    kernel_minor_version = '8' if kernel_patch_version[1] >= '1127'
+    # Lustre repo string will be built following the official doc
+    # https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html
+    if node['platform_version'].to_i == 7
+      os_minor_version = '.7' if kernel_patch_version[1] >= '1062'
+      os_minor_version = '.8' if kernel_patch_version[1] >= '1127'
+      os_minor_version = '.9' if kernel_patch_version[1] >= '1160'
+    elsif node['platform_version'].to_i == 8
+      os_minor_version = '.2' if kernel_patch_version[1] >= '193'
+      os_minor_version = '.3' if kernel_patch_version[1] >= '240'
+    else
+      raise "CentOS version #{node['platform_version']} not supported."
+    end
   end
 
-  kernel_minor_version
+  os_minor_version
 end
 
 # Return chrony service reload command


### PR DESCRIPTION
Add new records to handle mapping between the Lustre repository and the CentOS kernel version, as described in https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html

New AMI for CentOS 7.9 was released on November 10 2020 (e.g. ami-00e87074e52e6c9f9 in us-east-1)
New AMI for CentOS 8.3 will be released soon

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
