### PR TITLE
CentOS 8 PowerTools repo needs to be lowercase in newer kernel versions

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -332,11 +332,13 @@ default['cfncluster']['lustre']['public_key'] = value_for_platform(
   'centos' => { '>=7.7' => "https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc" },
   'ubuntu' => { 'default' => "https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-ubuntu-public-key.asc" }
 )
+# Lustre repo string is built following the official doc
+# https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html
 default['cfncluster']['lustre']['base_url'] = value_for_platform(
   'centos' => {
     # node['kernel']['machine'] contains the architecture: 'x86_64' or 'aarch64'
-    '>=8' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8#{find_rhel_minor_version}/#{node['kernel']['machine']}/",
-    'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7#{find_rhel_minor_version}/x86_64/"
+    '>=8' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8.#{find_rhel_minor_version}/#{node['kernel']['machine']}/",
+    'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/el/7.#{find_rhel_minor_version}/x86_64/"
   },
   'ubuntu' => { 'default' => "https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu" }
 )

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -330,15 +330,13 @@ def find_rhel_minor_version
     kernel_patch_version = node['kernel']['release'].match(/^\d+\.\d+\.\d+-(\d+)\..*$/)
     raise "Unable to retrieve the kernel patch version from #{node['kernel']['release']}." unless kernel_patch_version
 
-    # Lustre repo string will be built following the official doc
-    # https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html
     if node['platform_version'].to_i == 7
-      os_minor_version = '.7' if kernel_patch_version[1] >= '1062'
-      os_minor_version = '.8' if kernel_patch_version[1] >= '1127'
-      os_minor_version = '.9' if kernel_patch_version[1] >= '1160'
+      os_minor_version = '7' if kernel_patch_version[1] >= '1062'
+      os_minor_version = '8' if kernel_patch_version[1] >= '1127'
+      os_minor_version = '9' if kernel_patch_version[1] >= '1160'
     elsif node['platform_version'].to_i == 8
-      os_minor_version = '.2' if kernel_patch_version[1] >= '193'
-      os_minor_version = '.3' if kernel_patch_version[1] >= '240'
+      os_minor_version = '2' if kernel_patch_version[1] >= '193'
+      os_minor_version = '3' if kernel_patch_version[1] >= '240'
     else
       raise "CentOS version #{node['platform_version']} not supported."
     end

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -32,10 +32,10 @@ when 'rhel', 'amazon'
     end
   end
   if node['platform'] == 'centos' && node['platform_version'].to_i == 8
-    # Enable PowerTools Repo so *-devel packages can be installed with DNF
-    # Enable EPEL repos
-    execute 'dnf enable powertools and EPEL repos' do
-      command "dnf config-manager --set-enabled PowerTools && dnf install -y epel-release"
+    # Enable powertools repo so *-devel packages can be installed with DNF
+    powertools_repo = find_rhel_minor_version <= '2' ? "PowerTools" : "powertools"
+    execute 'dnf enable powertools' do
+      command "dnf config-manager --set-enabled #{powertools_repo}"
     end
   end
 


### PR DESCRIPTION
We're enabling `PowerTools` or `powertools` according to the kernel version:
https://access.redhat.com/articles/3078#RHEL8

The name changed with 8.3 release:
https://bugzilla.redhat.com/show_bug.cgi?id=1900785

## Additional changes

I changed the `find_rhel_minor_version` to return just a number, without the `.` character to be easier to compare it.

With this patch I'm also removing `epel-release` installation which is already performed as a packer step.


