### PR TITLE
Move cluster status management configuration on configure recipe

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/config_head_node.rb
@@ -15,6 +15,15 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+directory '/etc/parallelcluster/scheduler_plugin'
+
+template "/etc/parallelcluster/scheduler_plugin/clusterstatusmgtd.conf" do
+  source 'clusterstatusmgtd/clusterstatusmgtd.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end
+
 unless virtualized?
   execute 'initialize compute fleet status in DynamoDB' do
     # Initialize the status of the compute fleet in the DynamoDB table. Set it to RUNNING.

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install_clusterstatusmgtd.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install_clusterstatusmgtd.rb
@@ -31,12 +31,3 @@ cookbook_file "#{node['cluster']['scripts_dir']}/scheduler_plugin/clusterstatusm
   group 'root'
   mode '0755'
 end
-
-directory '/etc/parallelcluster/scheduler_plugin'
-
-template "/etc/parallelcluster/scheduler_plugin/clusterstatusmgtd.conf" do
-  source 'clusterstatusmgtd/clusterstatusmgtd.conf.erb'
-  owner 'root'
-  group 'root'
-  mode '0644'
-end


### PR DESCRIPTION
Required because during install recipe not all dna json variables are present

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.