### PR TITLE
Revert "Add libjwt package to compile Slurm with jwt support"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade PMIx to version 3.2.3
 - Download dependencies of Intel HPC platform during AMI build time to avoid contacting Internet during cluster creation time.
 - Do not strip `-` from compute resource name when configuring Slurm nodes.
-- Upgrade Slurm to version 21.08.4. As part of this upgrade we are also compiling Slurm binaries with slurmrestd and jwt plugin support.
+- Upgrade Slurm to version 21.08.4.
 
 **BUG FIXES**
 - Fix issue that is preventing cluster names to start with `parallelcluster-` prefix.

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -21,9 +21,9 @@ end
 
 slurm_build_deps = value_for_platform(
   'ubuntu' => {
-    'default' => %w(libjson-c-dev libhttp-parser-dev libjwt-dev),
+    'default' => %w(libjson-c-dev libhttp-parser-dev),
   },
-  'default' => %w(json-c-devel http-parser-devel libjwt-devel)
+  'default' => %w(json-c-devel http-parser-devel)
 )
 
 package slurm_build_deps do


### PR DESCRIPTION
Unfortunately there is no libjwt available in the Centos7 and Alinux2 repos for ARM architecture. Reverting this change for now.