### PR TITLE
Install AWSBatch CLI in virtual env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Add new SlurmctldParameters, power_save_min_interval=30, so power actions will be processed every 30 seconds
   - Add new SlurmctldParameters, cloud_reg_addrs, which will reset a node's NodeAddr automatically on power_down
   - Specify instance GPU model as GRES GPU Type in gres.conf
-  
+- Install ParallelCluster AWSBatch CLI in dedicated python3 virtual env.
+
 **BUG FIXES**
 - Fix `encrypted_ephemeral = true` when using Alinux2 or CentOS8
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,10 +36,14 @@ default['cfncluster']['system_pyenv_root'] = "#{node['cfncluster']['base_dir']}/
 default['cfncluster']['cookbook_virtualenv'] = 'cookbook_virtualenv'
 # Virtualenv Node Name
 default['cfncluster']['node_virtualenv'] = 'node_virtualenv'
+# Virtualenv AWSBatch Name
+default['cfncluster']['awsbatch_virtualenv'] = 'awsbatch_virtualenv'
 # Cookbook Virtualenv Path
 default['cfncluster']['cookbook_virtualenv_path'] = "#{node['cfncluster']['system_pyenv_root']}/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['cookbook_virtualenv']}"
 # Node Virtualenv Path
 default['cfncluster']['node_virtualenv_path'] = "#{node['cfncluster']['system_pyenv_root']}/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['node_virtualenv']}"
+# AWSBatch Virtualenv Path
+default['cfncluster']['awsbatch_virtualenv_path'] = "#{node['cfncluster']['system_pyenv_root']}/versions/#{node['cfncluster']['python-version']}/envs/#{node['cfncluster']['awsbatch_virtualenv']}"
 
 # Intel Packages
 default['cfncluster']['psxe']['version'] = '2020.4-17'

--- a/recipes/setup_python.rb
+++ b/recipes/setup_python.rb
@@ -33,6 +33,13 @@ activate_virtual_env node['cfncluster']['node_virtualenv'] do
   not_if { ::File.exist?("#{node['cfncluster']['node_virtualenv_path']}/bin/activate") }
 end
 
+# Install awsbatch virtualenv
+activate_virtual_env node['cfncluster']['awsbatch_virtualenv'] do
+  pyenv_path node['cfncluster']['awsbatch_virtualenv_path']
+  python_version node['cfncluster']['python-version']
+  not_if { ::File.exist?("#{node['cfncluster']['awsbatch_virtualenv_path']}/bin/activate") }
+end
+
 bash 'install CloudFormation helpers' do
   user 'root'
   group 'root'

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -593,3 +593,22 @@ if node['conditions']['arm_pl_supported']
     user node['cfncluster']['cfn_cluster_user']
   end
 end
+
+###################
+# Pcluster AWSBatch CLI
+###################
+if node['cfncluster']['cfn_scheduler'] == 'awsbatch' and node['cfncluster']['cfn_node_type'] == 'MasterServer'
+  # Test that batch commands can be accessed without absolute path
+  batch_cli_commands = ["awsbkill", "awsbqueues", "awsbsub", "awsbhosts", "awsbout", "awsbstat"]
+  batch_cli_commands.each do |cli_commmand|
+    bash "test_#{cli_commmand}" do
+      cwd Chef::Config[:file_cache_path]
+      code <<-BATCHCLI
+        set -e
+        source ~/.bash_profile
+        #{cli_commmand} -h
+      BATCHCLI
+      user node['cfncluster']['cfn_cluster_user']
+    end
+  end
+end

--- a/templates/default/pcluster_awsbatchcli.sh.erb
+++ b/templates/default/pcluster_awsbatchcli.sh.erb
@@ -1,0 +1,8 @@
+#
+# pcluster_awsbatchcli.sh:
+#   Setup ParallelCluster AWSBatch CLI environment variables
+#
+
+PATH=$PATH:<%= node['cfncluster']['awsbatch_virtualenv_path'] %>/bin
+
+export PATH


### PR DESCRIPTION
* Create separate python3 virtual env for AWSBatch CLI and install Batch CLI in this dedicated virtual env
* If using AWSBatch, add batch virtual env to profile.d so batch CLI commands are in default PATH

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
