### PR TITLE
[release-2.11] Remove DST ROOT CA X3 for centos8 to fix ca-certificate expiration

### DIFF
--- a/recipes/update_certificates.rb
+++ b/recipes/update_certificates.rb
@@ -19,6 +19,13 @@ package 'ca-certificates' do
   action :upgrade
 end
 
+# centos8 ca certificates file contains DST ROOT CA X3
+if node['cfncluster']['os'] == "centos8"
+  execute 'Remove DST ROOT CA X3' do
+    command 'sed -e ‘/^# DST Root CA X3/,/-----END CERTIFICATE-----/d’ /etc/ssl/certs/ca-bundle.crt'
+  end
+end
+
 # Prevent Chef from using outdated/distrusted CA certificates
 # https://github.com/chef/chef/issues/12126
 if node['platform'] == 'ubuntu'


### PR DESCRIPTION
Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
