### PR TITLE
[develop] Check whether previous cluster config exists

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -15,33 +15,34 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-unless ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path'])
-  # Generate pcluster specific configs
-  no_gpu = nvidia_installed? ? "" : "--no-gpu"
-  execute "generate_pcluster_slurm_configs" do
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_slurm_config_generator.py" \
-            " --output-directory /opt/slurm/etc/" \
-            " --template-directory #{node['cluster']['scripts_dir']}/slurm/templates/" \
-            " --input-file #{node['cluster']['cluster_config_path']}" \
-            " --instance-types-data #{node['cluster']['instance_types_data_path']}" \
-            " #{no_gpu}"
-  end
+execute "generate_pcluster_slurm_configs" do
+  command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_slurm_config_generator.py" \
+          " --output-directory /opt/slurm/etc/" \
+          " --template-directory #{node['cluster']['scripts_dir']}/slurm/templates/" \
+          " --input-file #{node['cluster']['cluster_config_path']}" \
+          " --instance-types-data #{node['cluster']['instance_types_data_path']}" \
+          " #{nvidia_installed? ? '' : '--no-gpu'}"
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path']) }
+end
 
-  execute 'stop clustermgtd' do
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl stop clustermgtd"
-  end
+execute 'stop clustermgtd' do
+  command "#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl stop clustermgtd"
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path']) }
+end
 
-  service 'slurmctld' do
-    action :restart
-  end
+service 'slurmctld' do
+  action :restart
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path']) }
+end
 
-  execute 'reload config for running nodes' do
-    command "/opt/slurm/bin/scontrol reconfigure && sleep 15"
-    retries 3
-    retry_delay 5
-  end
+execute 'reload config for running nodes' do
+  command "/opt/slurm/bin/scontrol reconfigure && sleep 15"
+  retries 3
+  retry_delay 5
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path']) }
+end
 
-  execute 'start clustermgtd' do
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl start clustermgtd"
-  end
+execute 'start clustermgtd' do
+  command "#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl start clustermgtd"
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path']) }
 end


### PR DESCRIPTION
`::FileUtils.identical?` throws an exception when one of the files
doesn't exist.

Signed-off-by: Tim Lane <tilne@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
