### PR TITLE
3.0: Make PATH include a required set of directories for every user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 
 - Drop support for SGE and Torque schedulers.
-- Drop support for CentOS8.  
+- Drop support for CentOS8.
 - Remove nodewatcher, sqswatcher, jobwatcher related code.
 - Remove Ganglia support.
 - Install ParallelCluster AWS Batch CLI at AMI build time.
@@ -18,6 +18,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Add explicit assignment of names, uids, gids for slurm, munge and dcvextauth users.
 - Remove packer.
 - Restrict access to IMDS to root and cluster admin users, only.
+- Make PATH include required directories for every user and recipes context.
 
 
 2.x.x

--- a/recipes/setup_envars.rb
+++ b/recipes/setup_envars.rb
@@ -15,11 +15,24 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-ruby_block 'Configure environment variable: PATH' do
+# PATH
+# PATH envar must include a set of directories, both within the recipe context and the resulting system
+path_required_directories = %w[/usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin /opt/aws/bin]
+
+# This block configures PATH for the recipes context
+ruby_block 'Configure environment variable for recipes context: PATH' do
   block do
-    directories = %w[/usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin /opt/aws/bin]
-    directories.each do |directory|
+    path_required_directories.each do |directory|
       ENV['PATH'] = "#{ENV['PATH']}:#{directory}" unless ":#{ENV['PATH']}:".include?(":#{directory}:")
     end
   end
+end
+
+# This block configures PATH for the system
+template '/etc/profile.d/path.sh' do
+  source 'profile/path.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  variables(path_required_directories: path_required_directories)
 end

--- a/recipes/test_envars.rb
+++ b/recipes/test_envars.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-directories = %w[/usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin]
+directories = %w[/usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin /opt/aws/bin]
 
 # Verifies PATH in the recipe context
 check_directories_in_path(directories)

--- a/recipes/test_envars.rb
+++ b/recipes/test_envars.rb
@@ -15,4 +15,11 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-check_directories_in_path(%w[/usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin])
+directories = %w[/usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin]
+
+# Verifies PATH in the recipe context
+check_directories_in_path(directories)
+
+# Verifies PATH in login shells for notable users
+users = %W[root #{node['cluster']['cluster_admin_user']} #{node['cluster']['slurm']['user']}]
+users.each { |user| check_directories_in_path(directories, user) }

--- a/templates/default/profile/path.sh.erb
+++ b/templates/default/profile/path.sh.erb
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PATH_REQUIRED_DIRECTORIES=(<%= @path_required_directories.join(' ') %>)
+
+for directory in "${PATH_REQUIRED_DIRECTORIES[@]}"; do
+    [[ ":$PATH:" == *":$directory:"* ]] || PATH="${PATH:+"$PATH:"}$directory"
+done
+
+export PATH


### PR DESCRIPTION
### Changes
1. Make PATH include a required set of directories for every user. In particular: /usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin /opt/aws/bin

### Tests
1. Manual test on alinux2,centos7 and ubuntu2004


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
