### PR TITLE
Use inclusive language for recipe names and internal naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 2.10.1
 ------
 
+**CHANGES**
+- Use inclusive language in recipe names and internal naming convention.
+
 **BUG FIXES**
 - Fix installation of Intel PSXE package on CentOS 7 by using yum4.
 

--- a/files/default/cloudwatch_logs/write_cloudwatch_agent_json.py
+++ b/files/default/cloudwatch_logs/write_cloudwatch_agent_json.py
@@ -34,7 +34,7 @@ def parse_args():
                         required=True,
                         choices=['MasterServer', 'ComputeFleet'],
                         help='Role this node plays in the cluster '
-                             '(i.e., is it a compute node or the master?)')
+                             '(i.e., is it a compute node or the head node?)')
     parser.add_argument('--scheduler',
                         required=True,
                         choices=['slurm', 'sge', 'torque', 'awsbatch'],

--- a/recipes/compute_base_config.rb
+++ b/recipes/compute_base_config.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Retrieve master node info
+# Retrieve head node info
 if node['cfncluster']['cfn_scheduler'] == 'slurm'
   ruby_block "retrieve head_node ip" do
     block do

--- a/recipes/head_node_base_config.rb
+++ b/recipes/head_node_base_config.rb
@@ -141,8 +141,8 @@ nfs_export "/opt/intel" do
   only_if { ::File.directory?("/opt/intel") }
 end
 
-# Setup RAID array on master node
-include_recipe 'aws-parallelcluster::setup_raid_on_master'
+# Setup RAID array on head node
+include_recipe 'aws-parallelcluster::setup_raid_on_head_node'
 
 # Configure Ganglia
 include_recipe 'aws-parallelcluster::ganglia_config'
@@ -200,6 +200,6 @@ template '/etc/sqswatcher.cfg' do
 end
 
 if node['cfncluster']['dcv_enabled'] == "master"
-  # Activate DCV on master Node
+  # Activate DCV on head node
   include_recipe 'aws-parallelcluster::dcv_config'
 end

--- a/recipes/prep_env_slurm.rb
+++ b/recipes/prep_env_slurm.rb
@@ -25,7 +25,7 @@ directory "#{node['cfncluster']['slurm_plugin_dir']}" do
   recursive true
 end
 
-# Retrieve compute and master node info from dynamodb and save into files
+# Retrieve compute and head node info from dynamodb and save into files
 if node['cfncluster']['cfn_node_type'] == "ComputeFleet"
 
   ruby_block "retrieve compute node info" do

--- a/recipes/setup_raid_on_head_node.rb
+++ b/recipes/setup_raid_on_head_node.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: setup_raid_on_master
+# Recipe:: setup_raid_on_head_node
 #
 # Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/recipes/sge_install.rb
+++ b/recipes/sge_install.rb
@@ -168,7 +168,7 @@ when 'ComputeFleet'
     action :create
   end
 
-  # Setup sgeadmin user without creating the home (mounted from master)
+  # Setup sgeadmin user without creating the home (mounted from head node)
   user "sgeadmin" do
     manage_home false
     comment 'sgeadmin user'

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -121,7 +121,7 @@ when 'ComputeFleet'
     action :create
   end
 
-  # Setup slurm user without creating the home (mounted from master)
+  # Setup slurm user without creating the home (mounted from head node)
   user "slurm" do
     manage_home false
     comment 'slurm user'

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -55,7 +55,7 @@ execute 'grep ssh_config' do
   command 'grep -Pz "Match exec \"ssh_target_checker.sh %h\"\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null" /etc/ssh/ssh_config'
 end
 
-# Test only on MasterServer since on ComputeFleet an empty /home is mounted for the Kitchen tests run
+# Test only on head node since on compute fleet an empty /home is mounted for the Kitchen tests run
 if node['cfncluster']['cfn_node_type'] == 'MasterServer'
   execute 'ssh localhost as user' do
     command "ssh localhost hostname"
@@ -283,7 +283,7 @@ if node['conditions']['intel_mpi_supported']
     end
   end
 
-  # Test only on MasterServer since on compute nodes we mount an empty /opt/intel drive in kitchen tests that
+  # Test only on head node since on compute nodes we mount an empty /opt/intel drive in kitchen tests that
   # overrides intel binaries.
   if node['cfncluster']['cfn_node_type'] == 'MasterServer'
     bash 'check intel mpi version' do

--- a/recipes/update_head_node.rb
+++ b/recipes/update_head_node.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: update_master
+# Recipe:: update_head_node
 #
 # Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
@@ -17,5 +17,5 @@
 
 
 if node['cfncluster']['cfn_scheduler'] == 'slurm'
-  include_recipe 'aws-parallelcluster::update_master_slurm'
+  include_recipe 'aws-parallelcluster::update_head_node_slurm'
 end

--- a/recipes/update_head_node_slurm.rb
+++ b/recipes/update_head_node_slurm.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: update_master_slurm
+# Recipe:: update_head_node_slurm
 #
 # Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/templates/default/fetch_and_run.erb
+++ b/templates/default/fetch_and_run.erb
@@ -21,7 +21,7 @@ function download_run (){
       wget -qO- ${url} > $tmpfile || return 1
     fi
     chmod +x $tmpfile || return 1
-    $tmpfile $@ || error_exit "Failed to run boot_as_master $ACTION, $file failed with non 0 return code: $?"
+    $tmpfile $@ || error_exit "Failed to run $ACTION, $file failed with non 0 return code: $?"
 }
 
 function run_preinstall () {
@@ -32,7 +32,7 @@ function run_preinstall () {
     else
         download_run ${cfn_preinstall}
     fi
-  fi || error_exit "Failed to run boot_as_master preinstall"
+  fi || error_exit "Failed to run preinstall"
 }
 
 function run_postinstall () {
@@ -44,7 +44,7 @@ function run_postinstall () {
     else
         download_run ${cfn_postinstall}
     fi
-  fi || error_exit "Failed to run boot_as_master postinstall"
+  fi || error_exit "Failed to run postinstall"
 }
 
 ACTION=${1#?}


### PR DESCRIPTION
+ Rename master to head node in comments and internal messages

Note: This patch requires a change in the CLI package: https://github.com/aws/aws-parallelcluster/pull/2275 because of the update recipe renaming.

Patch verified with the following 44 tests:

```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  cfn-init:
    test_cfn_init.py::test_install_args_quotes:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  cli_commands:
    test_cli_commands.py::test_hit_cli_commands:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
    test_cli_commands.py::test_sit_cli_commands:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["sge"]
  cloudwatch_logging:
    test_cloudwatch_logging.py::test_cloudwatch_logging:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  configure:
    test_pcluster_configure.py::test_pcluster_configure:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_ONE_PER_DISTRO }}
          schedulers: ["slurm", "sge"]
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
      dimensions:
        - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  createami:
    test_createami.py::test_createami:
      dimensions:
        - regions: ["eu-west-3"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux"] # temporary disable FPGA AMI since there is not enough free space on root partition
    test_createami.py::test_createami_post_install:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
  dashboard:
    test_dashboard.py::test_dashboard:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
        # DCV on GPU enabled instance
        - regions: ["eu-west-1"]
          instances: ["g3.8xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_dcv.py::test_dcv_with_remote_access:
      dimensions:
        - regions: ["ap-southeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos8"]
          schedulers: ["sge"]
  disable_hyperthreading:
    test_disable_hyperthreading.py::test_hit_disable_hyperthreading:
      dimensions:
        # Manually disabled HT
        - regions: ["us-west-1"]
          instances: ["m4.xlarge"]
          oss: ["ubuntu1604"]
          schedulers: ["slurm"]
        # HT disabled via CpuOptions
        - regions: ["us-west-1"]
          instances: ["c5.xlarge"]
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  efa:
    test_efa.py::test_hit_efa:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5n.18xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
  iam_policies:
    test_iam_policies.py::test_iam_policies:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
  networking:
    test_cluster_networking.py::test_cluster_in_private_subnet:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_networking.py::test_public_network_topology:
      dimensions:
        - regions: ["eu-central-1"]
    test_networking.py::test_public_private_network_topology:
      dimensions:
        - regions: ["eu-central-1"]
    test_security_groups.py::test_additional_sg_and_ssh_from:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  scaling:
    test_scaling.py::test_hit_scaling:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_ONE_PER_DISTRO }}
          schedulers: ["slurm"]
  schedulers:
    test_sge.py::test_sge:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos8"]
          schedulers: ["sge"]
    test_torque.py::test_torque:
      dimensions:
        - regions: ["ap-northeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: {{ common.OSS_COMMERCIAL_ARM }}
          schedulers: ["torque"]
    test_awsbatch.py::test_awsbatch:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_slurm.py::test_slurm:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux"]
          schedulers: ["slurm"]
  storage:
    test_fsx_lustre.py::test_fsx_lustre:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_efs.py::test_efs_same_az:
      dimensions:
        - regions: ["ap-northeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
    test_ebs.py::test_ebs_multiple:
      dimensions:
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  tags:
    test_tag_propagation.py::test_tag_propagation:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm", "awsbatch"]
  update:
    test_update.py::test_update_awsbatch:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_update.py::test_update_hit:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
    test_update.py::test_update_sit:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["sge"]
  resource_bucket:
    test_resource_bucket.py::test_resource_bucket:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```
