### PR TITLE
[3.0] Move set user ulimit from default_pre to default recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,11 @@
 # Validate OS type specified by the user is the same as the OS identified by Ohai
 validate_os_type
 
+# Calling user_ulimit will override every existing limit
+user_ulimit "*" do
+  filehandle_limit node['cluster']['filehandle_limit']
+end
+
 include_recipe 'aws-parallelcluster::slurm_install'
 include_recipe 'aws-parallelcluster::awsbatch_install'
 


### PR DESCRIPTION
Move is needed because default_pre will not be called anymore, now that update OS is handled through ImageBuilder component

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
