### PR TITLE
2.11: Disable Ubuntu unattended upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Slurm to version 20.11.8.
 - Upgrade Cinc Client to version 17.2.29.
 - Upgrade NICE DCV to version 2021.2-11190.
+- Disable unattended upgrades for Ubuntu.
 
 2.11.3
 -----

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -167,7 +167,8 @@
     {
       "type": "shell",
       "inline": [
-        "sudo flock $(apt-config shell StateDir Dir::State/d | sed -r \"s/.*'(.*)\\/?'$/\\1/\")/daily_lock systemctl stop apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service"
+        "sudo flock $(apt-config shell StateDir Dir::State/d | sed -r \"s/.*'(.*)\\/?'$/\\1/\")/daily_lock systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service",
+        "sudo sh -c \"sed \\\"/Update-Package-Lists/s/1/0/; /Unattended-Upgrade/s/1/0/;\\\" /etc/apt/apt.conf.d/20auto-upgrades > /etc/apt/apt.conf.d/51pcluster-unattended-upgrades\""
       ]
     },
     {

--- a/amis/packer_ubuntu2004.json
+++ b/amis/packer_ubuntu2004.json
@@ -167,7 +167,8 @@
     {
       "type": "shell",
       "inline": [
-        "sudo flock $(apt-config shell StateDir Dir::State/d | sed -r \"s/.*'(.*)\\/?'$/\\1/\")/daily_lock systemctl stop apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service"
+        "sudo flock $(apt-config shell StateDir Dir::State/d | sed -r \"s/.*'(.*)\\/?'$/\\1/\")/daily_lock systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service",
+        "sudo sh -c \"sed \\\"/Update-Package-Lists/s/1/0/; /Unattended-Upgrade/s/1/0/;\\\" /etc/apt/apt.conf.d/20auto-upgrades > /etc/apt/apt.conf.d/51pcluster-unattended-upgrades\""
       ]
     },
     {


### PR DESCRIPTION
`APT::Periodic::Update-Package-Lists` allows you to specify the frequency (in days) at which the package lists are refreshed (0=disable).

`APT::Periodic::Unattended-Upgrade`
When this option is enabled, the daily script will execute unattended-upgrade from the `unattended-upgrades` package.
The default configuration file for the `unattended-upgrades` package is at `/etc/apt/apt.conf.d/50unattended-upgrades`
we're overriding it by writing the `51unattended-upgrades` file.

Minor: we're also replacing `systemctl stop` with `systemctl disable --now` in the command executed before. This command is executed to be sure there are no unattended upgrades in progress.

Related patches (for 3.0.0):
* https://github.com/aws/aws-parallelcluster/pull/2915
* https://github.com/aws/aws-parallelcluster/pull/3267
