### PR TITLE
3.0: Restrict access to IMDS to root and cluster admin users, only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Run daemons as cluster admin user (not root).
 - Add explicit assignment of names, uids, gids for slurm, munge and dcvextauth users.
 - Remove packer.
+- Restrict access to IMDS to root and cluster admin users, only.
 
 
 2.x.x

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -306,7 +306,7 @@ when 'rhel', 'amazon'
                                              blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                              libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                              mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
-                                             iproute NetworkManager-config-routing-rules python3 python3-pip]
+                                             iproute NetworkManager-config-routing-rules python3 python3-pip iptables]
     if node['platform_version'].to_i >= 8
       # Do not install unversioned python
       default['cluster']['base_packages'].delete('python')
@@ -329,7 +329,7 @@ when 'rhel', 'amazon'
                                              rpm-build rpm-sign system-rpm-config cscope ctags diffstat doxygen elfutils
                                              gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl
                                              jq wget python-pip NetworkManager-config-routing-rules libibverbs-utils
-                                             librdmacm-utils python3 python3-pip]
+                                             librdmacm-utils python3 python3-pip iptables]
 
     # Install R via amazon linux extras
     default['cluster']['alinux_extras'] = ['R3.4']
@@ -346,7 +346,7 @@ when 'debian'
                                            libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev python
                                            r-base libblas-dev libfftw3-dev libffi-dev libxml2-dev mdadm
                                            libgcrypt20-dev libmysqlclient-dev libevent-dev iproute2 python3 python3-pip
-                                           libatlas-base-dev libglvnd-dev linux-headers-aws]
+                                           libatlas-base-dev libglvnd-dev linux-headers-aws iptables]
 
   case node['platform_version']
   when '18.04'
@@ -461,3 +461,7 @@ default['cluster']['is_official_ami_build'] = false
 
 # Additional instance types data
 default['cluster']['instance_types_data'] = nil
+
+# IMDS
+default['cluster']['head_node_imds_secured'] = 'true'
+default['cluster']['head_node_imds_allowed_users'] = ['root', node['cluster']['cluster_admin_user']]

--- a/files/default/imds/imds-access.sh
+++ b/files/default/imds/imds-access.sh
@@ -9,8 +9,6 @@ set -e
 # --flush                     Restore default IMDS access
 # --help                      Print this help message
 
-IPTABLES=$(whereis -b iptables | cut -d ' ' -f2)
-
 function error() {
   >&2 echo "[ERROR] $1"
   exit 1
@@ -49,7 +47,7 @@ function iptables_delete() {
     rule_args="$chain --destination $destination -j $jump -m owner --uid-owner $user"
   fi
 
-  local iptables_delete_command="$IPTABLES -D $rule_args"
+  local iptables_delete_command="iptables -D $rule_args"
 
   # Remove rules
   local should_remove=true
@@ -81,7 +79,7 @@ function iptables_add() {
     rule_args="$chain --destination $destination -j $jump -m owner --uid-owner $user"
   fi
 
-  local iptables_add_command="$IPTABLES -A $rule_args"
+  local iptables_add_command="iptables -A $rule_args"
 
   # Add rule
   eval $iptables_add_command
@@ -93,7 +91,7 @@ function setup_chain() {
   local source_chain=$2
   local destination=$3
 
-  $IPTABLES --new $chain 2>/dev/null && info "ParallelCluster chain created: $chain" \
+  iptables --new $chain 2>/dev/null && info "ParallelCluster chain created: $chain" \
   || info "ParallelCluster chain exists: $chain"
 
   iptables_add $source_chain $destination $chain
@@ -119,7 +117,7 @@ main() {
   done
 
   # Check required commands
-  command -v $IPTABLES >/dev/null || error "Cannot find required command: $IPTABLES"
+  command -v iptables >/dev/null || error "Cannot find required command: iptables"
 
   # Check arguments and options
   if [[ -z $allow_users && -z $deny_users && -z $unset_users && -z $flush ]]; then
@@ -131,7 +129,7 @@ main() {
 
   # Flush ParallelCluster chain, if required
   if [[ $flush == "true" ]]; then
-    $IPTABLES --flush $PARALLELCLUSTER_CHAIN
+    iptables --flush $PARALLELCLUSTER_CHAIN
     info "ParallelCluster chain flushed"
     exit 0
   fi

--- a/files/default/imds/imds-access.sh
+++ b/files/default/imds/imds-access.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+set -e
+#
+# Manage the access to IMDS
+#
+# --allow <user1,...,userN>   List of users to allow access to IMDS
+# --deny  <user1,...,userN>   List of users to deny access to IMDS
+# --unset <user1,...,userN>   Remove iptables rules related to IMDS for the given list of users
+# --flush                     Restore default IMDS access
+# --help                      Print this help message
+
+IPTABLES=$(whereis -b iptables | cut -d ' ' -f2)
+
+function error() {
+  >&2 echo "[ERROR] $1"
+  exit 1
+}
+
+function info() {
+  echo "[INFO] $1"
+}
+
+function help() {
+  local -- cmd=$(basename "$0")
+  cat <<EOF
+
+  Usage: ${cmd} [OPTION]...
+
+  Manage the access to IMDS
+
+  --allow <user1,...,userN>   Allow IMDS access to the given list of users
+  --deny  <user1,...,userN>   Deny IMDS access to the given list of users
+  --unset <user1,...,userN>   Remove iptables rules related to IMDS for the given list of users
+  --flush                     Restore default IMDS access
+  --help                      Print this help message
+EOF
+}
+
+function iptables_delete() {
+  local chain=$1
+  local destination=$2
+  local jump=$3
+  local user=$4
+
+  # Build iptables delete command
+  if [[ -z $user ]]; then
+    rule_args="$chain --destination $destination -j $jump"
+  else
+    rule_args="$chain --destination $destination -j $jump -m owner --uid-owner $user"
+  fi
+
+  local iptables_delete_command="$IPTABLES -D $rule_args"
+
+  # Remove rules
+  local should_remove=true
+  while $should_remove; do
+    eval $iptables_delete_command 1>/dev/null 2>/dev/null || should_remove=false
+  done
+}
+
+function iptables_add() {
+  local chain=$1
+  local destination=$2
+  local jump=$3
+  local user=$4
+
+  # Remove duplicate rules
+  iptables_delete $chain $destination $jump $user
+
+  # Remove opposite rules
+  if [[ $jump == "ACCEPT" ]]; then
+    iptables_delete $destination "REJECT" $user
+  elif [[ $jump == "REJECT" ]]; then
+    iptables_delete $destination "ACCEPT" $user
+  fi
+
+  # Build iptables add command
+  if [[ -z $user ]]; then
+    rule_args="$chain --destination $destination -j $jump"
+  else
+    rule_args="$chain --destination $destination -j $jump -m owner --uid-owner $user"
+  fi
+
+  local iptables_add_command="$IPTABLES -A $rule_args"
+
+  # Add rule
+  eval $iptables_add_command
+  info "Rule in chain $chain: $destination $jump $user"
+}
+
+function setup_chain() {
+  local chain=$1
+  local source_chain=$2
+  local destination=$3
+
+  $IPTABLES --new $chain 2>/dev/null && info "ParallelCluster chain created: $chain" \
+  || info "ParallelCluster chain exists: $chain"
+
+  iptables_add $source_chain $destination $chain
+}
+
+main() {
+  # Constants
+  PARALLELCLUSTER_CHAIN="PARALLELCLUSTER_IMDS"
+  OUTPUT_CHAIN="OUTPUT"
+  IMDS_IP="169.254.169.254"
+
+  # Parse options
+  while [ $# -gt 0 ] ; do
+      case "$1" in
+          --allow)    allow_users="$2"; shift;;
+          --deny)     deny_users="$2"; shift;;
+          --unset)    unset_users="$2"; shift;;
+          --flush)    flush="true";;
+          --help)     help; exit 0;;
+          *)          help; error "Unrecognized option '$1'";;
+      esac
+      shift
+  done
+
+  # Check required commands
+  command -v $IPTABLES >/dev/null || error "Cannot find required command: $IPTABLES"
+
+  # Check arguments and options
+  if [[ -z $allow_users && -z $deny_users && -z $unset_users && -z $flush ]]; then
+    error "Missing at least one mandatory option: '--allow', '--deny', '--unset', '--flush'"
+  fi
+
+  # Setup ParallelCluster chain
+  setup_chain $PARALLELCLUSTER_CHAIN $OUTPUT_CHAIN $IMDS_IP
+
+  # Flush ParallelCluster chain, if required
+  if [[ $flush == "true" ]]; then
+    $IPTABLES --flush $PARALLELCLUSTER_CHAIN
+    info "ParallelCluster chain flushed"
+    exit 0
+  fi
+
+  # Delete rule: ACCEPT/REJECT user, for every user to unset
+  IFS=","
+  for user in $unset_users; do
+    info "Deleting rules related to IMDS access for user: $user"
+    iptables_delete $PARALLELCLUSTER_CHAIN $IMDS_IP "ACCEPT" $user
+    iptables_delete $PARALLELCLUSTER_CHAIN $IMDS_IP "REJECT" $user
+  done
+
+  # Add rule: ACCEPT user, for every allowed user
+  for user in $allow_users; do
+    info "Allowing IMDS access for user: $user"
+    iptables_add $PARALLELCLUSTER_CHAIN $IMDS_IP "ACCEPT" $user
+  done
+
+  # Add rule: REJECT user, for every denied user
+  for user in $deny_users; do
+    info "Denying IMDS access for user: $user"
+    iptables_add $PARALLELCLUSTER_CHAIN $IMDS_IP "REJECT" $user
+  done
+
+  # Add rule: REJECT not allowed users
+  info "Denying IMDS access for not allowed users"
+  iptables_add $PARALLELCLUSTER_CHAIN $IMDS_IP "REJECT"
+}
+
+main "$@"

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -632,6 +632,24 @@ def check_imds_access(user, is_allowed)
   end
 end
 
+def check_directories_in_path(directories)
+  bash "check PATH contains #{directories}" do
+    cwd Chef::Config[:file_cache_path]
+    code <<-TEST
+      set -e
+
+      for directory in #{directories.join(' ')}; do
+        [[ ":$PATH:" == *":$directory:"* ]] || missing_directories="$missing_directories $directory"
+      done
+
+      if [[ ! -z $missing_directories ]]; then
+        >&2 echo "Missing expected directories in PATH: $missing_directories"
+        exit 1
+      fi
+    TEST
+  end
+end
+
 def get_system_users
   cmd = Mixlib::ShellOut.new("cat /etc/passwd | cut -d: -f1")
   cmd.run_command

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -15,6 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe "aws-parallelcluster::setup_envars"
 include_recipe 'aws-parallelcluster::base_install'
 
 # Restart sshd.service to make sure the service is running

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe "aws-parallelcluster::setup_envars"
+
 return if node['conditions']['ami_bootstrapped']
 
 include_recipe "aws-parallelcluster::cluster_admin_user_install"

--- a/recipes/head_node_base_config.rb
+++ b/recipes/head_node_base_config.rb
@@ -172,3 +172,6 @@ if node['cluster']['dcv_enabled'] == "head_node"
   # Activate DCV on head node
   include_recipe 'aws-parallelcluster::dcv_config'
 end
+
+# IMDS
+include_recipe 'aws-parallelcluster::imds_config'

--- a/recipes/head_node_slurm_config.rb
+++ b/recipes/head_node_slurm_config.rb
@@ -134,15 +134,15 @@ template "#{node['cluster']['scripts_dir']}/slurm/slurm_resume" do
 end
 
 file "/var/log/parallelcluster/slurm_resume.log" do
-  owner node['cluster']['slurm']['user']
-  group node['cluster']['slurm']['group']
+  owner node['cluster']['cluster_admin_user']
+  group node['cluster']['cluster_admin_group']
   mode '0644'
 end
 
 template "#{node['cluster']['slurm_plugin_dir']}/parallelcluster_slurm_resume.conf" do
   source 'slurm/parallelcluster_slurm_resume.conf.erb'
-  owner node['cluster']['slurm']['user']
-  group node['cluster']['slurm']['group']
+  owner node['cluster']['cluster_admin_user']
+  group node['cluster']['cluster_admin_group']
   mode '0644'
 end
 
@@ -154,15 +154,15 @@ template "#{node['cluster']['scripts_dir']}/slurm/slurm_suspend" do
 end
 
 file "/var/log/parallelcluster/slurm_suspend.log" do
-  owner node['cluster']['slurm']['user']
-  group node['cluster']['slurm']['group']
+  owner node['cluster']['cluster_admin_user']
+  group node['cluster']['cluster_admin_group']
   mode '0644'
 end
 
 template "#{node['cluster']['slurm_plugin_dir']}/parallelcluster_slurm_suspend.conf" do
   source 'slurm/parallelcluster_slurm_suspend.conf.erb'
-  owner node['cluster']['slurm']['user']
-  group node['cluster']['slurm']['group']
+  owner node['cluster']['cluster_admin_user']
+  group node['cluster']['cluster_admin_group']
   mode '0644'
 end
 
@@ -176,7 +176,7 @@ end
 # Create shared directory used to store clustermgtd heartbeat and computemgtd config
 directory "/opt/slurm/etc/pcluster/.slurm_plugin" do
   user node['cluster']['cluster_admin_user']
-  group node['cluster']['cluster_admin_user']
+  group node['cluster']['cluster_admin_group']
   mode '0755'
   action :create
   recursive true

--- a/recipes/imds_config.rb
+++ b/recipes/imds_config.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: imds_config
+#
+# Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+if node['cluster']['node_type'] == 'HeadNode' && node['cluster']['scheduler'] == 'slurm'
+
+  directory "#{node['cluster']['scripts_dir']}/imds" do
+    owner 'root'
+    group 'root'
+    mode '0744'
+    recursive true
+  end
+
+  imds_access_script = "#{node['cluster']['scripts_dir']}/imds/imds-access.sh"
+
+  cookbook_file imds_access_script do
+    source 'imds/imds-access.sh'
+    owner 'root'
+    group 'root'
+    mode '0744'
+  end
+
+  case node['cluster']['head_node_imds_secured']
+  when 'true'
+    imds_allowed_users = node['cluster']['head_node_imds_allowed_users'].join(',')
+    execute 'IMDS lockdown enable' do
+      command "bash #{imds_access_script} --flush && bash #{imds_access_script} --allow #{imds_allowed_users}"
+      user 'root'
+    end
+  when 'false'
+    execute 'IMDS lockdown disable' do
+      command "bash #{imds_access_script} --flush"
+      user 'root'
+    end
+  else
+    raise "head_node_imds_secured must be 'true' or 'false', but got #{node['cluster']['head_node_imds_secured']}"
+  end
+end

--- a/recipes/setup_envars.rb
+++ b/recipes/setup_envars.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: update_head_node
+# Recipe:: setup_envars
 #
 # Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
@@ -15,6 +15,11 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'aws-parallelcluster::setup_envars'
-include_recipe 'aws-parallelcluster::imds_config'
-include_recipe 'aws-parallelcluster::update_head_node_slurm' if node['cluster']['scheduler'] == 'slurm'
+ruby_block 'Configure environment variable: PATH' do
+  block do
+    directories = %w[/usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin /opt/aws/bin]
+    directories.each do |directory|
+      ENV['PATH'] = "#{ENV['PATH']}:#{directory}" unless ":#{ENV['PATH']}:".include?(":#{directory}:")
+    end
+  end
+end

--- a/recipes/test_envars.rb
+++ b/recipes/test_envars.rb
@@ -2,9 +2,9 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: update_head_node
+# Recipe:: test_envars
 #
-# Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -15,6 +15,4 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'aws-parallelcluster::setup_envars'
-include_recipe 'aws-parallelcluster::imds_config'
-include_recipe 'aws-parallelcluster::update_head_node_slurm' if node['cluster']['scheduler'] == 'slurm'
+check_directories_in_path(%w[/usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin])

--- a/recipes/test_imds.rb
+++ b/recipes/test_imds.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: test_imds
+#
+# Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+all_users = get_system_users
+allowed_users =
+  if node['cluster']['node_type'] == 'HeadNode' &&
+     node['cluster']['scheduler'] == 'slurm' &&
+     node['cluster']['head_node_imds_secured'] == 'true'
+    node['cluster']['head_node_imds_allowed_users']
+  else
+    all_users
+  end
+
+denied_users = all_users - allowed_users
+
+allowed_users.each { |allowed_user| check_imds_access(allowed_user, true) }
+
+denied_users.each { |denied_user| check_imds_access(denied_user, false) }

--- a/recipes/test_users.rb
+++ b/recipes/test_users.rb
@@ -95,10 +95,20 @@ end
 # Slurm sudoers
 ###################
 if node['cluster']['scheduler'] == 'slurm'
-  [node['cluster']['cluster_admin_user'], node['cluster']['slurm']['user']].each do |user|
-    check_sudoers_permissions(
-      "/etc/sudoers.d/99-parallelcluster-slurm",
-      user, "root", "SLURM_COMMANDS", "/opt/slurm/bin/scontrol"
-    )
-  end
+  sudoers_file = "/etc/sudoers.d/99-parallelcluster-slurm"
+  cluster_admin_user = node['cluster']['cluster_admin_user']
+  cluster_slurm_user = node['cluster']['slurm']['user']
+  venv_path = node['cluster']['node_virtualenv_path']
+
+  check_sudoers_permissions(
+    sudoers_file,
+    cluster_admin_user, "root", "SLURM_COMMANDS",
+    "/opt/slurm/bin/scontrol"
+  )
+
+  check_sudoers_permissions(
+    sudoers_file,
+    cluster_slurm_user, cluster_admin_user, "SLURM_HOOKS_COMMANDS",
+    "#{venv_path}/bin/slurm_suspend, #{venv_path}/bin/slurm_resume"
+  )
 end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -17,6 +17,7 @@
 
 include_recipe 'aws-parallelcluster::test_users'
 include_recipe 'aws-parallelcluster::test_processes'
+include_recipe 'aws-parallelcluster::test_imds'
 
 ###################
 # AWS Cli

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -15,6 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe 'aws-parallelcluster::test_envars'
 include_recipe 'aws-parallelcluster::test_users'
 include_recipe 'aws-parallelcluster::test_processes'
 include_recipe 'aws-parallelcluster::test_imds'

--- a/recipes/update_head_node.rb
+++ b/recipes/update_head_node.rb
@@ -16,3 +16,4 @@
 # limitations under the License.
 
 include_recipe 'aws-parallelcluster::update_head_node_slurm' if node['cluster']['scheduler'] == 'slurm'
+include_recipe 'aws-parallelcluster::imds_config'

--- a/templates/default/99-parallelcluster-slurm.erb
+++ b/templates/default/99-parallelcluster-slurm.erb
@@ -1,5 +1,6 @@
 Cmnd_Alias SLURM_COMMANDS = /opt/slurm/bin/scontrol
+Cmnd_Alias SLURM_HOOKS_COMMANDS = <%= node['cluster']['node_virtualenv_path'] %>/bin/slurm_suspend, <%= node['cluster']['node_virtualenv_path'] %>/bin/slurm_resume
 
 <%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SLURM_COMMANDS
 
-<%= node['cluster']['slurm']['user'] %> ALL = (root) NOPASSWD: SLURM_COMMANDS
+<%= node['cluster']['slurm']['user'] %> ALL = (<%= node['cluster']['cluster_admin_user'] %>) NOPASSWD: SLURM_HOOKS_COMMANDS

--- a/templates/default/slurm/resume_program.erb
+++ b/templates/default/slurm/resume_program.erb
@@ -1,2 +1,2 @@
 #!/bin/bash
-<%= node['cluster']['node_virtualenv_path'] %>/bin/slurm_resume "$@"
+sudo -u <%= node['cluster']['cluster_admin_user'] %> <%= node['cluster']['node_virtualenv_path'] %>/bin/slurm_resume "$@"

--- a/templates/default/slurm/suspend_program.erb
+++ b/templates/default/slurm/suspend_program.erb
@@ -1,2 +1,2 @@
 #!/bin/bash
-<%= node['cluster']['node_virtualenv_path'] %>/bin/slurm_suspend "$@"
+sudo -u <%= node['cluster']['cluster_admin_user'] %> <%= node['cluster']['node_virtualenv_path'] %>/bin/slurm_suspend "$@"


### PR DESCRIPTION
### Changes

1. Added the script `imds-access.sh` to manage access to IMDS. With this script it is possible to: 
   1. allow IMDS access for a given list of users
   2. deny IMDS access for a given list of users
   3. cleanup iptables rules for a given list of users
2. Added config recipe that uses the above script to restrict the IMDS access to root and cluster admin users, only.
3. Added kitchen tests covering the above recipe. 

### Tests
1. Tested on a personal cluster
2. Kitchen tests (ongoing)
3. Integration tests (pending)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
