### PR TITLE
Use retry mechanism in apt_update when adding package repo

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -378,7 +378,10 @@ def add_package_repository(repo_name, baseurl, gpgkey, distribution)
       retries 3
       retry_delay 5
     end
-    apt_update
+    apt_update 'update' do
+      retries 3
+      retry_delay 5
+    end
   else
     raise "platform not supported: #{node['platform_family']}"
   end


### PR DESCRIPTION
Failures with `apt update` have been registered in China regions due to networking issues. Adding retry mechanism to try to mitigate the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
