### PR TITLE
Call cinc-client instead of chef-client

### DIFF
--- a/system_tests/README.md
+++ b/system_tests/README.md
@@ -34,7 +34,7 @@ what would be present on a node during AMI creation.
 Finally, the Dockerfile runs the `bootstrap.sh` process. This script is
 responsible for mocking several applications which would be available on a node
 but do not make sense in a virtual environment (e.g. `sysctl`, `modprobe`, etc...).
-The `bootstrap.sh` process then launches the `chef-client` with the `aws-parallelcluster::default` recipe 
+The `bootstrap.sh` process then launches the `cinc-client` with the `aws-parallelcluster::default` recipe 
 as the cloudformation would.
 
 ### Configuration / Docker Run
@@ -69,7 +69,7 @@ Now simply run the command that was commented. This provides a convenient way
 to iterate on the installation scripts.
 
 ```
-chef-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/parallelcluster/image_dna.json --override-runlist aws-parallelcluster::default
+cinc-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/parallelcluster/image_dna.json --override-runlist aws-parallelcluster::default
 ```
 
 ### Testing the configuration

--- a/system_tests/bootstrap.sh
+++ b/system_tests/bootstrap.sh
@@ -63,7 +63,7 @@ else
     yum install -y kernel-modules
 fi
 
-chef-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/parallelcluster/image_dna.json --override-runlist aws-parallelcluster::default
+cinc-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/parallelcluster/image_dna.json --override-runlist aws-parallelcluster::default
 
 # disabling unmocking for configuration run
 # unmock

--- a/system_tests/systemd
+++ b/system_tests/systemd
@@ -76,11 +76,11 @@ mkdir /etc/parallelcluster/slurm_plugin
 mkdir -p /opt/slurm/etc/pcluster/.slurm_plugin/
 touch /opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat
 
-chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::init &&
+cinc-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::init &&
 /opt/parallelcluster/scripts/fetch_and_run -preinstall &&
-chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::config &&
+cinc-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::config &&
 /opt/parallelcluster/scripts/fetch_and_run -postinstall &&
-chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::finalize &&
+cinc-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::finalize &&
 
 # if there is a chef error, show it to the user.
 if [ -e /etc/chef/local-mode-cache/cache/cinc-stacktrace.out ]; then


### PR DESCRIPTION
Use directly cinc-client instead of chef-client. The latter is just a wrapper that uses ShellOut to call cinc with a timeout of 3600 seconds

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
