### PR TITLE
Revert "Upgrade NVIDIA CUDA to version 11.2.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Download Intel MPI and HPC packages from S3 rather than Intel yum repos.
 - Install Arm Performance Library 20.2.1 on ARM AMI(CentOS8, Alinux2, Ubuntu1804)
 - Upgrade Intel MPI to version U8.
-- Upgrade NVIDIA CUDA to version 11.2.0
 
 **BUG FIXES**
 - Fix installation of Intel PSXE package on CentOS 7 by using yum4.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -118,8 +118,8 @@ default['cfncluster']['ganglia_enabled'] = 'no'
 default['cfncluster']['nvidia']['enabled'] = 'no'
 default['cfncluster']['nvidia']['driver_version'] = '450.80.02'
 default['cfncluster']['nvidia']['driver_url'] = 'https://us.download.nvidia.com/tesla/450.80.02/NVIDIA-Linux-x86_64-450.80.02.run'
-default['cfncluster']['nvidia']['cuda_version'] = '11.2'
-default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/11.2.0/local_installers/cuda_11.2.0_460.27.04_linux.run'
+default['cfncluster']['nvidia']['cuda_version'] = '11.0'
+default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run'
 
 # NVIDIA fabric-manager
 default['cfncluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabricmanager-450"


### PR DESCRIPTION
According to https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
CUDA 11.2 requires a driver version >= 460.27.04

This reverts commit df4e225f7b109b604517c64a41192addf0a0dd71.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
