### PR TITLE
3.0: Make sudoers secure_path include the same directories in every platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Restrict access to IMDS to root and cluster admin users, only.
 - Make PATH include required directories for every user and recipes context.
 - Fail cluster creation when IMDS lockdown is not working correctly.
+- Make sudoers secure_path include the same directories in every platform.
 
 
 2.x.x

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -655,6 +655,17 @@ def check_directories_in_path(directories, user = nil)
   end
 end
 
+def check_sudo_command(command, user = nil)
+  bash "check sudo command from user #{user}: #{command}" do
+    cwd Chef::Config[:file_cache_path]
+    code <<-TEST
+      set -e
+      sudo #{command}
+    TEST
+    user user
+  end
+end
+
 def get_system_users
   cmd = Mixlib::ShellOut.new("cat /etc/passwd | cut -d: -f1")
   cmd.run_command

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 include_recipe "aws-parallelcluster::setup_envars"
+include_recipe "aws-parallelcluster::sudoers_install"
 
 return if node['conditions']['ami_bootstrapped']
 

--- a/recipes/sudoers_install.rb
+++ b/recipes/sudoers_install.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: sudoers_install
+#
+# Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# secure_path
+# secure_path must include the below set of directories
+secure_path_required_directories = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin]
+secure_path_required_directories += %w[/snap/bin] if platform?('ubuntu')
+
+template '/etc/sudoers.d/99-parallelcluster-secure-path' do
+  source 'sudoers/99-parallelcluster-secure-path.erb'
+  owner 'root'
+  group 'root'
+  mode '0600'
+  variables(secure_path_required_directories: secure_path_required_directories)
+end

--- a/recipes/test_sudoers.rb
+++ b/recipes/test_sudoers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: test_sudoers
+#
+# Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies that commands in the secure_path can be executed with sudo
+%W[root #{node['cluster']['cluster_user']}].each do |user|
+  check_sudo_command('aws --version', user)
+end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -19,6 +19,7 @@ include_recipe 'aws-parallelcluster::test_envars'
 include_recipe 'aws-parallelcluster::test_users'
 include_recipe 'aws-parallelcluster::test_processes'
 include_recipe 'aws-parallelcluster::test_imds'
+include_recipe 'aws-parallelcluster::test_sudoers'
 
 ###################
 # AWS Cli

--- a/templates/default/sudoers/99-parallelcluster-secure-path.erb
+++ b/templates/default/sudoers/99-parallelcluster-secure-path.erb
@@ -1,0 +1,1 @@
+Defaults secure_path = <%= @secure_path_required_directories.join(':') %>


### PR DESCRIPTION
### Changes
1. Make sudoers secure_path include required directories in every platform. In particular:
    1. the following directories will be included in every platform: [/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin]
    2. ubuntu only will also have /snap/bin, as expected by ubuntu default

### Tests
1. Manual test in alinux2, centos7 and ubuntu2004
2. Kitchen tests
3. Integ tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
