### PR TITLE
3.0: Fail cluster creation when IMDS lockdown is not working correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Remove packer.
 - Restrict access to IMDS to root and cluster admin users, only.
 - Make PATH include required directories for every user and recipes context.
+- Fail cluster creation when IMDS lockdown is not working correctly.
 
 
 2.x.x

--- a/recipes/imds_config.rb
+++ b/recipes/imds_config.rb
@@ -49,3 +49,5 @@ if node['cluster']['node_type'] == 'HeadNode' && node['cluster']['scheduler'] ==
     raise "head_node_imds_secured must be 'true' or 'false', but got #{node['cluster']['head_node_imds_secured']}"
   end
 end
+
+include_recipe 'aws-parallelcluster::test_imds'

--- a/recipes/update_head_node.rb
+++ b/recipes/update_head_node.rb
@@ -16,5 +16,4 @@
 # limitations under the License.
 
 include_recipe 'aws-parallelcluster::setup_envars'
-include_recipe 'aws-parallelcluster::imds_config'
 include_recipe 'aws-parallelcluster::update_head_node_slurm' if node['cluster']['scheduler'] == 'slurm'


### PR DESCRIPTION
### Changes
1. Fail cluster creation when IMDS lockdown is not working correctly

### Tests
1. (manual) Cluster creation succeeded when no bugs are introduced
2. (manual) Cluster creation fails when a bug is introduced into IMDS lockdown procedure
3. (manual) Cluster update succeeds anyway because IMDS access checks are skipped, as expected, to allow the customer to update the cluster even if she/he introduces possibly wrong customizations on IMDS access


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
