### PR TITLE
Set MODULEPATH config path based on CentOS version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -254,6 +254,14 @@ when 'rhel', 'amazon'
   default['cfncluster']['modulefile_dir'] = "/usr/share/Modules/modulefiles"
   # MODULESHOME
   default['cfncluster']['moduleshome'] = "/usr/share/Modules"
+  # Config file used to set default MODULEPATH list
+  default['cfncluster']['modulepath_config_file'] = value_for_platform(
+    'centos' => {
+      '~>8' => '/etc/environment-modules/modulespath',
+      '~>7' => "#{node['cfncluster']['moduleshome']}/init/.modulespath"
+    },
+    'amazon' => { 'default' => "#{node['cfncluster']['moduleshome']}/init/.modulespath" }
+  )
 
   case node['platform']
   when 'centos', 'redhat', 'scientific' # ~FC024
@@ -336,6 +344,8 @@ when 'debian'
   default['cfncluster']['modulefile_dir'] = "/usr/share/modules/modulefiles"
   # MODULESHOME
   default['cfncluster']['moduleshome'] = "/usr/share/modules"
+  # Config file used to set default MODULEPATH list
+  default['cfncluster']['modulepath_config_file'] = "#{node['cfncluster']['moduleshome']}/init/.modulespath"
   default['cfncluster']['kernel_generic_pkg'] = "linux-generic"
   default['cfncluster']['ganglia']['gmond_service'] = 'ganglia-monitor'
   default['cfncluster']['ganglia']['httpd_service'] = 'apache2'

--- a/recipes/intel_mpi.rb
+++ b/recipes/intel_mpi.rb
@@ -46,7 +46,7 @@ bash "install intel mpi" do
 end
 
 append_if_no_line "append intel modules file dir to modules conf" do
-  path "#{node['cfncluster']['moduleshome']}/init/.modulespath"
+  path node['cfncluster']['modulepath_config_file']
   line "/opt/intel/impi/#{node['cfncluster']['intelmpi']['version']}/intel64/modulefiles/"
 end
 


### PR DESCRIPTION
As part of the change from CentOS 8.2 to CentOS 8.3, the environment
modules package installed by default changed from
environment-modules-4.1.4-4 to environment-modules-4.5.2-1. According to
a changelog from rpmfind.net (linked at the end of this commit message),
one of the changes is to 'Make .modulespath a config file'. With this
change, it seems the value of the MODULEPATH environment variable (used
to tell the `module` command which directories to search) must be
configured via /etc/environment-modules/modulespath rather than
/usr/share/Modules/init/.modulespath. This commit sets this path
dynamically based on the OS in use.

Link to info for RPM providing environment-modules-4.5.2-1:
http://rpmfind.net/linux/RPM/centos/8-stream/baseos/x86_64/Packages/environment-modules-4.5.2-1.el8.x86_64.html

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
