### PR TITLE
Enable EFA driver installation on all ARM platforms but Centos8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,16 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **ENHANCEMENTS**
 - Configure NFS threads to be max(8, num_cores) for performance. This enhancement will not take effect on Ubuntu 16.04 unless the instance is rebooted.
+- EFA kernel module now installed also on ARM instances with `alinux2` and `ubuntu1804`
 
 **CHANGES**
+- Upgrade EFA installer to version 1.11.0
+  - EFA configuration: ``efa-config-1.5`` (from efa-config-1.4)
+  - EFA profile: ``efa-profile-1.1`` (from efa-profile-1.0.0)
+  - EFA kernel module: ``efa-1.10.2`` (from efa-1.6.0)
+  - RDMA core: ``rdma-core-31.2amzn`` (from rdma-core-31.amzn0)
+  - Libfabric: ``libfabric-1.11.1amzn1.1`` (from libfabric-1.10.1amzn1.1)
+  - Open MPI: ``openmpi40-aws-4.0.5`` (from openmpi40-aws-4.0.3)
 - Upgrade NICE DCV to version 2020.2-9662
 - Use inclusive language in recipe names and internal naming convention.
 - Download Intel MPI and HPC packages from S3 rather than Intel yum repos.

--- a/attributes/conditions.rb
+++ b/attributes/conditions.rb
@@ -20,5 +20,6 @@ default['conditions']['intel_mpi_supported'] = !arm_instance?
 default['conditions']['intel_hpc_platform_supported'] = !arm_instance? && platform_supports_intel_hpc_platform?
 default['conditions']['dcv_supported'] = platform_supports_dcv?
 default['conditions']['ami_bootstrapped'] = ami_bootstrapped?
+default['conditions']['efa_supported'] = !arm_instance? || (node['cfncluster']['cfn_base_os'] != "centos8")
 default['conditions']['overwrite_nfs_template'] = overwrite_nfs_template?
 default['conditions']['arm_pl_supported'] = arm_instance?

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -138,7 +138,7 @@ default['cfncluster']['nvidia']['fabricmanager']['repository_uri'] = value_for_p
 )
 
 # EFA
-default['cfncluster']['efa']['installer_version'] = '1.10.1'
+default['cfncluster']['efa']['installer_version'] = '1.11.0'
 default['cfncluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cfncluster']['efa']['installer_version']}.tar.gz"
 default['cfncluster']['enable_efa_gdr'] = "no"
 

--- a/recipes/efa_install.rb
+++ b/recipes/efa_install.rb
@@ -42,8 +42,8 @@ when 'debian'
 end
 
 installer_options = "-y"
-# efa-kmod currently unavailable for ARM instances
-installer_options += " -k" if arm_instance?
+# skip efa-kmod installation on not supported platforms
+installer_options += " -k" unless node['conditions']['efa_supported']
 # enable gpudirect support
 installer_options += " -g" if efa_gdr_enabled?
 


### PR DESCRIPTION
This commit removes the `--skip-kmod` argument on ARM instances, thus enabling the EFA driver to be installed in all platforms except for Centos8, which is currently still unsupported. The pinned version of the EFA installer is under development and will be replaced as soon at the official one will be available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
