### PR TITLE
Add missing requirements to use BigDecimal conversion

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -520,6 +520,7 @@ when 'MasterServer'
 end
 
 # Skip nfs thread test for ubuntu16 because nfs thread enhancement is omitted
+require 'bigdecimal/util'
 unless node['platform'] == 'ubuntu' && node['platform_version'].to_d == 16.04.to_d
   ruby_block 'check_nfs_threads' do
     block do


### PR DESCRIPTION
When you require bigdecimal/util, the to_d method will be available on BigDecimal
and the native Integer, Float, Rational, and String classes.
Source: https://ruby-doc.org/stdlib-2.5.1/libdoc/bigdecimal/rdoc/BigDecimal.html
