### PR TITLE
Enable EFA - Intel MPI kitchen tests for CentOS8

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -255,8 +255,7 @@ end
 ###################
 if node['conditions']['intel_mpi_supported']
   case node['cfncluster']['os']
-  # TODO add centos8 once EFA package is available
-  when 'alinux', 'centos7', 'alinux2'
+  when 'alinux', 'alinux2', 'centos7', 'centos8'
     execute 'check efa rpm installed' do
       command "rpm -qa | grep libfabric && rpm -qa | grep efa-"
       user node['cfncluster']['cfn_cluster_user']


### PR DESCRIPTION
We missed to include them when upgrading EFA installer to latest version, supporting CentOS 8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
