### PR TITLE
Add protected mode and decrease ResumeTimeout to 1800

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Add new SlurmctldParameters, power_save_min_interval=30, so power actions will be processed every 30 seconds
   - Add new SlurmctldParameters, cloud_reg_addrs, which will reset a node's NodeAddr automatically on power_down
   - Specify instance GPU model as GRES GPU Type in gres.conf
+  - Reduce default Slurm ResumeTimeout to from 3600 seconds to 1800 seconds
 - Upgrade Arm Performance Libraries (APL) to version 21.0.0
 - Upgrade NICE DCV to version 2021.0-10242.
 - Upgrade NVIDIA driver to version 460.73.01.

--- a/templates/default/slurm/slurm.conf.erb
+++ b/templates/default/slurm/slurm.conf.erb
@@ -34,7 +34,7 @@ SuspendProgram=<%= node['cfncluster']['scripts_dir'] %>/slurm/slurm_suspend
 ResumeProgram=<%= node['cfncluster']['scripts_dir'] %>/slurm/slurm_resume
 ResumeFailProgram=<%= node['cfncluster']['scripts_dir'] %>/slurm/slurm_suspend
 SuspendTimeout=120
-ResumeTimeout=3600
+ResumeTimeout=1800
 PrivateData=cloud
 ResumeRate=0
 SuspendRate=0


### PR DESCRIPTION
Add protected failure count, decrease ResumeTimeout to 1800 seconds

Signed-off-by: chenwany <chenwany@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
