### PR TITLE
Restore epel repo installation that is required for jq package

### DIFF
--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -160,6 +160,7 @@
     {
       "type" : "shell",
       "inline" : [
+        "sudo yum -y install epel-release",
         "sudo /bin/sed -r -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config"
       ]
     },

--- a/amis/packer_centos8.json
+++ b/amis/packer_centos8.json
@@ -159,6 +159,7 @@
     {
       "type" : "shell",
       "inline" : [
+        "sudo yum -y install epel-release",
         "sudo /bin/sed -r -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config"
       ]
     },


### PR DESCRIPTION
epel must be installed in the packer definition file because jq is essential to the early stages of the build process.
