### PR TITLE
Increase number of retries for kitchen instance init

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -1,7 +1,7 @@
 ---
 driver_config:
   retryable_sleep: 15
-  retryable_tries: 20
+  retryable_tries: 30
   retry_limit: 6
   aws_ssh_key_id: <%= ENV['AWS_KEYPAIR_NAME'] %>
   region: <%= ENV['AWS_DEFAULT_REGION'] %>


### PR DESCRIPTION
Over the past weeks there's been four kitchen test failures due to
instances not becoming ready in time. The error message given by these
failures is

> Ran out of time waiting for the server with id INSTANCE_ID to become ready.

This commit increases the amount of time the driver
will attempt to verify that an instance is ready from 20 to 30. This
will give instances an additional 150 seconds.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
