### PR TITLE
Increase timeout when attaching EBS volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+2.x.x
+-----
+
+**CHANGES**
+- Increase timeout when attaching EBS volumes from 3 to 5 minutes.
+
 2.10.1
 ------
 

--- a/files/default/attachVolume.py
+++ b/files/default/attachVolume.py
@@ -81,8 +81,8 @@ def main():
     state = response.get("State")
     x = 0
     while state != "attached":
-        if x == 36:
-            print("Volume %s failed to mount in 180 seconds." % volumeId)
+        if x == 60:
+            print("Volume %s failed to mount in 300 seconds." % volumeId)
             exit(1)
         if state in ["busy" or "detached"]:
             print("Volume %s in bad state %s" % (volumeId, state))


### PR DESCRIPTION
We detected some failures in Kitchen tests due to volume not ready to be attached in 3 minutes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
