### PR TITLE
Change logic to copy substack outputs into byos local dir

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/resources/execute_event_handler.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/resources/execute_event_handler.rb
@@ -83,8 +83,9 @@ action_class do # rubocop:disable Metrics/BlockLength
           ::File.write(source_scheduler_plugin_substack_outputs, scheduler_plugin_substack_outputs.to_json(:only))
         end
       end
-      FileUtils.cp(source_scheduler_plugin_substack_outputs, target_scheduler_plugin_substack_outputs)
     end
+
+    FileUtils.cp(source_scheduler_plugin_substack_outputs, target_scheduler_plugin_substack_outputs) if ::File.exist?(source_scheduler_plugin_substack_outputs)
 
     # Load static env from file or build it if file not found
     source_handler_env = "#{node['cluster']['shared_dir']}/handler-env.json"


### PR DESCRIPTION
Instead of checking if substack arn is set, copy the substack output into byos local dir depending on if it present in shared dir. This because substack arn isn't set in compute nodes

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
