### PR TITLE
3.0: Create SSM script to write AWS credentials for cluster admin user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Remove Ganglia support.
 - Install ParallelCluster AWS Batch CLI at AMI build time.
 - Run daemons as cluster admin user (not root).
+- Add SSM script to write AWS credentials for cluster admin user.
 
 
 2.x.x

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -563,7 +563,7 @@ def check_path_permissions(path, user, group, permissions)
   bash "check permissions on path #{path}" do
     cwd Chef::Config[:file_cache_path]
     code <<-TEST
-      if [[ ! -d "#{path}" ]]; then
+      if [[ ! -d "#{path}" && ! -f "#{path}" ]]; then
         >&2 echo "Expected path does not exist: #{path}"
         exit 1
       fi

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 include_recipe 'aws-parallelcluster::base_install'
-include_recipe "aws-parallelcluster::cluster_admin_user_config"
 
 # Restart sshd.service to make sure the service is running
 # This is a workaround for Centos 8 where the sshd.service fails at first start since it does not properly
@@ -69,6 +68,9 @@ when 'ComputeFleet'
 else
   raise "node_type must be HeadNode or ComputeFleet"
 end
+
+# Configure cluster admin user
+include_recipe "aws-parallelcluster::cluster_admin_user_config"
 
 # Ensure cluster user can sudo on SSH
 template '/etc/sudoers.d/99-parallelcluster-user-tty' do

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -69,9 +69,6 @@ else
   raise "node_type must be HeadNode or ComputeFleet"
 end
 
-# Configure cluster admin user
-include_recipe "aws-parallelcluster::cluster_admin_user_config"
-
 # Ensure cluster user can sudo on SSH
 template '/etc/sudoers.d/99-parallelcluster-user-tty' do
   source '99-parallelcluster-user-tty.erb'

--- a/recipes/cluster_admin_user_config.rb
+++ b/recipes/cluster_admin_user_config.rb
@@ -32,3 +32,11 @@ user node['cluster']['cluster_admin_user'] do
   home "/home/#{node['cluster']['cluster_admin_user']}"
   manage_home false
 end
+
+# Setup cluster admin home
+directory "/home/#{node['cluster']['cluster_admin_user']}" do
+  user node['cluster']['cluster_admin_user']
+  group node['cluster']['cluster_admin_group']
+  mode '0700'
+  recursive true
+end

--- a/recipes/prep_env.rb
+++ b/recipes/prep_env.rb
@@ -66,6 +66,12 @@ template "/opt/parallelcluster/scripts/fetch_and_run" do
   mode "0755"
 end
 
+# Configure cluster admin user
+include_recipe "aws-parallelcluster::cluster_admin_user_config"
+
+# SSM scripts
+include_recipe "aws-parallelcluster::ssm_config"
+
 include_recipe "aws-parallelcluster::setup_python"
 
 # Install cloudwatch, write configuration and start it.

--- a/recipes/prep_env.rb
+++ b/recipes/prep_env.rb
@@ -69,8 +69,11 @@ end
 # Configure cluster admin user
 include_recipe "aws-parallelcluster::cluster_admin_user_config"
 
-# SSM scripts
+# SSM scripts (requires: cfnconfig file and cluster admin user)
 include_recipe "aws-parallelcluster::ssm_config"
+
+#TODO Once we convert all the AWS calls from being executed as root to being executed as cluster admin user,
+# we must wait here for SSM providing credentials to the cluster admin user.
 
 include_recipe "aws-parallelcluster::setup_python"
 

--- a/recipes/ssm_config.rb
+++ b/recipes/ssm_config.rb
@@ -15,6 +15,11 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+service "amazon-ssm-agent" do
+  supports restart: true
+  action %i[enable start]
+end
+
 ssm_scripts_directory = "#{node['cluster']['scripts_dir']}/ssm"
 
 directory ssm_scripts_directory do

--- a/recipes/ssm_config.rb
+++ b/recipes/ssm_config.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: ssm_config
+#
+# Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+ssm_scripts_directory = "#{node['cluster']['scripts_dir']}/ssm"
+
+directory ssm_scripts_directory do
+  owner 'root'
+  group 'root'
+  mode '0744'
+end
+
+template "#{ssm_scripts_directory}/write_aws_credentials.sh" do
+  source 'ssm/write_aws_credentials.sh.erb'
+  user 'root'
+  group 'root'
+  mode '0744'
+end

--- a/recipes/test_ssm.rb
+++ b/recipes/test_ssm.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: test_ssm
+#
+# Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+######################################
+# Root access on SSM resources
+######################################
+ssm_scripts_directory = "#{node['cluster']['scripts_dir']}/ssm"
+
+check_path_permissions(
+  ssm_scripts_directory,
+  'root',
+  'root',
+  "drwxr--r--"
+)
+
+check_path_permissions(
+  "#{ssm_scripts_directory}/write_aws_credentials.sh",
+  'root',
+  'root',
+  "-rwxr--r--"
+)

--- a/recipes/test_users.rb
+++ b/recipes/test_users.rb
@@ -30,6 +30,13 @@ check_group_definition(
   node['cluster']['cluster_admin_group_id']
 )
 
+check_path_permissions(
+  "/home/#{node['cluster']['cluster_admin_user']}",
+  node['cluster']['cluster_admin_user'],
+  node['cluster']['cluster_admin_group'],
+  "drwx------"
+)
+
 if node['cluster']['node_type'] == 'HeadNode' && node['cluster']['scheduler'] == 'slurm'
   check_path_permissions(
     "/opt/slurm/etc/pcluster/.slurm_plugin",

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -17,6 +17,7 @@
 
 include_recipe 'aws-parallelcluster::test_users'
 include_recipe 'aws-parallelcluster::test_processes'
+include_recipe 'aws-parallelcluster::test_ssm'
 
 ###################
 # AWS Cli

--- a/templates/default/cfnconfig.erb
+++ b/templates/default/cfnconfig.erb
@@ -21,3 +21,4 @@ scheduler_queue_name=<%= node['cluster']['scheduler_queue_name'] %>
 <% if node['cluster']['node_type'] == 'HeadNode' -%>
 volume=<%= node['cluster']['volume'] %>
 <% end -%>
+scripts_dir=<%= node['cluster']['scripts_dir'] %>

--- a/templates/default/ssm/write_aws_credentials.sh.erb
+++ b/templates/default/ssm/write_aws_credentials.sh.erb
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# This script writes AWS credentials for the cluster admin user.
+# This script is meant to be called by SSM.
+#
+# Usage: $SCRIPT_NAME [AWS_IAM_ASSUMED_ROLE_ARN] [AWS_ACCESS_KEY_ID] [AWS_SECRET_ACCESS_KEY] [AWS_SESSION_TOKEN]
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+CLUSTER_ADMIN_USER=<%= node['cluster']['cluster_admin_user'] %>
+
+AWS_IAM_ASSUMED_ROLE_ARN=$1
+AWS_ACCESS_KEY_ID=$2
+AWS_SECRET_ACCESS_KEY=$3
+AWS_SESSION_TOKEN=$4
+
+function error () {
+  >&2 echo "ERROR: $1"
+  exit 1
+}
+
+echo "Running script: $SCRIPT_DIR/$SCRIPT_NAME"
+echo "Running as user: $(whoami)"
+echo "Running from folder: $(pwd)"
+echo "Running for cluster admin user: $CLUSTER_ADMIN_USER"
+
+[[ -n $AWS_IAM_ASSUMED_ROLE_ARN ]] || error "Required argument missing: AWS_IAM_ASSUMED_ROLE_ARN"
+[[ -n $AWS_ACCESS_KEY_ID ]] || error "Required argument missing: AWS_ACCESS_KEY_ID"
+[[ -n $AWS_SECRET_ACCESS_KEY ]] || error "Required argument missing: AWS_SECRET_ACCESS_KEY"
+[[ -n $AWS_SESSION_TOKEN ]] || error "Required argument missing: AWS_SESSION_TOKEN"
+
+[[ -n $(id -u $CLUSTER_ADMIN_USER 2>/dev/null) ]] || error "User does not exist: $CLUSTER_ADMIN_USER"
+
+CLUSTER_ADMIN_USER_HOME=$(sudo -u $CLUSTER_ADMIN_USER env | grep -e "^HOME=" | cut -d = -f 2)
+
+[[ -d $CLUSTER_ADMIN_USER_HOME ]] || error "User HOME does not exist: $CLUSTER_ADMIN_USER_HOME"
+
+CREDENTIALS_FILE="$CLUSTER_ADMIN_USER_HOME/.aws/credentials"
+
+echo "Writing AWS credentials for role $AWS_IAM_ASSUMED_ROLE_ARN in $CREDENTIALS_FILE"
+
+mkdir -p $(dirname $CREDENTIALS_FILE)
+
+cat > $CREDENTIALS_FILE <<EOL
+[default]
+aws_access_key_id = $AWS_ACCESS_KEY_ID
+aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
+aws_session_token = $AWS_SESSION_TOKEN
+EOL
+
+echo "AWS credentials written"
+
+echo "Checking AWS credentials"
+
+[[ $? == 0 ]] || error "Failed AWS credentials check: error when calling STS"
+actual_identity_arn=$(sudo -u $CLUSTER_ADMIN_USER aws sts get-caller-identity --output text --query 'Arn')
+[[ $actual_identity_arn == $AWS_IAM_ASSUMED_ROLE_ARN ]] || error "Failed AWS credentials check: expected identity is $AWS_IAM_ASSUMED_ROLE_ARN, but found $actual_identity_arn"
+
+echo "AWS credentials are correct"


### PR DESCRIPTION
### Changes
1. Create SSM script to write AWS credentials for cluster admin user.
2. Create cluster admin home during node configuration.
3. Added  `scripts_dir` to `cfnconfig`. This change is required by SSM scripts to know where to find the local scripts to run.
3. (minor) Make recipe test helper check_path_permissions handle both directories and files (used to test SSM recipe)
4. (minor) Moved inclusion of recipe `cluster_admin_user_config` after home mounting through NFS. Without this change kitchen tests on compute nodes fail due to home being overwritten.


### Tests
1. Tested on a personal cluster: creation, recipe test execution and script execution.
2. Kitchen tests succeeded

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
