### PR TITLE
Download/install aws-cfn-bootstrap-py3-latest.tar.gz for Ubuntu and CentOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade CUDA library to version 11.4.3.
 - Upgrade NVIDIA Fabric manager to `nvidia-fabricmanager-470`.
 - Disable unattended upgrades for Ubuntu.
+- Install Python 3 version of `aws-cfn-bootstrap` scripts on CentOS 7 and Ubuntu 18.04.
 
 2.11.3
 -----

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -298,9 +298,8 @@
         "region=\"{{user `region`}}\"",
         "bucket=\"s3.amazonaws.com\"",
         "[[ ${region} =~ ^cn- ]] && bucket=\"s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster\"",
-        "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
-        "which pip2",
-        "if [ $? -eq 0 ]; then sudo pip2 install /tmp/aws-cfn-bootstrap-latest.tar.gz; else sudo pip install /tmp/aws-cfn-bootstrap-latest.tar.gz; fi"
+        "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-py3-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz",
+        "sudo pip3 install /tmp/aws-cfn-bootstrap-py3-latest.tar.gz"
       ]
     },
     {

--- a/amis/packer_ubuntu1804.json
+++ b/amis/packer_ubuntu1804.json
@@ -295,8 +295,8 @@
         "region=\"{{user `region`}}\"",
         "bucket=\"s3.amazonaws.com\"",
         "[[ ${region} =~ ^cn- ]] && bucket=\"s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster\"",
-        "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
-        "sudo pip install /tmp/aws-cfn-bootstrap-latest.tar.gz"
+        "curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-py3-latest.tar.gz https://${bucket}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz",
+        "sudo pip3 install /tmp/aws-cfn-bootstrap-py3-latest.tar.gz"
       ]
     },
     {


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

The latest release (version 0.6.0) of [pystache](https://pypi.org/project/pystache/) removed the support for Python2. This package is a dependency of aws-cfn-bootstrap-latest.tar.gz.

The latest (version 1.4-34) [aws-cfn-bootstrap-latest.tar.gz](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/releasehistory-aws-cfn-bootstrap.html#releasehistory-aws-cfn-bootstrap-v1) became incompatible with Python2 after the pystache update, and it is recommended in [CloudFormation helper scripts reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-helper-scripts-reference.html) to use the latest installation package for Python3.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.