### PR TITLE
2.10: Upgrade Slurm from 20.02.4 to 20.02.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+2.10.4
+-----
+
+**CHANGES**
+- Upgrade Slurm to version 20.02.7
+
 2.10.3
 -----
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -98,9 +98,9 @@ default['cfncluster']['torque']['version'] = '6.1.2'
 default['cfncluster']['torque']['url'] = 'https://github.com/adaptivecomputing/torque/archive/6.1.2.tar.gz'
 # Slurm software
 default['cfncluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
-default['cfncluster']['slurm']['version'] = '20.02.4'
-default['cfncluster']['slurm']['url'] = 'https://download.schedmd.com/slurm/slurm-20.02.4.tar.bz2'
-default['cfncluster']['slurm']['sha1'] = '294de3a2e1410945eb516c40eff5f92087501893'
+default['cfncluster']['slurm']['version'] = '20-02-7-1'
+default['cfncluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['cfncluster']['slurm']['version']}.tar.gz"
+default['cfncluster']['slurm']['sha1'] = '36548efab7d19f24b3fef3bd52f75efb664349d9'
 # PMIx software
 default['cfncluster']['pmix']['version'] = '3.1.5'
 default['cfncluster']['pmix']['url'] = "https://github.com/openpmix/openpmix/releases/download/v#{node['cfncluster']['pmix']['version']}/pmix-#{node['cfncluster']['pmix']['version']}.tar.gz"

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -59,7 +59,7 @@ when 'MasterServer', nil
       source #{node['cfncluster']['cookbook_virtualenv_path']}/bin/activate
 
       tar xf #{slurm_tarball}
-      cd slurm-#{node['cfncluster']['slurm']['version']}
+      cd slurm-slurm-#{node['cfncluster']['slurm']['version']}
       ./configure --prefix=/opt/slurm --with-pmix=/opt/pmix
       CORES=$(grep processor /proc/cpuinfo | wc -l)
       make -j $CORES
@@ -89,7 +89,7 @@ when 'MasterServer', nil
     cwd Chef::Config[:file_cache_path]
     code <<-SLURMLICENSE
       set -e
-      cd slurm-#{node['cfncluster']['slurm']['version']}
+      cd slurm-slurm-#{node['cfncluster']['slurm']['version']}
       cp -v COPYING #{node['cfncluster']['license_dir']}/slurm/COPYING
       cp -v DISCLAIMER #{node['cfncluster']['license_dir']}/slurm/DISCLAIMER
       cp -v LICENSE.OpenSSL #{node['cfncluster']['license_dir']}/slurm/LICENSE.OpenSSL


### PR DESCRIPTION
+ Upgrade Slurm from 20.02.4 to 20.02.7
+ Use GitHub as repository to download source code (reverts https://github.com/aws/aws-parallelcluster-cookbook/commit/91cb7f7f4e58956cdfb017cc2a108e3c22698192) 

Signed-off-by: Enrico Usai <usai@amazon.com>

