### PR TITLE
3.0: Make parallelcluster-iptables script save current rules on start if no backup is found

### DIFF
--- a/files/default/init/parallelcluster-iptables
+++ b/files/default/init/parallelcluster-iptables
@@ -37,8 +37,12 @@ case "$1" in
 start|stop)
     $1
     ;;
+restart)
+    stop
+    start
+    ;;
 *)
-    echo "Usage: $0 {start|stop}"
+    echo "Usage: $0 {start|stop|restart}"
     exit 2
 esac
 

--- a/files/default/init/parallelcluster-iptables
+++ b/files/default/init/parallelcluster-iptables
@@ -17,32 +17,33 @@
 
 IPTABLES_RULES_FILE="/etc/parallelcluster/sysconfig/iptables.rules"
 
-function start() {
-  if [[ -f $IPTABLES_RULES_FILE ]]; then
-    iptables-restore < $IPTABLES_RULES_FILE
-    echo "iptables rules restored from file: $IPTABLES_RULES_FILE"
-  else
-    echo "iptables rules left unchanged as file was not found: $IPTABLES_RULES_FILE"
-  fi
-}
-
-function stop() {
+function save() {
   echo "saving iptables rules to file: $IPTABLES_RULES_FILE"
   mkdir -p $(dirname $IPTABLES_RULES_FILE)
   iptables-save > $IPTABLES_RULES_FILE
   echo "iptables rules saved to file: $IPTABLES_RULES_FILE"
 }
 
+function start() {
+  if [[ -f $IPTABLES_RULES_FILE ]]; then
+    iptables-restore < $IPTABLES_RULES_FILE
+    echo "iptables rules restored from file: $IPTABLES_RULES_FILE"
+  else
+    echo "iptables rules left unchanged as file was not found: $IPTABLES_RULES_FILE"
+    save
+  fi
+}
+
+function stop() {
+  save
+}
+
 case "$1" in
 start|stop)
     $1
     ;;
-restart)
-    stop
-    start
-    ;;
 *)
-    echo "Usage: $0 {start|stop|restart}"
+    echo "Usage: $0 {start|stop}"
     exit 2
 esac
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -631,6 +631,21 @@ def check_imds_access(user, is_allowed)
   end
 end
 
+# Check that the iptables backup file exists
+def check_iptables_rules_file(file)
+  bash "check iptables rules backup file exists: #{file}" do
+    cwd Chef::Config[:file_cache_path]
+    code <<-TEST
+      set -e
+
+      if [[ ! -f #{file} ]]; then
+        >&2 echo "Missing expected iptables rules file: #{file}"
+        exit 1
+      fi
+    TEST
+  end
+end
+
 # Check that PATH includes directories for the given user.
 # If user is specified, PATH is checked in the login shell for that user.
 # Otherwise, PATH is checked in the current recipes context.

--- a/recipes/imds_config.rb
+++ b/recipes/imds_config.rb
@@ -58,7 +58,7 @@ cookbook_file '/etc/init.d/parallelcluster-iptables' do
 end
 
 service "parallelcluster-iptables" do
-  action %i[enable restart]
+  action %i[enable start]
 end
 
 include_recipe 'aws-parallelcluster::test_imds'

--- a/recipes/imds_config.rb
+++ b/recipes/imds_config.rb
@@ -58,7 +58,7 @@ cookbook_file '/etc/init.d/parallelcluster-iptables' do
 end
 
 service "parallelcluster-iptables" do
-  action %i[enable start]
+  action %i[enable restart]
 end
 
 include_recipe 'aws-parallelcluster::test_imds'

--- a/recipes/imds_config.rb
+++ b/recipes/imds_config.rb
@@ -50,11 +50,18 @@ if node['cluster']['node_type'] == 'HeadNode' && node['cluster']['scheduler'] ==
   end
 end
 
-cookbook_file '/etc/init.d/parallelcluster-iptables' do
-  source 'init/parallelcluster-iptables'
+iptables_rules_file = '/etc/parallelcluster/sysconfig/iptables.rules'
+
+execute "Save iptables rules" do
+  command "mkdir -p $(dirname #{iptables_rules_file}) && iptables-save > #{iptables_rules_file}"
+end
+
+template '/etc/init.d/parallelcluster-iptables' do
+  source 'init/parallelcluster-iptables.erb'
   user 'root'
   group 'root'
   mode '0744'
+  variables(iptables_rules_file: iptables_rules_file)
 end
 
 service "parallelcluster-iptables" do

--- a/recipes/test_imds.rb
+++ b/recipes/test_imds.rb
@@ -32,3 +32,5 @@ allowed_users.each { |allowed_user| check_imds_access(allowed_user, true) }
 denied_users.each { |denied_user| check_imds_access(denied_user, false) }
 
 check_run_level_script('parallelcluster-iptables', %w[1 2 3 4 5], %w[0 6])
+
+check_iptables_rules_file('/etc/parallelcluster/sysconfig/iptables.rules')

--- a/templates/default/init/parallelcluster-iptables.erb
+++ b/templates/default/init/parallelcluster-iptables.erb
@@ -15,14 +15,7 @@
 # Description: Backup and restore iptables rules
 ### END INIT INFO
 
-IPTABLES_RULES_FILE="/etc/parallelcluster/sysconfig/iptables.rules"
-
-function save() {
-  echo "saving iptables rules to file: $IPTABLES_RULES_FILE"
-  mkdir -p $(dirname $IPTABLES_RULES_FILE)
-  iptables-save > $IPTABLES_RULES_FILE
-  echo "iptables rules saved to file: $IPTABLES_RULES_FILE"
-}
+IPTABLES_RULES_FILE="<%= @iptables_rules_file %>"
 
 function start() {
   if [[ -f $IPTABLES_RULES_FILE ]]; then
@@ -30,12 +23,14 @@ function start() {
     echo "iptables rules restored from file: $IPTABLES_RULES_FILE"
   else
     echo "iptables rules left unchanged as file was not found: $IPTABLES_RULES_FILE"
-    save
   fi
 }
 
 function stop() {
-  save
+  echo "saving iptables rules to file: $IPTABLES_RULES_FILE"
+  mkdir -p $(dirname $IPTABLES_RULES_FILE)
+  iptables-save > $IPTABLES_RULES_FILE
+  echo "iptables rules saved to file: $IPTABLES_RULES_FILE"
 }
 
 case "$1" in


### PR DESCRIPTION
### Changes
1. Save iptables rules after they have been configured during the imds_config recipe. This approach is safe than making iptables-rules script saving rules if no rules file has been found.

Notes: 
1. Remember that parallelcluster-iptables is started at config time just after the iptables configuration. That's the reason why it is enough to save the rule file in the start command
2. I've added a very simple kitchen test just to be sure that the iptables rules file has been written. Since the file is generated by iptables-save, I think we can assume that its content is correct without spending effort on checking the content.

### Test
1. Manual test
2. Kitchen test
3. Integration tests (pending)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
