### PR TITLE
Add directory service related logs to CloudWatch

### DIFF
--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
@@ -266,6 +266,84 @@
       ]
     },
     {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/sssd/sssd.log",
+      "log_stream_name": "sssd",
+      "schedulers": [
+        "slurm",
+        "plugin"
+      ],
+      "platforms": [
+        "centos",
+        "ubuntu",
+        "amazon"
+      ],
+      "node_roles": [
+        "HeadNode"
+      ],
+      "feature_conditions": [
+        {
+          "dna_key": [
+            "directory_service",
+            "enabled"
+          ],
+          "satisfying_values": ["true"]
+        }
+      ]
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/sssd/sssd_default.log",
+      "log_stream_name": "sssd_domain_default",
+      "schedulers": [
+        "slurm",
+        "plugin"
+      ],
+      "platforms": [
+        "centos",
+        "ubuntu",
+        "amazon"
+      ],
+      "node_roles": [
+        "HeadNode"
+      ],
+      "feature_conditions": [
+        {
+          "dna_key": [
+            "directory_service",
+            "enabled"
+          ],
+          "satisfying_values": ["true"]
+        }
+      ]
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/parallelcluster/pam_ssh_key_generator.log",
+      "log_stream_name": "pam_ssh_key_generator",
+      "schedulers": [
+        "slurm",
+        "plugin"
+      ],
+      "platforms": [
+        "centos",
+        "ubuntu",
+        "amazon"
+      ],
+      "node_roles": [
+        "HeadNode"
+      ],
+      "feature_conditions": [
+        {
+          "dna_key": [
+            "directory_service",
+            "generate_ssh_keys_for_users"
+          ],
+          "satisfying_values": ["true"]
+        }
+      ]
+    },
+    {
       "timestamp_format_key": "bracket_default",
       "file_path": "/var/log/parallelcluster/pcluster_dcv_connect.log",
       "log_stream_name": "dcv-ext-authenticator",

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files_schema.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files_schema.json
@@ -27,7 +27,7 @@
             "items": {
               "type": "object",
               "properties": {
-                "dna_key": {"type": "string"},
+                "dna_key": {"type": ["string", "array"]},
                 "satisfying_values": {"type": "array", "items": {"type": "string"}}
               },
               "required": ["dna_key", "satisfying_values"]

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/write_cloudwatch_agent_json.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/write_cloudwatch_agent_json.py
@@ -108,8 +108,15 @@ def select_configs_for_feature(configs):
     for config in configs:
         conditions = config.get("feature_conditions", [])
         for condition in conditions:
-            node_info_key = condition.get("dna_key")
-            if node_info.get(node_info_key) not in condition.get("satisfying_values"):
+            dna_keys = condition.get("dna_key")
+            if isinstance(dna_keys, str):  # dna_key can be a string for single level dict or a list for nested dicts
+                dna_keys = [dna_keys]
+            value = node_info
+            for key in dna_keys:
+                value = value.get(key)
+                if value is None:
+                    break
+            if value not in condition.get("satisfying_values"):
                 break
         else:
             selected_configs.append(config)


### PR DESCRIPTION
/var/log/sssd/sssd.log
/var/log/sssd/sssd_default.log
/var/log/parallelcluster/pam_ssh_key_generator.log

This commit also improves `cloudwatch_log_files.json` to allow `dna_key` be an array for nested dicts.

Signed-off-by: Hanwen <hanwenli@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
