### PR TITLE
Upgrade to Intel MPI U8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Use inclusive language in recipe names and internal naming convention.
 - Download Intel MPI and HPC packages from S3 rather than Intel yum repos.
 - Install Arm Performance Library 20.2.1 on ARM AMI(CentOS8, Alinux2, Ubuntu1804)
+- Upgrade Intel MPI to version U8.
 
 **BUG FIXES**
 - Fix installation of Intel PSXE package on CentOS 7 by using yum4.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -64,9 +64,9 @@ default['cfncluster']['intelpython2']['version'] = '2019.4-088'
 default['cfncluster']['intelpython3']['version'] = '2020.2-902'
 
 # Intel MPI
-default['cfncluster']['intelmpi']['version'] = '2019.7.217'
+default['cfncluster']['intelmpi']['version'] = '2019.8.254'
 default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/impi/#{node['cfncluster']['intelmpi']['version']}/intel64/modulefiles/mpi"
-default['cfncluster']['intelmpi']['kitchen_test_string'] = 'Version 2019 Update 7'
+default['cfncluster']['intelmpi']['kitchen_test_string'] = 'Version 2019 Update 8'
 
 # Arm Performance Library
 default['cfncluster']['armpl']['version'] = '20.2.1'


### PR DESCRIPTION
Intel MPI U8 relies on fixes provided by the newest version of the EFA installer provided by #829.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
