### PR TITLE
Skip test to verify no FFTW lib present on centos7

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -450,10 +450,12 @@ end
 ##################
 # Verify no FFTW packages
 ###################
-bash 'verify no FFTW packages' do
-  code <<-NOFFTW
-    lib64_fftw_libs="$(ls 2>/dev/null /usr/lib64/libfftw*)"
-    lib_fftw_libs="$(ls 2>/dev/null /usr/lib/libfftw*)"
-    [ -z "${lib64_fftw_libs}" ] && [ -z "${lib_fftw_libs}" ]
-  NOFFTW
+unless node['cluster']['base_os'] == 'centos7'
+  bash 'verify no FFTW packages' do
+    code <<-NOFFTW
+      lib64_fftw_libs="$(ls 2>/dev/null /usr/lib64/libfftw*)"
+      lib_fftw_libs="$(ls 2>/dev/null /usr/lib/libfftw*)"
+      [ -z "${lib64_fftw_libs}" ] && [ -z "${lib_fftw_libs}" ]
+    NOFFTW
+  end
 end


### PR DESCRIPTION
This test was added in #1078. Either an FFTW lib comes pre-installed in the CentOS 7 base AMIs or one of our dependencies installs it.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
