### PR TITLE
3.0: Fix kitchen test on sudoers permissions for cluster admin user

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -592,7 +592,7 @@ def check_sudoers_permissions(sudoers_file, user, run_as, command_alias, *comman
       fi
 
       expected_user_line="#{user} ALL = (#{run_as}) NOPASSWD: #{command_alias}"
-      actual_user_line=$(grep ^#{user} "#{sudoers_file}")
+      actual_user_line=$(grep "^#{user} .* #{command_alias}" "#{sudoers_file}")
       if [[ "$actual_user_line" != "$expected_user_line" ]]; then
         >&2 echo "Expected user line in #{sudoers_file}: $expected_user_line"
         >&2 echo "Actual user line in #{sudoers_file}: $actual_user_line"

--- a/recipes/test_users.rb
+++ b/recipes/test_users.rb
@@ -108,6 +108,12 @@ if node['cluster']['scheduler'] == 'slurm'
 
   check_sudoers_permissions(
     sudoers_file,
+    cluster_admin_user, "root", "SHUTDOWN",
+    "/usr/sbin/shutdown"
+  )
+
+  check_sudoers_permissions(
+    sudoers_file,
     cluster_slurm_user, cluster_admin_user, "SLURM_HOOKS_COMMANDS",
     "#{venv_path}/bin/slurm_suspend, #{venv_path}/bin/slurm_resume"
   )


### PR DESCRIPTION
### Changes
1. Fix kitchen test on sudoers permissions for cluster admin user. The test is now able to verify command alias when more than one command alias is assigned. In particular, we now test also the SHUTDOWN command alias.

### Tests
1. Manual test of the recipe


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
