### PR TITLE
Upgrade Slurm to version 21.08.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade PMIx to version 3.2.3
 - Download dependencies of Intel HPC platform during AMI build time to avoid contacting Internet during cluster creation time.
 - Do not strip `-` from compute resource name when configuring Slurm nodes.
-- Upgrade Slurm to version 21.08.4.
+- Upgrade Slurm to version 21.08.5.
 - Upgrade NICE DCV to version 2021.2-11445.
 - Upgrade NVIDIA driver to version 470.82.01.
 - Upgrade CUDA library to version 11.4.3.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -113,9 +113,9 @@ default['cluster']['parallelcluster-awsbatch-cli-version'] = '1.0.0'
 # URLs to software packages used during install recipes
 # Slurm software
 default['cluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
-default['cluster']['slurm']['version'] = '21-08-4-1'
+default['cluster']['slurm']['version'] = '21-08-5-1'
 default['cluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['cluster']['slurm']['version']}.tar.gz"
-default['cluster']['slurm']['sha1'] = '24dad6a71e7664a2781d0c8723bce30f6bc5ae47'
+default['cluster']['slurm']['sha1'] = '1416539a06c866605b8d464daf6c98d881592361'
 default['cluster']['slurm']['user'] = 'slurm'
 default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1
 default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']


### PR DESCRIPTION
### Description of changes
* Upgrade Slurm to 21.08.5 in order to include the following fix: https://github.com/SchedMD/slurm/commit/c129230c7af11863b3b970169774f964cf07fa94
* Full changelog: https://github.com/SchedMD/slurm/blob/slurm-21-08-5-1/NEWS

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.