### PR TITLE
[develop] Improve error reporting for run level and iptables checks

### DIFF
--- a/cookbooks/aws-parallelcluster-test/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-test/libraries/helpers.rb
@@ -135,8 +135,6 @@ def check_iptables_rules_file(file)
   bash "check iptables rules backup file exists: #{file}" do
     cwd Chef::Config[:file_cache_path]
     code <<-TEST
-      set -e
-
       if [[ ! -f #{file} ]]; then
         >&2 echo "Missing expected iptables rules file: #{file}"
         exit 1
@@ -153,8 +151,6 @@ def check_directories_in_path(directories, user = nil)
   bash "check PATH for #{context} contains #{directories}" do
     cwd Chef::Config[:file_cache_path]
     code <<-TEST
-      set -e
-
       #{user.nil? ? nil : "sudo su - #{user}"}
 
       for directory in #{directories.join(' ')}; do
@@ -173,8 +169,6 @@ def check_run_level_script(script_name, levels_on, levels_off)
   bash "check run level script #{script_name}" do
     cwd Chef::Config[:file_cache_path]
     code <<-TEST
-      set -e
-
       for level in #{levels_on.join(' ')}; do
         ls /etc/rc$level.d/ | egrep '^S[0-9]+#{script_name}$' > /dev/null
         [[ $? == 0 ]] || missing_levels_on="$missing_levels_on $level"


### PR DESCRIPTION
Test were written in order to collect the failures and then report a summary, but they were exiting right away at the first failure withouth reporting anything because of the set -e option.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.