### PR TITLE
Don't autoescape when rendering jija templates

### DIFF
--- a/files/default/slurm/pcluster_slurm_config_generator.py
+++ b/files/default/slurm/pcluster_slurm_config_generator.py
@@ -132,7 +132,10 @@ def _generate_slurm_parallelcluster_configs(
 def _get_jinja_env(template_directory):
     """Return jinja environment with trim_blocks/lstrip_blocks set to True."""
     file_loader = FileSystemLoader(template_directory)
-    env = Environment(loader=file_loader, trim_blocks=True, lstrip_blocks=True, autoescape=True)
+    # A nosec comment is appended to the following line in order to disable the B701 check.
+    # The contents of the default templates are known and the input configuration data is
+    # validated by the CLI.
+    env = Environment(loader=file_loader, trim_blocks=True, lstrip_blocks=True)  # nosec nosemgrep
     env.filters["sanify_instance_type"] = lambda value: re.sub(r"[^A-Za-z0-9]", "", value)
 
     return env


### PR DESCRIPTION
Signed-off-by: Tim Lane <tilne@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.