### PR TITLE
Install ubuntu-desktop using apt command instead of package resource

### DIFF
--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -112,8 +112,10 @@ if node['conditions']['dcv_supported']
         retry_delay 5
       end
       # Install the desktop environment and the desktop manager packages
-      prereq_packages = %w[ubuntu-desktop lightdm mesa-utils]
-      package prereq_packages do
+      prereq_packages = 'ubuntu-desktop lightdm mesa-utils'
+      execute "Install ubuntu desktop etc" do
+        # Use -y/--fix-broken option to prevent `dpkg was interrupted` error
+        command "apt-get install -y -f #{prereq_packages}"
         retries 10
         retry_delay 5
       end


### PR DESCRIPTION
* When using `package` resource and installation is interrupted, the package does not seem to be cleaned up correctly. Using apt command with cleanup command directly instead

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
