### PR TITLE
Separate stdout and stderr logs for event handler execution

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -132,7 +132,8 @@ default['cluster']['scheduler_plugin']['system_group_id_start'] = default['clust
 # BYOS event handler
 default['cluster']['scheduler_plugin']['home'] = '/home/pcluster-scheduler-plugin'
 default['cluster']['scheduler_plugin']['handler_dir'] = '/home/pcluster-scheduler-plugin/.parallelcluster'
-default['cluster']['scheduler_plugin']['handler_log'] = '/var/log/parallelcluster/scheduler-plugin.log'
+default['cluster']['scheduler_plugin']['handler_log_out'] = '/var/log/parallelcluster/scheduler-plugin.out.log'
+default['cluster']['scheduler_plugin']['handler_log_err'] = '/var/log/parallelcluster/scheduler-plugin.err.log'
 default['cluster']['scheduler_plugin']['shared_dir'] = "#{node['cluster']['shared_dir']}/scheduler-plugin"
 default['cluster']['scheduler_plugin']['local_dir'] = "#{node['cluster']['base_dir']}/scheduler-plugin"
 default['cluster']['scheduler_plugin']['scheduler_plugin_substack_outputs_path'] = "#{node['cluster']['shared_dir']}/scheduler-plugin-substack-outputs.json"

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
@@ -411,8 +411,26 @@
     },
     {
       "timestamp_format_key": "default",
-      "file_path": "/var/log/parallelcluster/scheduler-plugin.log",
-      "log_stream_name": "scheduler-plugin",
+      "file_path": "/var/log/parallelcluster/scheduler-plugin.out.log",
+      "log_stream_name": "scheduler-plugin-out",
+      "schedulers": [
+        "plugin"
+      ],
+      "platforms": [
+        "centos",
+        "ubuntu",
+        "amazon"
+      ],
+      "node_roles": [
+        "ComputeFleet",
+        "HeadNode"
+      ],
+      "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/parallelcluster/scheduler-plugin.err.log",
+      "log_stream_name": "scheduler-plugin-err",
       "schedulers": [
         "plugin"
       ],


### PR DESCRIPTION
This to avoid to have unexpected interleaved stream of stdout and stderr

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
