### PR TITLE
[nvidia-fabricmanager] lock package version to prevent upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
-
 3.0.0
 ------
 
@@ -32,6 +31,28 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Slurm to version 20.11.8
 - Upgrade NVIDIA driver to version 470.57.02.
 - Upgrade CUDA library to version 11.4.0.
+
+2.11.2
+-----
+
+**BUG FIXES**
+- Lock version of `nvidia-fabricmanager` package to prevent updates and misalignments with NVIDIA drivers
+
+2.11.1
+-----
+
+**ENHANCEMENTS**
+- Retry failed installations of aws-parallelcluster package on head node of clusters using AWS Batch as the scheduler.
+
+**CHANGES**
+- Restore ``noatime`` option, which has positive impact on the performances of NFS filesystem.
+- Upgrade EFA installer to version 1.12.3
+  - EFA configuration: ``efa-config-1.9`` (from ``efa-config-1.8-1``)
+  - EFA kernel module: ``efa-1.13.0`` (from ``efa-1.12.3``)
+
+**BUG FIXES**
+- Pin to version 1.247347 of the CloudWatch agent due to performance impact of latest CW agent version 1.247348.
+- Avoid failures when building SGE using instance type with vCPU >=32.
 
 2.11.0
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -301,7 +301,7 @@ when 'rhel', 'amazon'
                                              blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
                                              libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                              mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
-                                             iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel]
+                                             iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock]
     default['cluster']['rhel']['extra_repo'] = 'rhui-REGION-rhel-server-optional'
 
     if node['platform_version'].to_i == 7 && node['kernel']['machine'] == 'aarch64'
@@ -319,7 +319,7 @@ when 'rhel', 'amazon'
                                              rpm-build rpm-sign system-rpm-config cscope ctags diffstat doxygen elfutils
                                              gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl
                                              jq wget python-pip NetworkManager-config-routing-rules libibverbs-utils
-                                             librdmacm-utils python3 python3-pip iptables libcurl-devel]
+                                             librdmacm-utils python3 python3-pip iptables libcurl-devel yum-plugin-versionlock]
 
     # Install R via amazon linux extras
     default['cluster']['alinux_extras'] = ['R3.4']

--- a/recipes/nvidia_install.rb
+++ b/recipes/nvidia_install.rb
@@ -90,6 +90,7 @@ if node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['e
 
   package node['cluster']['nvidia']['fabricmanager']['package'] do
     version node['cluster']['nvidia']['fabricmanager']['version']
+    action %i[install lock]
   end
 
   remove_package_repository("nvidia-fm-repo")

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -435,3 +435,32 @@ bash 'check ipv4 gc_thresh is correctly configured' do
   GC
   user 'root'
 end
+
+###################
+# FabricManager
+###################
+# Verify FabricManager version is aligned with Nvidia drivers
+case node['platform_family']
+when 'rhel', 'amazon'
+  bash 'check for FabricManager' do
+    code <<-TESTFM
+      set -ex
+      # Verify version of fabric manager is the same as Nvidia drivers
+      nvidia_driver_version=$(modinfo -F version nvidia)
+      yum list installed | grep nvidia-fabricmanager | grep ${nvidia_driver_version}
+      # Check that the nvidia-fabricmanager is locked
+      yum versionlock list | grep nvidia-fabricmanager
+    TESTFM
+  end
+when 'debian'
+  bash 'check for FabricManager' do
+    code <<-TESTFM
+      set -ex
+      # Verify version of fabric manager is the same as Nvidia drivers
+      nvidia_driver_version=$(modinfo -F version nvidia)
+      apt list --installed | grep nvidia-fabricmanager | grep ${nvidia_driver_version}
+      # Check that the nvidia-fabricmanager is locked
+      apt-mark showhold | grep nvidia-fabricmanager
+    TESTFM
+  end
+end


### PR DESCRIPTION
nvidia-fabricmanager needs to be alwasy aligned with NVIDIA drivers version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
