### PR TITLE
Restart sshd.service to make sure the service is running

### DIFF
--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -17,6 +17,16 @@
 
 include_recipe 'aws-parallelcluster::base_install'
 
+# Restart sshd.service to make sure the service is running
+# This is a workaround for Centos 8 where the sshd.service fails at first start since it does not properly
+# wait for cloud-init.service to start. There is something wrong in Centos 8 systemd dependency chain.
+if node['platform'] == 'centos' && node['platform_version'].to_i == 8
+  service "sshd" do
+    supports restart: true
+    action %i[enable restart]
+  end
+end
+
 include_recipe 'aws-parallelcluster::nfs_config'
 
 # Setup ephemeral drives


### PR DESCRIPTION
### Root cause summary
* By looking at the `/val/log/messages` logs we noticed that the `sshd` service fails to start during the first attempt because it is not able to load the host keys. While these host keys were generated by `sshd-keygen` (that is a dependency of the sshd.service target), as reported in the /var/log/messages, the same are removed by `cloud-init` that replaces the keys when running its ssh module that takes care of configuring SSH on the instance. (Note that the ssh module of cloud-init runs by default and does not depend on ParallelCluster)

```
[centos@ip-172-31-33-169 ~]$ sudo cat /var/log/messages | grep ssh
Dec 17 09:32:35 ip-172-31-33-169 systemd[1]: sshd-keygen@rsa.service: Succeeded.
Dec 17 09:32:35 ip-172-31-33-169 systemd[1]: sshd-keygen@ecdsa.service: Succeeded.
Dec 17 09:32:35 ip-172-31-33-169 systemd[1]: sshd-keygen@ed25519.service: Succeeded.
Dec 17 09:32:35 ip-172-31-33-169 systemd[1]: Reached target sshd-keygen.target.
Dec 17 09:32:50 ip-172-31-33-169 sshd[1235]: Unable to load host key: /etc/ssh/ssh_host_rsa_key
Dec 17 09:32:50 ip-172-31-33-169 sshd[1235]: Unable to load host key: /etc/ssh/ssh_host_ecdsa_key
Dec 17 09:32:50 ip-172-31-33-169 sshd[1235]: Unable to load host key: /etc/ssh/ssh_host_ed25519_key
Dec 17 09:32:50 ip-172-31-33-169 sshd[1235]: sshd: no hostkeys available -- exiting.
Dec 17 09:32:50 ip-172-31-33-169 systemd[1]: sshd.service: Main process exited, code=exited, status=1/FAILURE

[root@ip-172-31-33-169 centos]# sudo cat /var/log/cloud-init.log | grep ssh
2020-12-17 09:32:46,585 - url_helper.py[DEBUG]: [0/6] open 'http://169.254.169.254/2016-09-02/meta-data/public-keys/0/openssh-key' with {'url': 'http://169.254.169.254/2016-09-02/meta-data/public-keys/0/openssh-key', 'allow_redirects': True, 'method': 'GET', 'timeout': 5.0, 'headers': {'X-aws-ec2-metadata-token': 'REDACTED'}} configuration
2020-12-17 09:32:46,587 - url_helper.py[DEBUG]: Read from http://169.254.169.254/2016-09-02/meta-data/public-keys/0/openssh-key (200, 393b) after 1 attempts
2020-12-17 09:32:50,031 - stages.py[DEBUG]: Running module ssh (<module 'cloudinit.config.cc_ssh' from '/usr/lib/python3.6/site-packages/cloudinit/config/cc_ssh.py'>) with frequency once-per-instance
2020-12-17 09:32:50,031 - handlers.py[DEBUG]: start: init-network/config-ssh: running config-ssh with frequency once-per-instance
2020-12-17 09:32:50,031 - util.py[DEBUG]: Writing to /var/lib/cloud/instances/i-0bcf6488af9393b09/sem/config_ssh - wb: [644] 24 bytes
2020-12-17 09:32:50,031 - helpers.py[DEBUG]: Running config-ssh using lock (<FileLock using file '/var/lib/cloud/instances/i-0bcf6488af9393b09/sem/config_ssh'>)
2020-12-17 09:32:50,032 - util.py[DEBUG]: Attempting to remove /etc/ssh/ssh_host_ecdsa_key
2020-12-17 09:32:50,032 - util.py[DEBUG]: Attempting to remove /etc/ssh/ssh_host_ecdsa_key.pub
2020-12-17 09:32:50,032 - util.py[DEBUG]: Attempting to remove /etc/ssh/ssh_host_ed25519_key
2020-12-17 09:32:50,032 - util.py[DEBUG]: Attempting to remove /etc/ssh/ssh_host_ed25519_key.pub
2020-12-17 09:32:50,032 - util.py[DEBUG]: Attempting to remove /etc/ssh/ssh_host_rsa_key
2020-12-17 09:32:50,032 - util.py[DEBUG]: Attempting to remove /etc/ssh/ssh_host_rsa_key.pub
```

* Since the sshd failed during its first attempt the daemon is then successfully restarted after 42 seconds by systemd, following the sshd.service configuration

```
[centos@ip-172-31-33-169 ~]$ sudo cat /var/log/messages | grep ssh
Dec 17 09:32:50 ip-172-31-33-169 systemd[1]: sshd.service: Main process exited, code=exited, status=1/FAILURE
Dec 17 09:32:50 ip-172-31-33-169 systemd[1]: sshd.service: Failed with result 'exit-code'.
Dec 17 09:33:32 ip-172-31-33-169 systemd[1]: sshd.service: Service RestartSec=42s expired, scheduling restart.
Dec 17 09:33:32 ip-172-31-33-169 systemd[1]: sshd.service: Scheduled restart job, restart counter is at 1.
```

* In case ParallelCluster chef-client run calls `ssh-keyscan` before the sshd daemon is started, the command fails and we experience the problem reported in this issue. This also explains why the issue does not always reproduce, since it depends on whether 42 seconds are enough for the chef-client run to reach the command that requires an interaction with sshd.

### Difference with the vanilla Centos8 AMI
Why in the vanilla Centos 8 AMI the sshd is restarted right away and not after 42 seconds?
This is due to cloud-init. In the vanilla AMI cloud-init finds `PasswordAuthentication=yes` in the sshd_config and changes it to `PasswordAuthentication=no`. When cloud-init performs such a change the daemon is explicitly restarted by the cloud-init ssh module as shown in the logs below:
```
[root@ip-172-31-85-193 centos]# sudo cat /var/log/cloud-init.log | grep ssh
...
2020-12-17 09:52:59,879 - ssh_util.py[DEBUG]: line 70: option PasswordAuthentication updated yes -> no
2020-12-17 09:52:59,879 - util.py[DEBUG]: Writing to /etc/ssh/sshd_config - wb: [600] 4268 bytes
2020-12-17 09:52:59,880 - util.py[DEBUG]: Restoring selinux mode for /etc/ssh/sshd_config (recursive=False)
2020-12-17 09:52:59,881 - util.py[DEBUG]: Restoring selinux mode for /etc/ssh/sshd_config (recursive=False)
2020-12-17 09:52:59,882 - util.py[DEBUG]: Running command ['service', 'sshd', 'restart'] with allowed return codes [0] (shell=False, capture=True)
2020-12-17 09:53:00,286 - cc_set_passwords.py[DEBUG]: Restarted the ssh daemon.
```
In a ParallelCluster AMI PasswordAuthentication is already set to no during AMI build time, hence cloud-init does not perform an explicit restart and we have to wait for the 42 seconds of systemd restart timeout:

```
[root@ip-172-31-33-169 centos]# sudo cat /var/log/cloud-init.log | grep ssh
...
2020-12-17 09:32:50,793 - ssh_util.py[DEBUG]: line 12: option PasswordAuthentication already set to no
2020-12-17 09:32:50,793 - cc_set_passwords.py[DEBUG]: No need to restart ssh service, PasswordAuthentication not updated.
```

### Difference with Centos7
By comparing the two svg diagrams attached to the PR, that show the timeline of the startup of all services, we can clearly see that while in centos7 `sshd.service` correctly starts at the end of the chain after sshd-keygen.service, in centos8 we don't have sshd.service but `system-sshd\x2dkeygen.slice` that starts right away.


[systemd-analyze plots.zip](https://github.com/aws/aws-parallelcluster-cookbook/files/5710404/systemd-analyze.plots.zip)

### Solution
Restart sshd.service during base_config run to make sure the service is running


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
