### PR TITLE
Include default cluster user in IMDS allow-list

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -458,5 +458,5 @@ default['cluster']['instance_types_data'] = nil
 
 # IMDS
 default['cluster']['head_node_imds_secured'] = 'true'
-default['cluster']['head_node_imds_allowed_users'] = ['root', node['cluster']['cluster_admin_user']]
+default['cluster']['head_node_imds_allowed_users'] = ['root', node['cluster']['cluster_admin_user'], node['cluster']['cluster_user']]
 default['cluster']['head_node_imds_allowed_users'].append('dcv') if node['cluster']['dcv_enabled'] == 'head_node'


### PR DESCRIPTION
This change adds the default cluster user to the list of users that are
enabled to access the head node's Instance MetaData Service by default.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
