### PR TITLE
Update deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 
 group :test do
   gem 'chefspec', '~> 9.2.1'
-  gem 'kitchen-vagrant', '~> 1.6.1'
+  gem 'kitchen-vagrant', '~> 1.8.0'
   gem 'safe_yaml', '~> 1.0.5'
   gem 'test-kitchen', '~> 2.11.2'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'berkshelf'
 group :style do
   gem 'foodcritic', '~> 16.2.0'
   gem 'rake', '~> 13.0.1'
-  gem 'rubocop', '~> 1.12.0'
+  gem 'rubocop', '~> 1.14.0'
   gem 'rubocop-gitlab-security', '~> 0.1.1'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :style do
 end
 
 group :test do
-  gem 'chefspec', '~> 9.2.1'
+  gem 'chefspec', '~> 9.3.0'
   gem 'kitchen-vagrant', '~> 1.8.0'
   gem 'safe_yaml', '~> 1.0.5'
   gem 'test-kitchen', '~> 2.11.2'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'berkshelf'
 
 group :style do
-  gem 'foodcritic', '~> 16.2.0'
+  gem 'foodcritic', '~> 16.3.0'
   gem 'rake', '~> 13.0.1'
   gem 'rubocop', '~> 1.14.0'
   gem 'rubocop-gitlab-security', '~> 0.1.1'


### PR DESCRIPTION
- Update rubocop requirement from ~> 1.12.0 to ~> 1.14.0 
- Update kitchen-vagrant requirement from ~> 1.6.1 to ~> 1.8.0 
- Update foodcritic requirement from ~> 16.2.0 to ~> 16.3.0 
- Update chefspec requirement from ~> 9.2.1 to ~> 9.3.0 
