### PR TITLE
Install and upgrade ca-certificates for all OSs and architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.0.1
+------
+
+**BUG FIXES**
+- Update ca-certificates package during AMI build time and prevent Chef from using outdated/distrusted CA certificates.
+
 3.0.0
 ------
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,9 @@
 # Validate OS type specified by the user is the same as the OS identified by Ohai
 validate_os_type
 
+# Update certificates
+include_recipe "aws-parallelcluster::update_certificates"
+
 # Calling user_ulimit will override every existing limit
 user_ulimit "*" do
   filehandle_limit node['cluster']['filehandle_limit']

--- a/recipes/update_certificates.rb
+++ b/recipes/update_certificates.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: update_certificates
+#
+# Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+package 'ca-certificates' do
+  action :upgrade
+end
+
+# Prevent Chef from using outdated/distrusted CA certificates
+# https://github.com/chef/chef/issues/12126
+if node['platform'] == 'ubuntu'
+  link '/opt/cinc/embedded/ssl/certs/cacert.pem' do
+    to '/etc/ssl/certs/ca-certificates.crt'
+  end
+else
+  link '/opt/cinc/embedded/ssl/certs/cacert.pem' do
+    to '/etc/ssl/certs/ca-bundle.crt'
+  end
+end


### PR DESCRIPTION
Prevent Chef/Cinc from using outdated CA certificates

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
