### PR TITLE
3.0: Downgrade python version to 3.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Remove nodewatcher, sqswatcher, jobwatcher related code.
 - Remove Ganglia support.
 - Install ParallelCluster AWS Batch CLI at AMI build time.
-- Upgrade Python version used in ParallelCluster virtualenvs from version 3.6.13 to version 3.9.4.
 
 
 2.x.x
@@ -45,6 +44,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade CUDA library to version 11.3.0.
 - Upgrade NVIDIA Fabric manager to `nvidia-fabricmanager-460`.
 - Install ParallelCluster AWSBatch CLI in dedicated python3 virtual env.
+- Upgrade Python version used in ParallelCluster virtualenvs from version 3.6.13 to version 3.7.10.
 
 2.10.3
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,7 +31,7 @@ default['cluster']['cluster_config_path'] = "#{node['cluster']['configs_dir']}/c
 default['cluster']['instance_types_data_path'] = "#{node['cluster']['configs_dir']}/instance-types-data.json"
 
 # Python Version
-default['cluster']['python-version'] = '3.9.4'
+default['cluster']['python-version'] = '3.7.10'
 # plcuster-specific pyenv system installation root
 default['cluster']['system_pyenv_root'] = "#{node['cluster']['base_dir']}/pyenv"
 # Virtualenv Cookbook Name


### PR DESCRIPTION
cfn-hup is not compatible with Python 3.8 and 3.9.

Therefore, we set the version to 3.7.10

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
