### PR TITLE
[3.0] Support restart/reboot for instance store (ephemeral drives) setup

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -56,7 +56,6 @@ suites:
         stack_name: <%= ENV['AWS_STACK_NAME'] %>
         volume: <%= ENV['VOLUME'] %>
         region: <%= ENV['AWS_DEFAULT_REGION'] %>
-        encrypted_ephemeral: <%= ENV['ENCRYPTED_VOLUME'] %>
         ephemeral_dir: <%= ENV['EPHEMERAL_DIR'] %>
         ebs_shared_dirs: <%= ENV['EBS_SHARED_DIRS'] %>
         cluster_user: <%= ENV['CLUSTER_USER'] %>
@@ -80,7 +79,6 @@ suites:
         stack_name: <%= ENV['AWS_STACK_NAME'] %>
         volume: <%= ENV['VOLUME'] %>
         region: <%= ENV['AWS_DEFAULT_REGION'] %>
-        encrypted_ephemeral: <%= ENV['ENCRYPTED_VOLUME'] %>
         ephemeral_dir: <%= ENV['EPHEMERAL_DIR'] %>
         ebs_shared_dirs: <%= ENV['EBS_SHARED_DIRS'] %>
         cluster_user: <%= ENV['CLUSTER_USER'] %>
@@ -114,7 +112,6 @@ suites:
         stack_name: <%= ENV['AWS_STACK_NAME'] %>
         volume: <%= ENV['VOLUME'] %>
         region: <%= ENV['AWS_DEFAULT_REGION'] %>
-        encrypted_ephemeral: <%= ENV['ENCRYPTED_VOLUME'] %>
         ephemeral_dir: <%= ENV['EPHEMERAL_DIR'] %>
         ebs_shared_dirs: <%= ENV['EBS_SHARED_DIRS'] %>
         cluster_user: <%= ENV['CLUSTER_USER'] %>
@@ -144,7 +141,6 @@ suites:
         stack_name: <%= ENV['AWS_STACK_NAME'] %>
         volume: <%= ENV['VOLUME'] %>
         region: <%= ENV['AWS_DEFAULT_REGION'] %>
-        encrypted_ephemeral: <%= ENV['ENCRYPTED_VOLUME'] %>
         ephemeral_dir: <%= ENV['EPHEMERAL_DIR'] %>
         ebs_shared_dirs: <%= ENV['EBS_SHARED_DIRS'] %>
         cluster_user: <%= ENV['CLUSTER_USER'] %>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Make PATH include required directories for every user and recipes context.
 - Fail cluster creation when IMDS lockdown is not working correctly.
 - Make sudoers secure_path include the same directories in every platform.
-- Support restart/reboot for instance with instance store (ephemeral drives).  
+- Support restart/reboot for instance with instance store (ephemeral drives).
+- Support restart/reboot for instance with instance store (ephemeral drives).
+- Remove option for instance store software encryption (encrypted_ephemeral).  
 - Add support for iptables restore on instance reboot.
 - Allow IMDS access for dcv user when dcv is enabled.
 - Restore ``noatime`` option, which has positive impact on the performances of NFS filesystem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Make PATH include required directories for every user and recipes context.
 - Fail cluster creation when IMDS lockdown is not working correctly.
 - Make sudoers secure_path include the same directories in every platform.
+- Support restart/reboot for instance with instance store (ephemeral drives).  
 - Add support for iptables restore on instance reboot.
 - Allow IMDS access for dcv user when dcv is enabled.
 - Restore ``noatime`` option, which has positive impact on the performances of NFS filesystem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 3.0.0
 ------
 
-**CHANGES**
+**ENHANCEMENTS**
+- Support restart/reboot for instance type with instance store (ephemeral drives).
 
+**CHANGES**
 - Drop support for SGE and Torque schedulers.
 - Drop support for CentOS8.
 - Remove nodewatcher, sqswatcher, jobwatcher related code.
@@ -21,8 +23,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Make PATH include required directories for every user and recipes context.
 - Fail cluster creation when IMDS lockdown is not working correctly.
 - Make sudoers secure_path include the same directories in every platform.
-- Support restart/reboot for instance with instance store (ephemeral drives).
-- Support restart/reboot for instance with instance store (ephemeral drives).
 - Remove option for instance store software encryption (encrypted_ephemeral).  
 - Add support for iptables restore on instance reboot.
 - Allow IMDS access for dcv user when dcv is enabled.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -427,7 +427,6 @@ default['cluster']['disable_hyperthreading_manually'] = 'false'
 default['cluster']['instance_slots'] = '1'
 default['cluster']['volume'] = nil
 default['cluster']['volume_fs_type'] = 'ext4'
-default['cluster']['encrypted_ephemeral'] = false
 default['cluster']['ephemeral_dir'] = '/scratch'
 default['cluster']['ebs_shared_dirs'] = '/shared'
 default['cluster']['efs_shared_dir'] = 'NONE'

--- a/files/default/setup-ephemeral-drives.sh
+++ b/files/default/setup-ephemeral-drives.sh
@@ -37,7 +37,7 @@ function exit_noop {
 }
 
 function parameter_check {
-  if [[ -n "${INPUT_MOUNTPOINT}" ]]; then
+  if [[ -z "${INPUT_MOUNTPOINT}" ]]; then
     exit_noop "Mount point not specified"
   fi
 }

--- a/files/default/setup-ephemeral.service
+++ b/files/default/setup-ephemeral.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Setup ephemeral drives service
+After=network.target
+
+[Service]
+ExecStart=/usr/local/sbin/setup-ephemeral-drives.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -28,10 +28,9 @@ end
 
 include_recipe 'aws-parallelcluster::nfs_config'
 
-# Setup ephemeral drives
-execute 'setup ephemeral' do
-  command '/usr/local/sbin/setup-ephemeral-drives.sh'
-  creates '/scratch'
+service "setup-ephemeral" do
+  supports restart: false
+  action %i[enable start]
 end
 
 # Increase somaxconn and tcp_max_syn_backlog for large scale setting

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -122,6 +122,14 @@ cookbook_file 'setup-ephemeral-drives.sh' do
   mode '0744'
 end
 
+cookbook_file 'setup-ephemeral.service' do
+  path '/etc/systemd/system/setup-ephemeral.service'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  only_if { node['init_package'] == 'systemd' }
+end
+
 include_recipe 'aws-parallelcluster::ec2_udev_rules'
 
 # Check whether install a custom aws-parallelcluster-node package or the standard one

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -309,6 +309,68 @@ unless node['cluster']['os'].end_with?("-custom")
 end
 
 ###################
+# instance store
+###################
+bash 'test instance store' do
+  cwd Chef::Config[:file_cache_path]
+  code <<-EPHEMERAL
+      set -xe
+      EPHEMERAL_DIR="#{node['cluster']['ephemeral_dir']}"
+
+      function set_imds_token(){
+        if [ -z "${IMDS_TOKEN}" ];then
+          IMDS_TOKEN=$(sudo curl --retry 3 --retry-delay 0 --fail -s -f -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 900" http://169.254.169.254/latest/api/token)
+          if [ "${?}" -gt 0 ] || [ -z "${IMDS_TOKEN}" ]; then
+            echo '[ERROR] Could not get IMDSv2 token. Instance Metadata might have been disabled or this is not an EC2 instance.'
+            exit 1
+          fi
+        fi
+      }
+      function get_meta() {
+          local IMDS_OUT=$(sudo curl --retry 3 --retry-delay 0 --fail -s -q -H "X-aws-ec2-metadata-token:${IMDS_TOKEN}" -f http://169.254.169.254/latest/${1})
+          echo -n "${IMDS_OUT}"
+      }
+      function print_block_device_mapping(){
+        echo 'block-device-mapping: '
+        DEVICES=$(get_meta meta-data/block-device-mapping/)
+        if [ -n "${DEVICES}" ]; then
+          for DEVICE in ${DEVICES}; do
+            echo -e '\t' ${DEVICE}: $(get_meta meta-data/block-device-mapping/${DEVICE})
+          done
+        else
+          echo "NOT AVAILABLE"
+        fi
+      }
+
+      # Check if instance has instance store
+      if ls /dev/nvme* &>/dev/null; then
+        # Ephemeral devices for NVME
+        EPHEMERAL_DEVS=$(realpath --relative-to=/dev/ -P /dev/disk/by-id/nvme*Instance_Storage* | grep -v "*Instance_Storage*" | uniq)
+      else
+        # Ephemeral devices for not-NVME
+        set_imds_token
+        EPHEMERAL_DEVS=$(print_block_device_mapping | grep ephemeral | awk '{print $2}' | sed 's/sd/xvd/')
+      fi
+
+      NUM_DEVS=0
+      set +e
+      for EPHEMERAL_DEV in ${EPHEMERAL_DEVS}; do
+        STAT_COMMAND="stat -t /dev/${EPHEMERAL_DEV}"
+        if ${STAT_COMMAND} &>/dev/null; then
+          let NUM_DEVS++
+        fi
+      done
+      set -e
+
+      if [ $NUM_DEVS -gt 0 ]; then
+        mkdir -p ${EPHEMERAL_DIR}/test_dir
+        touch ${EPHEMERAL_DIR}/test_dir/test_file
+      fi
+  EPHEMERAL
+  user node['cluster']['cluster_user']
+end
+
+###################
 # Pcluster AWSBatch CLI
 ###################
 if node['cluster']['scheduler'] == 'awsbatch' && node['cluster']['node_type'] == 'HeadNode'

--- a/templates/default/cfnconfig.erb
+++ b/templates/default/cfnconfig.erb
@@ -7,7 +7,6 @@ region=<%= node['cluster']['region'] %>
 scheduler=<%= node['cluster']['scheduler'] %>
 scheduler_slots=<%= node['cluster']['scheduler_slots'] %>
 instance_slots=<%= node['cluster']['instance_slots'] %>
-encrypted_ephemeral=<%= node['cluster']['encrypted_ephemeral'] %>
 ephemeral_dir=<%= node['cluster']['ephemeral_dir'] %>
 ebs_shared_dirs=<%= node['cluster']['ebs_shared_dirs'] %>
 proxy=<%= node['cluster']['proxy'] %>


### PR DESCRIPTION
Setup instance store (ephemeral drive) using OS Service Management (systemd).
This allows to setup again the instance store after an instance restart.

The creation of the fstab entry is removed: this because the ephemeral drive is replaced by EC2 on stop/start and the new drive needs to be formatted and mounted.

Instance or OS reboot is managed as well

Some output logs
```
# on c5.xlarge 
ParallelCluster - setup-ephemeral-drives.sh - [INFO] This instance type doesn't have instance store

# on c3-large (start case)
ParallelCluster - setup-ephemeral-drives.sh - This instance store may suffer first-write penalty unless initialized:
ParallelCluster - setup-ephemeral-drives.sh - please have a look at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/disk-performance.html
ParallelCluster - setup-ephemeral-drives.sh - This instance type has (2) device(s) for instance store: (/dev/xvdb /dev/xvdc)
ParallelCluster - setup-ephemeral-drives.sh - LVM (/dev/vg.01/lv_ephemeral) does not exist
  Wiping ext3 signature on /dev/xvdb.
  Wiping ext3 signature on /dev/xvdc.
  Physical volume "/dev/xvdb" successfully created.
  Physical volume "/dev/xvdc" successfully created.
  Volume group "vg.01" successfully created
  Logical volume "lv_ephemeral" created.
ParallelCluster - setup-ephemeral-drives.sh - Found LVM in state (a)
ParallelCluster - setup-ephemeral-drives.sh - LVM (/dev/vg.01/lv_ephemeral) already activated
ParallelCluster - setup-ephemeral-drives.sh - Found LVM fs type ()
ParallelCluster - setup-ephemeral-drives.sh - Formatting LVM /dev/vg.01/lv_ephemeral with FS type ext4
mke2fs 1.42.9 (28-Dec-2013)
Filesystem label=
OS type: Linux
Block size=4096 (log=2)
Fragment size=4096 (log=2)
Stride=16 blocks, Stripe width=32 blocks
2003120 inodes, 7997440 blocks
399872 blocks (5.00%) reserved for the super user
First data block=0
Maximum filesystem blocks=2155872256
245 block groups
32768 blocks per group, 32768 fragments per group
8176 inodes per group
Superblock backups stored on blocks:
    32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208,
    4096000, 7962624

Allocating group tables: done
Writing inode tables: done
Creating journal (32768 blocks): done
Writing superblocks and filesystem accounting information: done

ParallelCluster - setup-ephemeral-drives.sh  - LVM (/dev/vg.01/lv_ephemeral) not mounted, mounting it
mount: /dev/mapper/vg.01-lv_ephemeral mounted on /scratch.

# on p4d.24xlarge (reboot case)
ParallelCluster - setup-ephemeral-drives.sh - This instance type has (8) device(s) for instance store: (/dev/nvme2n1 /dev/nvme6n1 /dev/nvme4n1 /dev/nvme8n1 /dev/nvme3n1 /dev/nvme1n1 /dev/nvme7n1 /dev/nvme5n1)
ParallelCluster - setup-ephemeral-drives.sh - LVM (/dev/vg.01/lv_ephemeral) already exists
ParallelCluster - setup-ephemeral-drives.sh - Found LVM in state (a)
ParallelCluster - setup-ephemeral-drives.sh - LVM (/dev/vg.01/lv_ephemeral) already activated
ParallelCluster - setup-ephemeral-drives.sh - Found LVM fs type (ext4)
ParallelCluster - setup-ephemeral-drives.sh - LVM (/dev/vg.01/lv_ephemeral) already formatted with FS type (ext4)
ParallelCluster - setup-ephemeral-drives.sh - LVM (/dev/vg.01/lv_ephemeral) already mounted on (/scratch)
```

Resolve https://github.com/aws/aws-parallelcluster/issues/2080

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
