### PR TITLE
Copy munge key as root

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -463,13 +463,17 @@ end
 def setup_munge_compute_node
   # Get munge key
   bash 'get_munge_key' do
-    user 'munge'
-    group 'munge'
+    user 'root'
+    group 'root'
     cwd '/tmp'
     code <<-COMPUTE_MUNGE_KEY
       set -e
-      # Copy munge key from shared dir
+      # Copy munge key from shared dir as root
       cp -p /home/munge/.munge.key /etc/munge/munge.key
+      # Set ownership on the key
+      chown munge:munge /etc/munge/munge.key
+      # Enforce correct permission on the key
+      chmod 0600 /etc/munge/munge.key
     COMPUTE_MUNGE_KEY
   end
 


### PR DESCRIPTION
Copy munge key as root from shared dir and then set correct ownership and permission
This because `munge` user can be different between head and compute node (e.g. during baking at runtime), hence the shared home munge dir can have different permission.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>
(cherry picked from commit e33dc611229e6d2658ec4d20248cec3c877bf21f)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
