### PR TITLE
Add libjwt package to compile Slurm with jwt support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade PMIx to version 3.2.3
 - Download dependencies of Intel HPC platform during AMI build time to avoid contacting Internet during cluster creation time.
 - Do not strip `-` from compute resource name when configuring Slurm nodes.
-- Upgrade Slurm to version 21.08.4.
+- Upgrade Slurm to version 21.08.4. As part of this upgrade we are also compiling Slurm binaries with slurmrestd and jwt plugin support.
 
 **BUG FIXES**
 - Fix issue that is preventing cluster names to start with `parallelcluster-` prefix.

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -21,9 +21,9 @@ end
 
 slurm_build_deps = value_for_platform(
   'ubuntu' => {
-    'default' => %w(libjson-c-dev libhttp-parser-dev),
+    'default' => %w(libjson-c-dev libhttp-parser-dev libjwt-dev),
   },
-  'default' => %w(json-c-devel http-parser-devel)
+  'default' => %w(json-c-devel http-parser-devel libjwt-devel)
 )
 
 package slurm_build_deps do


### PR DESCRIPTION
Docs on Slurm jwt plugin: https://slurm.schedmd.com/jwt.html. libjwt is listed as a requirement to build support for the jwt plugin.

Tested by manually creating an alinux2 and ubuntu2008 cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
