### PR TITLE
Revise ssh_target_checker.sh syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **ENHANCEMENTS**
 - Make sure slurmd service is not enabled before finalize stage, which will prevent user from unintentionally making compute node available in post-install process.
+- Change to ssh_target_checker.sh syntax that makes the script compatible with pdsh
 
 **CHANGES**
 - Increase timeout when attaching EBS volumes from 3 to 5 minutes.

--- a/files/default/ssh_target_checker.sh
+++ b/files/default/ssh_target_checker.sh
@@ -24,7 +24,9 @@ retrieve_vpc_cidr_list() {
     fi
 
     vpc_cidr_uri="http://169.254.169.254/latest/meta-data/network/interfaces/macs/${mac}/vpc-ipv4-cidr-blocks"
-    if ! mapfile -t vpc_cidr_list < <(curl --retry 3 --retry-delay 0 --silent --fail "${vpc_cidr_uri}"); then
+    vpc_cidr_list=($(curl --retry 3 --retry-delay 0 --silent --fail "${vpc_cidr_uri}"))
+
+    if ! (( ${#vpc_cidr_list[@]} )); then
        log "Unable to retrieve VPC CIDR list from EC2 meta-data"
        exit 1
     fi


### PR DESCRIPTION
* Current ssh_target_checker.sh syntax works with ssh but might not be compatible with package that depends on ssh, such as pdsh. Change to simpler syntax when parsing VPC CIDR into array

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
