### PR TITLE
3.0: Upgrade Slurm from 20.11.5 to 20.11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Increase timeout when attaching EBS volumes from 3 to 5 minutes.
 - Retry `berkshelf` installation up to 3 times.
 - Root volume size increased to 35GB on all AMIs.
-- Upgrade Slurm to version 20.11.5.
+- Upgrade Slurm to version 20.11.7.
   - Update slurmctld and slurmd systemd unit files according to latest provided by slurm
   - Add new SlurmctldParameters, power_save_min_interval=30, so power actions will be processed every 30 seconds
   - Add new SlurmctldParameters, cloud_reg_addrs, which will reset a node's NodeAddr automatically on power_down

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -108,9 +108,9 @@ default['cluster']['parallelcluster-node-version'] = '3.0.0'
 # URLs to software packages used during install recipes
 # Slurm software
 default['cluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
-default['cluster']['slurm']['version'] = '20.11.5'
-default['cluster']['slurm']['url'] = 'https://download.schedmd.com/slurm/slurm-20.11.5.tar.bz2'
-default['cluster']['slurm']['sha1'] = '201a28afe6f02a717fb348542878900cad4ccf13'
+default['cluster']['slurm']['version'] = '20-11-7-1'
+default['cluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['cfncluster']['slurm']['version']}.tar.gz"
+default['cluster']['slurm']['sha1'] = 'ce927fbf2f7d5f908ed87c5d521abc696b9a2508'
 # PMIx software
 default['cluster']['pmix']['version'] = '3.1.5'
 default['cluster']['pmix']['url'] = "https://github.com/openpmix/openpmix/releases/download/v#{node['cluster']['pmix']['version']}/pmix-#{node['cluster']['pmix']['version']}.tar.gz"

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -59,7 +59,7 @@ when 'HeadNode', nil
       source #{node['cluster']['cookbook_virtualenv_path']}/bin/activate
 
       tar xf #{slurm_tarball}
-      cd slurm-#{node['cluster']['slurm']['version']}
+      cd slurm-slurm-#{node['cluster']['slurm']['version']}
       ./configure --prefix=/opt/slurm --with-pmix=/opt/pmix
       CORES=$(grep processor /proc/cpuinfo | wc -l)
       make -j $CORES
@@ -89,7 +89,7 @@ when 'HeadNode', nil
     cwd Chef::Config[:file_cache_path]
     code <<-SLURMLICENSE
       set -e
-      cd slurm-#{node['cluster']['slurm']['version']}
+      cd slurm-slurm-#{node['cluster']['slurm']['version']}
       cp -v COPYING #{node['cluster']['license_dir']}/slurm/COPYING
       cp -v DISCLAIMER #{node['cluster']['license_dir']}/slurm/DISCLAIMER
       cp -v LICENSE.OpenSSL #{node['cluster']['license_dir']}/slurm/LICENSE.OpenSSL


### PR DESCRIPTION
+ Use GitHub as repository to download source code.

Signed-off-by: Enrico Usai <usai@amazon.com>
Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
