### PR TITLE
Add PCLUSTER_PYTHON_ROOT to event handler environment

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/resources/execute_event_handler.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/resources/execute_event_handler.rb
@@ -185,6 +185,9 @@ action_class do # rubocop:disable Metrics/BlockLength
     # PCLUSTER_HEADNODE_HOSTNAME
     env.merge!(build_hash_from_node('PCLUSTER_HEADNODE_HOSTNAME', true, :hostname))
 
+    # PCLUSTER_PYTHON_ROOT
+    env.merge!({ 'PCLUSTER_PYTHON_ROOT' => "#{node['cluster']['scheduler_plugin']['virtualenv_path']}/bin" })
+
     # PCLUSTER_CLUSTER_CONFIG_OLD
     # TODO: to be implemented
 


### PR DESCRIPTION
PCLUSTER_PYTHON_ROOT points to the bin folder of the python installation for the event handler, e.g.
`/home/pcluster-scheduler-plugin/.pyenv/versions/3.9.9/envs/scheduler_plugin_virtualenv/bin`

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
