### PR TITLE
Force ENABLE_INTEL_HPC_PLATFORM param to be string

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -93,7 +93,7 @@ suites:
         os: <%= ENV['OS'] %>
         dcv_enabled: 'head_node'
         dcv_port: '8443'
-        enable_intel_hpc_platform: <%= ENV['ENABLE_INTEL_HPC_PLATFORM'] %>
+        enable_intel_hpc_platform: "<%= ENV['ENABLE_INTEL_HPC_PLATFORM'] %>"
         enable_efa: 'compute'
         nvidia:
           enabled: <%= ENV['NVIDIA_ENABLED'] %>


### PR DESCRIPTION
Force ENABLE_INTEL_HPC_PLATFORM param to be string and not a boolean

This because node['cluster']['enable_intel_hpc_platform'] == 'true' is compared as string

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
