### PR TITLE
Update default NFS mount options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - yum-6.1.1 (from yum-5.1.0)
   - yum-epel-4.1.2 (from yum-epel-3.3.0)
 - Drop ``lightdm`` package install from Ubuntu 18.04 DCV installation process.
+- Update default NFS options used by Compute nodes to mount shared filesystem from head node.
+  - Drop ``intr`` option, which is deprecated since kernel 2.6.25
+  - Drop ``noatime`` option, which is not relevant for NFS mount
 
 2.10.4
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -398,6 +398,9 @@ when 'debian'
   end
 end
 
+# Default NFS mount options
+default['cfncluster']['nfs']['hard_mount_options'] = 'hard,_netdev'
+
 # Lustre defaults (for CentOS >=7.7 and Ubuntu)
 default['cfncluster']['lustre']['public_key'] = value_for_platform(
   'centos' => { '>=7.7' => "https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc" },

--- a/recipes/compute_base_config.rb
+++ b/recipes/compute_base_config.rb
@@ -47,7 +47,7 @@ if raid_shared_dir != "NONE"
   mount raid_shared_dir do
     device(lazy { "#{node['cfncluster']['cfn_master_private_ip']}:#{raid_shared_dir}" })
     fstype 'nfs'
-    options 'hard,intr,noatime,_netdev'
+    options node['cfncluster']['nfs']['hard_mount_options']
     action %i[mount enable]
     retries 10
     retry_delay 6
@@ -58,7 +58,7 @@ end
 mount '/home' do
   device(lazy { "#{node['cfncluster']['cfn_master_private_ip']}:/home" })
   fstype 'nfs'
-  options 'hard,intr,noatime,_netdev'
+  options node['cfncluster']['nfs']['hard_mount_options']
   action %i[mount enable]
   retries 10
   retry_delay 6
@@ -68,7 +68,7 @@ end
 mount '/opt/intel' do
   device(lazy { "#{node['cfncluster']['cfn_master_private_ip']}:/opt/intel" })
   fstype 'nfs'
-  options 'hard,intr,noatime,_netdev'
+  options node['cfncluster']['nfs']['hard_mount_options']
   action %i[mount enable]
   retries 10
   retry_delay 6
@@ -110,7 +110,7 @@ shared_dir_array.each do |dir|
   mount dirname do
     device(lazy { "#{node['cfncluster']['cfn_master_private_ip']}:#{dirname}" })
     fstype 'nfs'
-    options 'hard,intr,noatime,_netdev'
+    options node['cfncluster']['nfs']['hard_mount_options']
     action %i[mount enable]
     retries 10
     retry_delay 6

--- a/recipes/compute_sge_config.rb
+++ b/recipes/compute_sge_config.rb
@@ -19,7 +19,7 @@
 mount '/opt/sge' do
   device(lazy { "#{node['cfncluster']['cfn_master_private_ip']}:/opt/sge" })
   fstype "nfs"
-  options 'hard,intr,noatime,_netdev'
+  options node['cfncluster']['nfs']['hard_mount_options']
   action %i[mount enable]
   retries 10
   retry_delay 6

--- a/recipes/compute_slurm_config.rb
+++ b/recipes/compute_slurm_config.rb
@@ -29,7 +29,7 @@ end
 mount '/opt/slurm' do
   device(lazy { "#{node['cfncluster']['cfn_master_private_ip']}:/opt/slurm" })
   fstype "nfs"
-  options 'hard,intr,noatime,_netdev'
+  options node['cfncluster']['nfs']['hard_mount_options']
   action %i[mount enable]
   retries 10
   retry_delay 6


### PR DESCRIPTION
* Drop ``intr`` option, which is deprecated since kernel 2.6.25
* Drop ``noatime`` option, which is not relevant for NFS mount

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
