### PR TITLE
Run apt update non-interactively

### DIFF
--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -173,7 +173,7 @@
       "inline" : [
         "sudo apt-cache search build-essential",
         "sudo apt-get clean",
-        "sudo apt-get update"
+        "sudo apt update -y"
       ]
     },
     {

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -174,7 +174,7 @@
       "inline" : [
         "sudo apt-cache search build-essential",
         "sudo apt-get clean",
-        "sudo apt-get update"
+        "sudo apt update -y"
       ]
     },
     {


### PR DESCRIPTION
Assume "yes" as answer to apt update prompts and run non-interactively. If an undesirable situation occurs, such as changing a held package or removing an essential package, then command will still abort.

This solves https://github.com/aws/aws-parallelcluster/issues/2401

Please notice the difference between `apt-get update -y` and `apt update -y`:
The former will return without actually answering yes, hence failing. The latter will answer yes to the prompt
```
$ sudo apt-get update -y
Reading package lists... Done
E: Repository 'https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu bionic InRelease' changed its 'Origin' value from '' to 'AWS-FSx-for-Lustre'
E: Repository 'https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu bionic InRelease' changed its 'Suite' value from '' to 'stable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.

$ echo $?
100
```

```
$ sudo apt update -y
E: Repository 'https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu bionic InRelease' changed its 'Origin' value from '' to 'AWS-FSx-for-Lustre'
E: Repository 'https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu bionic InRelease' changed its 'Suite' value from '' to 'stable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
Do you want to accept these changes and continue updating from this repository? [y/N] Y
Get:6 https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu bionic/main amd64 Packages [8389 B]
Fetched 11.7 kB in 1s (15.8 kB/s)
Reading package lists... Done
Building dependency tree
Reading state information... Done
31 packages can be upgraded. Run 'apt list --upgradable' to see them.
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
