### PR TITLE
3.0: Modify uploadCookbook utility to be aligned with new S3 Bucket tree structure

### DIFF
--- a/recipes/awsbatch_install.rb
+++ b/recipes/awsbatch_install.rb
@@ -35,7 +35,12 @@ if !node['cluster']['custom_awsbatchcli_package'].nil? && !node['cluster']['cust
     cwd Chef::Config[:file_cache_path]
     code <<-CLI
       set -e
-      curl --retry 3 -L -o aws-parallelcluster.tgz #{node['cluster']['custom_awsbatchcli_package']}
+      if [[ "#{node['cluster']['custom_awsbatchcli_package']}" =~ ^s3:// ]]; then
+        custom_package_url=$(#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3 presign #{node['cluster']['custom_awsbatchcli_package']} --region #{node['cluster']['region']})
+      else
+        custom_package_url=#{node['cluster']['custom_awsbatchcli_package']}
+      fi
+      curl --retry 3 -L -o aws-parallelcluster.tgz ${custom_package_url}
       mkdir aws-parallelcluster-custom-cli
       tar -xzf aws-parallelcluster.tgz --directory aws-parallelcluster-custom-cli
       cd aws-parallelcluster-custom-cli/*aws-parallelcluster-*

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -145,7 +145,12 @@ if !node['cluster']['custom_node_package'].nil? && !node['cluster']['custom_node
       echo "PATH is $PATH"
       source #{node['cluster']['node_virtualenv_path']}/bin/activate
       pip uninstall --yes aws-parallelcluster-node
-      curl --retry 3 -L -o aws-parallelcluster-node.tgz #{node['cluster']['custom_node_package']}
+      if [[ "#{node['cluster']['custom_node_package']}" =~ ^s3:// ]]; then
+        custom_package_url=$(#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3 presign #{node['cluster']['custom_node_package']} --region #{node['cluster']['region']})
+      else
+        custom_package_url=#{node['cluster']['custom_node_package']}
+      fi
+      curl --retry 3 -L -o aws-parallelcluster-node.tgz ${custom_package_url}
       mkdir aws-parallelcluster-custom-node
       tar -xzf aws-parallelcluster-node.tgz --directory aws-parallelcluster-custom-node
       cd aws-parallelcluster-custom-node/*aws-parallelcluster-node-*

--- a/util/upload-cookbook.sh
+++ b/util/upload-cookbook.sh
@@ -92,10 +92,11 @@ main() {
     md5sum aws-parallelcluster-cookbook-${_version}.tgz > aws-parallelcluster-cookbook-${_version}.md5
 
     # upload packages
-    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-cookbook-${_version}.tgz s3://${_bucket}/cookbooks/aws-parallelcluster-cookbook-${_version}.tgz || _error_exit 'Failed to push cookbook to S3'
-    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-cookbook-${_version}.md5 s3://${_bucket}/cookbooks/aws-parallelcluster-cookbook-${_version}.md5 || _error_exit 'Failed to push cookbook md5 to S3'
-    aws ${_profile} --region "${_region}" s3api head-object --bucket ${_bucket} --key cookbooks/aws-parallelcluster-cookbook-${_version}.tgz --output text --query LastModified > aws-parallelcluster-cookbook-${_version}.tgz.date || _error_exit 'Failed to fetch LastModified date'
-    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-cookbook-${_version}.tgz.date s3://${_bucket}/cookbooks/aws-parallelcluster-cookbook-${_version}.tgz.date || _error_exit 'Failed to push cookbook date'
+    _key_path="parallelcluster/${_version}/cookbooks"
+    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-cookbook-${_version}.tgz s3://${_bucket}/${_key_path}/aws-parallelcluster-cookbook-${_version}.tgz || _error_exit 'Failed to push cookbook to S3'
+    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-cookbook-${_version}.md5 s3://${_bucket}/${_key_path}/aws-parallelcluster-cookbook-${_version}.md5 || _error_exit 'Failed to push cookbook md5 to S3'
+    aws ${_profile} --region "${_region}" s3api head-object --bucket ${_bucket} --key ${_key_path}/aws-parallelcluster-cookbook-${_version}.tgz --output text --query LastModified > aws-parallelcluster-cookbook-${_version}.tgz.date || _error_exit 'Failed to fetch LastModified date'
+    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-cookbook-${_version}.tgz.date s3://${_bucket}/${_key_path}/aws-parallelcluster-cookbook-${_version}.tgz.date || _error_exit 'Failed to push cookbook date'
 
     _bucket_region=$(aws ${_profile} s3api get-bucket-location --bucket ${_bucket} --output text)
     if [ ${_bucket_region} = "None" ]; then
@@ -105,8 +106,11 @@ main() {
     fi
 
     echo ""
-    echo "Done. Add the following variable to the pcluster config file, under the [cluster ...] section"
-    echo "custom_chef_cookbook = https://s3${_bucket_region}.amazonaws.com/${_bucket}/cookbooks/aws-parallelcluster-cookbook-${_version}.tgz"
+    echo "Done. Add the following configuration to the pcluster create config file:"
+    echo ""
+    echo "DevSettings:"
+    echo "  Cookbook:"
+    echo "    ChefCookbook: s3://${_bucket}/${_key_path}/aws-parallelcluster-cookbook-${_version}.tgz"
 }
 
 main "$@"


### PR DESCRIPTION
```
custom-bucket  # bucket selected by user for custom artifacts
└── parallelcluster
    └── 3.0.0 # new folder
        ├── cli # uploaded by uploadCLI.sh script
        │   └── aws-parallelcluster-3.0.0.tgz
        ├── cookbooks  # uploaded by uploadCookbok.sh script
        │   └── aws-parallelcluster-cookbook-3.0.0.*
        └── node  # uploaded by uploadNode.sh script
            └── aws-parallelcluster-node-3.0.0.*
```
