### PR TITLE
Run nvidia-smi for gpu instance with Nvidia installed

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/dcv.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/dcv.rb
@@ -65,8 +65,8 @@ end
 
 if node['conditions']['dcv_supported'] && node['cluster']['node_type'] == "HeadNode"
   node.default['cluster']['dcv']['is_graphic_instance'] = graphic_instance?
-
-  if node.default['cluster']['dcv']['is_graphic_instance']
+  node.default['cluster']['dcv']['is_graphic_instance_with_nvidia_installed'] = graphic_instance? && nvidia_installed?
+  if node.default['cluster']['dcv']['is_graphic_instance_with_nvidia_installed']
     # Enable graphic acceleration in dcv conf file for graphic instances.
     allow_gpu_acceleration
   else

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_compute.rb
@@ -38,6 +38,13 @@ end
 # Check to see if is GPU instance with Nvidia installed
 Chef::Log.warn("GPU instance but no Nvidia drivers found") if graphic_instance? && !nvidia_installed?
 
+# Run nvidia-smi triggers loading of the kernel module and creation of the device files
+if graphic_instance? && nvidia_installed?
+  execute "run_nvidiasmi" do
+    command 'nvidia-smi'
+  end
+end
+
 cookbook_file '/etc/systemd/system/slurmd.service' do
   source 'compute_slurm/slurmd.service'
   owner 'root'


### PR DESCRIPTION
* Run nvidia-smi to trigger loading of the kernel module and creation of the device files.
* Enable graphic acceleration in dcv conf file for graphic instances only when Nvidia installed.

Signed-off-by: chenwany <chenwany@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
