### PR TITLE
[ad_integration] change directory service enabled to false

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -464,7 +464,7 @@ default['cluster']['head_node_private_ip'] = nil
 default['cluster']['volume'] = nil
 
 # ParallelCluster internal variables to configure active directory service
-default['cluster']["directory_service"]["enabled"] = nil
+default['cluster']["directory_service"]["enabled"] = 'false'
 default['cluster']["directory_service"]["domain_name"] = nil
 default['cluster']["directory_service"]["domain_addr"] = nil
 default['cluster']["directory_service"]["password_secret_arn"] = nil


### PR DESCRIPTION
This commit will fix a cluster creation issue when directory service is not enabled. This bug came from the removal of `directory_service` from compute nodes' dna.json in this [PR](https://github.com/aws/aws-parallelcluster/pull/3528). With the fix, the default of `default['cluster']["directory_service"]["enabled"]` is `false`, and the directory service recipe will be skipped if `directory_service` does not present in dna.json

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
