### PR TITLE
Increase root volume size from 25G to 35G for kitchen test

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -36,7 +36,7 @@ platforms:
       block_device_mappings:
         - device_name: /dev/xvda
           ebs:
-            volume_size: <%= ENV['VOLUME_SIZE'] || 25 %>
+            volume_size: <%= ENV['VOLUME_SIZE'] || 35 %>
             volume_type: gp2
             delete_on_termination: true
         - device_name: /dev/xvdba
@@ -97,7 +97,7 @@ platforms:
       block_device_mappings:
         - device_name: /dev/xvda
           ebs:
-            volume_size: <%= ENV['VOLUME_SIZE'] || 25 %>
+            volume_size: <%= ENV['VOLUME_SIZE'] || 35 %>
             volume_type: gp2
             delete_on_termination: true
         - device_name: /dev/xvdba
@@ -158,7 +158,7 @@ platforms:
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
-            volume_size: <%= ENV['VOLUME_SIZE'] || 25 %>
+            volume_size: <%= ENV['VOLUME_SIZE'] || 35 %>
             volume_type: gp2
             delete_on_termination: true
         - device_name: /dev/xvdba
@@ -219,7 +219,7 @@ platforms:
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
-            volume_size: <%= ENV['VOLUME_SIZE'] || 25 %>
+            volume_size: <%= ENV['VOLUME_SIZE'] || 35 %>
             volume_type: gp2
             delete_on_termination: true
         - device_name: /dev/xvdba
@@ -280,7 +280,7 @@ platforms:
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
-            volume_size: <%= ENV['VOLUME_SIZE'] || 25 %>
+            volume_size: <%= ENV['VOLUME_SIZE'] || 35 %>
             volume_type: gp2
             delete_on_termination: true
         - device_name: /dev/xvdba
@@ -341,7 +341,7 @@ platforms:
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
-            volume_size: <%= ENV['VOLUME_SIZE'] || 25 %>
+            volume_size: <%= ENV['VOLUME_SIZE'] || 35 %>
             volume_type: gp2
             delete_on_termination: true
         - device_name: /dev/xvdba


### PR DESCRIPTION
Increase the volume size to create AMI from 25G to 35 G for kitchen test since the AMI size is 35G now
Signed-off-by: chenwany <chenwany@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
