### PR TITLE
Use cinc-client instead of chef-client when building AMIs

### DIFF
--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -198,7 +198,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "json" : {
         "cfncluster" : {
           "default_pre_reboot" : "false"
@@ -235,7 +235,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]
@@ -253,7 +253,7 @@
         }
       },
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]

--- a/amis/packer_alinux2.json
+++ b/amis/packer_alinux2.json
@@ -198,7 +198,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "json" : {
         "cfncluster" : {
           "default_pre_reboot" : "false"
@@ -235,7 +235,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]
@@ -253,7 +253,7 @@
         }
       },
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -214,7 +214,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "json" : {
         "cfncluster" : {
           "default_pre_reboot" : "false"
@@ -254,7 +254,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]
@@ -272,7 +272,7 @@
         }
       },
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]

--- a/amis/packer_centos8.json
+++ b/amis/packer_centos8.json
@@ -213,7 +213,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "json" : {
         "cfncluster" : {
           "default_pre_reboot" : "false"
@@ -253,7 +253,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]
@@ -271,7 +271,7 @@
         }
       },
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -219,7 +219,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "json" : {
         "cfncluster" : {
           "default_pre_reboot" : "false"
@@ -256,7 +256,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]
@@ -274,7 +274,7 @@
         }
       },
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -220,7 +220,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "json" : {
         "cfncluster" : {
           "default_pre_reboot" : "false"
@@ -260,7 +260,7 @@
         "/etc/chef/cookbooks"
       ],
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]
@@ -278,7 +278,7 @@
         }
       },
       "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "execute_command" : "sudo cinc-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
         "aws-parallelcluster::default"
       ]


### PR DESCRIPTION
When using chef-client with CINC, CINC wrapper launches the process in a Mixlib::ShellOut process with timeout=3600s. This will cause an issue with long Chef runs when building an AMI. Using the cinc-client directly avoid this wrapper logic and timeout restriction.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
