### PR TITLE
Add new test runner parameter `--createami-custom-node-url`

### DIFF
--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -247,6 +247,7 @@
       ],
       "json" : {
         "cfncluster" : {
+          "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "alinux"
         }
       },

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -247,6 +247,7 @@
       ],
       "json" : {
         "cfncluster" : {
+          "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "alinux2"
         }
       },

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -266,6 +266,7 @@
       ],
       "json" : {
         "cfncluster" : {
+          "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "centos7"
         }
       },

--- a/amis/packer_centos8.json
+++ b/amis/packer_centos8.json
@@ -265,6 +265,7 @@
       ],
       "json" : {
         "cfncluster" : {
+          "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "centos8"
         }
       },

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -268,6 +268,7 @@
       ],
       "json" : {
         "cfncluster" : {
+          "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "ubuntu1604"
         }
       },

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -272,6 +272,7 @@
       ],
       "json" : {
         "cfncluster" : {
+          "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "ubuntu1804"
         }
       },


### PR DESCRIPTION
The new parameter allows to specify a custom node for the createami test.
This new parameter permits to specify a custom node URL, that is needed when version bump is done and node package is not yet present in PyPi.

Linked To https://github.com/aws/aws-parallelcluster/pull/2242

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
