### PR TITLE
Move handler dir under a local directory

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -119,7 +119,7 @@ default['cluster']['slurm']['user'] = 'slurm'
 default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1
 default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']
 default['cluster']['slurm']['group_id'] = node['cluster']['slurm']['user_id']
-# BYOS (Custom Scheduler) Configuration
+# Scheduler plugin Configuration
 default['cluster']['scheduler_plugin']['name'] = 'pcluster-scheduler-plugin'
 default['cluster']['scheduler_plugin']['user'] = default['cluster']['scheduler_plugin']['name']
 default['cluster']['scheduler_plugin']['user_id'] = node['cluster']['reserved_base_uid'] + 4
@@ -129,13 +129,13 @@ default['cluster']['scheduler_plugin']['group_id'] = default['cluster']['schedul
 default['cluster']['scheduler_plugin']['system_user_id_start'] = node['cluster']['reserved_base_uid'] + 10
 default['cluster']['scheduler_plugin']['system_group_id_start'] = default['cluster']['scheduler_plugin']['system_user_id_start']
 
-# BYOS event handler
+# Scheduler plugin event handler
 default['cluster']['scheduler_plugin']['home'] = '/home/pcluster-scheduler-plugin'
-default['cluster']['scheduler_plugin']['handler_dir'] = '/home/pcluster-scheduler-plugin/.parallelcluster'
 default['cluster']['scheduler_plugin']['handler_log_out'] = '/var/log/parallelcluster/scheduler-plugin.out.log'
 default['cluster']['scheduler_plugin']['handler_log_err'] = '/var/log/parallelcluster/scheduler-plugin.err.log'
 default['cluster']['scheduler_plugin']['shared_dir'] = "#{node['cluster']['shared_dir']}/scheduler-plugin"
 default['cluster']['scheduler_plugin']['local_dir'] = "#{node['cluster']['base_dir']}/scheduler-plugin"
+default['cluster']['scheduler_plugin']['handler_dir'] = "#{node['cluster']['scheduler_plugin']['local_dir']}/.configs"
 default['cluster']['scheduler_plugin']['scheduler_plugin_substack_outputs_path'] = "#{node['cluster']['shared_dir']}/scheduler-plugin-substack-outputs.json"
 default['cluster']['scheduler_plugin']['python_version'] = '3.9.9'
 default['cluster']['scheduler_plugin']['virtualenv'] = 'scheduler_plugin_virtualenv'

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install.rb
@@ -20,7 +20,6 @@ include_recipe "aws-parallelcluster-scheduler-plugin::install_user"
 # setup Pyenv and Virtualenv
 include_recipe "aws-parallelcluster-scheduler-plugin::install_python"
 
-# create e.g. /opt/parallelcluster/byos
 directory node['cluster']['scheduler_plugin']['local_dir'] do
   owner node['cluster']['scheduler_plugin']['user']
   group node['cluster']['scheduler_plugin']['user']
@@ -28,7 +27,13 @@ directory node['cluster']['scheduler_plugin']['local_dir'] do
   action :create
 end
 
-# create e.g. /opt/parallelcluster/shared/byos
+directory node['cluster']['scheduler_plugin']['handler_dir'] do
+  owner node['cluster']['scheduler_plugin']['user']
+  group node['cluster']['scheduler_plugin']['user']
+  mode '0755'
+  action :create
+end
+
 directory node['cluster']['scheduler_plugin']['shared_dir'] do
   owner node['cluster']['scheduler_plugin']['user']
   group node['cluster']['scheduler_plugin']['user']

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install_user.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install_user.rb
@@ -15,14 +15,14 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Setup byos group
+# Setup scheduler-plugin group
 group node['cluster']['scheduler_plugin']['group'] do
   comment 'ParallelCluster scheduler plugin group'
   gid node['cluster']['scheduler_plugin']['group_id']
   system true
 end
 
-# Setup byos user
+# Setup scheduler-plugin user
 user node['cluster']['scheduler_plugin']['user'] do
   comment 'ParallelCluster scheduler plugin user'
   uid node['cluster']['scheduler_plugin']['user_id']
@@ -40,12 +40,4 @@ bash "set virtualenv in scheduler plugin user bash profile " do
     echo "PATH=#{node['cluster']['scheduler_plugin']['virtualenv_path']}/bin:\\$PATH" >> "#{node['cluster']['scheduler_plugin']['home']}/.bash_profile"
     echo "export PATH" >> "#{node['cluster']['scheduler_plugin']['home']}/.bash_profile"
   PROFILE
-end
-
-# create dir /home/byos/.parallelcluster
-directory node['cluster']['scheduler_plugin']['handler_dir'] do
-  owner node['cluster']['scheduler_plugin']['user']
-  group node['cluster']['scheduler_plugin']['user']
-  mode '0755'
-  action :create
 end


### PR DESCRIPTION
Move handler dir from a shared dir /home/scheduler-plugin to a local dir /opt/parallelcluster/scheduler-plugin. This to avoid concurrency when N nodes write on the same target file

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
