### PR TITLE
Check S3 bucket owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
-2.x.x
+2.10.2
 -----
 
 **CHANGES**
 - Increase timeout when attaching EBS volumes from 3 to 5 minutes.
 - Retry `berkshelf` installation up to 3 times.
+
+**ENHANCEMENTS**
+
+- Check bucket owner when accessing public ParallelCluster artifacts to prevent S3 buckets sniping
 
 2.10.1
 ------

--- a/amis/build_ami.sh
+++ b/amis/build_ami.sh
@@ -143,10 +143,13 @@ check_options() {
 
     if [ "${_partition}" == "commercial" ]; then
       export AWS_REGION="${AWS_REGION-us-east-1}"
+      export PARALLELCLUSTER_ACCOUNT_ID="247102896272"
     elif [ "${_partition}" == "govcloud" ]; then
       export AWS_REGION="${AWS_REGION-us-gov-west-1}"
+      export PARALLELCLUSTER_ACCOUNT_ID="124026578433"
     elif [ "${_partition}" == "china" ]; then
       export AWS_REGION="${AWS_REGION-cn-north-1}"
+      export PARALLELCLUSTER_ACCOUNT_ID="036028979999"
     elif [ "${_partition}" == "region" ]; then
       export AWS_REGION="${_region}"
     else

--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -25,7 +25,8 @@
     "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}",
     "ami_arch" : "{{env `AMI_ARCH`}}",
     "user_data_file" : "{{env `USER_DATA_SCRIPT`}}",
-    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}"
+    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}",
+    "parallelcluster_account_id" : "{{env `PARALLELCLUSTER_ACCOUNT_ID`}}"
   },
   "builders" : [
     {
@@ -174,7 +175,7 @@
         "region=\"{{user `region`}}\"",
         "chef_install_url=\"https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\" || exit 0)/archives/cinc/cinc-install.sh\"",
         "[ -n  \"{{user `chef_custom_install_url`}}\" ] && chef_install_url=\"{{user `chef_custom_install_url`}}\"",
-        "curl --retry 3 -L ${chef_install_url} | sudo bash -s -- -v {{user `chef_version`}}"
+        "curl --retry 3 -L ${chef_install_url} -H x-amz-expected-bucket-owner:{{user `parallelcluster_account_id`}} | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -25,7 +25,8 @@
     "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}",
     "ami_arch" : "{{env `AMI_ARCH`}}",
     "user_data_file" : "{{env `USER_DATA_SCRIPT`}}",
-    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}"
+    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}",
+    "parallelcluster_account_id" : "{{env `PARALLELCLUSTER_ACCOUNT_ID`}}"
   },
   "builders" : [
     {
@@ -174,7 +175,7 @@
         "region=\"{{user `region`}}\"",
         "chef_install_url=\"https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\" || exit 0)/archives/cinc/cinc-install.sh\"",
         "[ -n  \"{{user `chef_custom_install_url`}}\" ] && chef_install_url=\"{{user `chef_custom_install_url`}}\"",
-        "curl --retry 3 -L ${chef_install_url} | sudo bash -s -- -v {{user `chef_version`}}"
+        "curl --retry 3 -L ${chef_install_url} -H x-amz-expected-bucket-owner:{{user `parallelcluster_account_id`}} | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -26,7 +26,8 @@
     "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}",
     "ami_arch" : "{{env `AMI_ARCH`}}",
     "user_data_file" : "{{env `USER_DATA_SCRIPT`}}",
-    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}"
+    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}",
+    "parallelcluster_account_id" : "{{env `PARALLELCLUSTER_ACCOUNT_ID`}}"
   },
   "builders" : [
     {
@@ -190,7 +191,7 @@
         "region=\"{{user `region`}}\"",
         "chef_install_url=\"https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\" || exit 0)/archives/cinc/cinc-install.sh\"",
         "[ -n  \"{{user `chef_custom_install_url`}}\" ] && chef_install_url=\"{{user `chef_custom_install_url`}}\"",
-        "curl --retry 3 -L ${chef_install_url} | sudo bash -s -- -v {{user `chef_version`}}"
+        "curl --retry 3 -L ${chef_install_url} -H x-amz-expected-bucket-owner:{{user `parallelcluster_account_id`}} | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {

--- a/amis/packer_centos8.json
+++ b/amis/packer_centos8.json
@@ -25,7 +25,8 @@
     "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}",
     "ami_arch" : "{{env `AMI_ARCH`}}",
     "user_data_file" : "{{env `USER_DATA_SCRIPT`}}",
-    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}"
+    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}",
+    "parallelcluster_account_id" : "{{env `PARALLELCLUSTER_ACCOUNT_ID`}}"
   },
   "builders" : [
     {
@@ -189,7 +190,7 @@
         "region=\"{{user `region`}}\"",
         "chef_install_url=\"https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\" || exit 0)/archives/cinc/cinc-install.sh\"",
         "[ -n  \"{{user `chef_custom_install_url`}}\" ] && chef_install_url=\"{{user `chef_custom_install_url`}}\"",
-        "curl --retry 3 -L ${chef_install_url} | sudo bash -s -- -v {{user `chef_version`}}"
+        "curl --retry 3 -L ${chef_install_url} -H x-amz-expected-bucket-owner:{{user `parallelcluster_account_id`}} | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -25,7 +25,8 @@
     "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}",
     "ami_arch" : "{{env `AMI_ARCH`}}",
     "user_data_file" : "{{env `USER_DATA_SCRIPT`}}",
-    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}"
+    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}",
+    "parallelcluster_account_id" : "{{env `PARALLELCLUSTER_ACCOUNT_ID`}}"
   },
   "builders" : [
     {
@@ -195,7 +196,7 @@
         "region=\"{{user `region`}}\"",
         "chef_install_url=\"https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\" || exit 0)/archives/cinc/cinc-install.sh\"",
         "[ -n  \"{{user `chef_custom_install_url`}}\" ] && chef_install_url=\"{{user `chef_custom_install_url`}}\"",
-        "curl --retry 3 -L ${chef_install_url} | sudo bash -s -- -v {{user `chef_version`}}"
+        "curl --retry 3 -L ${chef_install_url} -H x-amz-expected-bucket-owner:{{user `parallelcluster_account_id`}} | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -26,7 +26,8 @@
     "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}",
     "ami_arch" : "{{env `AMI_ARCH`}}",
     "user_data_file" : "{{env `USER_DATA_SCRIPT`}}",
-    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}"
+    "iam_instance_profile" : "{{env `AWS_IAM_PROFILE`}}",
+    "parallelcluster_account_id" : "{{env `PARALLELCLUSTER_ACCOUNT_ID`}}"
   },
   "builders" : [
     {
@@ -196,7 +197,7 @@
         "region=\"{{user `region`}}\"",
         "chef_install_url=\"https://${region}-aws-parallelcluster.s3.${region}.amazonaws.com$([ \"${region}\" != \"${region#cn-*}\" ] && echo \".cn\" || exit 0)/archives/cinc/cinc-install.sh\"",
         "[ -n  \"{{user `chef_custom_install_url`}}\" ] && chef_install_url=\"{{user `chef_custom_install_url`}}\"",
-        "curl --retry 3 -L ${chef_install_url} | sudo bash -s -- -v {{user `chef_version`}}"
+        "curl --retry 3 -L ${chef_install_url} -H x-amz-expected-bucket-owner:{{user `parallelcluster_account_id`}} | sudo bash -s -- -v {{user `chef_version`}}"
       ]
     },
     {

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -432,3 +432,13 @@ def overwrite_nfs_template?
     node['platform'] == 'centos' && node['platform_version'].to_i == 8
   ].any?
 end
+
+def parallelcluster_accound_id
+  if node['cfncluster']['cfn_region'].start_with?("cn-")
+    "036028979999"
+  elsif node['cfncluster']['cfn_region'].start_with?("us-gov-")
+    "124026578433"
+  else
+    "247102896272"
+  end
+end

--- a/recipes/arm_pl_install.rb
+++ b/recipes/arm_pl_install.rb
@@ -26,6 +26,7 @@ remote_file armpl_installer do
   mode '0644'
   retries 3
   retry_delay 5
+  headers("x-amz-expected-bucket-owner" => parallelcluster_accound_id)
   not_if { ::File.exist?("/opt/arm/armpl/#{node['cfncluster']['armpl']['version']}") }
 end
 

--- a/recipes/intel_install.rb
+++ b/recipes/intel_install.rb
@@ -35,6 +35,7 @@ def download_intel_hpc_pkg_from_s3(pkg_subdir_key, package_basename, dest_path)
     mode '0744'
     retries 3
     retry_delay 5
+    headers("x-amz-expected-bucket-owner" => parallelcluster_accound_id)
     not_if { ::File.exist?(dest_path) }
   end
 end

--- a/recipes/intel_mpi.rb
+++ b/recipes/intel_mpi.rb
@@ -28,6 +28,7 @@ remote_file intelmpi_installer_path do
   mode '0744'
   retries 3
   retry_delay 5
+  headers("x-amz-expected-bucket-owner" => parallelcluster_accound_id)
   not_if { ::File.exist?("/opt/intel/impi/#{node['cfncluster']['intelmpi']['version']}") }
 end
 

--- a/util/chef-install.sh
+++ b/util/chef-install.sh
@@ -115,7 +115,7 @@ capture_tmp_stderr() {
 # do_wget URL FILENAME
 do_wget() {
   echo "trying wget..."
-  wget --user-agent="User-Agent: mixlib-install/3.12.1" -O "$2" "$1" 2>$tmp_dir/stderr
+  wget -E --header x-amz-expected-bucket-owner:${PARALLELCLUSTER_ACCOUNT_ID} --user-agent="User-Agent: mixlib-install/3.12.1" -O "$2" "$1" 2>$tmp_dir/stderr
   rc=$?
   # check for 404
   grep "ERROR 404" $tmp_dir/stderr 2>&1 >/dev/null
@@ -136,7 +136,7 @@ do_wget() {
 # do_curl URL FILENAME
 do_curl() {
   echo "trying curl..."
-  curl -A "User-Agent: mixlib-install/3.12.1" --retry 5 -sL -D $tmp_dir/stderr "$1" > "$2"
+  curl -H x-amz-expected-bucket-owner:${PARALLELCLUSTER_ACCOUNT_ID} -A "User-Agent: mixlib-install/3.12.1" --retry 5 -sL -D $tmp_dir/stderr "$1" > "$2"
   rc=$?
   # check for 404
   grep "404 Not Found" $tmp_dir/stderr 2>&1 >/dev/null

--- a/util/cinc-install.sh
+++ b/util/cinc-install.sh
@@ -115,7 +115,7 @@ capture_tmp_stderr() {
 # do_wget URL FILENAME
 do_wget() {
   echo "trying wget..."
-  wget --user-agent="User-Agent: mixlib-install/3.11.27" -O "$2" "$1" 2>$tmp_dir/stderr
+  wget -E --header x-amz-expected-bucket-owner:${PARALLELCLUSTER_ACCOUNT_ID} --user-agent="User-Agent: mixlib-install/3.11.27" -O "$2" "$1" 2>$tmp_dir/stderr
   rc=$?
   # check for 404
   grep "ERROR 404" $tmp_dir/stderr 2>&1 >/dev/null
@@ -136,7 +136,7 @@ do_wget() {
 # do_curl URL FILENAME
 do_curl() {
   echo "trying curl..."
-  curl -A "User-Agent: mixlib-install/3.11.27" --retry 5 -sL -D $tmp_dir/stderr "$1" > "$2"
+  curl -H x-amz-expected-bucket-owner:${PARALLELCLUSTER_ACCOUNT_ID} -A "User-Agent: mixlib-install/3.11.27" --retry 5 -sL -D $tmp_dir/stderr "$1" > "$2"
   rc=$?
   # check for 404
   grep "404 Not Found" $tmp_dir/stderr 2>&1 >/dev/null


### PR DESCRIPTION
Check bucket owner when retrieving ParallelCluster public artifacts from S3 to prevent bucket sniping attacks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
