### PR TITLE
3.0: use new configuration file to generate slurm configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           - Python 3.6 Tests
           - Python 3.7 Tests
           - Python 3.8 Tests
+          - Python 3.9 Tests
           - Code Checks
         include:
           - name: Python 3.6 Tests
@@ -64,8 +65,11 @@ jobs:
           - name: Python 3.8 Tests
             python: 3.8
             toxenv: py38
+          - name: Python 3.9 Tests
+            python: 3.9
+            toxenv: py39
           - name: Code Checks
-            python: 3.6
+            python: 3.9
             toxenv: code-linters
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade CUDA library to version 11.3.0.
 - Upgrade NVIDIA Fabric manager to `nvidia-fabricmanager-460`.
 - Install ParallelCluster AWSBatch CLI in dedicated python3 virtual env.
+- Upgrade Python version used in ParallelCluster virtualenvs from version 3.6.13 to version 3.9.4.
 
 2.10.3
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,7 @@ default['cfncluster']['cluster_config_version'] = nil
 default['cfncluster']['cluster_config_path'] = "#{node['cfncluster']['configs_dir']}/cluster_config.json"
 
 # Python Version
-default['cfncluster']['python-version'] = '3.6.13'
+default['cfncluster']['python-version'] = '3.9.4'
 # plcuster-specific pyenv system installation root
 default['cfncluster']['system_pyenv_root'] = "#{node['cfncluster']['base_dir']}/pyenv"
 # Virtualenv Cookbook Name

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 toxworkdir=.tox
 skipsdist=True
 envlist =
-    py{36,37,38}
+    py{36,37,38,39}
     code-linters
 
 # Default testenv. Used to run tests on all python versions.


### PR DESCRIPTION
To unblock end-to-end test, this commit will use the new configuration file to generate slurm configuration. There are still some known issues left behind, namely: enable_efa is not handled, pcluster update is not done.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
