### PR TITLE
Add libcurl devel library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **ENHANCEMENTS**
 - Support restart/reboot for instance type with instance store (ephemeral drives).
+- Compile Slurm with jobcomp/elasticsearch support.
 
 **CHANGES**
 - Drop support for SGE and Torque schedulers.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -301,7 +301,7 @@ when 'rhel', 'amazon'
                                              blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                              libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                              mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
-                                             iproute NetworkManager-config-routing-rules python3 python3-pip iptables]
+                                             iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel]
     default['cluster']['rhel']['extra_repo'] = 'rhui-REGION-rhel-server-optional'
 
     if node['platform_version'].to_i == 7 && node['kernel']['machine'] == 'aarch64'
@@ -319,7 +319,7 @@ when 'rhel', 'amazon'
                                              rpm-build rpm-sign system-rpm-config cscope ctags diffstat doxygen elfutils
                                              gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl
                                              jq wget python-pip NetworkManager-config-routing-rules libibverbs-utils
-                                             librdmacm-utils python3 python3-pip iptables]
+                                             librdmacm-utils python3 python3-pip iptables libcurl-devel]
 
     # Install R via amazon linux extras
     default['cluster']['alinux_extras'] = ['R3.4']
@@ -336,7 +336,7 @@ when 'debian'
                                            libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev python
                                            r-base libblas-dev libfftw3-dev libffi-dev libxml2-dev mdadm
                                            libgcrypt20-dev libmysqlclient-dev libevent-dev iproute2 python3 python3-pip
-                                           libatlas-base-dev libglvnd-dev linux-headers-aws iptables]
+                                           libatlas-base-dev libglvnd-dev linux-headers-aws iptables libcurl4-openssl-dev]
 
   case node['platform_version']
   when '18.04'


### PR DESCRIPTION
libcurl devel library allows to have Slurm compiled with jobcomp/elasticsearch support, https://github.com/asanchez1987/jobcomp-elasticsearch

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
