### PR TITLE
Fix kernel devel installation for ARM architecture

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -285,7 +285,7 @@ case node['platform_family']
 when 'rhel', 'amazon'
 
   default['cfncluster']['kernel_devel_pkg']['name'] = "kernel-devel"
-  default['cfncluster']['kernel_devel_pkg']['version'] = node['kernel']['release'].chomp('.x86_64')
+  default['cfncluster']['kernel_devel_pkg']['version'] = node['kernel']['release'].chomp('.x86_64').chomp('.aarch64')
 
   # Modulefile Directory
   default['cfncluster']['modulefile_dir'] = "/usr/share/Modules/modulefiles"


### PR DESCRIPTION
In the kernel_devel_pkg version retrieval I'm adding an extra chomp for aarch64 substring
to make the code works with both architectures.

Kernel version has the form: `4.14.232-176.381.amzn2.aarch64` or `4.18.0-193.28.1.el7.aarch64`when using arm instances.

