### PR TITLE
3Add logic to install new aws-parallelcluster-awsbatch-cli package

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -104,6 +104,7 @@ default['cluster']['armpl']['url'] = [
 default['cluster']['parallelcluster-version'] = '3.0.0'
 default['cluster']['parallelcluster-cookbook-version'] = '3.0.0'
 default['cluster']['parallelcluster-node-version'] = '3.0.0'
+default['cluster']['parallelcluster-awsbatch-cli-version'] = '1.0.0'
 
 # URLs to software packages used during install recipes
 # Slurm software

--- a/recipes/awsbatch_install.rb
+++ b/recipes/awsbatch_install.rb
@@ -27,7 +27,7 @@ template "/etc/profile.d/pcluster_awsbatchcli.sh" do
   mode '0644'
 end
 
-# Check whether install a custom aws-parallelcluster package (for aws-parallelcluster-awsbatchcli) or the standard one
+# Check whether install a custom aws-parallelcluster-awsbatch-cli package or the standard one
 # Install awsbatch cli into awsbatch virtual env
 if !node['cluster']['custom_awsbatchcli_package'].nil? && !node['cluster']['custom_awsbatchcli_package'].empty?
   # Install custom aws-parallelcluster package
@@ -41,15 +41,15 @@ if !node['cluster']['custom_awsbatchcli_package'].nil? && !node['cluster']['cust
         custom_package_url=#{node['cluster']['custom_awsbatchcli_package']}
       fi
       curl --retry 3 -L -o aws-parallelcluster.tgz ${custom_package_url}
-      mkdir aws-parallelcluster-custom-cli
-      tar -xzf aws-parallelcluster.tgz --directory aws-parallelcluster-custom-cli
-      cd aws-parallelcluster-custom-cli/*aws-parallelcluster-*
-      #{node['cluster']['awsbatch_virtualenv_path']}/bin/pip install cli/
+      mkdir aws-parallelcluster-awsbatch-cli
+      tar -xzf aws-parallelcluster.tgz --directory aws-parallelcluster-awsbatch-cli
+      cd aws-parallelcluster-awsbatch-cli/*aws-parallelcluster-*
+      #{node['cluster']['awsbatch_virtualenv_path']}/bin/pip install awsbatch-cli/
     CLI
   end
 else
-  # Install aws-parallelcluster package (for aws-parallelcluster-awsbatchcli)
-  execute "pip_install_parallelcluster" do
-    command "#{node['cluster']['awsbatch_virtualenv_path']}/bin/pip install aws-parallelcluster==#{node['cluster']['parallelcluster-version']}"
+  # Install aws-parallelcluster-awsbatch-cli package
+  execute "pip_install_parallelcluster_awsbatch_cli" do
+    command "#{node['cluster']['awsbatch_virtualenv_path']}/bin/pip install aws-parallelcluster-awsbatch-cli==#{node['cluster']['parallelcluster-awsbatch-cli-version']}"
   end
 end

--- a/util/bump-version.sh
+++ b/util/bump-version.sh
@@ -2,16 +2,24 @@
 
 set -ex
 
-if [ -z "$1" ]; then
-    echo "New version not specified. Usage: bump-version.sh NEW_VERSION"
+if [ -z "$1" -o -z "$2" ]; then
+    echo "New version not specified. Usage: bump-version.sh NEW_PCLUSTER_VERSION NEW_AWSBATCH_CLI_VERSION"
     exit 1
 fi
 
-NEW_VERSION=$1
-CURRENT_VERSION=$(sed -ne "s/^version '\(.*\)'/\1/p" metadata.rb)
+NEW_PCLUSTER_VERSION=$1
+NEW_AWSBATCH_CLI_VERSION=$2
 
-sed -i -e "s/\(.*parallelcluster.*version.*\)$CURRENT_VERSION.*\(\".*\)/\1$NEW_VERSION\2/g" amis/packer_variables.json
-sed -i "s/default\['cluster'\]\['parallelcluster-version'\] = '$CURRENT_VERSION'/default['cluster']['parallelcluster-version'] = '$NEW_VERSION'/g" attributes/default.rb
-sed -i "s/default\['cluster'\]\['parallelcluster-cookbook-version'\] = '$CURRENT_VERSION'/default['cluster']['parallelcluster-cookbook-version'] = '$NEW_VERSION'/g" attributes/default.rb
-sed -i "s/default\['cluster'\]\['parallelcluster-node-version'\] = '$CURRENT_VERSION'/default['cluster']['parallelcluster-node-version'] = '$NEW_VERSION'/g" attributes/default.rb
-sed -i "s/version '$CURRENT_VERSION'/version '$NEW_VERSION'/g" metadata.rb
+
+CURRENT_PCLUSTER_VERSION=$(sed -ne "s/^version '\(.*\)'/\1/p" metadata.rb)
+
+sed -i -e "s/\(.*parallelcluster.*version.*\)${CURRENT_PCLUSTER_VERSION}.*\(\".*\)/\1${NEW_PCLUSTER_VERSION}\2/g" amis/packer_variables.json
+sed -i "s/default\['cluster'\]\['parallelcluster-version'\] = '${CURRENT_PCLUSTER_VERSION}'/default['cluster']['parallelcluster-version'] = '${NEW_PCLUSTER_VERSION}'/g" attributes/default.rb
+sed -i "s/default\['cluster'\]\['parallelcluster-cookbook-version'\] = '$CURRENT_PCLUSTER_VERSION'/default['cluster']['parallelcluster-cookbook-version'] = '${NEW_PCLUSTER_VERSION}'/g" attributes/default.rb
+sed -i "s/default\['cluster'\]\['parallelcluster-node-version'\] = '${CURRENT_PCLUSTER_VERSION}'/default['cluster']['parallelcluster-node-version'] = '${NEW_PCLUSTER_VERSION}'/g" attributes/default.rb
+sed -i "s/version '${CURRENT_PCLUSTER_VERSION}'/version '${NEW_PCLUSTER_VERSION}'/g" metadata.rb
+
+
+CURRENT_AWSBATCH_CLI_VERSION=$(sed -ne "s/^default\['cluster'\]\['parallelcluster-awsbatch-cli-version'\] = '\(.*\)'/\1/p" attributes/default.rb)
+
+sed -i "s/default\['cluster'\]\['parallelcluster-awsbatch-cli-version'\] = '${CURRENT_AWSBATCH_CLI_VERSION}'/default['cluster']['parallelcluster-awsbatch-cli-version'] = '${NEW_AWSBATCH_CLI_VERSION}'/g" attributes/default.rb


### PR DESCRIPTION
* bump-version.sh now accepts two versions (pcluster and awsbatch cli) not aligned
* custom package will be installed from awsbatch-cli folder


Related to https://github.com/aws/aws-parallelcluster/pull/2659