### PR TITLE
Restore ``noatime`` option for NFS filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Make sudoers secure_path include the same directories in every platform.
 - Add support for iptables restore on instance reboot.
 - Allow IMDS access for dcv user when dcv is enabled.
+- Restore ``noatime`` option, which has positive impact on the performances of NFS filesystem
 
 2.11.0
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -362,7 +362,7 @@ when 'debian'
 end
 
 # Default NFS mount options
-default['cfncluster']['nfs']['hard_mount_options'] = 'hard,_netdev'
+default['cfncluster']['nfs']['hard_mount_options'] = 'hard,_netdev,noatime'
 
 # Lustre defaults (for CentOS >=7.7 and Ubuntu)
 default['cluster']['lustre']['public_key'] = value_for_platform(


### PR DESCRIPTION
According to the documentation below noatime is going to have a positive impact on the performances avoiding write operations when accessing files on a mounted NFS filesystem:

* https://www.cyberciti.biz/faq/linux-unix-tuning-nfs-server-client-performance
* https://tldp.org/LDP/solrhe/Securing-Optimizing-Linux-RH-Edition-v1.3/chap6sec73.html

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
