### PR TITLE
Implement workaround for Slurm+OpenMPI when `add_node_hostnames_in_hosts_file`  is set to true

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -510,6 +510,7 @@ default['cluster']['raid_parameters'] = 'NONE'
 default['cluster']['raid_vol_ids'] = nil
 default['cluster']['dns_domain'] = nil
 default['cluster']['use_private_hostname'] = 'false'
+default['cluster']['add_node_hostnames_in_hosts_file'] = node['cluster']['use_private_hostname']
 default['cluster']['skip_install_recipes'] = 'yes'
 
 # AWS domain

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
@@ -522,6 +522,28 @@
         "HeadNode"
       ],
       "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/parallelcluster/slurm_prolog_epilog.log",
+      "log_stream_name": "slurm_prolog_epilog",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "centos",
+        "ubuntu",
+        "amazon"
+      ],
+      "node_roles": [
+        "ComputeFleet"
+      ],
+      "feature_conditions": [
+        {
+          "dna_key": "use_private_hostname",
+          "satisfying_values": ["true"]
+        }
+      ]
     }
   ]
 }

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/epilog
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/epilog
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Cookbook Name:: aws-parallelcluster
+#
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script removes content with the following format to /etc/hosts file
+# #HOSTS_JOB_<JOBID>
+# 192.168.1.2 queue-0-st-compute-resource-0-1 ip-192-168-1-2
+# 192.168.1.10 queue-0-st-compute-resource-0-2 ip-192-168-1-10
+# #END_JOB_<JOBID>
+#
+# SLURM_JOB_ID is a env var provide by Slurm
+
+LOG_FILE_PATH="/var/log/parallelcluster/slurm_prolog_epilog.log"
+
+_log() {
+    text=$1
+    level="${2:-INFO}" # If the second argument is not provided, "INFO" is the default log level
+    log_time=$(date "+%Y-%m-%d %H:%M:%S")
+    echo "${log_time} - ${level} - Job ${SLURM_JOB_ID} - ${text}" >> "${LOG_FILE_PATH}"
+}
+
+_log "Removing nodes from /etc/hosts"
+if ! sed_output=$(sed -i "/#HOSTS_JOB_${SLURM_JOB_ID}/,/#END_JOB_${SLURM_JOB_ID}/d" /etc/hosts 2>&1); then
+    _log "Failed to remove nodes: ${sed_output}" "ERROR"
+    exit 1
+fi
+_log "Finished removing nodes from /etc/hosts"
+exit 0

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/prolog
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/prolog
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Cookbook Name:: aws-parallelcluster
+#
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script writes content with the following format to /etc/hosts file
+# #HOSTS_JOB_<JOBID>
+# 192.168.1.2 queue-0-st-compute-resource-0-1 ip-192-168-1-2
+# 192.168.1.10 queue-0-st-compute-resource-0-2 ip-192-168-1-10
+# #END_JOB_<JOBID>
+# This content contains the DNS information for all nodes the job <JOBID> that is allocated to.
+# The nodes information of newer job is always inserted before nodes information of older job
+# to ensure the latest DNS information is used.
+#
+# SlURM_NODE_ALIASES and SLURM_JOB_ID are an env vars provided by Slurm,
+
+LOG_FILE_PATH="/var/log/parallelcluster/slurm_prolog_epilog.log"
+
+_log() {
+    text=$1
+    level="${2:-INFO}" # If the second argument is not provided, "INFO" is the default log level
+    log_time=$(date "+%Y-%m-%d %H:%M:%S")
+    echo "${log_time} - ${level} - Job ${SLURM_JOB_ID} - ${text}" >> "${LOG_FILE_PATH}"
+}
+
+_log "Adding nodes to /etc/hosts"
+# SLURM_NODE_ALIASES has value like "queue-0-dy-compute-resource-0-1:[192.168.1.2]:ip-192-168-1-2"
+# The following line transforms this line to "192.168.1.2 queue-0-dy-compute-resource ip-192-168-1-2"
+hosts=$(echo "${SLURM_NODE_ALIASES}" | awk 'BEGIN{RS=","; FS=":"}; {gsub(/\[|\]/,"",$2); print $2,$1,$3}')
+lines='#HOSTS_JOB_'"${SLURM_JOB_ID}\n${hosts}\n"'#END_JOB_'"${SLURM_JOB_ID}"
+if grep -q '^#HOSTS_JOB_.*' /etc/hosts
+then
+    # If there is other nodes information in the file, the newest nodes information is inserted before the older ones.
+    if ! sed_output=$(sed -i '0,/^#HOSTS_JOB_.*/s//'"${lines}\n&/" /etc/hosts 2>&1); then
+        # If the sed command errored, log the stdout and stderr. Note that when executing the command, the stderr is redirected to stdout
+        _log "Failed to add nodes: ${sed_output}" "ERROR"
+        exit 1
+    fi
+else
+    # If there is no other nodes information in the file, the nodes information is appended to the file.
+    echo -e "${lines}" >> /etc/hosts
+fi
+_log "Finished adding nodes to /etc/hosts"
+exit 0

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -173,6 +173,22 @@ cookbook_file '/etc/systemd/system/slurmctld.service' do
   action :create
 end
 
+if node['cluster']['add_node_hostnames_in_hosts_file'] == "true"
+  cookbook_file '/opt/slurm/etc/pcluster/prolog' do
+    source 'head_node_slurm/prolog'
+    owner node['cluster']['slurm']['user']
+    group node['cluster']['slurm']['group']
+    mode '0744'
+  end
+
+  cookbook_file '/opt/slurm/etc/pcluster/epilog' do
+    source 'head_node_slurm/epilog'
+    owner node['cluster']['slurm']['user']
+    group node['cluster']['slurm']['group']
+    mode '0744'
+  end
+end
+
 service "slurmctld" do
   supports restart: false
   action %i(enable start)

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -37,6 +37,19 @@ ResumeTimeout=1800
 PrivateData=cloud
 ResumeRate=0
 SuspendRate=0
+<% if node["cluster"]["add_node_hostnames_in_hosts_file"] == 'true' -%>
+#
+# PROLOG AND EPILOG
+# prolog is executed to add nodes info to /etc/hosts on compute nodes when each job is allocated
+# epilog is executed to clean contents written by prolog
+# PrologFlags specifies the prolog is executed at job allocation and prologs and epilogs are of different jobs are executed serially
+# SchedulerParameters allows jobs to be requeued to other nodes if prolog error exits.
+# Note the error exit of prolog drains a node, because the error of prolog is considered as a node error.
+Epilog=/opt/slurm/etc/pcluster/epilog
+Prolog=/opt/slurm/etc/pcluster/prolog
+PrologFlags=alloc,serial
+SchedulerParameters=nohold_on_prolog_fail
+<% end -%>
 #
 # TIMERS
 SlurmctldTimeout=300


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
See commit descriptions for details

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
`test_cluster_in_no_internet_subnet` is the integration tests for this feature.
I also manually submitted 150 OSU benchmark jobs that require 76 nodes in total. The jobs succeeded


### References
* Link to related PRs in other packages (i.e. cookbook, node).
This PR only works with https://github.com/aws/aws-parallelcluster/pull/3644

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.