### PR TITLE
3.0: Make SSH target checker depend on a static VPC CIDR list retrieved at config time

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -697,3 +697,46 @@ def get_system_users
   cmd.run_command
   cmd.stdout.split(/\n+/)
 end
+
+# Return the VPC CIDR list from IMDS
+def get_vpc_cidr_list
+  imds_ip = '169.254.169.254'
+  curl_options = '--retry 3 --retry-delay 0 --silent --fail'
+
+  token = run_command("curl http://#{imds_ip}/latest/api/token -X PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 300' #{curl_options}")
+  raise('Unable to retrieve token from EC2 meta-data') if token.empty?
+
+  mac = run_command("curl http://#{imds_ip}/latest/meta-data/mac -H 'X-aws-ec2-metadata-token: #{token}' #{curl_options}")
+  raise('Unable to retrieve MAC address from EC2 meta-data') if mac.empty?
+
+  vpc_cidr_list = run_command("curl http://#{imds_ip}/latest/meta-data/network/interfaces/macs/#{mac}/vpc-ipv4-cidr-blocks -H 'X-aws-ec2-metadata-token: #{token}' #{curl_options}")
+  raise('Unable to retrieve VPC CIDR list from EC2 meta-data') if vpc_cidr_list.empty?
+
+  vpc_cidr_list.split(/\n+/)
+end
+
+def run_command(command)
+  Mixlib::ShellOut.new(command).run_command.stdout.strip
+end
+
+def check_ssh_target_checker_vpc_cidr_list(ssh_target_checker_script, expected_cidr_list)
+  bash "check #{ssh_target_checker_script} contains the correct vpc cidr list: #{expected_cidr_list}" do
+    cwd Chef::Config[:file_cache_path]
+    code <<-TEST
+      if [[ ! -f #{ssh_target_checker_script} ]]; then
+        >&2 echo "SSH target checker in #{ssh_target_checker_script} not found"
+        exit 1
+      fi
+
+      actual_value=$(egrep 'VPC_CIDR_LIST[ ]*=[ ]' #{ssh_target_checker_script})
+
+      egrep 'VPC_CIDR_LIST[ ]*=[ ]*\\([ ]*#{expected_cidr_list.join('[ ]*')}[ ]*\\)' #{ssh_target_checker_script}
+      if [[ $? != 0 ]]; then
+        >&2 echo "SSH target checker in #{ssh_target_checker_script} contains wrong VPC CIDR list"
+        >&2 echo "Expected VPC CIDR list: #{expected_cidr_list}"
+        >&2 echo "Actual VPC CIDR list: $actual_value"
+        exit 1
+      fi
+    TEST
+  end
+end

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -17,6 +17,7 @@
 
 include_recipe "aws-parallelcluster::setup_envars"
 include_recipe 'aws-parallelcluster::base_install'
+include_recipe 'aws-parallelcluster::openssh_config'
 
 # Restore old behavior with sticky bits in Ubuntu 20 to allow root writing to files created by other users
 if node['platform'] == 'ubuntu' && node['platform_version'].to_i == 20

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -94,14 +94,6 @@ end
 # Manage SSH via Chef
 include_recipe "openssh"
 
-# Install SSH target checker
-cookbook_file 'ssh_target_checker.sh' do
-  path "/usr/bin/ssh_target_checker.sh"
-  owner "root"
-  group "root"
-  mode "0755"
-end
-
 # Disable selinux
 selinux_state "SELinux Disabled" do
   action :disabled

--- a/recipes/openssh_config.rb
+++ b/recipes/openssh_config.rb
@@ -2,9 +2,9 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: update_head_node
+# Recipe:: openssh_config
 #
-# Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -15,6 +15,11 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'aws-parallelcluster::setup_envars'
-include_recipe 'aws-parallelcluster::openssh_config'
-include_recipe 'aws-parallelcluster::update_head_node_slurm' if node['cluster']['scheduler'] == 'slurm'
+# Install SSH target checker
+template '/usr/bin/ssh_target_checker.sh' do
+  source 'openssh/ssh_target_checker.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  variables(vpc_cidr_list: get_vpc_cidr_list)
+end

--- a/recipes/test_openssh.rb
+++ b/recipes/test_openssh.rb
@@ -2,9 +2,9 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: update_head_node
+# Recipe:: test_openssh
 #
-# Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -15,6 +15,5 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'aws-parallelcluster::setup_envars'
-include_recipe 'aws-parallelcluster::openssh_config'
-include_recipe 'aws-parallelcluster::update_head_node_slurm' if node['cluster']['scheduler'] == 'slurm'
+# Verifies that ssh_target_checker.sh contains the correct VPC CIDR list
+check_ssh_target_checker_vpc_cidr_list('/usr/bin/ssh_target_checker.sh', get_vpc_cidr_list)

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -20,6 +20,7 @@ include_recipe 'aws-parallelcluster::test_users'
 include_recipe 'aws-parallelcluster::test_processes'
 include_recipe 'aws-parallelcluster::test_imds'
 include_recipe 'aws-parallelcluster::test_sudoers'
+include_recipe 'aws-parallelcluster::test_openssh'
 
 ###################
 # AWS Cli

--- a/recipes/update_head_node_slurm.rb
+++ b/recipes/update_head_node_slurm.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+include_recipe 'aws-parallelcluster::openssh_config'
+
 updated_cluster_config_path = "/tmp/cluster-config.updated.yaml"
 fetch_config_command = "#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3api get-object"\
                        " --bucket #{node['cluster']['cluster_s3_bucket']}"\

--- a/templates/default/openssh/ssh_target_checker.sh.erb
+++ b/templates/default/openssh/ssh_target_checker.sh.erb
@@ -13,6 +13,8 @@
 
 set -o pipefail
 
+VPC_CIDR_LIST=(<%= @vpc_cidr_list.join(' ') %>)
+
 log() {
     echo "$@" | logger -t "pcluster_ssh_target_checker"
 }
@@ -74,9 +76,7 @@ if [[ "${resolved_ip}" == "127.0.0.1" ]]; then
    exit 0
 fi
 
-IFS=" " read -r -a vpc_cidr_list <<< "$(retrieve_vpc_cidr_list)"
-
-for vpc_cidr in "${vpc_cidr_list[@]}"
+for vpc_cidr in "${VPC_CIDR_LIST[@]}"
 do
   check_ip_in_cidr "${resolved_ip}" "${vpc_cidr}"
   if check_ip_in_cidr "${resolved_ip}" "${vpc_cidr}"; then


### PR DESCRIPTION
### Changes
1. Make SSH target checker depend on a static VPC CIDR list retrieved at config time

Notes: 
2. I've added a kitchen test to verify the expected value of VPC CIDR list. This test does not fully protect us from errors but I think it would be better to have at least a minimum protection.

### Tests
1. Manual test
2. Kitchen tests
3. Integration tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
