### PR TITLE
3.0: Preserve iptables rules on instance reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Make PATH include required directories for every user and recipes context.
 - Fail cluster creation when IMDS lockdown is not working correctly.
 - Make sudoers secure_path include the same directories in every platform.
+- Add support for iptables restore on instance reboot.
 
 
 2.x.x

--- a/files/default/init/parallelcluster-iptables
+++ b/files/default/init/parallelcluster-iptables
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# parallelcluster-iptables
+#
+# chkconfig: 12345 99 99
+# description: Backup and restore iptables rules
+
+### BEGIN INIT INFO
+# Provides: $parallelcluster-iptables
+# Required-Start: $network
+# Required-Stop: $network
+# Default-Start: 1 2 3 4 5
+# Default-Stop: 0 6
+# Short-Description: Backup and restore iptables rules
+# Description: Backup and restore iptables rules
+### END INIT INFO
+
+IPTABLES_RULES_FILE="/etc/parallelcluster/sysconfig/iptables.rules"
+
+function start() {
+  if [[ -f $IPTABLES_RULES_FILE ]]; then
+    iptables-restore < $IPTABLES_RULES_FILE
+    echo "iptables rules restored from file: $IPTABLES_RULES_FILE"
+  else
+    echo "iptables rules left unchanged as file was not found: $IPTABLES_RULES_FILE"
+  fi
+}
+
+function stop() {
+  echo "saving iptables rules to file: $IPTABLES_RULES_FILE"
+  mkdir -p $(dirname $IPTABLES_RULES_FILE)
+  iptables-save > $IPTABLES_RULES_FILE
+  echo "iptables rules saved to file: $IPTABLES_RULES_FILE"
+}
+
+case "$1" in
+start|stop)
+    $1
+    ;;
+*)
+    echo "Usage: $0 {start|stop}"
+    exit 2
+esac
+
+exit $?

--- a/recipes/compute_base_config.rb
+++ b/recipes/compute_base_config.rb
@@ -113,3 +113,6 @@ shared_dir_array.each do |dir|
     retry_delay 5
   end
 end
+
+# IMDS
+include_recipe 'aws-parallelcluster::imds_config'

--- a/recipes/imds_config.rb
+++ b/recipes/imds_config.rb
@@ -50,4 +50,15 @@ if node['cluster']['node_type'] == 'HeadNode' && node['cluster']['scheduler'] ==
   end
 end
 
+cookbook_file '/etc/init.d/parallelcluster-iptables' do
+  source 'init/parallelcluster-iptables'
+  user 'root'
+  group 'root'
+  mode '0744'
+end
+
+service "parallelcluster-iptables" do
+  action %i[enable start]
+end
+
 include_recipe 'aws-parallelcluster::test_imds'

--- a/recipes/test_imds.rb
+++ b/recipes/test_imds.rb
@@ -30,3 +30,5 @@ denied_users = all_users - allowed_users
 allowed_users.each { |allowed_user| check_imds_access(allowed_user, true) }
 
 denied_users.each { |denied_user| check_imds_access(denied_user, false) }
+
+check_run_level_script('parallelcluster-iptables', %w[1 2 3 4 5], %w[0 6])


### PR DESCRIPTION
### Changes
1. Preserve iptables rules on instance reboot


### Tests
1. Manual test
2. Kitchen tests
3. Integ tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
