### PR TITLE
Support development instance_types_data configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -439,3 +439,6 @@ default['cfncluster']['aws_domain'] = aws_domain
 
 # Official ami build
 default['cfncluster']['is_official_ami_build'] = false
+
+# Additional instance types data
+default['instance_types_data'] = nil

--- a/templates/default/jobwatcher.cfg.erb
+++ b/templates/default/jobwatcher.cfg.erb
@@ -4,3 +4,4 @@ scheduler = <%= node['cfncluster']['cfn_scheduler'] %>
 stack_name = <%= node['cfncluster']['stack_name'] %>
 cfncluster_dir = <%= node['cfncluster']['base_dir'] %>
 proxy = <%= node['cfncluster']['cfn_proxy'] %>
+instance_types_data = <%= node['instance_types_data'].to_json %>

--- a/templates/default/nodewatcher.cfg.erb
+++ b/templates/default/nodewatcher.cfg.erb
@@ -4,3 +4,4 @@ scheduler = <%= node['cfncluster']['cfn_scheduler'] %>
 proxy = <%= node['cfncluster']['cfn_proxy'] %>
 scaledown_idletime = <%= node['cfncluster']['cfn_scaledown_idletime'] %>
 stack_name = <%= node['cfncluster']['stack_name'] %>
+instance_types_data = <%= node['instance_types_data'].to_json %>

--- a/templates/default/sqswatcher.cfg.erb
+++ b/templates/default/sqswatcher.cfg.erb
@@ -6,3 +6,4 @@ scheduler = <%= node['cfncluster']['cfn_scheduler'] %>
 cluster_user = <%= node['cfncluster']['cfn_cluster_user'] %>
 proxy = <%= node['cfncluster']['cfn_proxy'] %>
 stack_name = <%= node['cfncluster']['stack_name'] %>
+instance_types_data = <%= node['instance_types_data'].to_json %>


### PR DESCRIPTION
This commit integrates the support for the new `instance_types_data` configuration parameter, copying the value coming from configuration, if present, into ParallelCluster daemons configuration files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
