### PR TITLE
[recipes/finalize] Add run time to the output of the finalize recipe.

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -48,7 +48,7 @@ include_recipe 'aws-parallelcluster-config::chrony'
 include_recipe "aws-parallelcluster-config::nvidia"
 
 # EFA runtime configuration
-include_recipe "aws-parallelcluster-config::efa" unless virtualized?
+include_recipe "aws-parallelcluster-config::efa"
 
 case node['cluster']['node_type']
 when 'HeadNode'

--- a/cookbooks/aws-parallelcluster-config/recipes/finalize.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/finalize.rb
@@ -25,3 +25,7 @@ end
 
 include_recipe 'aws-parallelcluster-scheduler-plugin::finalize' if node['cluster']['scheduler'] == 'plugin'
 include_recipe 'aws-parallelcluster-slurm::finalize' if node['cluster']['scheduler'] == 'slurm'
+
+# Log the uptime at the end of running chef scripts.
+uptime_ms = IO.read('/proc/uptime').split[0].to_f * 1000
+printf("Recipes Finish Uptime: %f\n", uptime_ms)

--- a/system_tests/README.md
+++ b/system_tests/README.md
@@ -50,7 +50,8 @@ configuration recipes as would be done during node boot time.
 
 
 ### Full Testing
-The `system_tests/test.sh` script runs the full process described above.
+The `system_tests/test_ubuntu.sh` and `system_tests/test_centos7` scripts runs
+the full process described above for the respective operating system.
 
 ### Skipping tests
 A few of the tests are not setup to run in the virtual enviroment and thus can be

--- a/system_tests/bootstrap.sh
+++ b/system_tests/bootstrap.sh
@@ -58,7 +58,7 @@ mkdir -p /lib/modules/`uname -r`
 platform=$(cat /etc/*-release | grep ID_LIKE | sed 's/.*=//')
 
 if [ "$platform" == "debian" ]; then
-    apt install -y linux-modules-`uname -r`
+    apt install -y linux-modules-${KERNEL_RELEASE}
 else
     yum install -y kernel-modules
 fi

--- a/system_tests/systemd
+++ b/system_tests/systemd
@@ -35,7 +35,7 @@ mkdir -p /home/ubuntu/.ssh
 chown -R ubuntu:ubuntu /home/ubuntu/.ssh
 
 mkdir -p /opt/parallelcluster
-echo "aws-parallelcluster-cookbook-3.0.1" > /opt/parallelcluster/.bootstrapped
+echo "aws-parallelcluster-cookbook-3.1.0b1" > /opt/parallelcluster/.bootstrapped
 
 mkdir -p /opt/parallelcluster/scripts
 mkdir -p /etc/parallelcluster

--- a/util/bump-version.sh
+++ b/util/bump-version.sh
@@ -31,6 +31,7 @@ sed -i "s/version '${CURRENT_PCLUSTER_VERSION_SHORT}'/version '${NEW_PCLUSTER_VE
 sed -i "s/version '${CURRENT_PCLUSTER_VERSION_SHORT}'/version '${NEW_PCLUSTER_VERSION_SHORT}'/g" cookbooks/aws-parallelcluster-slurm/metadata.rb
 sed -i "s/version '${CURRENT_PCLUSTER_VERSION_SHORT}'/version '${NEW_PCLUSTER_VERSION_SHORT}'/g" cookbooks/aws-parallelcluster-scheduler-plugin/metadata.rb
 sed -i "s/version '${CURRENT_PCLUSTER_VERSION_SHORT}'/version '${NEW_PCLUSTER_VERSION_SHORT}'/g" cookbooks/aws-parallelcluster-awsbatch/metadata.rb
+sed -i "s/aws-parallelcluster-cookbook-.*\"/aws-parallelcluster-cookbook-${NEW_PCLUSTER_VERSION}\"/" system_tests/systemd
 
 CURRENT_AWSBATCH_CLI_VERSION=$(sed -ne "s/^default\['cluster'\]\['parallelcluster-awsbatch-cli-version'\] = '\(.*\)'/\1/p" attributes/default.rb)
 


### PR DESCRIPTION
### Description of changes
- Add the uptime in milliseconds as output at the end of the finalize recipe so that we can compare the configuration time for different settings across compute nodes.
- Enable building of EFA in system tests as the kernel version in GitHub actions is new enough
- Install the kernel modules based on the supplied kernel version (rather than the host kernel)
- Update the bootstrapped file to point to 3.1.0b1
- Add updating of the `system_tests/systemd` file to the `bump-version.sh` script to automate the above process in the future.

### Tests
* Tested locally via system tests

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.