### PR TITLE
Fix awscli installation failure

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -92,7 +92,7 @@ bash "install awscli" do
   code <<-CLI
     set -e
     curl --retry 5 --retry-delay 5 "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-    unzip awscli-bundle.zip
+    unzip -o awscli-bundle.zip
     #{node['cfncluster']['cookbook_virtualenv_path']}/bin/python awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
   CLI
   not_if { ::File.exist?("/usr/local/bin/aws") }


### PR DESCRIPTION
* add -o option to overwrite existing files without prompting
* when testing install_awscli script, hit the error replace awscli-bundle/install? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
(EOF or read error, treating as "[N]one" ...). It may cause awscli install failure in kitchen test.

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
