### PR TITLE
Upgrade EFA installer to version 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Configure NFS threads to be max(8, num_cores) for performance. This enhancement will not take effect on Ubuntu 16.04.
 
 **CHANGES**
-- Upgrade EFA installer to version 1.11.0.
-  - EFA configuration: ``efa-config-1.5`` (from efa-config-1.4)
-  - EFA profile: ``efa-profile-1.1`` (from efa-profile-1.0.0)
-  - EFA kernel module: ``efa-1.10.2`` (from efa-1.6.0)
+- Upgrade EFA installer to version 1.11.1.
+  - EFA configuration: ``efa-config-1.7`` (from efa-config-1.5)
+  - EFA profile: ``efa-profile-1.3`` (from efa-profile-1.1)
+  - EFA kernel module: ``efa-1.10.2`` (no change)
   - RDMA core: ``rdma-core-31.2amzn`` (from rdma-core-31.amzn0)
-  - Libfabric: ``libfabric-1.11.1amzn1.1`` (from libfabric-1.10.1amzn1.1)
-  - Open MPI: ``openmpi40-aws-4.0.5`` (from openmpi40-aws-4.0.3)
+  - Libfabric: ``libfabric-1.11.1amzn1.0`` (from libfabric-1.11.1amzn1.1)
+  - Open MPI: ``openmpi40-aws-4.1.0`` (from openmpi40-aws-4.0.5)
 - Upgrade Intel MPI to version U8.
 - Upgrade NICE DCV to version 2020.2-9662.
 - Set default systemd runlevel to multi-user.target on all OSes during ParallelCluster official ami creation.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -138,7 +138,7 @@ default['cfncluster']['nvidia']['fabricmanager']['repository_uri'] = value_for_p
 )
 
 # EFA
-default['cfncluster']['efa']['installer_version'] = '1.11.0'
+default['cfncluster']['efa']['installer_version'] = '1.11.1'
 default['cfncluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cfncluster']['efa']['installer_version']}.tar.gz"
 default['cfncluster']['enable_efa_gdr'] = "no"
 


### PR DESCRIPTION
Changelog
```
  - EFA configuration: ``efa-config-1.7`` (from efa-config-1.5)
  - EFA profile: ``efa-profile-1.3`` (from efa-profile-1.1)
  - EFA kernel module: ``efa-1.10.2`` (no change)
  - RDMA core: ``rdma-core-31.2amzn`` (from rdma-core-31.amzn0)
  - Libfabric: ``libfabric-1.11.1amzn1.0`` (from libfabric-1.11.1amzn1.1)
  - Open MPI: ``openmpi40-aws-4.1.0`` (from openmpi40-aws-4.0.5)
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
