### PR TITLE
Skip nvidia-smi execution if drivers not installed

### DIFF
--- a/recipes/compute_slurm_config.rb
+++ b/recipes/compute_slurm_config.rb
@@ -38,7 +38,7 @@ end
 # Check to see if there is GPU on the instance, only execute run_nvidiasmi if there is GPU
 if graphic_instance?
   execute "run_nvidiasmi" do
-    command 'nvidia-smi'
+    command 'if which nvidia-smi &>/dev/null; then nvidia-smi; else echo "GPU instance but no Nvidia drivers found"; fi'
   end
 end
 


### PR DESCRIPTION
This can happen when GPU instance is used and no Nvidia drivers are installed

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
