### PR TITLE
Disable x/gdm daemon on compute instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **ENHANCEMENTS**
 - Configure NFS threads to be max(8, num_cores) for performance. This enhancement will not take effect on Ubuntu 16.04 unless the instance is rebooted.
 - EFA kernel module now installed also on ARM instances with `alinux2` and `ubuntu1804`
+- Set default systemd runlevel to multi-user.target on all OSes during ami creation. The runlevel is set to graphical.target only when DCV is enabled.
 
 **CHANGES**
 - Upgrade EFA installer to version 1.11.0

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -227,11 +227,11 @@ if node['conditions']['dcv_supported']
       only_if 'which getenforce'
     end
   end
+end
 
-  # Switch runlevel to multi-user.target
-  if node['init_package'] == 'systemd'
-    execute "set default systemd runlevel to multi-user.target" do
-      command "systemctl set-default multi-user.target"
-    end
+# Switch runlevel to multi-user.target
+if node['init_package'] == 'systemd'
+  execute "set default systemd runlevel to multi-user.target" do
+    command "systemctl set-default multi-user.target"
   end
 end

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -227,4 +227,11 @@ if node['conditions']['dcv_supported']
       only_if 'which getenforce'
     end
   end
+
+  # Switch runlevel to multi-user.target
+  if node['init_package'] == 'systemd'
+    execute "set default systemd runlevel to multi-user.target" do
+      command "systemctl set-default multi-user.target"
+    end
+  end
 end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -250,6 +250,20 @@ if node['cfncluster']['cfn_node_type'] == "MasterServer" &&
   end
 end
 
+if node['cfncluster']['dcv_enabled'] == "false" || node['cfncluster']['cfn_node_type'] == "ComputeFleet"
+  execute 'check gdm service is disabled' do
+    command "systemctl status gdm.service | grep inactive"
+    user node['cfncluster']['cfn_cluster_user']
+  end
+end
+
+if node['cfncluster']['dcv_enabled'] == "master" && node['cfncluster']['cfn_node_type'] == "MasterServer" && (node['cfncluster']['os'] == "ubuntu1804" || node['cfncluster']['os'] == "alinux2")
+  execute 'check gdm service is enabled' do
+    command "systemctl status gdm.service | grep running"
+    user node['cfncluster']['cfn_cluster_user']
+  end
+end
+
 ###################
 # EFA - Intel MPI
 ###################

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -259,7 +259,7 @@ if node['conditions']['dcv_supported'] && node['cfncluster']['dcv_enabled'] == "
       command "systemctl show -p SubState gdm | grep -i running"
     end
   end
-else
+elsif node['init_package'] == 'systemd'
   execute 'check systemd default runlevel' do
     command "systemctl get-default | grep -i multi-user.target"
   end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -252,7 +252,7 @@ end
 
 if node['conditions']['dcv_supported'] && node['cfncluster']['dcv_enabled'] == "master" && node['cfncluster']['cfn_node_type'] == "MasterServer"
   execute 'check systemd default runlevel' do
-    command "systemctl get-default | grep -i grephical.target"
+    command "systemctl get-default | grep -i graphical.target"
   end
   if node['cfncluster']['os'] == "ubuntu1804" || node['cfncluster']['os'] == "alinux2"
     execute 'check gdm service is running' do


### PR DESCRIPTION
* Set default systemd runlevel to multi-user.target on all OSes during ami creation. The runlevel is set to graphical.target only when DCV is enabled.
* In ParallelCluster 2.10.0, centos7/centos8 use multi-user.target and ubuntu1804/alinux2 use graphical.target. multi-user.target won't start x/gdm service when booting. So, the solution is during ubuntu1804/alinux2 AMI build, switching graphical.target to multi-user.target to disable x/gdm service, then if dcv is enabled, switch multi-user.target to graphical.target and enable x/gdm service on head node.
* Manually test
```
pcluster dcv connect -k {aws_key} cluster
pcluster dcv connect -k {aws_key} --show-url cluster
connect to http://{public_ip}/ganglia
```
* Build and test
centos8 and ubuntu1804+arm have failure due to lustre_client, will test them when OSes are fixed.
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  cfn-init:
    test_cfn_init.py::test_install_args_quotes:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  cli_commands:
    test_cli_commands.py::test_hit_cli_commands:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
    test_cli_commands.py::test_sit_cli_commands:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["sge"]
  cloudwatch_logging:
    test_cloudwatch_logging.py::test_cloudwatch_logging:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  configure:
    test_pcluster_configure.py::test_pcluster_configure:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_ONE_PER_DISTRO }}
          schedulers: ["slurm", "sge"]
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
      dimensions:
        - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  createami:
    test_createami.py::test_createami:
      dimensions:
        - regions: ["eu-west-3"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux"] # temporary disable FPGA AMI since there is not enough free space on root partition
    test_createami.py::test_createami_post_install:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
  dashboard:
    test_dashboard.py::test_dashboard:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
        # DCV on GPU enabled instance
        - regions: ["eu-west-1"]
          instances: ["g3.8xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_dcv.py::test_dcv_with_remote_access:
      dimensions:
        - regions: ["ap-southeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos8"]
          schedulers: ["sge"]
  disable_hyperthreading:
    test_disable_hyperthreading.py::test_hit_disable_hyperthreading:
      dimensions:
        # Manually disabled HT
        - regions: ["us-west-1"]
          instances: ["m4.xlarge"]
          oss: ["ubuntu1604"]
          schedulers: ["slurm"]
        # HT disabled via CpuOptions
        - regions: ["us-west-1"]
          instances: ["c5.xlarge"]
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  efa:
    test_efa.py::test_hit_efa:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5n.18xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
  iam_policies:
    test_iam_policies.py::test_iam_policies:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
  networking:
    test_cluster_networking.py::test_cluster_in_private_subnet:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_networking.py::test_public_network_topology:
      dimensions:
        - regions: ["eu-central-1"]
    test_networking.py::test_public_private_network_topology:
      dimensions:
        - regions: ["eu-central-1"]
    test_security_groups.py::test_additional_sg_and_ssh_from:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  scaling:
    test_scaling.py::test_hit_scaling:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_ONE_PER_DISTRO }}
          schedulers: ["slurm"]
  schedulers:
    test_sge.py::test_sge:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos8"]
          schedulers: ["sge"]
    test_torque.py::test_torque:
      dimensions:
        - regions: ["ap-northeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: {{ common.OSS_COMMERCIAL_ARM }}
          schedulers: ["torque"]
    test_awsbatch.py::test_awsbatch:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_slurm.py::test_slurm:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux"]
          schedulers: ["slurm"]
  storage:
    test_fsx_lustre.py::test_fsx_lustre:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_efs.py::test_efs_same_az:
      dimensions:
        - regions: ["ap-northeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
    test_ebs.py::test_ebs_multiple:
      dimensions:
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  tags:
    test_tag_propagation.py::test_tag_propagation:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm", "awsbatch"]
  update:
    test_update.py::test_update_awsbatch:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_update.py::test_update_hit:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
    test_update.py::test_update_sit:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["sge"]
  resource_bucket:
    test_resource_bucket.py::test_resource_bucket:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
