### PR TITLE
Use yum4 to install Intel PSXE package on Centos7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+2.10.1
+------
+
+**ENHANCEMENTS**
+- 
+
+**CHANGES**
+- 
+
+**BUG FIXES**
+- Fix installation of Intel PSXE package on CentOS 7 by using yum4.
+
 2.10.0
 ------
 


### PR DESCRIPTION
We have frequent failures in the retry of the installation block because `rpm` command fails when the package is already installed.

By using `yum` we can have a safe retry but as reported in Intel documentation it's better to use `yum4`.
I'm now differentiating centos7 and centos8 installation.

This problem has been introduced with CentOS8 support: https://github.com/aws/aws-parallelcluster-cookbook/commit/2ea0470ade7ee71ff136070f9d71193f3dceca85

### Intel documentation

> Due to a known bug in YUM 3.x, you may see failures when trying to install specific versions of the Intel Parallel Studio XE Runtime package.
> The bug is fixed in YUM 4 so we recommend you update your local instance of the client to the latest YUM version.
>If you're running YUM 3.x or older, you will only be able to install the latest version available of the Intel products.

Source: https://software.intel.com/content/www/us/en/develop/articles/installing-intel-parallel-studio-xe-runtime-2020-using-yum-repository.html

### Tests

Kitchen tests succeded for both Centos7 and Centos8.
