### PR TITLE
Downgrade python version to 3.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade CUDA library to version 11.3.0.
 - Upgrade NVIDIA Fabric manager to `nvidia-fabricmanager-460`.
 - Install ParallelCluster AWSBatch CLI in dedicated python3 virtual env.
-- Upgrade Python version used in ParallelCluster virtualenvs from version 3.6.13 to version 3.9.4.
+- Upgrade Python version used in ParallelCluster virtualenvs from version 3.6.13 to version 3.7.10.
 
 2.10.3
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,7 @@ default['cfncluster']['cluster_config_version'] = nil
 default['cfncluster']['cluster_config_path'] = "#{node['cfncluster']['configs_dir']}/cluster_config.json"
 
 # Python Version
-default['cfncluster']['python-version'] = '3.9.4'
+default['cfncluster']['python-version'] = '3.7.10'
 # plcuster-specific pyenv system installation root
 default['cfncluster']['system_pyenv_root'] = "#{node['cfncluster']['base_dir']}/pyenv"
 # Virtualenv Cookbook Name


### PR DESCRIPTION
This commit will amend the #943

cfn-hup is not compatible with Python 3.8 and 3.9.

Therefore, we set the version to 3.7.10

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
