### PR TITLE
[release-3.0] Upgrade EFA to version 1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Fix issue that is preventing cluster names to start with `parallelcluster-` prefix.
+- Upgrade EFA installer to version 1.14.1. Thereafter, EFA enables GDR support by default on supported instance type(s).
+    ParallelCluster does not reinstall EFA during node start. Previously, EFA was reinstalled if `enable_efa_gdr` had been
+    turned on in the configuration file.
+- EFA configuration: ``efa-config-1.9-1``
+- EFA profile: ``efa-profile-1.5-1``
+- EFA kernel module: ``efa-1.14.2``
+- RDMA core: ``rdma-core-37.0``
+- Libfabric: ``libfabric-1.13.2``
+- Open MPI: ``openmpi40-aws-4.1.1-2``
 
 3.0.1
 ------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -154,9 +154,8 @@ default['cluster']['nvidia']['fabricmanager']['repository_uri'] = value_for_plat
 )
 
 # EFA
-default['cluster']['efa']['installer_version'] = '1.13.0'
+default['cluster']['efa']['installer_version'] = '1.14.1'
 default['cluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cluster']['efa']['installer_version']}.tar.gz"
-default['cluster']['enable_efa_gdr'] = "no"
 default['cluster']['efa']['unsupported_aarch64_oses'] = %w[centos7]
 
 # NICE DCV

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -380,17 +380,6 @@ def get_nvswitches
   nvswitch_check.stdout.strip.to_i
 end
 
-# Check if EFA GDR is enabled (and supported) on this instance
-def efa_gdr_enabled?
-  config_value = node['cluster']['enable_efa_gdr']
-  enabling_value = if node['cluster']['node_type'] == "ComputeFleet"
-                     "compute"
-                   else
-                     "head_node"
-                   end
-  (config_value == enabling_value || config_value == "cluster") && graphic_instance?
-end
-
 # Alinux OSs currently not correctly supported by NFS cookbook
 # Overwriting templates for node['nfs']['config']['server_template'] used by NFS cookbook for these OSs
 # When running, NFS cookbook will use nfs.conf.erb templates provided in this cookbook to generate server_template

--- a/recipes/efa_config.rb
+++ b/recipes/efa_config.rb
@@ -15,9 +15,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Installation recipe must be re-executed at runtime to enable GDR
-include_recipe "aws-parallelcluster::efa_install"
-
 if node['platform'] == 'ubuntu' && node['cluster']['enable_efa'] == 'compute' && node['cluster']['node_type'] == 'ComputeFleet'
   # Disabling ptrace protection is needed for EFA in order to use SHA transfer for intra-node communication.
   replace_or_add "disable ptrace protection" do

--- a/recipes/efa_install.rb
+++ b/recipes/efa_install.rb
@@ -19,7 +19,7 @@ efa_tarball = "#{node['cluster']['sources_dir']}/aws-efa-installer.tar.gz"
 efa_installed = efa_installed?
 
 if efa_installed && !::File.exist?(efa_tarball)
-  Chef::Log.warn("Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration. enable_gdr option will be ignored.")
+  Chef::Log.warn("Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration.")
   return
 end
 
@@ -50,8 +50,6 @@ end
 installer_options = "-y"
 # skip efa-kmod installation on not supported platforms
 installer_options += " -k" unless node['conditions']['efa_supported']
-# enable gpudirect support
-installer_options += " -g" if efa_gdr_enabled?
 
 bash "install efa" do
   cwd node['cluster']['sources_dir']
@@ -62,5 +60,5 @@ bash "install efa" do
     ./efa_installer.sh #{installer_options}
     rm -rf #{node['cluster']['sources_dir']}/aws-efa-installer
   EFAINSTALL
-  not_if { efa_installed && !efa_gdr_enabled? }
+  not_if { efa_installed }
 end


### PR DESCRIPTION
Starting from EFA 1.14.0, GDR support is enabled by default. Therefore, this commit also removes the logic to reinstall EFA if GDR is enabled.
In kitchen test:
1. EFA test is migrated from pclster 2.11
2. the GDR check is moved to only check official built AMIs. This does not reduce the coverage of the test, because the check had `efa_gdr_enabled?` as part of the condition to execute. `enable_efa_gdr?` checks `node['cfncluster']['enable_efa_gdr']` in dna.json. However, in .kitchen.yml `enable_efa_gdr` was never provided. So the check was never executed.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
