### PR TITLE
Remove cloud_reg_addrs option from SlurmctldParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Slurm to version 20.11.7.
   - Update slurmctld and slurmd systemd unit files according to latest provided by slurm
   - Add new SlurmctldParameters, power_save_min_interval=30, so power actions will be processed every 30 seconds
-  - Add new SlurmctldParameters, cloud_reg_addrs, which will reset a node's NodeAddr automatically on power_down
   - Specify instance GPU model as GRES GPU Type in gres.conf, instead of previous hardcoded value ``Type=tesla`` for all GPU
 - Upgrade Arm Performance Libraries (APL) to version 21.0.0
 - Upgrade NICE DCV to version 2021.1-10557.

--- a/templates/default/slurm/slurm.conf.erb
+++ b/templates/default/slurm/slurm.conf.erb
@@ -24,10 +24,10 @@ ReconfigFlags=KeepPartState
 #
 # CLOUD CONFIGS OPTIONS
 <% if node['cfncluster']['use_private_hostname'] == 'true' or node['cfncluster']['cfn_dns_domain'].nil? or node['cfncluster']['cfn_dns_domain'].empty? -%>
-SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,cloud_reg_addrs
+SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30
 TreeWidth=65533
 <% else -%>
-SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,cloud_reg_addrs,cloud_dns
+SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,cloud_dns
 <% end -%>
 CommunicationParameters=NoAddrCache
 SuspendProgram=<%= node['cfncluster']['scripts_dir'] %>/slurm/slurm_suspend


### PR DESCRIPTION
* When specifying cloud_reg_addrs, compute node hostname is automatically updated when slurmd starts and compute node comes online. However, the updated hostname(i.e. ip-172-31-4-136) is not consistent with the hostname return by running hostname command on the machine, which should be the compute nodename(i.e. q1-dy-c5xlarge-1). This can cause DNS resolution issues when using custom DNS. Removing cloud_reg_addrs in order to restore old behavior.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
