### PR TITLE
Skip FabricManager check on custom built AMIs

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -465,8 +465,9 @@ if get_nvswitches > 1
   end
 end
 
-unless arm_instance?
-  # Verify FabricManager version is aligned with Nvidia drivers (Nvidia drivers are only installed on x86)
+unless arm_instance? || node['cfncluster']['os'].end_with?("-custom")
+  # Verify FabricManager version is aligned with Nvidia drivers
+  # (Nvidia drivers are only installed on x86, Nvidia recipe is not executed for custom build.)
   case node['platform_family']
   when 'rhel', 'amazon'
     bash 'check for FabricManager' do


### PR DESCRIPTION
Nvidia recipe is not executed for custom build.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
