### PR TITLE
Do not install EFA if found on AMI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 2.11.2
 -----
 
+**CHANGES**
+- Do not re-install EFA with GDR enabled at node bootstrap time in case EFA was already installed in the base AMI
+  during the createami process.
+
 **BUG FIXES**
 - Lock version of `nvidia-fabricmanager` package to prevent updates and misalignments with NVIDIA drivers
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -531,3 +531,13 @@ def configure_gc_thresh_values
     end
   end
 end
+
+def efa_installed?
+  dir_exist = ::Dir.exist?('/opt/amazon/efa')
+  if dir_exist
+    modinfo_efa_stdout = Mixlib::ShellOut.new("modinfo efa").run_command.stdout
+    efa_installed_packages_file = Mixlib::ShellOut.new("cat /opt/amazon/efa_installed_packages").run_command.stdout
+    Chef::Log.info("`/opt/amazon/efa` directory already exists. \nmodinfo efa stdout: \n#{modinfo_efa_stdout} \nefa_installed_packages_file_content: \n#{efa_installed_packages_file}")
+  end
+  dir_exist
+end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -341,8 +341,30 @@ if node['conditions']['intel_mpi_supported']
 end
 
 ###################
-# EFA - GDR (GPUDirect RDMA)
+# EFA
 ###################
+if node['cfncluster']['os'].end_with?("-custom")
+  # only check EFA is installed because when found in the base AMI we skip installation
+  bash 'check efa installed' do
+    cwd Chef::Config[:file_cache_path]
+    code <<-EFA
+      set -ex
+      modinfo efa
+      cat /opt/amazon/efa_installed_packages
+    EFA
+  end
+else
+  # check EFA is installed and the version is expected
+  bash 'check correct version of efa installed' do
+    cwd Chef::Config[:file_cache_path]
+    code <<-EFA
+      set -ex
+      modinfo efa
+      grep "EFA installer version: #{node['cfncluster']['efa']['installer_version']}" /opt/amazon/efa_installed_packages
+    EFA
+  end
+end
+# GDR (GPUDirect RDMA)
 if node['conditions']['efa_supported'] && efa_gdr_enabled?
   execute 'check efa gdr installed' do
     command "modinfo efa | grep 'gdr:\ *Y'"


### PR DESCRIPTION
enable_gdr setting is ignored when EFA installation is not managed by ParallelCluster


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
