### PR TITLE
Use .cn domain for NVIDIA Fabric Manager repo in China

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -136,11 +136,11 @@ default['cfncluster']['nvidia']['fabricmanager']['version'] = value_for_platform
   'ubuntu' => { 'default' => "#{node['cfncluster']['nvidia']['driver_version']}*" }
 )
 default['cfncluster']['nvidia']['fabricmanager']['repository_uri'] = value_for_platform(
-  'default' => "https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64",
+  'default' => "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/x86_64",
   'centos' => {
-    '~>8' => "https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64"
+    '~>8' => "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel8/x86_64"
   },
-  'ubuntu' => { 'default' => "https://developer.download.nvidia.com/compute/cuda/repos/#{node['cfncluster']['cfn_base_os']}/x86_64" }
+  'ubuntu' => { 'default' => "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cfncluster']['cfn_base_os']}/x86_64" }
 )
 
 # EFA

--- a/recipes/nvidia_install.rb
+++ b/recipes/nvidia_install.rb
@@ -78,10 +78,13 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes' || node['cfncluster']['nvidi
   end
 
   # Install NVIDIA Fabric Manager
+  repo_domain = "com"
+  repo_domain = "cn" if node['cfncluster']['cfn_region'].start_with?("cn-")
+  repo_uri = node['cfncluster']['nvidia']['fabricmanager']['repository_uri'].gsub('_domain_', repo_domain)
   add_package_repository(
     "nvidia-fm-repo",
-    node['cfncluster']['nvidia']['fabricmanager']['repository_uri'],
-    "#{node['cfncluster']['nvidia']['fabricmanager']['repository_uri']}/#{node['cfncluster']['nvidia']['fabricmanager']['repository_key']}",
+    repo_uri,
+    "#{repo_uri}/#{node['cfncluster']['nvidia']['fabricmanager']['repository_key']}",
     "/"
   )
 


### PR DESCRIPTION
The NVIDIA FM package repo fails during the update in Ubuntu 20 in China regions.
Registering the .cn repo instead of the .com one fixes the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
