### PR TITLE
2.x: Upgrade to Intel MPI Library 2021.4.0.441

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade NVIDIA driver to version 470.82.01.
 - Upgrade CUDA library to version 11.4.3.
 - Upgrade NVIDIA Fabric manager to 470.82.01.
+- Upgrade Intel MPI Library to 2021.4.0.441.
 - Disable unattended packages update on Ubuntu.
 - Install Python 3 version of `aws-cfn-bootstrap` scripts on CentOS 7 and Ubuntu 18.04, aligning with Ubuntu 20.04 and Amazon Linux 2.
-
 
 2.11.3
 -----

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,9 +63,11 @@ default['cfncluster']['intelpython2']['version'] = '2019.4-088'
 default['cfncluster']['intelpython3']['version'] = '2020.2-902'
 
 # Intel MPI
-default['cfncluster']['intelmpi']['version'] = '2019.8.254'
-default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/impi/#{node['cfncluster']['intelmpi']['version']}/intel64/modulefiles/mpi"
-default['cfncluster']['intelmpi']['kitchen_test_string'] = 'Version 2019 Update 8'
+default['cfncluster']['intelmpi']['version'] = '2021.4.0'
+default['cfncluster']['intelmpi']['full_version'] = "#{node['cfncluster']['intelmpi']['version']}.441"
+default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/mpi/#{node['cfncluster']['intelmpi']['version']}/modulefiles/mpi"
+default['cfncluster']['intelmpi']['kitchen_test_string'] = 'Version 2021 Update 4'
+default['cfncluster']['intelmpi']['qt_version'] = '5.15.2'
 
 # Arm Performance Library
 default['cfncluster']['armpl']['major_minor_version'] = '21.0'

--- a/templates/default/intel_mpi/qt_source_code.erb
+++ b/templates/default/intel_mpi/qt_source_code.erb
@@ -1,0 +1,3 @@
+You can get Qt source code here:
+
+https://<%= node['cfncluster']['cfn_region'] %>-aws-parallelcluster.s3.<%= node['cfncluster']['cfn_region'] %>.<%= node['cfncluster']['aws_domain'] %>/archives/impi/qt-src-<%= node['cfncluster']['intelmpi']['qt_version'] %>-linux.src.tgz


### PR DESCRIPTION
### Description of changes
Intel MPI is now part of the OneAPI package. The standalone offline installer is available [here](https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#mpi).

Relevant changes:
- The installation path doesn't contain the patch version `.441`
- The EULA file is available in the `/opt/intel/licensing` path
- The base modules folder has been renamed from `impi` to `mpi`
- Installer options have been changed
- Extracted folder can be automatically deleted through the `--remove-extracted-files` flag
- Added Qt source code file to comply with https://www.qt.io/licensing/open-source-lgpl-obligations

### Tests
Integ tests:
* test_hit_efa[eu-west-2-c5n.18xlarge-alinux2-slurm] 
* test_hit_efa[eu-west-2-c5n.18xlarge-centos7-slurm] 
* test_hit_efa[us-east-2-c5n.18xlarge-ubuntu2004-slurm]
* test_sit_efa[eu-west-2-c5n.18xlarge-alinux2-slurm] 
* test_sit_efa[eu-west-2-c5n.18xlarge-centos7-slurm]
* test_sit_efa[me-south-1-c5n.18xlarge-alinux2-sge]
* test_sit_efa[me-south-1-c5n.18xlarge-ubuntu1804-slurm] 
* test_sit_efa[us-east-1-c5n.18xlarge-ubuntu1804-sge] 
* test_sit_efa[us-east-2-c5n.18xlarge-ubuntu2004-slurm]

Manual tests on Alinux2. Manual execution of the `intel_mpi.rb` recipe then verified modules:
```
$ module avail
...
----------------- /opt/intel/mpi/2021.4.0/modulefiles/ -----------------
intelmpi

$ module load intelmpi
Loading mpi version 2021.4.0
$ mpicc --version
gcc (GCC) 7.3.1 20180712 (Red Hat 7.3.1-13)
Copyright (C) 2017 Free Software Foundation, Inc.
```

### References
* IntelMPI licensing (OneApi section): https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html
* Intel MPI download: https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#mpi
* Modules documentation: https://modules.readthedocs.io/en/latest/module.html

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
