### PR TITLE
Upgrade EFA to version 1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Do not strip `-` from compute resource name when configuring Slurm nodes.
 - Upgrade Slurm to version 21.08.4.
 
-**BUG FIXES**
-- Fix issue that is preventing cluster names to start with `parallelcluster-` prefix.
 
 3.0.2
 ------
@@ -33,6 +31,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - RDMA core: ``rdma-core-37.0``
   - Libfabric: ``libfabric-1.13.2``
   - Open MPI: ``openmpi40-aws-4.1.1-2``
+
+**BUG FIXES**
+- Fix issue that is preventing cluster names to start with `parallelcluster-` prefix.
 
 3.0.1
 ------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -187,9 +187,8 @@ default['cluster']['nvidia']['fabricmanager']['repository_uri'] = value_for_plat
 )
 
 # EFA
-default['cluster']['efa']['installer_version'] = '1.13.0'
+default['cluster']['efa']['installer_version'] = '1.14.1'
 default['cluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cluster']['efa']['installer_version']}.tar.gz"
-default['cluster']['enable_efa_gdr'] = "no"
 default['cluster']['efa']['unsupported_aarch64_oses'] = %w(centos7)
 
 # NICE DCV

--- a/cookbooks/aws-parallelcluster-config/recipes/efa.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/efa.rb
@@ -15,9 +15,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Installation recipe must be re-executed at runtime to enable GDR
-include_recipe "aws-parallelcluster-install::efa"
-
 if platform?('ubuntu') && node['cluster']['enable_efa'] == 'compute' && node['cluster']['node_type'] == 'ComputeFleet'
   # Disabling ptrace protection is needed for EFA in order to use SHA transfer for intra-node communication.
   sysctl 'kernel.yama.ptrace_scope' do

--- a/cookbooks/aws-parallelcluster-install/recipes/efa.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/efa.rb
@@ -19,7 +19,7 @@ efa_tarball = "#{node['cluster']['sources_dir']}/aws-efa-installer.tar.gz"
 efa_installed = efa_installed?
 
 if efa_installed && !::File.exist?(efa_tarball)
-  Chef::Log.warn("Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration. enable_gdr option will be ignored.")
+  Chef::Log.warn("Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration.")
   return
 end
 
@@ -50,8 +50,6 @@ end
 installer_options = "-y"
 # skip efa-kmod installation on not supported platforms
 installer_options += " -k" unless node['conditions']['efa_supported']
-# enable gpudirect support
-installer_options += " -g" if efa_gdr_enabled?
 
 bash "install efa" do
   cwd node['cluster']['sources_dir']
@@ -62,5 +60,5 @@ bash "install efa" do
     ./efa_installer.sh #{installer_options}
     rm -rf #{node['cluster']['sources_dir']}/aws-efa-installer
   EFAINSTALL
-  not_if { efa_installed && !efa_gdr_enabled? }
+  not_if { efa_installed }
 end

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -222,12 +222,34 @@ if node['conditions']['intel_mpi_supported']
 end
 
 ###################
-# EFA - GDR (GPUDirect RDMA)
+# EFA
 ###################
-if node['conditions']['efa_supported'] && efa_gdr_enabled?
-  execute 'check efa gdr installed' do
-    command "modinfo efa | grep 'gdr:\ *Y'"
-    user node['cluster']['cluster_user']
+if node['conditions']['efa_supported']
+  if node['cluster']['os'].end_with?("-custom")
+    # only check EFA is installed because when found in the base AMI we skip installation
+    bash 'check efa installed' do
+      cwd Chef::Config[:file_cache_path]
+      code <<-EFA
+        set -ex
+        modinfo efa
+        cat /opt/amazon/efa_installed_packages
+      EFA
+    end
+  else
+    # check EFA is installed and the version is expected
+    bash 'check correct version of efa installed' do
+      cwd Chef::Config[:file_cache_path]
+      code <<-EFA
+        set -ex
+        modinfo efa
+        grep "EFA installer version: #{node['cluster']['efa']['installer_version']}" /opt/amazon/efa_installed_packages
+      EFA
+    end
+    # GDR (GPUDirect RDMA)
+    execute 'check efa gdr installed' do
+      command "modinfo efa | grep 'gdr:\ *Y'"
+      user node['cluster']['cluster_user']
+    end
   end
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -396,17 +396,6 @@ def get_nvswitches
   nvswitch_check.stdout.strip.to_i
 end
 
-# Check if EFA GDR is enabled (and supported) on this instance
-def efa_gdr_enabled?
-  config_value = node['cluster']['enable_efa_gdr']
-  enabling_value = if node['cluster']['node_type'] == "ComputeFleet"
-                     "compute"
-                   else
-                     "head_node"
-                   end
-  (config_value == enabling_value || config_value == "cluster") && graphic_instance?
-end
-
 # Alinux OSs currently not correctly supported by NFS cookbook
 # Overwriting templates for node['nfs']['config']['server_template'] used by NFS cookbook for these OSs
 # When running, NFS cookbook will use nfs.conf.erb templates provided in this cookbook to generate server_template


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
Starting from EFA 1.14.0, GDR support is enabled by default. Therefore, this commit also removes the logic to reinstall EFA if GDR is enabled.
* Link to impacted open issues.
This commit is cherry picked from https://github.com/aws/aws-parallelcluster-cookbook/commit/82154c95b347de908c77d95802dea768af0eb0d9 and https://github.com/aws/aws-parallelcluster-cookbook/commit/9ebd58e7aaf44bfeda1a6cc340ffaa6b20459a63

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.