### PR TITLE
Increase root volume size on all OSs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Increase timeout when attaching EBS volumes from 3 to 5 minutes.
 - Retry `berkshelf` installation up to 3 times.
+- Root volume size increased to 35GB on all AMIs.
   
 **BUG FIXES**
 - Fix `encrypted_ephemeral = true` when using Alinux2 or CentOS8

--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -75,7 +75,7 @@
       "launch_block_device_mappings" : [
         {
           "device_name" : "/dev/xvda",
-          "volume_size" : "25",
+          "volume_size" : "35",
           "volume_type" : "gp2",
           "delete_on_termination" : true
         },

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -75,7 +75,7 @@
       "launch_block_device_mappings" : [
         {
           "device_name" : "/dev/xvda",
-          "volume_size" : "25",
+          "volume_size" : "35",
           "volume_type" : "gp2",
           "delete_on_termination" : true
         },

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -76,7 +76,7 @@
       "launch_block_device_mappings" : [
         {
           "device_name" : "/dev/sda1",
-          "volume_size" : "25",
+          "volume_size" : "35",
           "volume_type" : "gp2",
           "delete_on_termination" : true
         },

--- a/amis/packer_centos8.json
+++ b/amis/packer_centos8.json
@@ -75,7 +75,7 @@
       "launch_block_device_mappings" : [
         {
           "device_name" : "/dev/sda1",
-          "volume_size" : "25",
+          "volume_size" : "35",
           "volume_type" : "gp2",
           "delete_on_termination" : true
         },

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -75,7 +75,7 @@
       "launch_block_device_mappings" : [
         {
           "device_name" : "/dev/sda1",
-          "volume_size" : "25",
+          "volume_size" : "35",
           "volume_type" : "gp2",
           "delete_on_termination" : true
         },

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -76,7 +76,7 @@
       "launch_block_device_mappings" : [
         {
           "device_name" : "/dev/sda1",
-          "volume_size" : "25",
+          "volume_size" : "35",
           "volume_type" : "gp2",
           "delete_on_termination" : true
         },


### PR DESCRIPTION
Centos8 AMI needs ~10GB extra space to host Intel HPC software.
Increasing volume size for all OSs for consistency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
