### PR TITLE
Fix sge_preinstall and runtime bake on Ubuntu18

### DIFF
--- a/recipes/sge_install.rb
+++ b/recipes/sge_install.rb
@@ -58,7 +58,8 @@ when 'MasterServer', nil
       'TARBALL_ROOT_DIR' => "sge-#{node['cfncluster']['sge']['version']}",
       'TARBALL_PATH' => sge_tarball,
       'TARBALL_URL' => node['cfncluster']['sge']['url'],
-      'REGION' => node['cfncluster']['cfn_region']
+      'REGION' => node['cfncluster']['cfn_region'],
+      'HOME' => '/root'
     )
     command 'sh /tmp/sge_preinstall.sh'
     not_if { ::File.exist?(sge_tarball) }


### PR DESCRIPTION
* When using `environment` for `execute` resource, `HOME` will not be exported automatically. If execute command depend on `HOME`, it needs to be export explicitly. This change might have happened when upgrading from CINC 15 to CINC 16.
* sge_preinstall depends on `HOME` because `gpg` will save imported key in `~/.gnupg/trustedkeys.gpg` by default. Without setting `HOME`, imported key is saved to `/.gnupg/trustedkeys.gpg`, which cannot be recognized by `dpkg-source`, and results in `dpkg-source: error: failed to verify signature on ./gridengine_8.1.9+dfsg-9.dsc` error.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
