### PR TITLE
2.11: Upgrade Slurm from 20.11.7 to 20.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+2.11.4
+-----
+
+**CHANGES**
+- Upgrade Slurm to version 20.11.8
+
 2.11.3
 -----
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -115,9 +115,9 @@ default['cfncluster']['torque']['version'] = '6.1.2'
 default['cfncluster']['torque']['url'] = 'https://github.com/adaptivecomputing/torque/archive/6.1.2.tar.gz'
 # Slurm software
 default['cfncluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
-default['cfncluster']['slurm']['version'] = '20-11-7-1'
+default['cfncluster']['slurm']['version'] = '20-11-8-1'
 default['cfncluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['cfncluster']['slurm']['version']}.tar.gz"
-default['cfncluster']['slurm']['sha1'] = 'ce927fbf2f7d5f908ed87c5d521abc696b9a2508'
+default['cfncluster']['slurm']['sha1'] = 'bc91a25355400f85ece1a204121591e6a2424617'
 # PMIx software
 default['cfncluster']['pmix']['version'] = '3.1.5'
 default['cfncluster']['pmix']['url'] = "https://github.com/openpmix/openpmix/releases/download/v#{node['cfncluster']['pmix']['version']}/pmix-#{node['cfncluster']['pmix']['version']}.tar.gz"


### PR DESCRIPTION
Cherry pick of: https://github.com/aws/aws-parallelcluster-cookbook/pull/1056


