### PR TITLE
3.1: Configure LDAP access filter in SSSD

### DIFF
--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
@@ -20,6 +20,10 @@ ldap_referrals = False
 <%= "#{param} = #{value}" %>
   <% end %>
 <% end %>
+<% if node['cluster']['directory_service']['ldap_access_filter'] %>
+access_provider = ldap
+ldap_access_filter = <%= node['cluster']['directory_service']['ldap_access_filter'] %>
+<% end %>
 
 [domain/local]
 id_provider = local


### PR DESCRIPTION
### Description of changes
* Include the following properties in SSSD configuration when ldap_access_filter is specified:
```
access_provider = ldap
ldap_access_filter = [VALUE OF PC PROPERTY LdapAccessFilter]
```

### Tests
Manually tested user discoverability and SSH access in the following scenarios:
1. `LdapAccessFilter` unspecified --> all directory users can access to the cluster;
2. `LdapAccessFilter memberOf=CN=TeamOne,OU=Users,OU=CORP,DC=corp,DC=mgiacomo,DC=com` --> only users belonging to group TeamOne can access to the cluster;
3. `LdapAccessFilter (|(memberOf=CN=TeamTwo,OU=Users,OU=CORP,DC=corp,DC=mgiacomo,DC=com)(memberOf=CN=TeamThree,OU=Users,OU=CORP,DC=corp,DC=mgiacomo,DC=com)`) --> only users belonging to group TeamTwo or TeamThree can access to the cluster;

### References
1.  https://linux.die.net/man/5/sssd-ldap
2. https://linux.die.net/man/5/sssd.conf

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.