### PR TITLE
Revert DB initialization for the byos case

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/config_head_node.rb
@@ -24,17 +24,6 @@ template "/etc/parallelcluster/scheduler_plugin/clusterstatusmgtd.conf" do
   mode '0644'
 end
 
-unless virtualized?
-  execute 'initialize compute fleet status in DynamoDB' do
-    # Initialize the status of the compute fleet in the DynamoDB table. Set it to RUNNING.
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/aws dynamodb put-item --table-name #{node['cluster']['cluster_ddb_table']}"\
-            " --item '{\"Id\": {\"S\": \"COMPUTE_FLEET\"}, \"Data\": {\"M\": {\"status\": {\"S\": \"RUNNING\"}, \"lastStatusUpdatedTime\": {\"S\": \"#{Time.now.utc}\"}}}}'" \
-            " --region #{node['cluster']['region']}"
-    retries 3
-    retry_delay 5
-  end
-end
-
 execute_event_handler 'HeadConfigure' do
   event_command(lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :SchedulerDefinition, :Events, :HeadConfigure, :ExecuteCommand, :Command) })
 end


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Revert DB initialization for the byos case because DDB table is not yet defined

### Tests
N/A

### References

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.