### PR TITLE
[develop] Skip download instance type data file if already present

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/fetch_config.rb
@@ -20,7 +20,8 @@ unless virtualized?
   fetch_config_command = "#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3api get-object"\
                          " --bucket #{node['cluster']['cluster_s3_bucket']}"\
                          " --key #{node['cluster']['cluster_config_s3_key']}"\
-                         " --region #{node['cluster']['region']} #{node['cluster']['cluster_config_path']}"
+                         " --region #{node['cluster']['region']}"\
+                         " #{node['cluster']['cluster_config_path']}"
   fetch_config_command += " --version-id #{node['cluster']['cluster_config_version']}" unless node['cluster']['cluster_config_version'].nil?
   execute "copy_cluster_config_from_s3" do
     command fetch_config_command
@@ -33,11 +34,15 @@ unless virtualized?
   load_cluster_config
 
   # Copy instance type infos file from S3 URI
-  fetch_config_command = "#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3api get-object --bucket #{node['cluster']['cluster_s3_bucket']}"\
-                           " --key #{node['cluster']['instance_types_data_s3_key']} --region #{node['cluster']['region']} #{node['cluster']['instance_types_data_path']}"
+  fetch_config_command = "#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3api get-object"\
+                         " --bucket #{node['cluster']['cluster_s3_bucket']}"\
+                         " --key #{node['cluster']['instance_types_data_s3_key']}"\
+                         " --region #{node['cluster']['region']}"\
+                         " #{node['cluster']['instance_types_data_path']}"
   execute "copy_instance_type_data_from_s3" do
     command fetch_config_command
     retries 3
     retry_delay 5
+    not_if { ::File.exist?(node['cluster']['instance_types_data_path']) }
   end
 end


### PR DESCRIPTION
Skip download instance type data configuration file if already present. This is required for compute nodes, that should find the file already present in the shared folder

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
