### PR TITLE
Add dcv user to IMDS allowed users only when DCV is both enabled and supported. Execute IMDS lockdown test on all system users only when recipes are executed by kitchen test.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -463,4 +463,4 @@ default['cluster']['instance_types_data'] = nil
 # IMDS
 default['cluster']['head_node_imds_secured'] = 'true'
 default['cluster']['head_node_imds_allowed_users'] = ['root', node['cluster']['cluster_admin_user'], node['cluster']['cluster_user']]
-default['cluster']['head_node_imds_allowed_users'].append('dcv') if node['cluster']['dcv_enabled'] == 'head_node'
+default['cluster']['head_node_imds_allowed_users'].append('dcv') if node['cluster']['dcv_enabled'] == 'head_node' && platform_supports_dcv?

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -750,3 +750,8 @@ def check_ssh_target_checker_vpc_cidr_list(ssh_target_checker_script, expected_c
     TEST
   end
 end
+
+# Check if recipes are executed during kitchen tests.
+def kitchen_test?
+  node['kitchen'] == 'true'
+end


### PR DESCRIPTION
### Changes
1. Add dcv user to IMDS allowed users only when DCV is both enabled and supported
2. Execute IMDS lockdown test on all system users only when recipes are executed by kitchen test, otherwise consider only a sample of relevant users


### Tests
1. Manual test creating a cluster with dcv enabled
2. Manual test creating a cluster with dcv disabled
3. Ongoing kitchen test
4. Ongoing integration tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
