### PR TITLE
2.11: Upgrade Nvidia Drivers, CUDA and fabric manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Slurm to version 20.11.8.
 - Upgrade Cinc Client to version 17.2.29.
 - Upgrade NICE DCV to version 2021.2-11190.
+- Upgrade NVIDIA driver to version 470.82.01.
+- Upgrade CUDA library to version 11.4.3.
+- Upgrade NVIDIA Fabric manager to `nvidia-fabricmanager-470`.
 - Disable unattended upgrades for Ubuntu.
 
 2.11.3

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -123,13 +123,17 @@ default['cfncluster']['ganglia_enabled'] = 'no'
 
 # NVIDIA
 default['cfncluster']['nvidia']['enabled'] = 'no'
-default['cfncluster']['nvidia']['driver_version'] = '460.73.01'
-default['cfncluster']['nvidia']['driver_url'] = 'https://us.download.nvidia.com/tesla/460.73.01/NVIDIA-Linux-x86_64-460.73.01.run'
-default['cfncluster']['nvidia']['cuda_version'] = '11.3'
-default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.19.01_linux.run'
+default['cfncluster']['nvidia']['driver_version'] = '470.82.01'
+default['cfncluster']['nvidia']['driver_url'] = 'https://us.download.nvidia.com/tesla/470.82.01/NVIDIA-Linux-x86_64-470.82.01.run'
+default['cfncluster']['nvidia']['cuda_version'] = '11.4'
+default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_470.82.01_linux.run'
 
-# NVIDIA fabric-manager
-default['cfncluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabricmanager-460"
+# The package name of Fabric Manager for alinux2 and centos7 is nvidia-fabric-manager-<version>
+# For ubuntu, it is nvidia-fabricmanager-<major-version>_<version>
+default['cfncluster']['nvidia']['fabricmanager']['package'] = value_for_platform(
+  'default' => "nvidia-fabric-manager",
+  'ubuntu' => { 'default' => "nvidia-fabricmanager-470" }
+)
 default['cfncluster']['nvidia']['fabricmanager']['repository_key'] = "7fa2af80.pub"
 default['cfncluster']['nvidia']['fabricmanager']['version'] = value_for_platform(
   'default' => node['cfncluster']['nvidia']['driver_version'],


### PR DESCRIPTION
The latest version of Tesla driver is 470.82 that is not aligned to the latest Fabric manager version available (495.29).
We're upgrading the three packages to stay aligned with the latest version of drivers available, so:
* Nvidia and Fabric manager from 460.73 to 470.82
* CUDA from 11.3 to 11.4 (we're avoid the upgrade to 11.5 to keep driver version aligned)

See:
* https://docs.nvidia.com/datacenter/tesla/index.html
* https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/

Note: the name of the Fabric Manager package in the repo has been changed.


Edit: CentOS8 has been deprecated by: https://github.com/aws/aws-parallelcluster-cookbook/pull/1259 so the following comments are no longer needed.

## ~~CentOS8 changes~~
~~In RHEL8, to be able to install a package version different from the latest one it is required to enable the module stream for that version. See:~~
* ~~NVIDIA/yum-packaging-fabric-manager#3~~
* ~~https://docs.fedoraproject.org/en-US/modularity/installing-modules/~~

~~To enable `nvidia-driver:470` stream and manage DFN modules on RHEL8+, the `dnf_module` cookbook resource is required. In this patch we're upgrading the yum package from 6.1.1 to [7.2.0](https://github.com/sous-chefs/yum/releases/tag/7.2.0) including the new `dnf_module` resource.~~
