### PR TITLE
Rename missing cfncluster to cluster and cfn_cluster_user to cluster_user

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -362,7 +362,7 @@ when 'debian'
 end
 
 # Default NFS mount options
-default['cfncluster']['nfs']['hard_mount_options'] = 'hard,_netdev,noatime'
+default['cluster']['nfs']['hard_mount_options'] = 'hard,_netdev,noatime'
 
 # Lustre defaults (for CentOS >=7.7 and Ubuntu)
 default['cluster']['lustre']['public_key'] = value_for_platform(
@@ -401,9 +401,9 @@ default['cluster']['lustre']['client_url'] = value_for_platform(
 )
 
 # Default gc_thresh values for performance at scale
-default['cfncluster']['sysctl']['ipv4']['gc_thresh1'] = 0
-default['cfncluster']['sysctl']['ipv4']['gc_thresh2'] = 15_360
-default['cfncluster']['sysctl']['ipv4']['gc_thresh3'] = 16_384
+default['cluster']['sysctl']['ipv4']['gc_thresh1'] = 0
+default['cluster']['sysctl']['ipv4']['gc_thresh2'] = 15_360
+default['cluster']['sysctl']['ipv4']['gc_thresh3'] = 16_384
 
 # ParallelCluster internal variables (also in /etc/parallelcluster/cfnconfig)
 default['cluster']['region'] = 'us-east-1'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -502,7 +502,7 @@ def configure_gc_thresh_values
   (1..3).each do |i|
     # Configure gc_thresh values to be consistent with alinux2 default values
     sysctl "net.ipv4.neigh.default.gc_thresh#{i}" do
-      value node['cfncluster']['sysctl']['ipv4']["gc_thresh#{i}"]
+      value node['cluster']['sysctl']['ipv4']["gc_thresh#{i}"]
       action :apply
     end
   end

--- a/recipes/arm_pl_install.rb
+++ b/recipes/arm_pl_install.rb
@@ -26,11 +26,6 @@ armpl_url = "https://#{node['cluster']['region']}-aws-parallelcluster.s3.#{node[
 package 'centos-release-scl-rh' if node['cluster']['base_os'] == 'centos7'
 package 'devtoolset-8-binutils' if node['cluster']['base_os'] == 'centos7'
 
-# binutils v2.30 is required for Centos7 architecture detection
-# these must be installed in this order
-package 'centos-release-scl-rh' if node['cfncluster']['cfn_base_os'] == 'centos7'
-package 'devtoolset-8-binutils' if node['cfncluster']['cfn_base_os'] == 'centos7'
-
 # fetch armpl installer script
 remote_file armpl_installer do
   source armpl_url

--- a/recipes/compute_base_config.rb
+++ b/recipes/compute_base_config.rb
@@ -47,7 +47,7 @@ if raid_shared_dir != "NONE"
   mount raid_shared_dir do
     device(lazy { "#{node['cluster']['head_node_private_ip']}:#{raid_shared_dir}" })
     fstype 'nfs'
-    options node['cfncluster']['nfs']['hard_mount_options']
+    options node['cluster']['nfs']['hard_mount_options']
     action %i[mount enable]
     retries 10
     retry_delay 6
@@ -58,7 +58,7 @@ end
 mount '/home' do
   device(lazy { "#{node['cluster']['head_node_private_ip']}:/home" })
   fstype 'nfs'
-  options node['cfncluster']['nfs']['hard_mount_options']
+  options node['cluster']['nfs']['hard_mount_options']
   action %i[mount enable]
   retries 10
   retry_delay 6
@@ -68,7 +68,7 @@ end
 mount '/opt/intel' do
   device(lazy { "#{node['cluster']['head_node_private_ip']}:/opt/intel" })
   fstype 'nfs'
-  options node['cfncluster']['nfs']['hard_mount_options']
+  options node['cluster']['nfs']['hard_mount_options']
   action %i[mount enable]
   retries 10
   retry_delay 6
@@ -107,7 +107,7 @@ shared_dir_array.each do |dir|
   mount dirname do
     device(lazy { "#{node['cluster']['head_node_private_ip']}:#{dirname}" })
     fstype 'nfs'
-    options node['cfncluster']['nfs']['hard_mount_options']
+    options node['cluster']['nfs']['hard_mount_options']
     action %i[mount enable]
     retries 10
     retry_delay 6

--- a/recipes/compute_slurm_config.rb
+++ b/recipes/compute_slurm_config.rb
@@ -29,7 +29,7 @@ end
 mount '/opt/slurm' do
   device(lazy { "#{node['cluster']['head_node_private_ip']}:/opt/slurm" })
   fstype "nfs"
-  options node['cfncluster']['nfs']['hard_mount_options']
+  options node['cluster']['nfs']['hard_mount_options']
   action %i[mount enable]
   retries 10
   retry_delay 6

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -330,7 +330,7 @@ end
 ##################
 # Verify enough space on AMIs
 ###################
-unless node['cfncluster']['os'].end_with?("-custom")
+unless node['cluster']['os'].end_with?("-custom")
   bash 'verify 10 GB of space left on root volume' do
     cwd Chef::Config[:file_cache_path]
     # This test assumes the df output is as follows:
@@ -344,7 +344,7 @@ unless node['cfncluster']['os'].end_with?("-custom")
         exit 1
       fi
     CAPACITY_CHECK
-    user node['cfncluster']['cfn_cluster_user']
+    user node['cluster']['cluster_user']
   end
 end
 
@@ -353,7 +353,7 @@ end
 ###################
 expected_gc_settings = []
 (1..3).each do |i|
-  expected_gc_settings.append(node['cfncluster']['sysctl']['ipv4']["gc_thresh#{i}"])
+  expected_gc_settings.append(node['cluster']['sysctl']['ipv4']["gc_thresh#{i}"])
 end
 expected_gc_settings = expected_gc_settings.join(',').to_s
 bash 'check ipv4 gc_thresh is correctly configured' do


### PR DESCRIPTION
These missed renaming are coming from the merge of wip/pcluster3 into develop.
