### PR TITLE
[nvidia-fabricmanager] lock package version to prevent upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+2.11.2
+-----
+
+**BUG FIXES**
+- Lock version of `nvidia-fabricmanager` package to prevent updates and misalignments with NVIDIA drivers
+
 2.11.1
 -----
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -308,7 +308,7 @@ when 'rhel', 'amazon'
                                                 blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                                 libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                                 mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
-                                                iproute NetworkManager-config-routing-rules python3 python3-pip]
+                                                iproute NetworkManager-config-routing-rules python3 python3-pip yum-plugin-versionlock]
     if node['platform_version'].to_i >= 8
       # Do not install unversioned python
       default['cfncluster']['base_packages'].delete('python')
@@ -338,7 +338,7 @@ when 'rhel', 'amazon'
                                                 rpm-build rpm-sign system-rpm-config cscope ctags diffstat doxygen elfutils
                                                 gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl
                                                 jq wget python-pip NetworkManager-config-routing-rules libibverbs-utils
-                                                librdmacm-utils python3 python3-pip]
+                                                librdmacm-utils python3 python3-pip yum-plugin-versionlock]
 
     # Install R via amazon linux extras
     default['cfncluster']['alinux_extras'] = ['R3.4']

--- a/files/default/dcv/pcluster_dcv_authenticator.py
+++ b/files/default/dcv/pcluster_dcv_authenticator.py
@@ -122,7 +122,7 @@ class DCVAuthenticator(BaseHTTPRequestHandler):
     - the authenticator verifies the validity of the authenticationToken and permits the user to access to the session.
     """
 
-    class IncorrectRequestException(Exception):
+    class IncorrectRequestException(Exception):  # noqa N818
         """Class used to generate an exception when an incorrect request arrives to the DCVAuthenticator."""
 
         pass

--- a/recipes/nvidia_install.rb
+++ b/recipes/nvidia_install.rb
@@ -90,6 +90,7 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes' || node['cfncluster']['nvidi
 
   package node['cfncluster']['nvidia']['fabricmanager']['package'] do
     version node['cfncluster']['nvidia']['fabricmanager']['version']
+    action %i[install lock]
   end
 
   remove_package_repository("nvidia-fm-repo")

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -443,6 +443,32 @@ if get_nvswitches > 1
   end
 end
 
+# Verify FabricManager version is aligned with Nvidia drivers
+case node['platform_family']
+when 'rhel', 'amazon'
+  bash 'check for FabricManager' do
+    code <<-TESTFM
+      set -ex
+      # Verify version of fabric manager is the same as Nvidia drivers
+      nvidia_driver_version=$(modinfo -F version nvidia)
+      yum list installed | grep nvidia-fabricmanager | grep ${nvidia_driver_version}
+      # Check that the nvidia-fabricmanager is locked
+      yum versionlock list | grep nvidia-fabricmanager
+    TESTFM
+  end
+when 'debian'
+  bash 'check for FabricManager' do
+    code <<-TESTFM
+      set -ex
+      # Verify version of fabric manager is the same as Nvidia drivers
+      nvidia_driver_version=$(modinfo -F version nvidia)
+      apt list --installed | grep nvidia-fabricmanager | grep ${nvidia_driver_version}
+      # Check that the nvidia-fabricmanager is locked
+      apt-mark showhold | grep nvidia-fabricmanager
+    TESTFM
+  end
+end
+
 ###################
 # CloudWatch
 ###################


### PR DESCRIPTION
nvidia-fabricmanager needs to be alwasy aligned with NVIDIA drivers version



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
