### PR TITLE
Configure default gc_thresh values for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Install SSM agent on CentOS 7 and 8.
 - Transition from IMDSv1 to IMDSv2.
 - Add support for `security_group_id` in packer custom builders. Customers can export `AWS_SECURITY_GROUP_ID` environment variable to specify security group for custom builders when building custom AMIs.
+- Configure the following default gc_thresh values for performance at scale.
+  - net.ipv4.neigh.default.gc_thresh1 = 0
+  - net.ipv4.neigh.default.gc_thresh2 = 15360
+  - net.ipv4.neigh.default.gc_thresh3 = 16384
 
 **CHANGES**
 - Ubuntu 16.04 is no longer supported.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -435,6 +435,11 @@ default['cfncluster']['lustre']['client_url'] = value_for_platform(
   }
 )
 
+# Default gc_thresh values for performance at scale
+default['cfncluster']['sysctl']['ipv4']['gc_thresh1'] = 0
+default['cfncluster']['sysctl']['ipv4']['gc_thresh2'] = 15_360
+default['cfncluster']['sysctl']['ipv4']['gc_thresh3'] = 16_384
+
 # ParallelCluster internal variables (also in /etc/parallelcluster/cfnconfig)
 default['cfncluster']['cfn_region'] = 'us-east-1'
 default['cfncluster']['stack_name'] = nil

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -521,3 +521,13 @@ def rm_libmpich
     action :remove
   end
 end
+
+def configure_gc_thresh_values
+  (1..3).each do |i|
+    # Configure gc_thresh values to be consistent with alinux2 default values
+    sysctl "net.ipv4.neigh.default.gc_thresh#{i}" do
+      value node['cfncluster']['sysctl']['ipv4']["gc_thresh#{i}"]
+      action :apply
+    end
+  end
+end

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -180,6 +180,9 @@ else
   end
 end
 
+# Configure gc_thresh values to be consistent with alinux2 default values for performance at scale
+configure_gc_thresh_values
+
 # Put supervisord config in place
 cookbook_file "supervisord.conf" do
   path "/etc/supervisord.conf"

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -659,3 +659,29 @@ unless node['cfncluster']['os'].end_with?("-custom")
     user node['cfncluster']['cfn_cluster_user']
   end
 end
+
+##################
+# ipv4 gc_thresh
+###################
+expected_gc_settings = []
+(1..3).each do |i|
+  expected_gc_settings.append(node['cfncluster']['sysctl']['ipv4']["gc_thresh#{i}"])
+end
+expected_gc_settings = expected_gc_settings.join(',').to_s
+bash 'check ipv4 gc_thresh is correctly configured' do
+  cwd Chef::Config[:file_cache_path]
+  code <<-GC
+    set -e
+
+    for i in {1..3}; do
+      declare "actual_gc_thresh${i}=`cat /proc/sys/net/ipv4/neigh/default/gc_thresh${i}`"
+    done
+    actual_settings="${actual_gc_thresh1},${actual_gc_thresh2},${actual_gc_thresh3}"
+    if [ "${actual_settings}" != "#{expected_gc_settings}" ]; then
+            echo "ERROR: Incorrect gc_thresh settings!"
+            echo "Expected "#{expected_gc_settings}" but actual is ${actual_settings}"
+            exit 1
+    fi
+  GC
+  user 'root'
+end


### PR DESCRIPTION
* Explicitly configure default gc_thresh values to be consistent with default AL2 values
* net.ipv4.neigh.default.gc_thresh1 = 0
* net.ipv4.neigh.default.gc_thresh2 = 15360
* net.ipv4.neigh.default.gc_thresh3 = 16384

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
