### PR TITLE
Apply network configuration for Ubuntu18 at Chef converge time

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -260,7 +260,11 @@ end
 #
 def reload_network_config
   if node['platform'] == 'ubuntu' && node['platform_version'].to_i == 18
-    Mixlib::ShellOut.new("netplan apply").run_command
+    ruby_block "apply network configuration" do
+      block do
+        Mixlib::ShellOut.new("netplan apply").run_command
+      end
+    end
   else
     restart_network_service
   end

--- a/recipes/network_interfaces_config.rb
+++ b/recipes/network_interfaces_config.rb
@@ -95,7 +95,6 @@ if macs.length > 1
     end
   end
 
-
   # Apply configuration
   reload_network_config
 end


### PR DESCRIPTION
The `reload_network_config` is a helper function that defines for all OSes (but Ubuntu18) a `service` Chef resource that is executed at converge time.

For Ubuntu18 it was executed at compilation time because there was no a chef resource, now by defining a `ruby_block` we're executing it a converge time like the other OSes.

