### PR TITLE
Only add more retry for metadata for ssh_target_checker

### DIFF
--- a/files/default/configure-pat.sh
+++ b/files/default/configure-pat.sh
@@ -13,8 +13,8 @@
 
 set -x
 echo "Determining the MAC address"
-TOKEN=$(curl --retry 20 --retry-delay 1 --fail -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
-MAC=$(curl --retry 20 --retry-delay 1 --silent --fail -H "X-aws-ec2-metadata-token: ${TOKEN}" http://169.254.169.254/latest/meta-data/mac)
+TOKEN=$(curl --retry 3 --retry-delay 0 --fail -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
+MAC=$(curl --retry 3 --retry-delay 0 --silent --fail -H "X-aws-ec2-metadata-token: ${TOKEN}" http://169.254.169.254/latest/meta-data/mac)
 if [ $? -ne 0 ] ; then
    echo "Unable to determine MAC address" | logger -t "ec2"
    exit 1
@@ -25,7 +25,7 @@ echo "Found MAC: ${MAC} on the first network device" | logger -t "ec2"
 VPC_CIDR_URI="http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC}/vpc-ipv4-cidr-block"
 echo "Metadata location for vpc ipv4 range: ${VPC_CIDR_URI}" | logger -t "ec2"
 
-VPC_CIDR_RANGE=$(curl --retry 20 --retry-delay 1 --silent --fail -H "X-aws-ec2-metadata-token: ${TOKEN}" ${VPC_CIDR_URI})
+VPC_CIDR_RANGE=$(curl --retry 3 --retry-delay 0 --silent --fail -H "X-aws-ec2-metadata-token: ${TOKEN}" ${VPC_CIDR_URI})
 if [ $? -ne 0 ] ; then
    echo "Unable to retrive VPC CIDR range from meta-data. Using 0.0.0.0/0 instead. PAT may not function correctly" | logger -t "ec2"
    VPC_CIDR_RANGE="0.0.0.0/0"

--- a/files/default/setup-ephemeral-drives.sh
+++ b/files/default/setup-ephemeral-drives.sh
@@ -33,7 +33,7 @@ function exec_command() {
 
 function set_imds_token(){
   if [ -z "${IMDS_TOKEN}" ];then
-    IMDS_TOKEN=$(curl --retry 20 --retry-delay 1 --fail -s -f -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 900" http://169.254.169.254/latest/api/token)
+    IMDS_TOKEN=$(curl --retry 3 --retry-delay 0 --fail -s -f -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 900" http://169.254.169.254/latest/api/token)
     if [ "${?}" -gt 0 ] || [ -z "${IMDS_TOKEN}" ]; then
       echo '[ERROR] Could not get IMDSv2 token. Instance Metadata might have been disabled or this is not an EC2 instance.'
       exit 1
@@ -43,7 +43,7 @@ function set_imds_token(){
 
 # param1 = query
 function get_meta() {
-    local imds_out=$(curl --retry 20 --retry-delay 1 --fail -s -q -H "X-aws-ec2-metadata-token:${IMDS_TOKEN}" -f http://169.254.169.254/latest/${1})
+    local imds_out=$(curl --retry 3 --retry-delay 0 --fail -s -q -H "X-aws-ec2-metadata-token:${IMDS_TOKEN}" -f http://169.254.169.254/latest/${1})
     echo -n "${imds_out}"
 }
 

--- a/templates/default/compute_ready.erb
+++ b/templates/default/compute_ready.erb
@@ -5,10 +5,10 @@ set -e
 
 # Notify compute is ready
 instance_id_url="http://169.254.169.254/latest/meta-data/instance-id"
-token=$(curl --retry 20 --retry-delay 1 --fail -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
-instance_id=$(curl --retry 20 --retry-delay 1 --silent --fail -H "X-aws-ec2-metadata-token: ${token}" ${instance_id_url})
+token=$(curl --retry 3 --retry-delay 0 --fail -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
+instance_id=$(curl --retry 3 --retry-delay 0 --silent --fail -H "X-aws-ec2-metadata-token: ${token}" ${instance_id_url})
 instance_type_url="http://169.254.169.254/latest/meta-data/instance-type"
-instance_type=$(curl --retry 20 --retry-delay 1 --silent --fail -H "X-aws-ec2-metadata-token: ${token}" ${instance_type_url})
+instance_type=$(curl --retry 3 --retry-delay 0 --silent --fail -H "X-aws-ec2-metadata-token: ${token}" ${instance_type_url})
 local_hostname_url="http://169.254.169.254/latest/meta-data/local-hostname"
-local_hostname=$(curl --retry 20 --retry-delay 1 --silent --fail -H "X-aws-ec2-metadata-token: ${token}" ${local_hostname_url})
+local_hostname=$(curl --retry 3 --retry-delay 0 --silent --fail -H "X-aws-ec2-metadata-token: ${token}" ${local_hostname_url})
 <%= node['cfncluster']['cookbook_virtualenv_path'] %>/bin/aws --region ${cfn_region} sqs send-message --queue-url ${cfn_sqs_queue} --endpoint-url https://sqs.${cfn_region}.amazonaws.com$([[ ${cfn_region} =~ ^cn- ]] && echo ".cn") --message-body '{"Type" : "Notification", "Message" : "{\"StatusCode\":\"Complete\",\"Description\":\"Succesfully launched '${instance_id}'\",\"Event\":\"parallelcluster:COMPUTE_READY\",\"EC2InstanceId\":\"'${instance_id}'\",\"Slots\":\"'${cfn_instance_slots}'\",\"LocalHostname\":\"'${local_hostname}'\",\"EC2InstanceType\":\"'${instance_type}'\"}"}'


### PR DESCRIPTION
Only add more retry for metadata in ssh_target_checker since it only get throthing with some specified cases with ssh.

Signed-off-by: chenwany <chenwany@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
