### PR TITLE
[ad_integration] Minor Changes to Directory Services Parameters

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -473,6 +473,7 @@ default['cluster']["directory_service"]["ldap_tls_ca_cert"] = nil
 default['cluster']["directory_service"]["ldap_tls_req_cert"] = nil
 default['cluster']["directory_service"]["ldap_access_filter"] = nil
 default['cluster']["directory_service"]["generate_ssh_keys_for_users"] = nil
+default['cluster']['directory_service']['additional_sssd_configs'] = nil
 
 # Other ParallelCluster internal variables
 default['cluster']['ddb_table'] = nil

--- a/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
@@ -58,6 +58,13 @@ if node['cluster']['node_type'] == 'HeadNode'
     sensitive true
   end
 
+  bash 'Enable SSH password authentication on head node' do
+    user 'root'
+    code <<-AD
+      sed -ri 's/\s*PasswordAuthentication\s+no$/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+    AD
+  end
+
   if node['cluster']["directory_service"]["generate_ssh_keys_for_users"] == 'true'
     generate_ssh_key_path = "#{node['cluster']['scripts_dir']}/generate_ssh_key.sh"
     template generate_ssh_key_path do
@@ -87,10 +94,8 @@ end
 bash 'Configure Directory Service' do
   user 'root'
   # Tell NSS, PAM to use SSSD for system authentication and identity information
-  # Modify SSHD config to enable password login
   code <<-AD
       authconfig --enablemkhomedir --enablesssdauth --enablesssd --updateall
-      sed -ri 's/\s*PasswordAuthentication\s+no$/PasswordAuthentication yes/g' /etc/ssh/sshd_config
   AD
   sensitive true
 end

--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
@@ -1,28 +1,26 @@
-# TODO: check what parameters should we keep inside this file
 [domain/default]
-debug_level = 0x1f0
 id_provider = ldap
 cache_credentials = True
 ldap_schema = AD
-ldap_uri = <%=  node['cluster']["directory_service"]["domain_addr"] %>
-ldap_search_base = <%=  node['cluster']["directory_service"]["domain_name"] %>
-ldap_default_bind_dn = <%=  node['cluster']["directory_service"]["domain_read_only_user"] %>
+ldap_uri = <%=  node['cluster']['directory_service']['domain_addr'] %>
+ldap_search_base = <%=  node['cluster']['directory_service']['domain_name'] %>
+ldap_default_bind_dn = <%=  node['cluster']['directory_service']['domain_read_only_user'] %>
 ldap_default_authtok = <%= @ldap_default_authtok %>
-ldap_tls_cacert = <%=  node['cluster']["directory_service"]["ldap_tls_ca_cert"] %>
-ldap_tls_reqcert = <%=  node['cluster']["directory_service"]["ldap_tls_req_cert"] %>
+ldap_tls_cacert = <%=  node['cluster']['directory_service']['ldap_tls_ca_cert'] %>
+ldap_tls_reqcert = <%=  node['cluster']['directory_service']['ldap_tls_req_cert'] %>
 ldap_id_mapping = True
-ldap_referrals = False
-enumerate = True
 fallback_homedir = /home/%u
 default_shell = /bin/bash
-# TODO:  use SSL
-ldap_auth_disable_tls_never_use_in_production = true
 use_fully_qualified_names = False
+<% if node['cluster']['directory_service']['additional_sssd_configs'] %>
+  <% node['cluster']['directory_service']['additional_sssd_configs'].each_pair do |param, value| %>
+<%= "#{param} = #{value}" %>
+  <% end %>
+<% end %>
 
 [domain/local]
 id_provider = local
 enumerate = True
-
 
 [sssd]
 config_file_version = 2
@@ -36,4 +34,3 @@ filter_groups = nobody,root
 
 [pam]
 offline_credentials_expiration = 7
-

--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
@@ -6,7 +6,9 @@ ldap_uri = <%=  node['cluster']['directory_service']['domain_addr'] %>
 ldap_search_base = <%=  node['cluster']['directory_service']['domain_name'] %>
 ldap_default_bind_dn = <%=  node['cluster']['directory_service']['domain_read_only_user'] %>
 ldap_default_authtok = <%= @ldap_default_authtok %>
+<% if node['cluster']['directory_service']['ldap_tls_ca_cert'] %>
 ldap_tls_cacert = <%=  node['cluster']['directory_service']['ldap_tls_ca_cert'] %>
+<% end %>
 ldap_tls_reqcert = <%=  node['cluster']['directory_service']['ldap_tls_req_cert'] %>
 ldap_id_mapping = True
 fallback_homedir = /home/%u


### PR DESCRIPTION
* Assume directory service section's domain address parameter should use ldaps protocol if none is specified
* Enable the setting of arbitrary parameters in the directory service section of the SSSD configuration file
* Only write ldap_tls_ca_cert parameter if supplied
* Only enable SSH password auth on head node

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
