### PR TITLE
Rename internal variables, functions and recipes from master_* to head_node_*

### DIFF
--- a/files/default/slurm/templates/slurm_parallelcluster.conf
+++ b/files/default/slurm/templates/slurm_parallelcluster.conf
@@ -3,7 +3,7 @@
 # Please add user-specific slurm configuration options in slurm.conf
 {% set ns = namespace(has_static=false) %}
 
-SlurmctldHost={{ master_config.master_hostname }}({{ master_config.master_ip }})
+SlurmctldHost={{ head_node_config.head_node_hostname }}({{ head_node_config.head_node_ip }})
 SuspendTime={{ scaling_config.scaledown_idletime * 60 }}
 
 {% for queue_name, queue_config in queues_config.items() %}

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -182,13 +182,13 @@ def raise_os_not_match(current_os, specified_os)
 end
 
 #
-# Retrieve master ip and dns from file (HIT only)
+# Retrieve head node ip and dns from file (HIT only)
 #
-def hit_master_info
-  master_private_ip_file = "#{node['cfncluster']['slurm_plugin_dir']}/master_private_ip"
-  master_private_dns_file = "#{node['cfncluster']['slurm_plugin_dir']}/master_private_dns"
+def hit_head_node_info
+  head_node_private_ip_file = "#{node['cfncluster']['slurm_plugin_dir']}/master_private_ip"
+  head_node_private_dns_file = "#{node['cfncluster']['slurm_plugin_dir']}/master_private_dns"
 
-  [IO.read(master_private_ip_file).chomp, IO.read(master_private_dns_file).chomp]
+  [IO.read(head_node_private_ip_file).chomp, IO.read(head_node_private_dns_file).chomp]
 end
 
 #
@@ -215,13 +215,13 @@ def hit_dynamodb_info
 
   raise "Failed when retrieving Compute info from DynamoDB" if output == "None"
 
-  slurm_nodename, master_private_ip, master_private_dns = output.split(/\s+/)
+  slurm_nodename, head_node_private_ip, head_node_private_dns = output.split(/\s+/)
 
   Chef::Log.info("Retrieved Slurm nodename is: #{slurm_nodename}")
-  Chef::Log.info("Retrieved master private ip: #{master_private_ip}")
-  Chef::Log.info("Retrieved master private dns: #{master_private_dns}")
+  Chef::Log.info("Retrieved head node private ip: #{head_node_private_ip}")
+  Chef::Log.info("Retrieved head node private dns: #{head_node_private_dns}")
 
-  [slurm_nodename, master_private_ip, master_private_dns]
+  [slurm_nodename, head_node_private_ip, head_node_private_dns]
 end
 
 #

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -43,7 +43,7 @@ include_recipe "aws-parallelcluster::efa_config"
 
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer'
-  include_recipe 'aws-parallelcluster::master_base_config'
+  include_recipe 'aws-parallelcluster::head_node_base_config'
 when 'ComputeFleet'
   include_recipe 'aws-parallelcluster::compute_base_config'
 else

--- a/recipes/compute_base_config.rb
+++ b/recipes/compute_base_config.rb
@@ -17,11 +17,11 @@
 
 # Retrieve master node info
 if node['cfncluster']['cfn_scheduler'] == 'slurm'
-  ruby_block "retrieve master ip" do
+  ruby_block "retrieve head_node ip" do
     block do
-      master_private_ip, master_private_dns = hit_master_info
-      node.force_default['cfncluster']['cfn_master'] = master_private_dns
-      node.force_default['cfncluster']['cfn_master_private_ip'] = master_private_ip
+      head_node_private_ip, head_node_private_dns = hit_head_node_info
+      node.force_default['cfncluster']['cfn_master'] = head_node_private_dns
+      node.force_default['cfncluster']['cfn_master_private_ip'] = head_node_private_ip
     end
     retries 5
     retry_delay 3

--- a/recipes/finalize.rb
+++ b/recipes/finalize.rb
@@ -23,7 +23,7 @@ end
 
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer'
-  include_recipe 'aws-parallelcluster::master_slurm_finalize' if node['cfncluster']['cfn_scheduler'] == 'slurm'
+  include_recipe 'aws-parallelcluster::head_node_slurm_finalize' if node['cfncluster']['cfn_scheduler'] == 'slurm'
 when 'ComputeFleet'
   if node['cfncluster']['cfn_scheduler'] == 'slurm'
     include_recipe 'aws-parallelcluster::compute_slurm_finalize'

--- a/recipes/head_node_base_config.rb
+++ b/recipes/head_node_base_config.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: master_base_config
+# Recipe:: head_node_base_config
 #
 # Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/recipes/head_node_sge_config.rb
+++ b/recipes/head_node_sge_config.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: master_sge_config
+# Recipe:: head_node_sge_config
 #
 # Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/recipes/head_node_slurm_config.rb
+++ b/recipes/head_node_slurm_config.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: master_slurm_config
+# Recipe:: head_node_slurm_config
 #
 # Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/recipes/head_node_slurm_finalize.rb
+++ b/recipes/head_node_slurm_finalize.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: master_slurm_finalize
+# Recipe:: head_node_slurm_finalize
 #
 # Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/recipes/head_node_torque_config.rb
+++ b/recipes/head_node_torque_config.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: master_torque_config
+# Recipe:: head_node_torque_config
 #
 # Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/recipes/prep_env_slurm.rb
+++ b/recipes/prep_env_slurm.rb
@@ -30,10 +30,10 @@ if node['cfncluster']['cfn_node_type'] == "ComputeFleet"
 
   ruby_block "retrieve compute node info" do
     block do
-      slurm_nodename, master_private_ip, master_private_dns = hit_dynamodb_info
+      slurm_nodename, head_node_private_ip, head_node_private_dns = hit_dynamodb_info
       node.force_default['cfncluster']['slurm_nodename'] = slurm_nodename
-      node.force_default['cfncluster']['cfn_master'] = master_private_dns
-      node.force_default['cfncluster']['cfn_master_private_ip'] = master_private_ip
+      node.force_default['cfncluster']['cfn_master'] = head_node_private_dns
+      node.force_default['cfncluster']['cfn_master_private_ip'] = head_node_private_ip
     end
     retries 5
     retry_delay 3

--- a/recipes/sge_config.rb
+++ b/recipes/sge_config.rb
@@ -20,7 +20,7 @@ include_recipe 'aws-parallelcluster::sge_install'
 
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer'
-  include_recipe 'aws-parallelcluster::master_sge_config'
+  include_recipe 'aws-parallelcluster::head_node_sge_config'
 when 'ComputeFleet'
   include_recipe 'aws-parallelcluster::compute_sge_config'
 else

--- a/recipes/slurm_config.rb
+++ b/recipes/slurm_config.rb
@@ -41,7 +41,7 @@ end
 
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer'
-  include_recipe 'aws-parallelcluster::master_slurm_config'
+  include_recipe 'aws-parallelcluster::head_node_slurm_config'
 when 'ComputeFleet'
   include_recipe 'aws-parallelcluster::compute_slurm_config'
 else

--- a/recipes/torque_config.rb
+++ b/recipes/torque_config.rb
@@ -86,7 +86,7 @@ end
 # case node['cfncluster']['cfn_node_type']
 case node['cfncluster']['cfn_node_type']
 when 'MasterServer'
-  include_recipe 'aws-parallelcluster::master_torque_config'
+  include_recipe 'aws-parallelcluster::head_node_torque_config'
 when 'ComputeFleet'
   include_recipe 'aws-parallelcluster::compute_torque_config'
 else

--- a/test/unit/slurm/test_slurm_config_generator.py
+++ b/test/unit/slurm/test_slurm_config_generator.py
@@ -76,7 +76,7 @@ def test_generate_slurm_config_files(mocker, test_datadir, tmpdir):
 
     mocker.patch("slurm.pcluster_slurm_config_generator.gethostname", return_value="ip-1-0-0-0", autospec=True)
     mocker.patch(
-        "slurm.pcluster_slurm_config_generator._get_master_private_ip", return_value="ip.1.0.0.0", autospec=True
+        "slurm.pcluster_slurm_config_generator._get_head_node_private_ip", return_value="ip.1.0.0.0", autospec=True
     )
     template_directory = os.path.dirname(slurm.__file__) + "/templates"
     generate_slurm_config_files(tmpdir, template_directory, input_file, dryrun=False)


### PR DESCRIPTION
Patch verified with the following 44 tests:

```
test-suites:
  cfn-init:
    test_cfn_init.py::test_install_args_quotes:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  cli_commands:
    test_cli_commands.py::test_hit_cli_commands:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
    test_cli_commands.py::test_sit_cli_commands:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["sge"]
  cloudwatch_logging:
    test_cloudwatch_logging.py::test_cloudwatch_logging:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  configure:
    test_pcluster_configure.py::test_pcluster_configure:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_ONE_PER_DISTRO }}
          schedulers: ["slurm", "sge"]
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
      dimensions:
        - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  dashboard:
    test_dashboard.py::test_dashboard:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
        # DCV on GPU enabled instance
        - regions: ["eu-west-1"]
          instances: ["g3.8xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_dcv.py::test_dcv_with_remote_access:
      dimensions:
        - regions: ["ap-southeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos8"]
          schedulers: ["sge"]
  disable_hyperthreading:
    test_disable_hyperthreading.py::test_hit_disable_hyperthreading:
      dimensions:
        # Manually disabled HT
        - regions: ["us-west-1"]
          instances: ["m4.xlarge"]
          oss: ["ubuntu1604"]
          schedulers: ["slurm"]
        # HT disabled via CpuOptions
        - regions: ["us-west-1"]
          instances: ["c5.xlarge"]
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  efa:
    test_efa.py::test_hit_efa:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5n.18xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
  iam_policies:
    test_iam_policies.py::test_iam_policies:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
  networking:
    test_cluster_networking.py::test_cluster_in_private_subnet:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_networking.py::test_public_network_topology:
      dimensions:
        - regions: ["eu-central-1"]
    test_networking.py::test_public_private_network_topology:
      dimensions:
        - regions: ["eu-central-1"]
    test_security_groups.py::test_additional_sg_and_ssh_from:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  scaling:
    test_scaling.py::test_hit_scaling:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_ONE_PER_DISTRO }}
          schedulers: ["slurm"]
  schedulers:
    test_sge.py::test_sge:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos8"]
          schedulers: ["sge"]
    test_torque.py::test_torque:
      dimensions:
        - regions: ["ap-northeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: {{ common.OSS_COMMERCIAL_ARM }}
          schedulers: ["torque"]
    test_awsbatch.py::test_awsbatch:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_slurm.py::test_slurm:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux"]
          schedulers: ["slurm"]
  storage:
    test_fsx_lustre.py::test_fsx_lustre:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_efs.py::test_efs_same_az:
      dimensions:
        - regions: ["ap-northeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
    test_ebs.py::test_ebs_multiple:
      dimensions:
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  tags:
    test_tag_propagation.py::test_tag_propagation:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm", "awsbatch"]
  update:
    test_update.py::test_update_awsbatch:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_update.py::test_update_hit:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
    test_update.py::test_update_sit:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["sge"]
  resource_bucket:
    test_resource_bucket.py::test_resource_bucket:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```
