### PR TITLE
Revert "Restrict permissions on scheduler plugin directories"

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install.rb
@@ -23,21 +23,21 @@ include_recipe "aws-parallelcluster-scheduler-plugin::install_python"
 directory node['cluster']['scheduler_plugin']['local_dir'] do
   owner node['cluster']['scheduler_plugin']['user']
   group node['cluster']['scheduler_plugin']['user']
-  mode '0700'
+  mode '0755'
   action :create
 end
 
 directory node['cluster']['scheduler_plugin']['handler_dir'] do
   owner node['cluster']['scheduler_plugin']['user']
   group node['cluster']['scheduler_plugin']['user']
-  mode '0700'
+  mode '0755'
   action :create
 end
 
 directory node['cluster']['scheduler_plugin']['shared_dir'] do
   owner node['cluster']['scheduler_plugin']['user']
   group node['cluster']['scheduler_plugin']['user']
-  mode '0700'
+  mode '0755'
   action :create
 end
 


### PR DESCRIPTION
We want to keep scheduler plugin directorie as readable and searchable
but not writable by everybody. This allows users to access scheduler binaries
if needed.

This reverts commit 221cc1631dd91bfc3b74f321fdc4f20cb614247a.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.