### PR TITLE
Do not remove 'parallelcluster-' prefix from stack name to get cluster name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Download dependencies of Intel HPC platform during AMI build time to avoid contacting Internet during cluster creation time.
 - Do not strip `-` from compute resource name when configuring Slurm nodes.
 
+**BUG FIXES**
+- Fix issue that is preventing cluster names to start with `parallelcluster-` prefix.
+
 3.0.1
 ------
 

--- a/cookbooks/aws-parallelcluster-config/templates/default/awsbatch/awsbatch-cli.cfg.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/awsbatch/awsbatch-cli.cfg.erb
@@ -1,3 +1,3 @@
 [main]
-cluster_name = <%= node['cluster']['stack_name'].sub("parallelcluster-", "") %>
+cluster_name = <%= node['cluster']['stack_name'] %>
 region = <%= node['cluster']['region'] %>

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -1,5 +1,5 @@
 [clustermgtd]
-cluster_name = <%= node['cluster']['stack_name'].sub("parallelcluster-", "") %>
+cluster_name = <%= node['cluster']['stack_name'] %>
 region = <%= node['cluster']['region'] %>
 proxy = <%= node['cluster']['proxy'] %>
 heartbeat_file_path = /opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_computemgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_computemgtd.conf.erb
@@ -1,5 +1,5 @@
 [computemgtd]
-cluster_name = <%= node['cluster']['stack_name'].sub("parallelcluster-", "") %>
+cluster_name = <%= node['cluster']['stack_name'] %>
 region = <%= node['cluster']['region'] %>
 proxy = <%= node['cluster']['proxy'] %>
 clustermgtd_heartbeat_file_path = /opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
@@ -1,5 +1,5 @@
 [slurm_resume]
-cluster_name = <%= node['cluster']['stack_name'].sub("parallelcluster-", "") %>
+cluster_name = <%= node['cluster']['stack_name'] %>
 region = <%= node['cluster']['region'] %>
 proxy = <%= node['cluster']['proxy'] %>
 dynamodb_table = <%= node['cluster']['ddb_table'] %>


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
