### PR TITLE
[develop] Fix cookbook name

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/finalize.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/finalize.rb
@@ -24,4 +24,4 @@ service "supervisord" do
 end
 
 include_recipe 'aws-parallelcluster-scheduler-plugin::finalize' if node['cluster']['scheduler'] == 'plugin'
-include_recipe 'aws-parallelcluster-scheduler-plugin::finalize' if node['cluster']['scheduler'] == 'slurm'
+include_recipe 'aws-parallelcluster-slurm::finalize' if node['cluster']['scheduler'] == 'slurm'


### PR DESCRIPTION
Regression introduced by https://github.com/aws/aws-parallelcluster-cookbook/pull/1210

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
