### PR TITLE
3.0: Install AWS Batch CLI at AMI build time

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,7 +43,10 @@ suites:
   - name: slurm_install
     run_list:
       - recipe[aws-parallelcluster::slurm_install]
-    attributes:
+
+  - name: awsbatch_install
+    run_list:
+      - recipe[aws-parallelcluster::awsbatch_install]
 
   - name: base_config_HeadNode
     run_list:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Drop support for SGE and Torque schedulers.
 - Remove nodewatcher, sqswatcher, jobwatcher related code.
 - Remove Ganglia support.
+- Install ParallelCluster AWS Batch CLI at AMI build time. 
 
 
 2.x.x

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -20,6 +20,7 @@
     "region" : "{{env `AWS_REGION`}}",
     "custom_ami_id" : "{{env `CUSTOM_AMI_ID`}}",
     "custom_node_package" : "{{env `PARALLELCLUSTER_NODE_URL`}}",
+    "custom_awsbatchcli_package" : "{{env `PARALLELCLUSTER_URL`}}",
     "parallelcluster_ref" : "{{env `PARALLELCLUSTER_REF`}}",
     "parallelcluster_cookbook_ref" : "{{env `PARALLELCLUSTER_COOKBOOK_REF`}}",
     "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}",
@@ -229,6 +230,7 @@
           },
           "is_official_ami_build": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
+          "custom_awsbatchcli_package" : "{{user `custom_awsbatchcli_package`}}",
           "base_os" : "alinux2"
         }
       },
@@ -250,6 +252,7 @@
       "json" : {
         "cluster" : {
           "custom_node_package" : "{{user `custom_node_package`}}",
+          "custom_awsbatchcli_package" : "{{user `custom_awsbatchcli_package`}}",
           "base_os" : "alinux2"
         }
       },

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -21,6 +21,7 @@
     "region" : "{{env `AWS_REGION`}}",
     "custom_ami_id" : "{{env `CUSTOM_AMI_ID`}}",
     "custom_node_package" : "{{env `PARALLELCLUSTER_NODE_URL`}}",
+    "custom_awsbatchcli_package" : "{{env `PARALLELCLUSTER_URL`}}",
     "parallelcluster_ref" : "{{env `PARALLELCLUSTER_REF`}}",
     "parallelcluster_cookbook_ref" : "{{env `PARALLELCLUSTER_COOKBOOK_REF`}}",
     "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}",
@@ -248,6 +249,7 @@
           },
           "is_official_ami_build": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
+          "custom_awsbatchcli_package" : "{{user `custom_awsbatchcli_package`}}",
           "base_os" : "centos7"
         }
       },
@@ -269,6 +271,7 @@
       "json" : {
         "cluster" : {
           "custom_node_package" : "{{user `custom_node_package`}}",
+          "custom_awsbatchcli_package" : "{{user `custom_awsbatchcli_package`}}",
           "base_os" : "centos7"
         }
       },

--- a/amis/packer_centos8.json
+++ b/amis/packer_centos8.json
@@ -21,6 +21,7 @@
     "region" : "{{env `AWS_REGION`}}",
     "custom_ami_id" : "{{env `CUSTOM_AMI_ID`}}",
     "custom_node_package" : "{{env `PARALLELCLUSTER_NODE_URL`}}",
+    "custom_awsbatchcli_package" : "{{env `PARALLELCLUSTER_URL`}}",
     "parallelcluster_ref" : "{{env `PARALLELCLUSTER_REF`}}",
     "parallelcluster_cookbook_ref" : "{{env `PARALLELCLUSTER_COOKBOOK_REF`}}",
     "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}",
@@ -248,6 +249,7 @@
             "installed" : "{{user `dcv_installed`}}"
           },
           "custom_node_package" : "{{user `custom_node_package`}}",
+          "custom_awsbatchcli_package" : "{{user `custom_awsbatchcli_package`}}",
           "base_os" : "centos8"
         }
       },
@@ -269,6 +271,7 @@
       "json" : {
         "cluster" : {
           "custom_node_package" : "{{user `custom_node_package`}}",
+          "custom_awsbatchcli_package" : "{{user `custom_awsbatchcli_package`}}",
           "base_os" : "centos8"
         }
       },

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -21,6 +21,7 @@
     "region" : "{{env `AWS_REGION`}}",
     "custom_ami_id" : "{{env `CUSTOM_AMI_ID`}}",
     "custom_node_package" : "{{env `PARALLELCLUSTER_NODE_URL`}}",
+    "custom_awsbatchcli_package" : "{{env `PARALLELCLUSTER_URL`}}",
     "parallelcluster_ref" : "{{env `PARALLELCLUSTER_REF`}}",
     "parallelcluster_cookbook_ref" : "{{env `PARALLELCLUSTER_COOKBOOK_REF`}}",
     "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}",
@@ -254,6 +255,7 @@
           },
           "is_official_ami_build": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
+          "custom_awsbatchcli_package" : "{{user `custom_awsbatchcli_package`}}",
           "base_os" : "ubuntu1804"
         }
       },
@@ -275,6 +277,7 @@
       "json" : {
         "cluster" : {
           "custom_node_package" : "{{user `custom_node_package`}}",
+          "custom_awsbatchcli_package" : "{{user `custom_awsbatchcli_package`}}",
           "base_os" : "ubuntu1804"
         }
       },

--- a/amis/packer_ubuntu2004.json
+++ b/amis/packer_ubuntu2004.json
@@ -21,6 +21,7 @@
     "region" : "{{env `AWS_REGION`}}",
     "custom_ami_id" : "{{env `CUSTOM_AMI_ID`}}",
     "custom_node_package" : "{{env `PARALLELCLUSTER_NODE_URL`}}",
+    "custom_awsbatchcli_package" : "{{env `PARALLELCLUSTER_URL`}}",
     "parallelcluster_ref" : "{{env `PARALLELCLUSTER_REF`}}",
     "parallelcluster_cookbook_ref" : "{{env `PARALLELCLUSTER_COOKBOOK_REF`}}",
     "parallelcluster_node_ref" : "{{env `PARALLELCLUSTER_NODE_REF`}}",
@@ -254,6 +255,7 @@
           },
           "is_official_ami_build": "true",
           "custom_node_package" : "{{user `custom_node_package`}}",
+          "custom_awsbatchcli_package" : "{{user `custom_awsbatchcli_package`}}",
           "base_os" : "ubuntu2004"
         }
       },
@@ -275,6 +277,7 @@
       "json" : {
         "cluster" : {
           "custom_node_package" : "{{user `custom_node_package`}}",
+          "custom_awsbatchcli_package" : "{{user `custom_awsbatchcli_package`}}",
           "base_os" : "ubuntu2004"
         }
       },

--- a/recipes/awsbatch_config.rb
+++ b/recipes/awsbatch_config.rb
@@ -4,7 +4,7 @@
 # Cookbook Name:: aws-parallelcluster
 # Recipe:: aws_batch_config
 #
-# Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -17,15 +17,7 @@
 
 # Use these recipes to add a custom scheduler
 include_recipe 'aws-parallelcluster::base_config'
-include_recipe 'aws-parallelcluster::base_install'
-
-# Add awsbatch virtualenv to default path
-template "/etc/profile.d/pcluster_awsbatchcli.sh" do
-  source "pcluster_awsbatchcli.sh.erb"
-  owner 'root'
-  group 'root'
-  mode '0644'
-end
+include_recipe 'aws-parallelcluster::awsbatch_install'
 
 # Install aws-parallelcluster-awsbatch-cli.cfg
 awsbatch_cli_config_dir = "/home/#{node['cluster']['cluster_user']}/.parallelcluster/"
@@ -41,26 +33,4 @@ template "#{awsbatch_cli_config_dir}/awsbatch-cli.cfg" do
   owner node['cluster']['cluster_user']
   group node['cluster']['cluster_user']
   mode '0644'
-end
-
-# Check whether install a custom aws-parallelcluster package (for aws-parallelcluster-awsbatchcli) or the standard one
-# Install awsbatch cli into awsbatch virtual env
-if !node['cluster']['custom_awsbatchcli_package'].nil? && !node['cluster']['custom_awsbatchcli_package'].empty?
-  # Install custom aws-parallelcluster package
-  bash "install aws-parallelcluster-awsbatch-cli" do
-    cwd Chef::Config[:file_cache_path]
-    code <<-CLI
-      set -e
-      curl --retry 3 -L -o aws-parallelcluster.tgz #{node['cluster']['custom_awsbatchcli_package']}
-      mkdir aws-parallelcluster-custom-cli
-      tar -xzf aws-parallelcluster.tgz --directory aws-parallelcluster-custom-cli
-      cd aws-parallelcluster-custom-cli/*aws-parallelcluster-*
-      #{node['cluster']['awsbatch_virtualenv_path']}/bin/pip install cli/
-    CLI
-  end
-else
-  # Install aws-parallelcluster package (for aws-parallelcluster-awsbatchcli)
-  execute "pip_install_parallelcluster" do
-    command "#{node['cluster']['awsbatch_virtualenv_path']}/bin/pip install aws-parallelcluster==#{node['cluster']['parallelcluster-version']}"
-  end
 end

--- a/recipes/awsbatch_install.rb
+++ b/recipes/awsbatch_install.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: aws_batch_install
+#
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+return if node['conditions']['ami_bootstrapped']
+
+include_recipe 'aws-parallelcluster::base_install'
+
+# Add awsbatch virtualenv to default path
+template "/etc/profile.d/pcluster_awsbatchcli.sh" do
+  source "pcluster_awsbatchcli.sh.erb"
+  owner 'root'
+  group 'root'
+  mode '0644'
+end
+
+# Check whether install a custom aws-parallelcluster package (for aws-parallelcluster-awsbatchcli) or the standard one
+# Install awsbatch cli into awsbatch virtual env
+if !node['cluster']['custom_awsbatchcli_package'].nil? && !node['cluster']['custom_awsbatchcli_package'].empty?
+  # Install custom aws-parallelcluster package
+  bash "install aws-parallelcluster-awsbatch-cli" do
+    cwd Chef::Config[:file_cache_path]
+    code <<-CLI
+      set -e
+      curl --retry 3 -L -o aws-parallelcluster.tgz #{node['cluster']['custom_awsbatchcli_package']}
+      mkdir aws-parallelcluster-custom-cli
+      tar -xzf aws-parallelcluster.tgz --directory aws-parallelcluster-custom-cli
+      cd aws-parallelcluster-custom-cli/*aws-parallelcluster-*
+      #{node['cluster']['awsbatch_virtualenv_path']}/bin/pip install cli/
+    CLI
+  end
+else
+  # Install aws-parallelcluster package (for aws-parallelcluster-awsbatchcli)
+  execute "pip_install_parallelcluster" do
+    command "#{node['cluster']['awsbatch_virtualenv_path']}/bin/pip install aws-parallelcluster==#{node['cluster']['parallelcluster-version']}"
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@
 validate_os_type
 
 include_recipe 'aws-parallelcluster::slurm_install'
+include_recipe 'aws-parallelcluster::awsbatch_install'
 
 # DCV recipe installs Gnome, X and their dependencies so it must be installed as latest to not break the environment
 # used to build the schedulers packages


### PR DESCRIPTION
The config recipe is used to populate the `aws-parallelcluster-awsbatch-cli.cfg` file according to cluster parameters.

