### PR TITLE
Remove password obfuscation

### DIFF
--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/set_obfuscated_password.sh.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/set_obfuscated_password.sh.erb
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-LDAP_UNOBFUSCATED_PASSWORD=$(aws secretsmanager get-secret-value --secret-id <%=  node['cluster']["directory_service"]["password_secret_arn"] %> --region <%= node['cluster']['region'] %> --query 'SecretString' --output text)
-echo -n ${LDAP_UNOBFUSCATED_PASSWORD} | sudo sss_obfuscate -d default -s

--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
@@ -7,8 +7,7 @@ ldap_schema = AD
 ldap_uri = <%=  node['cluster']["directory_service"]["domain_addr"] %>
 ldap_search_base = <%=  node['cluster']["directory_service"]["domain_name"] %>
 ldap_default_bind_dn = <%=  node['cluster']["directory_service"]["domain_read_only_user"] %>
-ldap_default_authtok_type = obfuscated_password
-ldap_default_authtok = to_be_replaced
+ldap_default_authtok = <%= @ldap_default_authtok %>
 ldap_tls_cacert = <%=  node['cluster']["directory_service"]["ldap_tls_ca_cert"] %>
 ldap_tls_reqcert = <%=  node['cluster']["directory_service"]["ldap_tls_req_cert"] %>
 ldap_id_mapping = True


### PR DESCRIPTION
"obfuscating the password provides no real security benefit as it is still possible for an attacker to reverse-engineer the password back. Using better authentication mechanisms such as client side certificates or GSSAPI is strongly advised."

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
