### PR TITLE
[develop] Move execution of imds recipe on init phase

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/compute_base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/compute_base.rb
@@ -90,6 +90,3 @@ shared_dir_array.each do |dir|
     retry_delay 6
   end
 end
-
-# IMDS
-include_recipe 'aws-parallelcluster-config::imds'

--- a/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
@@ -176,6 +176,3 @@ if node['cluster']['dcv_enabled'] == "head_node"
   # Activate DCV on head node
   include_recipe 'aws-parallelcluster-config::dcv'
 end
-
-# IMDS
-include_recipe 'aws-parallelcluster-config::imds' unless virtualized?

--- a/cookbooks/aws-parallelcluster-config/recipes/imds.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/imds.rb
@@ -36,9 +36,8 @@ if node['cluster']['node_type'] == 'HeadNode' && node['cluster']['scheduler'] !=
 
   case node['cluster']['head_node_imds_secured']
   when 'true'
-    imds_allowed_users = node['cluster']['head_node_imds_allowed_users'].join(',')
     execute 'IMDS lockdown enable' do
-      command "bash #{imds_access_script} --flush && bash #{imds_access_script} --allow #{imds_allowed_users}"
+      command(lazy { "bash #{imds_access_script} --flush && bash #{imds_access_script} --allow #{node['cluster']['head_node_imds_allowed_users'].join(',')}" })
       user 'root'
     end
   when 'false'

--- a/cookbooks/aws-parallelcluster-config/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/init.rb
@@ -81,3 +81,6 @@ include_recipe "aws-parallelcluster-config::fetch_config" unless node['cluster']
 
 include_recipe "aws-parallelcluster-slurm::init" if node['cluster']['scheduler'] == 'slurm'
 include_recipe "aws-parallelcluster-byos::init" if node['cluster']['scheduler'] == 'byos'
+
+# IMDS
+include_recipe 'aws-parallelcluster-config::imds' unless virtualized?


### PR DESCRIPTION
The list of imds allowed users is than evaluated at converge time, to be able to read the changes eventually performed during by the byos create user resource 

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
