### PR TITLE
[develop] Fix export and mount shared dir

### DIFF
--- a/cookbooks/aws-parallelcluster-byos/recipes/init_compute.rb
+++ b/cookbooks/aws-parallelcluster-byos/recipes/init_compute.rb
@@ -15,16 +15,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Mount /opt/parallelcluster/shared over NFS
-mount node['cluster']['shared_dir'] do
-  device(lazy { "#{node['cluster']['head_node_private_ip']}:#{node['cluster']['scheduler']['opt_shared_path']}" })
-  fstype "nfs"
-  options node['cluster']['nfs']['hard_mount_options']
-  action %i[mount enable]
-  retries 10
-  retry_delay 6
-end
-
 execute_event_handler 'ComputeInit' do
   event_command(lazy { node['cluster']['config'].dig(:Scheduling, :ByosSettings, :SchedulerDefinition, :Events, :ComputeInit, :ExecuteCommand, :Command) })
 end

--- a/cookbooks/aws-parallelcluster-byos/recipes/init_head_node.rb
+++ b/cookbooks/aws-parallelcluster-byos/recipes/init_head_node.rb
@@ -15,13 +15,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Export /opt/parallelcluster/shared
-nfs_export node['cluster']['shared_dir'] do
-  network get_vpc_cidr_list
-  writeable true
-  options ['no_root_squash']
-end
-
 execute_event_handler 'HeadInit' do
   event_command(lazy { node['cluster']['config'].dig(:Scheduling, :ByosSettings, :SchedulerDefinition, :Events, :HeadInit, :ExecuteCommand, :Command) })
 end

--- a/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
@@ -118,6 +118,13 @@ nfs_export "/home" do
   options ['no_root_squash']
 end
 
+# Export /opt/parallelcluster/shared
+nfs_export node['cluster']['shared_dir'] do
+  network get_vpc_cidr_list
+  writeable true
+  options ['no_root_squash']
+end
+
 # Export /opt/intel if it exists
 nfs_export "/opt/intel" do
   network get_vpc_cidr_list

--- a/cookbooks/aws-parallelcluster-config/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/init.rb
@@ -75,9 +75,9 @@ include_recipe "aws-parallelcluster-config::cloudwatch_agent"
 # Configure additional Networking Interfaces (if present)
 include_recipe "aws-parallelcluster-config::network_interfaces" unless virtualized?
 
-include_recipe "aws-parallelcluster-config::mount_home" if node['cluster']['node_type'] == "ComputeFleet"
+include_recipe "aws-parallelcluster-config::mount_shared" if node['cluster']['node_type'] == "ComputeFleet"
 
-include_recipe "aws-parallelcluster-config::fetch_config" unless node['cluster']['scheduler'] == 'awsbastch'
+include_recipe "aws-parallelcluster-config::fetch_config"
 
 include_recipe "aws-parallelcluster-slurm::init" if node['cluster']['scheduler'] == 'slurm'
 include_recipe "aws-parallelcluster-byos::init" if node['cluster']['scheduler'] == 'byos'

--- a/cookbooks/aws-parallelcluster-config/recipes/mount_shared.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/mount_shared.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook Name:: aws-parallelcluster
-# Recipe:: mount_home
+# Recipe:: mount_shared
 #
 # Copyright 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
@@ -19,6 +19,16 @@
 mount '/home' do
   device(lazy { "#{node['cluster']['head_node_private_ip']}:/home" })
   fstype 'nfs'
+  options node['cluster']['nfs']['hard_mount_options']
+  action %i[mount enable]
+  retries 10
+  retry_delay 6
+end
+
+# Mount /opt/parallelcluster/shared over NFS
+mount node['cluster']['shared_dir'] do
+  device(lazy { "#{node['cluster']['head_node_private_ip']}:#{node['cluster']['scheduler']['opt_shared_path']}" })
+  fstype "nfs"
   options node['cluster']['nfs']['hard_mount_options']
   action %i[mount enable]
   retries 10


### PR DESCRIPTION
Fix export and mount of /opt/parallelcluster/shared. Dir is required by both slurm and byos

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
