### PR TITLE
Do not use regionalized domain for Lustre in China

### DIFF
--- a/recipes/fsx_mount.rb
+++ b/recipes/fsx_mount.rb
@@ -32,18 +32,12 @@ if fsx_shared_dir != "NONE"
     action :create
   end
 
-  dns_domain = if node['cfncluster']['cfn_region'].include? 'cn'
-                 'com.cn'
-               else
-                 'com'
-               end
-
   dns_name = if node['cfncluster']['cfn_fsx_dns_name'] && !node['cfncluster']['cfn_fsx_dns_name'].empty?
                node['cfncluster']['cfn_fsx_dns_name']
              else
                # Hardcoded DNSname only valid for filesystem created after Mar-1 2021
                # For older filesystems, DNSname needs to be retrieved from FSx API
-               "#{node['cfncluster']['cfn_fsx_fs_id']}.fsx.#{node['cfncluster']['cfn_region']}.amazonaws.#{dns_domain}"
+               "#{node['cfncluster']['cfn_fsx_fs_id']}.fsx.#{node['cfncluster']['cfn_region']}.amazonaws.com"
              end
 
   mountname = node['cfncluster']['cfn_fsx_mount_name']


### PR DESCRIPTION
* FSx Lustre does not use regionalized domain `amazonaws.com.cn` in China. There is no plan to use regionalized domain in the short term. Remove related logic and use `amazonaws.com` in China instead.

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
