### PR TITLE
Add clustermgtd heartbeat path to resume and suspend program configs

### DIFF
--- a/recipes/head_node_slurm_config.rb
+++ b/recipes/head_node_slurm_config.rb
@@ -164,7 +164,7 @@ end
 directory "/opt/slurm/etc/pcluster/.slurm_plugin" do
   user 'root'
   group 'root'
-  mode '0644'
+  mode '0755'
   action :create
   recursive true
 end

--- a/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
+++ b/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
@@ -8,3 +8,4 @@ dns_domain = <%= node['cfncluster']['cfn_dns_domain'] %>
 use_private_hostname = <%= node['cfncluster']['use_private_hostname'] %>
 master_private_ip = <%= node['ec2']['local_ipv4'] %>
 master_hostname = <%= node['ec2']['local_hostname'] %>
+clustermgtd_heartbeat_file_path = /opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat

--- a/templates/default/slurm/parallelcluster_slurm_suspend.conf.erb
+++ b/templates/default/slurm/parallelcluster_slurm_suspend.conf.erb
@@ -1,1 +1,2 @@
 [slurm_suspend]
+clustermgtd_heartbeat_file_path = /opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat


### PR DESCRIPTION
* Add clustermgtd heartbeat file path to resume program and suspend program config, so cloud bursting program can have logic to prevent cluster usage when clustermgtd is down
* Change permission of /opt/slurm/etc/pcluster/.slurm_plugin from 0644 to 0755 so files in the directory can be listed and read
* Related to https://github.com/aws/aws-parallelcluster-node/pull/272

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
