### PR TITLE
[develop] Remove run_list and prefer using --override-runlist param

### DIFF
--- a/system_tests/dna.json
+++ b/system_tests/dna.json
@@ -38,6 +38,5 @@
     "custom_node_package": "",
     "custom_awsbatchcli_package": "",
     "head_node_imds_secured": "true"
-  },
-  "run_list": "recipe[aws-parallelcluster::slurm_config]"
+  }
 }

--- a/system_tests/systemd
+++ b/system_tests/systemd
@@ -76,10 +76,9 @@ mkdir /etc/parallelcluster/slurm_plugin
 mkdir -p /opt/slurm/etc/pcluster/.slurm_plugin/
 touch /opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat
 
-run_list=$(cat /etc/chef/dna.json | jq -r '.run_list')
 chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::init &&
 /opt/parallelcluster/scripts/fetch_and_run -preinstall &&
-chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist "${run_list}" &&
+chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::config &&
 /opt/parallelcluster/scripts/fetch_and_run -postinstall &&
 chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::finalize &&
 


### PR DESCRIPTION
Remove run_list from dna.json and always call chef run setting runlist override with --override-runlist

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
