### PR TITLE
Fix routing with multiple Network Interfaces in Ubuntu 1804

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Fix installation of Intel PSXE package on CentOS 7 by using yum4.
+- Fix routing issues with multiple Network Interfaces on Ubuntu 18.04.
 
 2.10.0
 ------


### PR DESCRIPTION
When private IP addresses are assigned to network interfaces, kernel creates automatic routes to the subnet. Since all multiple Network Interfaces are on the same subnet and these routes have all the same metrics (0 by default), the order by which they are declared determines which Network Interface will be used to reach other nodes on the same subnet.
In Ubuntu 18 the order of these routes is reverted from that of the devices and this makes a secondary interface being selected to connect to other nodes in the subnet. This breaks the contract by which compute nodes are expected to work in ParallelCluster and can lead to unexpected failures, for instance when MPI jobs are run with Ubuntu 18 and SGE scheduler. This in turn is due to the way SGE resolves the hostnames starting from node IPs: since compute nodes can be contacted from secondary Network Interfaces of other nodes the resolved hostname won't match with the real one asigned to the node, leading to errors like this:
```
error: commlib error: access denied (client IP resolved to host name "ip-172-31-45-139.us-west-2.compute.internal". This is not identical to clients host name "ip-172-31-34-150.us-west-2.compute.internal")
```

This commit fixes this issue by ensuring that the primary network interface is selected to contact other nodes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
