### PR TITLE
Install SGE from Debian sources in Ubuntu18

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -302,7 +302,8 @@ when 'debian'
   if node['platform_version'] == '18.04'
     default['cfncluster']['base_packages'].delete('libatlas-dev')
     default['cfncluster']['base_packages'].push('libatlas-base-dev', 'libssl-dev', 'libglvnd-dev')
-    default['cfncluster']['sge']['version'] = '8.1.9+dfsg-9build2'
+    default['cfncluster']['sge']['url'] = 'https://deb.debian.org/debian/pool/main/g/gridengine/gridengine_8.1.9+dfsg.orig.tar.gz'
+    default['cfncluster']['sge']['version'] = '8.1.9+dfsg-9'
   end
 
   # Modulefile Directory


### PR DESCRIPTION
This align with the same build path used in Alinux2 and allows to point to a source package without a `build` substring in the name.

Test suite
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  schedulers:
    test_sge.py::test_sge:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["sge"]
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["ubuntu1804"]
          schedulers: ["sge"]
  scaling:
    test_scaling.py::test_multiple_jobs_submission:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["sge"]
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["ubuntu1804"]
          schedulers: ["sge"]    
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
