### PR TITLE
Fix Centos7 Packer SSM installation

### DIFF
--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -165,7 +165,7 @@
         "[[ ${region} =~ ^cn- ]] && domain=\".amazonaws.com.cn\" || domain=\".amazonaws.com\"",
         "[[ {{user `ami_arch`}} == \"arm64\" ]] && arch=\"arm64\" || arch=\"amd64\"",
         "ssm_agent_url=\"https://s3.${region}${domain}/amazon-ssm-${region}/latest/linux_${arch}/amazon-ssm-agent.rpm\"",
-        "sudo yum install -y ${ssm_agent_url}",
+        "sudo yum localinstall -y ${ssm_agent_url}",
         "sudo systemctl enable amazon-ssm-agent",
         "sudo systemctl start amazon-ssm-agent"
       ]


### PR DESCRIPTION
* On Centos7, re-installing an already installed rpm explicitly(issue does not happen when installing by package name) with `yum install` will produce "Error: Nothing to do", with exit code 1. Therefore, running createami on an AMI that already has amazon-ssm-agent will break the createami process.
* Use `yum localinstall` so re-installation will not exit 1: https://serverfault.com/a/991002
* Alinux2 yum has the same limitation, but we do not install amazon-ssm-agent or any other rpm explicitly in packer script so no fix needed.
* The issue is fixed in RHEL 8 so Centos8 verison of dnf/yum will not produce an error in this case and will exit 0, so no fix needed.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
