### PR TITLE
3.0: Install EFA before Lustre

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -197,12 +197,12 @@ end
 # Install NVIDIA and CUDA
 include_recipe "aws-parallelcluster::nvidia_install"
 
-# Install FSx options
-include_recipe "aws-parallelcluster::lustre_install"
-
 # Install EFA & Intel MPI
 include_recipe "aws-parallelcluster::efa_install"
 include_recipe "aws-parallelcluster::intel_mpi"
+
+# Install FSx options
+include_recipe "aws-parallelcluster::lustre_install"
 
 # Install the AWS cloudwatch agent
 include_recipe "aws-parallelcluster::cloudwatch_agent_install"


### PR DESCRIPTION
* Install EFA before Lustre as a workaround for a compatibility issue between efa_installer v1.12.1 and lustre-client-modules for ubuntu2004

Signed-off-by: Rex <shuningc@amazon.com>
