### PR TITLE
Fix uninstall efa deps

### DIFF
--- a/recipes/efa_install.rb
+++ b/recipes/efa_install.rb
@@ -53,7 +53,7 @@ end
 package 'uninstall efa deps before installing efa' do
   action :remove
   package_name %w[rdma-core]
-  only_if { !efa_installed || efa_gdr_enabled? && node['platform_family'] == 'amazon' }
+  only_if { (!efa_installed || efa_gdr_enabled?) && node['platform_family'] == 'amazon' }
 end
 
 installer_options = "-y"


### PR DESCRIPTION
`&&` operator has higher precedence than `||`. So the parenthesis is necessary

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
