### PR TITLE
[develop] Fix comparison of config object for the clusterstatusmgtd

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/files/default/clusterstatusmgtd/clusterstatusmgtd.py
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/files/default/clusterstatusmgtd/clusterstatusmgtd.py
@@ -257,6 +257,14 @@ class ClusterstatusmgtdConfig:
         attrs = ", ".join([f"{key}={repr(value)}" for key, value in self.__dict__.items()])
         return f"{self.__class__.__name__}({attrs})"
 
+    def __eq__(self, other):  # noqa: D105
+        if type(other) is type(self):
+            return self._config == other._config
+        return False
+
+    def __ne__(self, other):  # noqa: D105
+        return not self.__eq__(other)
+
     @log_exception(
         log, "reading cluster status manger configuration file", catch_exception=IOError, raise_on_error=True
     )


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Fix comparison of config object for the clusterstatusmgtd

### Tests
Tested manually looking at the clusterstatusmgtd logs

### References

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.