### PR TITLE
Switch to multi_user.target runlevel only for official ami build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **ENHANCEMENTS**
 - Configure NFS threads to be max(8, num_cores) for performance. This enhancement will not take effect on Ubuntu 16.04 unless the instance is rebooted.
 - EFA kernel module now installed also on ARM instances with `alinux2` and `ubuntu1804`
-- Set default systemd runlevel to multi-user.target on all OSes during ami creation. The runlevel is set to graphical.target only when DCV is enabled.
+- Set default systemd runlevel to multi-user.target on all OSes during ParallelCluster official ami creation. The runlevel is set to graphical.target on head node only when DCV is enabled.
 
 **CHANGES**
 - Upgrade EFA installer to version 1.11.0

--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -226,6 +226,7 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
+          "is_official_ami": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "alinux"
         }

--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -226,7 +226,7 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
-          "is_official_ami": "true",
+          "is_official_ami_build": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "alinux"
         }

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -226,7 +226,7 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
-          "is_official_ami": "true",
+          "is_official_ami_build": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "alinux2"
         }

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -226,6 +226,7 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
+          "is_official_ami": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "alinux2"
         }

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -245,6 +245,7 @@
           "dcv": {
             "installed" : "{{user `dcv_installed`}}"
           },
+          "is_official_ami": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "centos7"
         }

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -245,7 +245,7 @@
           "dcv": {
             "installed" : "{{user `dcv_installed`}}"
           },
-          "is_official_ami": "true",
+          "is_official_ami_build": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "centos7"
         }

--- a/amis/packer_centos8.json
+++ b/amis/packer_centos8.json
@@ -241,7 +241,7 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
-          "is_official_ami": "true",
+          "is_official_ami_build": "true",
           "dcv": {
             "installed" : "{{user `dcv_installed`}}"
           },

--- a/amis/packer_centos8.json
+++ b/amis/packer_centos8.json
@@ -241,6 +241,7 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
+          "is_official_ami": "true",
           "dcv": {
             "installed" : "{{user `dcv_installed`}}"
           },

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -247,6 +247,7 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
+          "is_official_ami": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "ubuntu1604"
         }

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -247,7 +247,7 @@
           "nvidia" : {
             "enabled" : "{{user `nvidia_enabled`}}"
           },
-          "is_official_ami": "true",
+          "is_official_ami_build": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "ubuntu1604"
         }

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -251,7 +251,7 @@
           "dcv": {
             "installed" : "{{user `dcv_installed`}}"
           },
-          "is_official_ami": "true",
+          "is_official_ami_build": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "ubuntu1804"
         }

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -251,6 +251,7 @@
           "dcv": {
             "installed" : "{{user `dcv_installed`}}"
           },
+          "is_official_ami": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
           "cfn_base_os" : "ubuntu1804"
         }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -439,4 +439,4 @@ default['cfncluster']['scheduler_queue_name'] = nil
 default['cfncluster']['aws_domain'] = aws_domain
 
 # Official ami build
-default['cfncluster']['is_official_ami'] = true
+default['cfncluster']['is_official_ami'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -439,4 +439,4 @@ default['cfncluster']['scheduler_queue_name'] = nil
 default['cfncluster']['aws_domain'] = aws_domain
 
 # Official ami build
-default['cfncluster']['is_official_ami'] = false
+default['cfncluster']['is_official_ami_build'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -437,3 +437,6 @@ default['cfncluster']['scheduler_queue_name'] = nil
 
 # AWS domain
 default['cfncluster']['aws_domain'] = aws_domain
+
+# Official ami build
+default['cfncluster']['is_official_ami'] = true

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -230,7 +230,7 @@ if node['conditions']['dcv_supported']
 end
 
 # Switch runlevel to multi-user.target for official ami
-if node['cfncluster']['is_official_ami']
+if node['cfncluster']['is_official_ami_build']
   if node['init_package'] == 'systemd'
     execute "set default systemd runlevel to multi-user.target" do
       command "systemctl set-default multi-user.target"

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -229,9 +229,11 @@ if node['conditions']['dcv_supported']
   end
 end
 
-# Switch runlevel to multi-user.target
-if node['init_package'] == 'systemd'
-  execute "set default systemd runlevel to multi-user.target" do
-    command "systemctl set-default multi-user.target"
+# Switch runlevel to multi-user.target for official ami
+if node['cfncluster']['is_official_ami']
+  if node['init_package'] == 'systemd'
+    execute "set default systemd runlevel to multi-user.target" do
+      command "systemctl set-default multi-user.target"
+    end
   end
 end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -259,7 +259,7 @@ if node['conditions']['dcv_supported'] && node['cfncluster']['dcv_enabled'] == "
       command "systemctl show -p SubState gdm | grep -i running"
     end
   end
-elsif node['init_package'] == 'systemd'
+elsif node['init_package'] == 'systemd' && node['conditions']['ami_bootstrapped']
   execute 'check systemd default runlevel' do
     command "systemctl get-default | grep -i multi-user.target"
   end


### PR DESCRIPTION
* Add a new attribute `is_official_ami_build` to cookbook to distinguish official ami build and custom ami build
* Switch to user_multi.target runlevel only for official ami build

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
