### PR TITLE
Fix hostname configuration in case of custom DHCP domain with a space in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.x.x
+-----
+
+**BUG FIXES**
+* Handle case where domain name in custom DHCP option set contains a space.
+
 3.2.0
 ------
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
@@ -58,7 +58,7 @@ if node['cluster']['scheduler'] == 'slurm' && node['cluster']['use_private_hostn
 
         if node['cluster']['dns_domain'].nil? || node['cluster']['dns_domain'].empty?
           # Use domain from DHCP
-          dhcp_domain = node['ec2']['local_hostname'].split('.', 2).last
+          dhcp_domain = node['ec2']['local_hostname'].split()[0].split('.', 2).last
           node.force_default['cluster']['assigned_hostname'] = "#{assigned_hostname}.#{dhcp_domain}"
         else
           # Use cluster domain
@@ -71,13 +71,13 @@ if node['cluster']['scheduler'] == 'slurm' && node['cluster']['use_private_hostn
 
   else
     # Head node
-    node.force_default['cluster']['assigned_hostname'] = node['ec2']['local_hostname']
+    node.force_default['cluster']['assigned_hostname'] = node['ec2']['local_hostname'].split()[0]
     node.force_default['cluster']['assigned_short_hostname'] = node['ec2']['local_hostname'].split('.')[0].to_s
   end
 
 else
   # Single Instance Type
-  node.force_default['cluster']['assigned_hostname'] = node['ec2']['local_hostname']
+  node.force_default['cluster']['assigned_hostname'] = node['ec2']['local_hostname'].split()[0]
   node.force_default['cluster']['assigned_short_hostname'] = node['ec2']['local_hostname'].split('.')[0].to_s
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -8,6 +8,6 @@ hosted_zone = <%= node['cluster']['hosted_zone'] %>
 dns_domain = <%= node['cluster']['dns_domain'] %>
 use_private_hostname = <%= node['cluster']['use_private_hostname'] %>
 head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
-head_node_hostname = <%= node['ec2']['local_hostname'] %>
+head_node_hostname = <%= node['fqdn'] %>
 node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout'] %>
 insufficient_capacity_timeout = 600

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
@@ -7,5 +7,5 @@ hosted_zone = <%= node['cluster']['hosted_zone'] %>
 dns_domain = <%= node['cluster']['dns_domain'] %>
 use_private_hostname = <%= node['cluster']['use_private_hostname'] %>
 head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
-head_node_hostname = <%= node['ec2']['local_hostname'] %>
+head_node_hostname = <%= node['fqdn'] %>
 clustermgtd_heartbeat_file_path = <%= node['cluster']['slurm']['install_dir'] %>/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat


### PR DESCRIPTION
In case a custom DHCP option set is configured with a domain name containing a space:
```
domain-name: my.domain eu-west-1.compute.internal
domain-name-servers: 205.251.192.72, AmazonProvidedDNS
```
node['ec2']['local_hostname'] is something like `ip-192-168-112-168.my.domain eu-west-1.compute.internal`



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
