### PR TITLE
Load proxy env before starting cfn-hup demon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+2.11.x
+-----
+
+**BUG FIXES**
+- Fix cluster update when using proxy setup.
+
 2.11.2
 -----
 

--- a/templates/default/parallelcluster_supervisord.conf.erb
+++ b/templates/default/parallelcluster_supervisord.conf.erb
@@ -5,7 +5,7 @@
 <% when 'MasterServer' -%>
 <% if node['cfncluster']['cfn_scheduler'] == 'slurm' -%>
 [program:cfn-hup]
-command = <%= node['cfncluster']['cookbook_virtualenv_path'] %>/bin/python <%= node['cfncluster']['cookbook_virtualenv_path'] %>/bin/cfn-hup
+command = bash -c "[ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh; <%= node['cfncluster']['cookbook_virtualenv_path'] %>/bin/python <%= node['cfncluster']['cookbook_virtualenv_path'] %>/bin/cfn-hup"
 # The following are needed because cfn-hup starts as a daemon
 exitcodes = 0
 autorestart = unexpected


### PR DESCRIPTION
Proxy env must be loaded before starting cfn-hup demon so that signals to CloudFormation stack are possible when networking uses proxy setup

This resolve https://github.com/aws/aws-parallelcluster/issues/3191

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
