### PR TITLE
Install EFA before Lustre

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -211,12 +211,12 @@ include_recipe "aws-parallelcluster::ganglia_install"
 # Install NVIDIA and CUDA
 include_recipe "aws-parallelcluster::nvidia_install"
 
-# Install FSx options
-include_recipe "aws-parallelcluster::lustre_install"
-
 # Install EFA & Intel MPI
 include_recipe "aws-parallelcluster::efa_install"
 include_recipe "aws-parallelcluster::intel_mpi"
+
+# Install FSx options
+include_recipe "aws-parallelcluster::lustre_install"
 
 # Install the AWS cloudwatch agent
 include_recipe "aws-parallelcluster::cloudwatch_agent_install"


### PR DESCRIPTION
* Install EFA before Lustre as a workaround for a compatibility issue between efa_installer v1.12.1 and lustre-client-modules for Ubuntu20

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
