### PR TITLE
3.0: Assign explicit names, uids and gids for slurm, munge, and dcvextauth users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Remove Ganglia support.
 - Install ParallelCluster AWS Batch CLI at AMI build time.
 - Run daemons as cluster admin user (not root).
+- Add explicit assignment of names, uids, gids for slurm, munge and dcvextauth users.
 
 
 2.x.x

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,7 @@ default['cluster']['cluster_config_version'] = nil
 default['cluster']['instance_types_data_s3_key'] = nil
 default['cluster']['cluster_config_path'] = "#{node['cluster']['configs_dir']}/cluster-config.yaml"
 default['cluster']['instance_types_data_path'] = "#{node['cluster']['configs_dir']}/instance-types-data.json"
+default['cluster']['reserved_base_uid'] = 400
 
 # Python Version
 default['cluster']['python-version'] = '3.7.10'
@@ -112,6 +113,10 @@ default['cluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
 default['cluster']['slurm']['version'] = '20-11-7-1'
 default['cluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['cluster']['slurm']['version']}.tar.gz"
 default['cluster']['slurm']['sha1'] = 'ce927fbf2f7d5f908ed87c5d521abc696b9a2508'
+default['cluster']['slurm']['user'] = 'slurm'
+default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1
+default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']
+default['cluster']['slurm']['group_id'] = node['cluster']['slurm']['user_id']
 # PMIx software
 default['cluster']['pmix']['version'] = '3.1.5'
 default['cluster']['pmix']['url'] = "https://github.com/openpmix/openpmix/releases/download/v#{node['cluster']['pmix']['version']}/pmix-#{node['cluster']['pmix']['version']}.tar.gz"
@@ -119,6 +124,10 @@ default['cluster']['pmix']['sha1'] = '36bfb962858879cefa7a04a633c1b6984cea03ec'
 # Munge
 default['cluster']['munge']['munge_version'] = '0.5.14'
 default['cluster']['munge']['munge_url'] = "https://github.com/dun/munge/archive/munge-#{node['cluster']['munge']['munge_version']}.tar.gz"
+default['cluster']['munge']['user'] = 'munge'
+default['cluster']['munge']['user_id'] = node['cluster']['reserved_base_uid'] + 2
+default['cluster']['munge']['group'] = node['cluster']['munge']['user']
+default['cluster']['munge']['group_id'] = node['cluster']['munge']['user_id']
 
 # NVIDIA
 default['cluster']['nvidia']['enabled'] = 'no'
@@ -228,6 +237,9 @@ default['cluster']['dcv']['gl'] = value_for_platform( # required to enable GPU s
 default['cluster']['dcv']['url'] = "https://d1uj6qtbmh3dt5.cloudfront.net/2021.0/Servers/#{node['cluster']['dcv']['package']}.tgz"
 # DCV external authenticator configuration
 default['cluster']['dcv']['authenticator']['user'] = "dcvextauth"
+default['cluster']['dcv']['authenticator']['user_id'] = node['cluster']['reserved_base_uid'] + 3
+default['cluster']['dcv']['authenticator']['group'] = node['cluster']['dcv']['authenticator']['user']
+default['cluster']['dcv']['authenticator']['group_id'] = node['cluster']['dcv']['authenticator']['user_id']
 default['cluster']['dcv']['authenticator']['user_home'] = "/home/#{node['cluster']['dcv']['authenticator']['user']}"
 default['cluster']['dcv']['authenticator']['certificate'] = "/etc/parallelcluster/ext-auth-certificate.pem"
 default['cluster']['dcv']['authenticator']['private_key'] = "/etc/parallelcluster/ext-auth-private-key.pem"
@@ -424,7 +436,6 @@ default['cluster']['efs_shared_dir'] = 'NONE'
 default['cluster']['efs_fs_id'] = nil
 default['cluster']['head_node'] = nil
 default['cluster']['head_node_private_ip'] = nil
-default['cluster']['reserved_base_uid'] = 400
 default['cluster']['cluster_admin_user'] = 'pcluster'
 default['cluster']['cluster_admin_user_id'] = node['cluster']['reserved_base_uid']
 default['cluster']['cluster_admin_group'] = node['cluster']['cluster_admin_user']

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 include_recipe 'aws-parallelcluster::base_install'
-include_recipe "aws-parallelcluster::cluster_admin_user_config"
 
 # Restart sshd.service to make sure the service is running
 # This is a workaround for Centos 8 where the sshd.service fails at first start since it does not properly

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -17,6 +17,8 @@
 
 return if node['conditions']['ami_bootstrapped']
 
+include_recipe "aws-parallelcluster::cluster_admin_user_install"
+
 case node['platform_family']
 when 'rhel', 'amazon'
   include_recipe 'yum'

--- a/recipes/cluster_admin_user_install.rb
+++ b/recipes/cluster_admin_user_install.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return if node['conditions']['ami_bootstrapped']
+
 # Setup cluster admin group
 group node['cluster']['cluster_admin_group'] do
   comment 'AWS ParallelCluster Admin group'

--- a/recipes/compute_slurm_config.rb
+++ b/recipes/compute_slurm_config.rb
@@ -19,8 +19,8 @@ setup_munge_compute_node
 
 # Create directory configured as SlurmdSpoolDir
 directory '/var/spool/slurmd' do
-  user 'slurm'
-  group 'slurm'
+  user node['cluster']['slurm']['user']
+  group node['cluster']['slurm']['group']
   mode '0700'
 end
 

--- a/recipes/head_node_slurm_config.rb
+++ b/recipes/head_node_slurm_config.rb
@@ -33,8 +33,8 @@ end
 
 # Create directory configured as StateSaveLocation
 directory '/var/spool/slurm.state' do
-  user 'slurm'
-  group 'slurm'
+  user node['cluster']['slurm']['user']
+  group node['cluster']['slurm']['group']
   mode '0700'
 end
 
@@ -128,41 +128,41 @@ end
 
 template "#{node['cluster']['scripts_dir']}/slurm/slurm_resume" do
   source 'slurm/resume_program.erb'
-  owner 'slurm'
-  group 'slurm'
+  owner node['cluster']['slurm']['user']
+  group node['cluster']['slurm']['group']
   mode '0744'
 end
 
 file "/var/log/parallelcluster/slurm_resume.log" do
-  owner 'slurm'
-  group 'slurm'
+  owner node['cluster']['slurm']['user']
+  group node['cluster']['slurm']['group']
   mode '0644'
 end
 
 template "#{node['cluster']['slurm_plugin_dir']}/parallelcluster_slurm_resume.conf" do
   source 'slurm/parallelcluster_slurm_resume.conf.erb'
-  owner 'slurm'
-  group 'slurm'
+  owner node['cluster']['slurm']['user']
+  group node['cluster']['slurm']['group']
   mode '0644'
 end
 
 template "#{node['cluster']['scripts_dir']}/slurm/slurm_suspend" do
   source 'slurm/suspend_program.erb'
-  owner 'slurm'
-  group 'slurm'
+  owner node['cluster']['slurm']['user']
+  group node['cluster']['slurm']['group']
   mode '0744'
 end
 
 file "/var/log/parallelcluster/slurm_suspend.log" do
-  owner 'slurm'
-  group 'slurm'
+  owner node['cluster']['slurm']['user']
+  group node['cluster']['slurm']['group']
   mode '0644'
 end
 
 template "#{node['cluster']['slurm_plugin_dir']}/parallelcluster_slurm_suspend.conf" do
   source 'slurm/parallelcluster_slurm_suspend.conf.erb'
-  owner 'slurm'
-  group 'slurm'
+  owner node['cluster']['slurm']['user']
+  group node['cluster']['slurm']['group']
   mode '0644'
 end
 

--- a/recipes/munge_install.rb
+++ b/recipes/munge_install.rb
@@ -58,15 +58,24 @@ bash 'make install' do
 end
 
 # Updated munge init script for Amazon Linux
-cookbook_file "munge-init" do
-  path '/etc/init.d/munge'
-  user 'root'
+template '/etc/init.d/munge' do
+  source 'slurm/munge-init.erb'
+  owner 'root'
   group 'root'
   mode '0755'
 end
 
-# Make sure the munge user exists
-user 'munge' do
+# Setup munge group
+group node['cluster']['munge']['group'] do
+  comment 'munge group'
+  gid node['cluster']['munge']['group_id']
+  system true
+end
+
+# Setup munge user
+user node['cluster']['munge']['user'] do
+  uid node['cluster']['munge']['user_id']
+  gid node['cluster']['munge']['group_id']
   manage_home false
   comment 'munge user'
   system true
@@ -78,7 +87,7 @@ dirs = ["/var/log/munge", "/etc/munge", "/var/run/munge"]
 dirs.each do |dir|
   directory dir do
     action :create
-    owner "munge"
-    group "munge"
+    owner node['cluster']['munge']['user']
+    group node['cluster']['munge']['group']
   end
 end

--- a/recipes/test_users.rb
+++ b/recipes/test_users.rb
@@ -40,10 +40,62 @@ if node['cluster']['node_type'] == 'HeadNode' && node['cluster']['scheduler'] ==
 end
 
 ###################
+# Slurm user
+###################
+if node['cluster']['scheduler'] == 'slurm'
+  check_user_definition(
+    node['cluster']['slurm']['user'],
+    node['cluster']['slurm']['user_id'],
+    node['cluster']['slurm']['group_id'],
+    'slurm user'
+  )
+
+  check_group_definition(
+    node['cluster']['slurm']['group'],
+    node['cluster']['slurm']['group_id']
+  )
+end
+
+###################
+# Munge user
+###################
+if node['cluster']['scheduler'] == 'slurm'
+  check_user_definition(
+    node['cluster']['munge']['user'],
+    node['cluster']['munge']['user_id'],
+    node['cluster']['munge']['group_id'],
+    'munge user',
+    '/sbin/nologin'
+  )
+
+  check_group_definition(
+    node['cluster']['munge']['group'],
+    node['cluster']['munge']['group_id']
+  )
+end
+
+###################
+# DCV ExtAuth user
+###################
+if node['conditions']['dcv_supported']
+  check_user_definition(
+    node['cluster']['dcv']['authenticator']['user'],
+    node['cluster']['dcv']['authenticator']['user_id'],
+    node['cluster']['dcv']['authenticator']['group_id'],
+    'NICE DCV External Authenticator user'
+  )
+
+  check_group_definition(
+    node['cluster']['dcv']['authenticator']['group'],
+    node['cluster']['dcv']['authenticator']['group_id']
+  )
+end
+
+###################
 # Slurm sudoers
 ###################
 if node['cluster']['scheduler'] == 'slurm'
-  [node['cluster']['cluster_admin_user'], "slurm"].each do |user|
+  [node['cluster']['cluster_admin_user'], node['cluster']['slurm']['user']].each do |user|
     check_sudoers_permissions(
       "/etc/sudoers.d/99-parallelcluster-slurm",
       user, "root", "SLURM_COMMANDS", "/opt/slurm/bin/scontrol"

--- a/templates/default/99-parallelcluster-slurm.erb
+++ b/templates/default/99-parallelcluster-slurm.erb
@@ -2,4 +2,4 @@ Cmnd_Alias SLURM_COMMANDS = /opt/slurm/bin/scontrol
 
 <%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SLURM_COMMANDS
 
-slurm ALL = (root) NOPASSWD: SLURM_COMMANDS
+<%= node['cluster']['slurm']['user'] %> ALL = (root) NOPASSWD: SLURM_COMMANDS

--- a/templates/default/slurm/munge-init.erb
+++ b/templates/default/slurm/munge-init.erb
@@ -38,8 +38,8 @@ DAEMON_EXEC="$sbindir/munged"
 #CONFIG=#_NOT_SUPPORTED_#
 PIDFILE="$localstatedir/run/munge/munged.pid"
 #NICE=
-USER="munge"
-GROUP="munge"
+USER=<%= node['cluster']['munge']['user'] %>
+GROUP=<%= node['cluster']['munge']['group'] %>
 #SIGHUP_RELOAD=#_NOT_SUPPORTED_#
 VARRUNDIR="$localstatedir/run/munge"
 

--- a/templates/default/slurm/slurm.conf.erb
+++ b/templates/default/slurm/slurm.conf.erb
@@ -10,7 +10,7 @@
 #
 # CLUSTER SETTINGS
 ClusterName=parallelcluster
-SlurmUser=slurm
+SlurmUser=<%= node['cluster']['slurm']['user'] %>
 SlurmctldPort=6820-6829
 SlurmdPort=6818
 AuthType=auth/munge


### PR DESCRIPTION
### Changes
1. Added support for explicitly assigning names, uids and gids for slurm, munge, and dcvextauth users
2. Reordered some related entries in `attributes/default`
3. Reduced code duplication related to user creation for slurm and munge users

### Tests
1. Successful cluster creation on personal account
2. Kitchen tests (ongoing)
3. Integration tests (pending). Will be submitted after the code review


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
