### PR TITLE
Remove FSx mount on access after reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - yum-6.1.1 (from yum-5.1.0)
   - yum-epel-4.1.2 (from yum-epel-3.3.0)
 - Drop ``lightdm`` package install from Ubuntu 18.04 DCV installation process.
+- Remove Lustre mount on access options from `fstab`. FSx Lustre will be mounted immediately after reboot.
 
 2.10.4
 -----

--- a/recipes/fsx_mount.rb
+++ b/recipes/fsx_mount.rb
@@ -43,8 +43,6 @@ if fsx_shared_dir != "NONE"
   mountname = node['cfncluster']['cfn_fsx_mount_name']
   mount_options = %w[defaults _netdev flock user_xattr noatime]
 
-  mount_options.concat(%w[noauto x-systemd.automount]) if node['init_package'] == 'systemd'
-
   # Mount FSx over NFS
   mount fsx_shared_dir do
     device "#{dns_name}@tcp:/#{mountname}"


### PR DESCRIPTION
The options were added to avoid long cluster creation. However, during cluster creation, the FSx is mounted anyway by the cookbook because of `action %i[mount enable]`. So the mount on access only takes effect after instance reboot for CentOS and Amazon Linux. Removing these options make behavior more consistent between cluster creation and instance reboot, and across OSes.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
