### PR TITLE
Release 2.10: Fix `encrypted_ephemeral = true` when using Alinux2 or CentOS8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Use non interactive `apt update` command when building custom Ubuntu AMIs.
-- Fix `encrypted_ephemeral = true` when using Alinux2
+- Fix `encrypted_ephemeral = true` when using Alinux2 or CentOS8
 
 2.10.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Use non interactive `apt update` command when building custom Ubuntu AMIs.
+- Fix `encrypted_ephemeral = true` when using Alinux2
 
 2.10.1
 ------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -279,7 +279,8 @@ when 'rhel', 'amazon'
       # gdisk required for FSx
       # environment-modules required for IntelMPI
       # libtirpc and libtirpc-devel required for SGE
-      default['cfncluster']['base_packages'].push(%w[python3 python3-pip iptables nvme-cli gdisk environment-modules libtirpc libtirpc-devel])
+      # cryptsetup used for ephemeral drive encryption
+      default['cfncluster']['base_packages'].push(%w[python3 python3-pip iptables nvme-cli gdisk environment-modules libtirpc libtirpc-devel cryptsetup])
     end
 
     default['cfncluster']['rhel']['extra_repo'] = 'rhui-REGION-rhel-server-optional'

--- a/files/default/setup-ephemeral-drives.sh
+++ b/files/default/setup-ephemeral-drives.sh
@@ -81,6 +81,7 @@ function setup_ephemeral_drives () {
     vgcreate vg.01 $PARTITIONS || RC=1
     lvcreate -i $NUM_DEVS -I 64 -l 100%FREE -n lv_ephemeral vg.01 || RC=1
     if [ "$cfn_encrypted_ephemeral" == "true" ]; then
+      modprobe brd || RC=1
       mkfs -q /dev/ram1 1024 || RC=1
       mkdir -p /root/keystore || RC=1
       mount /dev/ram1 /root/keystore || RC=1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
