### PR TITLE
Avoid fetching configs for awsbatch

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/init.rb
@@ -77,7 +77,7 @@ include_recipe "aws-parallelcluster-config::network_interfaces" unless virtualiz
 
 include_recipe "aws-parallelcluster-config::mount_shared" if node['cluster']['node_type'] == "ComputeFleet"
 
-include_recipe "aws-parallelcluster-config::fetch_config"
+include_recipe "aws-parallelcluster-config::fetch_config" unless node['cluster']['scheduler'] == 'awsbatch'
 
 include_recipe "aws-parallelcluster-slurm::init" if node['cluster']['scheduler'] == 'slurm'
 include_recipe "aws-parallelcluster-byos::init" if node['cluster']['scheduler'] == 'byos'


### PR DESCRIPTION
This because fetch_config recipe is fetching cluster config and instance types data. The latter is not available in the awsbatch case

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
