### PR TITLE
3.0: Do not install EFA if found on AMI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 2.11.2
 -----
 
+**CHANGES**
+When using a custom AMI with a preinstalled EFA package, no actions are taken at node bootstrap time in case GPUDirect RDMA is enabled. The original EFA package deployment is preserved as during the Image build process.
+
 **BUG FIXES**
 - Lock version of `nvidia-fabricmanager` package to prevent updates and misalignments with NVIDIA drivers
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -744,3 +744,13 @@ end
 def kitchen_test?
   node['kitchen'] == 'true'
 end
+
+def efa_installed?
+  dir_exist = ::Dir.exist?('/opt/amazon/efa')
+  if dir_exist
+    modinfo_efa_stdout = Mixlib::ShellOut.new("modinfo efa").run_command.stdout
+    efa_installed_packages_file = Mixlib::ShellOut.new("cat /opt/amazon/efa_installed_packages").run_command.stdout
+    Chef::Log.info("`/opt/amazon/efa` directory already exists. \nmodinfo efa stdout: \n#{modinfo_efa_stdout} \nefa_installed_packages_file_content: \n#{efa_installed_packages_file}")
+  end
+  dir_exist
+end

--- a/recipes/efa_install.rb
+++ b/recipes/efa_install.rb
@@ -16,6 +16,12 @@
 # limitations under the License.
 
 efa_tarball = "#{node['cluster']['sources_dir']}/aws-efa-installer.tar.gz"
+efa_installed = efa_installed?
+
+if efa_installed && !::File.exist?(efa_tarball)
+  Chef::Log.warn("Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration. enable_gdr option will be ignored.")
+  return
+end
 
 # Get EFA Installer
 remote_file efa_tarball do
@@ -32,12 +38,12 @@ case node['platform_family']
 when 'rhel', 'amazon'
   package %w[openmpi-devel openmpi] do
     action :remove
-    not_if { ::Dir.exist?('/opt/amazon/efa') }
+    not_if { efa_installed }
   end
 when 'debian'
   package "libopenmpi-dev" do
     action :remove
-    not_if { ::Dir.exist?('/opt/amazon/efa') }
+    not_if { efa_installed }
   end
 end
 
@@ -54,6 +60,7 @@ bash "install efa" do
     tar -xzf #{efa_tarball}
     cd aws-efa-installer
     ./efa_installer.sh #{installer_options}
+    rm -rf #{node['cluster']['sources_dir']}/aws-efa-installer
   EFAINSTALL
-  not_if { ::Dir.exist?('/opt/amazon/efa') && !efa_gdr_enabled? }
+  not_if { efa_installed && !efa_gdr_enabled? }
 end


### PR DESCRIPTION
`enable_gdr` setting is ignored when EFA installation is not managed by ParallelCluster

Backport of: https://github.com/aws/aws-parallelcluster-cookbook/pull/1067 + Renamed `cfncluster` to `cluster` in cookbook properties.