### PR TITLE
Remove libmpich-dev after scheduler install for ubuntu1804

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -366,7 +366,9 @@ when 'debian'
 
   case node['platform_version']
   when '18.04'
-    default['cfncluster']['base_packages'].push('python-pip', 'python-parted')
+    # Install libmpich12 and mpich explicitly to preserve existing behavior
+    # libmpich-dev need to be removed after scheduler compilation due to a compatibility issue with efa installer v1.12.x
+    default['cfncluster']['base_packages'].push('python-pip', 'python-parted', 'libmpich12', 'mpich')
   when '20.04'
     default['cfncluster']['base_packages'].push('python3-parted')
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -510,3 +510,14 @@ def get_metadata_with_token(token, uri)
   metadata = res.body if res.code == '200'
   metadata
 end
+
+def rm_libmpich
+  # Uninstall libmpich-dev, which configures an /usr/lib/libmpi.so symlink
+  # The symlink causes an mpicc issue with -L/usr/lib linker flag in efa installer v1.12.x + ubuntu1804
+  # Compile slurm with the package to enable mpich binding for slurm, and remove after
+  return unless node['platform_version'] == '18.04'
+
+  package "libmpich-dev" do
+    action :remove
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,9 @@ include_recipe 'aws-parallelcluster::sge_install'
 include_recipe 'aws-parallelcluster::torque_install'
 include_recipe 'aws-parallelcluster::slurm_install'
 
+# TODO: remove from code if not using efa installer v1.12.x
+rm_libmpich
+
 # DCV recipe installs Gnome, X and their dependencies so it must be installed as latest to not break the environment
 # used to build the schedulers packages
 include_recipe "aws-parallelcluster::dcv_install"


### PR DESCRIPTION
* libmpich12 and mpich were installed as dependency and recommended package of libmpich-dev.
* To preserve existing behavior, install libmpich12 and mpich explicitly.
* Remove libmpich-dev after scheduler installs so scheduler can compile with mpich plugins if needed.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
