### PR TITLE
Fix fsx mounting options

### DIFF
--- a/recipes/fsx_mount.rb
+++ b/recipes/fsx_mount.rb
@@ -49,7 +49,7 @@ if fsx_shared_dir != "NONE"
   mountname = node['cfncluster']['cfn_fsx_mount_name']
   mount_options = %w[defaults _netdev flock user_xattr noatime]
 
-  mount_options.push(%w[noauto x-systemd.automount]) if node['init_package'] == 'systemd'
+  mount_options.concat(%w[noauto x-systemd.automount]) if node['init_package'] == 'systemd'
 
   # Mount FSx over NFS
   mount fsx_shared_dir do


### PR DESCRIPTION
After cinc version upgrade to 16.13.16, ruby version using in cinc client is updated from 2.6 to 2.7.
The command in `fsx_mount.rb`
```
mount_options = %w[defaults _netdev flock user_xattr noatime]
mount_options.push(%w[noauto x-systemd.automount]) if node['init_package'] == 'systemd'
```
will have the result 
```
mount_options = [defaults, _netdev, flock, user_xattr, noatime, [noauto, x-systemd.automount]]
```
with the new version, it will cause an error: undefined method `strip' for ["noauto", "x-systemd.automount"]:Array
The expected output is:
```
mount_options = [defaults, _netdev, flock, user_xattr, noatime, noauto, x-systemd.automount]
```

By changing `mount_options.push` into `mount_options.concat`, we are able to get the expected output
```
mount_options = [defaults, _netdev, flock, user_xattr, noatime, noauto, x-systemd.automount]
```
Signed-off-by: chenwany <chenwany@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
