### PR TITLE
Share munge key from dir owned by root, under the default user home f…

### DIFF
--- a/recipes/munge_install.rb
+++ b/recipes/munge_install.rb
@@ -67,11 +67,10 @@ end
 
 # Make sure the munge user exists
 user 'munge' do
-  manage_home true
+  manage_home false
   comment 'munge user'
-  home "/home/munge"
   system true
-  shell '/usr/sbin/nologin'
+  shell '/sbin/nologin'
 end
 
 # Create required directories for munge


### PR DESCRIPTION
…older

Share munge key from dir owned by root from head node, than setup it in compute node
This because `munge` user can be different between head and compute node (e.g. during baking at runtime), hence the shared home munge dir can have different permission.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
