### PR TITLE
Fix ephemeral drive encryption on CentOS8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Retry `berkshelf` installation up to 3 times.
   
 **BUG FIXES**
-- Fix `encrypted_ephemeral = true` when using Alinux2
+- Fix `encrypted_ephemeral = true` when using Alinux2 or CentOS8
 
 2.10.1
 ------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -281,7 +281,8 @@ when 'rhel', 'amazon'
       # gdisk required for FSx
       # environment-modules required for IntelMPI
       # libtirpc and libtirpc-devel required for SGE
-      default['cfncluster']['base_packages'].push(%w[python3 python3-pip iptables nvme-cli gdisk environment-modules libtirpc libtirpc-devel])
+      # cryptsetup used for ephemeral drive encryption
+      default['cfncluster']['base_packages'].push(%w[python3 python3-pip iptables nvme-cli gdisk environment-modules libtirpc libtirpc-devel cryptsetup])
     end
 
     default['cfncluster']['rhel']['extra_repo'] = 'rhui-REGION-rhel-server-optional'


### PR DESCRIPTION
Add installation of cryptsetup package used for encryption of ephemeral drive

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
