### PR TITLE
[byos] Remove retrieval of headnode private ip and hostname from dynamo or f…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -439,7 +439,6 @@ default['cluster']['ebs_shared_dirs'] = '/shared'
 default['cluster']['proxy'] = 'NONE'
 default['cluster']['node_type'] = nil
 default['cluster']['cluster_user'] = 'ec2-user'
-default['cluster']['head_node'] = nil
 default['cluster']['head_node_private_ip'] = nil
 default['cluster']['volume'] = nil
 

--- a/cookbooks/aws-parallelcluster-config/recipes/compute_base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/compute_base.rb
@@ -15,19 +15,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Retrieve head node info
-if node['cluster']['scheduler'] == 'slurm'
-  ruby_block "retrieve head_node ip" do
-    block do
-      head_node_private_ip, head_node_private_dns = hit_head_node_info
-      node.force_default['cluster']['head_node'] = head_node_private_dns
-      node.force_default['cluster']['head_node_private_ip'] = head_node_private_ip
-    end
-    retries 5
-    retry_delay 3
-  end
-end
-
 # Parse and get RAID shared directory info and turn into an array
 raid_shared_dir = node['cluster']['raid_parameters'].split(',')[0]
 

--- a/cookbooks/aws-parallelcluster-config/recipes/prep_env_slurm.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/prep_env_slurm.rb
@@ -25,41 +25,23 @@ directory node['cluster']['slurm_plugin_dir'] do
   recursive true
 end
 
-# Retrieve compute and head node info from dynamodb and save into files
+# Retrieve compute info from dynamodb and save into file
 if node['cluster']['node_type'] == "ComputeFleet"
 
   ruby_block "retrieve compute node info" do
     block do
-      slurm_nodename, head_node_private_ip, head_node_private_dns = hit_dynamodb_info
+      slurm_nodename = hit_dynamodb_info
       node.force_default['cluster']['slurm_nodename'] = slurm_nodename
-      node.force_default['cluster']['head_node'] = head_node_private_dns
-      node.force_default['cluster']['head_node_private_ip'] = head_node_private_ip
     end
     retries 5
     retry_delay 3
     not_if do
-      !node['cluster']['slurm_nodename'].nil? && !node['cluster']['slurm_nodename'].empty? &&
-        !node['cluster']['head_node'].nil? && !node['cluster']['head_node'].empty? &&
-        !node['cluster']['head_node_private_ip'].nil? && !node['cluster']['head_node_private_ip'].empty?
+      !node['cluster']['slurm_nodename'].nil? && !node['cluster']['slurm_nodename'].empty?
     end
   end
 
   file "#{node['cluster']['slurm_plugin_dir']}/slurm_nodename" do # ~FC005
     content(lazy { node['cluster']['slurm_nodename'] })
-    mode '0644'
-    owner 'root'
-    group 'root'
-  end
-
-  file "#{node['cluster']['slurm_plugin_dir']}/head_node_private_dns" do
-    content(lazy { node['cluster']['head_node'] })
-    mode '0644'
-    owner 'root'
-    group 'root'
-  end
-
-  file "#{node['cluster']['slurm_plugin_dir']}/head_node_private_ip" do
-    content(lazy { node['cluster']['head_node_private_ip'] })
     mode '0644'
     owner 'root'
     group 'root'

--- a/cookbooks/aws-parallelcluster-config/templates/default/prep_env/cfnconfig.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/prep_env/cfnconfig.erb
@@ -13,7 +13,7 @@ cfn_proxy=<%= node['cluster']['proxy'] %>
 cfn_node_type=<%= node['cluster']['node_type'] %>
 cfn_cluster_user=<%= node['cluster']['cluster_user'] %>
 <% if node['cluster']['node_type'] == 'ComputeFleet' -%>
-cfn_head_node=<%= node['cluster']['head_node'] %>
+cfn_head_node=ip-<%= node['cluster']['head_node_private_ip'].gsub('.', '-') %>
 cfn_head_node_private_ip=<%= node['cluster']['head_node_private_ip'] %>
 cfn_scheduler_queue_name=<%= node['cluster']['scheduler_queue_name'] %>
 <% end -%>

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -196,16 +196,6 @@ def raise_os_not_match(current_os, specified_os)
 end
 
 #
-# Retrieve head node ip and dns from file (HIT only)
-#
-def hit_head_node_info
-  head_node_private_ip_file = "#{node['cluster']['slurm_plugin_dir']}/head_node_private_ip"
-  head_node_private_dns_file = "#{node['cluster']['slurm_plugin_dir']}/head_node_private_dns"
-
-  [IO.read(head_node_private_ip_file).chomp, IO.read(head_node_private_dns_file).chomp]
-end
-
-#
 # Retrieve compute nodename from file (HIT only)
 #
 def hit_slurm_nodename
@@ -224,18 +214,16 @@ def hit_dynamodb_info
                       "--region #{node['cluster']['region']} query --table-name #{node['cluster']['ddb_table']} " \
                       "--index-name InstanceId --key-condition-expression 'InstanceId = :instanceid' " \
                       "--expression-attribute-values '{\":instanceid\": {\"S\":\"#{node['ec2']['instance_id']}\"}}' " \
-                      "--projection-expression 'Id,HeadNodePrivateIp,HeadNodeHostname' " \
-                      "--output text --query 'Items[0].[Id.S,HeadNodePrivateIp.S,HeadNodeHostname.S]'", user: 'root').stdout.strip
+                      "--projection-expression 'Id' " \
+                      "--output text --query 'Items[0].[Id.S]'", user: 'root').stdout.strip
 
   raise "Failed when retrieving Compute info from DynamoDB" if output == "None"
 
-  slurm_nodename, head_node_private_ip, head_node_private_dns = output.split(/\s+/)
+  slurm_nodename = output
 
   Chef::Log.info("Retrieved Slurm nodename is: #{slurm_nodename}")
-  Chef::Log.info("Retrieved head node private ip: #{head_node_private_ip}")
-  Chef::Log.info("Retrieved head node private dns: #{head_node_private_dns}")
 
-  [slurm_nodename, head_node_private_ip, head_node_private_dns]
+  slurm_nodename
 end
 
 #


### PR DESCRIPTION
…iles

The headnode private ip is injected into dna.json during chef execution from the compute launchtemplate.
The above change is done in https://github.com/aws/aws-parallelcluster/pull/3367

The headnode hostname is built based on private ip

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
