### PR TITLE
Fix NFS Threads kitchen test by restarting NFS before checking threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **ENHANCEMENTS**
-- Configure NFS threads to be max(8, num_cores) for performance
+- Configure NFS threads to be max(8, num_cores) for performance. This enhancement will not take effect on Ubuntu 16.04 unless the instance is rebooted.
 
 **CHANGES**
 - Upgrade NICE DCV to version 2020.2-9662

--- a/recipes/nfs_config.rb
+++ b/recipes/nfs_config.rb
@@ -15,7 +15,11 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# For performance, set NFS threads to max(num_cores, 8); note cores, not vcpus
+# For performance, set NFS threads to max(num_cores, 8)
+# This change will not be effective on Ubuntu1604 unless instance is restarted
+# Changing thread in /etc/default/nfs-kernel-server and restarting NFS server will not change nfsd settings for Ubuntu1604
+# See: https://ubuntuforums.org/showthread.php?t=2345636
+# NFS threads enhancement is omitted for Ubuntu1604
 node.force_override['nfs']['threads'] = [node['cpu']['cores'].to_i, 8].max
 
 if node['platform'] == 'centos' && node['platform_version'].to_i == 8
@@ -36,4 +40,9 @@ if node['conditions']['overwrite_nfs_template']
     source 'nfs.conf.erb'
     cookbook 'aws-parallelcluster'
   end
+end
+
+# Explicitly restart NFS server for thread setting to take effect
+service node['nfs']['service']['server'] do
+  action :restart
 end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -480,13 +480,16 @@ elsif node['cfncluster']['cfn_node_type'] == 'MasterServer'
   end
 end
 
-ruby_block 'check nfs threads' do
-  block do
-    nfs_threads = shell_out!("cat /proc/net/rpc/nfsd | grep th | awk '{print$2}'").stdout.strip.to_i
-    Chef::Log.debug("nfs threads configured on machine is #{nfs_threads}")
-    expected_threads = [node['cpu']['cores'].to_i, 8].max
-    if nfs_threads != expected_threads
-      raise "Expected number of nfs threads configured to be #{expected_threads} but is actually #{nfs_threads}"
+# Skip nfs thread test for ubuntu16 because nfs thread enhancement is omitted
+unless node['platform'] == 'ubuntu' && node['platform_version'].to_f == 16.04
+  ruby_block 'check nfs threads' do
+    block do
+      nfs_threads = shell_out!("cat /proc/net/rpc/nfsd | grep th | awk '{print$2}'").stdout.strip.to_i
+      Chef::Log.debug("nfs threads configured on machine is #{nfs_threads}")
+      expected_threads = [node['cpu']['cores'].to_i, 8].max
+      if nfs_threads != expected_threads
+        raise "Expected number of nfs threads configured to be #{expected_threads} but is actually #{nfs_threads}"
+      end
     end
   end
 end


### PR DESCRIPTION
* Notifications to restart NFS are queued at the end of Chef run by default
* This causes the kitchen test to fail because NFS server does not restart and load updated NFS config before tests recipe runs
* Add logic in kitchen test to restart NFS so that new config is loaded before checking NFS threads. Actual cluster creation case always worked because services are restarted at the end of chef run
* Add notification to restart NFS when overwriting template. Originally restart was triggered anyway from nfs::_common, but adding this notification as a reassurance that NFS needs to be restarted after config is modified

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
