### PR TITLE
Do not enable slurmd before finalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 2.x.x
 -----
 
+**ENHANCEMENTS**
+- Make sure slurmd service is not enabled before finalize stage, which will prevent user from unintentionally making compute node available in post-install process.
+
 **CHANGES**
 - Increase timeout when attaching EBS volumes from 3 to 5 minutes.
 - Retry `berkshelf` installation up to 3 times.

--- a/recipes/compute_slurm_config.rb
+++ b/recipes/compute_slurm_config.rb
@@ -48,15 +48,3 @@ cookbook_file '/etc/systemd/system/slurmd.service' do
   action :create
   only_if { node['init_package'] == 'systemd' }
 end
-
-if node['init_package'] == 'systemd'
-  service "slurmd" do
-    supports restart: false
-    action %i[enable]
-  end
-else
-  service "slurm" do
-    supports restart: false
-    action %i[enable]
-  end
-end


### PR DESCRIPTION
* Remove code to enable slurmd service in compute_slurm_config.rb. This code might cause user to start slurmd unintentionally when switching system targets in post-install, making compute node available for jobs before bootstrap completes.
* Logic to enable and start slurmd service already in place in compute_slurm_finalize.rb, so slurmd will start and compute node will be available as last step in the bootstrap process.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
