### PR TITLE
Install Ubuntu DCV pre-req with bash script

### DIFF
--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -106,31 +106,22 @@ if node['conditions']['dcv_supported']
 
     when 'ubuntu'
       apt_update
-      # Must install whoopsie separately before installing ubuntu-desktop to avoid whoopsie crash pop-up
-      package 'whoopsie' do
-        retries 3
-        retry_delay 5
-      end
-      # Install the desktop environment and the desktop manager packages
-      prereq_packages = %w[ubuntu-desktop mesa-utils]
-      package prereq_packages do
-        retries 10
-        retry_delay 5
-      end
-      # Must purge ifupdown before creating the AMI or the instance will have an ssh failure
-      package 'ifupdown' do
-        action :purge
-        retries 3
-        retry_delay 5
-      end
-      bash 'setup pre-req' do
+
+      bash 'install pre-req' do
         cwd Chef::Config[:file_cache_path]
+        # Must install whoopsie separately before installing ubuntu-desktop to avoid whoopsie crash pop-up
+        # Must purge ifupdown before creating the AMI or the instance will have an ssh failure
+        # Run dpkg --configure -a if there is a `dpkg interrupted` issue when installing ubuntu-desktop
         code <<-PREREQ
           set -e
+          DEBIAN_FRONTEND=noninteractive
+          apt -y install whoopsie
+          apt -y install ubuntu-desktop && apt -y install mesa-utils || (dpkg --configure -a && exit 1)
+          apt -y purge ifupdown
           wget https://d1uj6qtbmh3dt5.cloudfront.net/NICE-GPG-KEY
           gpg --import NICE-GPG-KEY
         PREREQ
-        retries 3
+        retries 10
         retry_delay 5
       end
 


### PR DESCRIPTION
* Install Ubuntu DCV pre-req with bash script because using chef `package` resource would often result in `dpkg interrupted` error when building in China
* Run `dpkg --configure -a` if there is a `dpkg interrupted` issue when installing `ubuntu-desktop`

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
