### PR TITLE
Fix creation of ram device on Alinux2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Increase timeout when attaching EBS volumes from 3 to 5 minutes.
 - Retry `berkshelf` installation up to 3 times.
+  
+**BUG FIXES**
+- Fix `encrypted_ephemeral = true` when using Alinux2
 
 2.10.1
 ------

--- a/files/default/setup-ephemeral-drives.sh
+++ b/files/default/setup-ephemeral-drives.sh
@@ -81,6 +81,7 @@ function setup_ephemeral_drives () {
     vgcreate vg.01 $PARTITIONS || RC=1
     lvcreate -i $NUM_DEVS -I 64 -l 100%FREE -n lv_ephemeral vg.01 || RC=1
     if [ "$cfn_encrypted_ephemeral" == "true" ]; then
+      modprobe brd || RC=1
       mkfs -q /dev/ram1 1024 || RC=1
       mkdir -p /root/keystore || RC=1
       mount /dev/ram1 /root/keystore || RC=1


### PR DESCRIPTION
Before creating the ram device, be sure that the brd (block ram disk) module is loaded,
otherwise you'll get the error:
```
# mkfs -q /dev/ram1 1024
Could not stat /dev/ram1 --- No such file or directory

The device apparently does not exist; did you specify it correctly?
```

Fix https://github.com/aws/aws-parallelcluster/issues/2407

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
