### PR TITLE
Regenerate substack output file during update

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/files/default/event_handler/invoke-scheduler-plugin-event-handler.sh
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/files/default/event_handler/invoke-scheduler-plugin-event-handler.sh
@@ -361,7 +361,7 @@ if [[ -f "/etc/chef/dna.json" ]]; then
   fi
 
   if [[ -z "${scheduler_plugin_substack_outputs}" ]]; then
-    log "Scheduler plugion substack outputs not specified, will be generated under (${ORIGINAL_SCHEDULER_PLUGIN_SUBSTACK_OUTPUTS}) if there is a substack with outputs."
+    log "Scheduler plugin substack outputs not specified, will be generated under (${ORIGINAL_SCHEDULER_PLUGIN_SUBSTACK_OUTPUTS}) if there is a substack with outputs."
     scheduler_plugin_substack_outputs="${ORIGINAL_SCHEDULER_PLUGIN_SUBSTACK_OUTPUTS}"
   fi
   source_dna_json="/etc/chef/dna.json"

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/resources/execute_event_handler.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/resources/execute_event_handler.rb
@@ -72,7 +72,7 @@ action_class do # rubocop:disable Metrics/BlockLength
     scheduler_plugin_substack_arn = node.dig(:cluster, :scheduler_plugin_substack_arn)
     if scheduler_plugin_substack_arn && !scheduler_plugin_substack_arn.empty?
       Chef::Log.info("Found scheduler plugin substack (#{scheduler_plugin_substack_arn})")
-      unless ::File.exist?(source_scheduler_plugin_substack_outputs)
+      if !::File.exist?(source_scheduler_plugin_substack_outputs) || new_resource.event_name == 'HeadClusterUpdate'
         scheduler_plugin_substack_outputs = { 'Outputs' => {} }
         Chef::Log.info("Executing describe-stack on scheduler plugin substack (#{scheduler_plugin_substack_arn})")
         cmd = command_with_retries("aws cloudformation describe-stacks --region #{node.dig(:ec2, :region)} --stack-name #{scheduler_plugin_substack_arn}", 3, 'root', nil, nil)


### PR DESCRIPTION
Regenerate substack output file when update is performed (HeadClusterUpdate) event.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
