### PR TITLE
Avoid failures when building SGE using instance type with vCPU >=32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Retry failed installations of aws-parallelcluster package on head node of clusters using AWS Batch as the scheduler.
 
 **CHANGES**
-- Restore ``noatime`` option, which has positive impact on the performances of NFS filesystem
+- Restore ``noatime`` option, which has positive impact on the performances of NFS filesystem.
 
 **BUG FIXES**
 - Pin to version 1.247347 of the CloudWatch agent due to performance impact of latest CW agent version 1.247348.
+- Avoid failures when building SGE using instance type with vCPU >=32.
 
 2.11.0
 -----

--- a/recipes/sge_install.rb
+++ b/recipes/sge_install.rb
@@ -93,6 +93,10 @@ when 'MasterServer', nil
       tar xf #{sge_tarball}
       cd sge-#{node['cfncluster']['sge']['version']}/source
       CORES=$(grep processor /proc/cpuinfo | wc -l)
+      if which yum &>/dev/null || which dnf &>/dev/null && [[ ${CORES} -ge 32 ]]; then
+        # for yum/dnf OS avoid failures when using high parallelism
+        CORES=31
+      fi
       sh scripts/bootstrap.sh -no-java -no-jni -no-herd
       ./aimk -pam -no-remote -no-java -no-jni -no-herd -parallel $CORES
       ./aimk -man -no-java -no-jni -no-herd -parallel $CORES


### PR DESCRIPTION
For yum/dnf OS (alinux2, centos7 and centos8) avoid SGE build failures when using high parallelism (64 threads) due to undeclared prerequisites for pdc.

This resolves https://github.com/aws/aws-parallelcluster/issues/2934

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
