### PR TITLE
Set cluster config and instance type data s3 bucket and key

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -187,6 +187,9 @@ suites:
         base_os: <%= ENV['BASE_OS'] %>
         slurm_nodename: 'fake-dy-compute-1'
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
+        cluster_s3_bucket: <%= ENV['CLUSTER_CONFIG_S3_BUCKET'] %>
+        cluster_config_s3_key: <%= ENV['CLUSTER_CONFIG_S3_KEY'] %>
+        instance_types_data_s3_key: <%= ENV['INSTANCE_TYPES_DATA_S3_KEY'] %>
         # os attribute is used in pipeline code. i.e. centos7, centos7-custom
         os: <%= ENV['OS'] %>
         dcv_enabled: 'head_node'
@@ -222,6 +225,9 @@ suites:
         base_os: <%= ENV['BASE_OS'] %>
         scheduler_plugin_nodename: 'fake-dy-compute-1'
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
+        cluster_s3_bucket: <%= ENV['CLUSTER_CONFIG_S3_BUCKET'] %>
+        cluster_config_s3_key: <%= ENV['CLUSTER_CONFIG_S3_KEY'] %>
+        instance_types_data_s3_key: <%= ENV['INSTANCE_TYPES_DATA_S3_KEY'] %>
         # os attribute is used in pipeline code. i.e. centos7, centos7-custom
         os: <%= ENV['OS'] %>
         dcv_enabled: 'head_node'


### PR DESCRIPTION
Set to kitchen compute configuration, so that they can be downloaded from compute as well

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
