### PR TITLE
Remove wrong boolean operator in string comparison

### DIFF
--- a/cookbooks/aws-parallelcluster-install/files/default/ec2_udev_rules/attachVolume.py
+++ b/cookbooks/aws-parallelcluster-install/files/default/ec2_udev_rules/attachVolume.py
@@ -136,7 +136,7 @@ def main():
         if x == 60:
             print("Volume %s failed to mount in 300 seconds." % volume_id)
             exit(1)
-        if state in ["busy" or "detached"]:
+        if state in ["busy", "detached"]:
             print("Volume %s in bad state %s" % (volume_id, state))
             exit(1)
         print("Volume %s in state %s ... waiting to be 'attached'" % (volume_id, state))


### PR DESCRIPTION
### Description of changes
* Using strings as booleans in Python has unexpected results. 
  * `"one" and "two"` will return "two". 
  * `"one" or "two"` will return "one". 
* In Python, strings are truthy,and strings with a non-zero length evaluate to `True`.
* In this case the code was always comparing the `state` with `"busy"` string.

### Tests
* None, we should add tests for the whole attachVolume.py script.

### References
* https://en.wikipedia.org/wiki/Short-circuit_evaluation

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

