### PR TITLE
3.x: Upgrade to Intel MPI Library 2021.4.0.441

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade NVIDIA driver to version 470.82.01.
 - Upgrade CUDA library to version 11.4.3.
 - Upgrade NVIDIA Fabric manager to version 470.82.01.
+- Upgrade Intel MPI Library to 2021.4.0.441.
 
 3.0.3
 ------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -75,9 +75,11 @@ default['cluster']['intelpython2']['version'] = '2019.4-088'
 default['cluster']['intelpython3']['version'] = '2020.2-902'
 
 # Intel MPI
-default['cluster']['intelmpi']['version'] = '2019.8.254'
-default['cluster']['intelmpi']['modulefile'] = "/opt/intel/impi/#{node['cluster']['intelmpi']['version']}/intel64/modulefiles/mpi"
-default['cluster']['intelmpi']['kitchen_test_string'] = 'Version 2019 Update 8'
+default['cluster']['intelmpi']['version'] = '2021.4.0'
+default['cluster']['intelmpi']['full_version'] = "#{node['cluster']['intelmpi']['version']}.441"
+default['cluster']['intelmpi']['modulefile'] = "/opt/intel/mpi/#{node['cluster']['intelmpi']['version']}/modulefiles/mpi"
+default['cluster']['intelmpi']['kitchen_test_string'] = 'Version 2021 Update 4'
+default['cluster']['intelmpi']['qt_version'] = '5.15.2'
 
 # Arm Performance Library
 default['cluster']['armpl']['major_minor_version'] = '21.0'

--- a/cookbooks/aws-parallelcluster-install/recipes/intel_mpi.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/intel_mpi.rb
@@ -4,7 +4,7 @@
 # Cookbook:: aws-parallelcluster
 # Recipe:: intel_mpi
 #
-# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -17,10 +17,11 @@
 
 return unless node['conditions']['intel_mpi_supported']
 
-intelmpi_modulefile = "/opt/intel/impi/#{node['cluster']['intelmpi']['version']}/intel64/modulefiles/intelmpi"
-intelmpi_installer_archive = "l_mpi_#{node['cluster']['intelmpi']['version']}.tgz"
-intelmpi_installer_path = "#{node['cluster']['sources_dir']}/#{intelmpi_installer_archive}"
-intelmpi_installer_url = "https://#{node['cluster']['region']}-aws-parallelcluster.s3.#{node['cluster']['region']}.#{aws_domain}/archives/impi/#{intelmpi_installer_archive}"
+intelmpi_installation_path = "/opt/intel/mpi/#{node['cluster']['intelmpi']['version']}"
+intelmpi_modulefile = "#{intelmpi_installation_path}/modulefiles/intelmpi"
+intelmpi_installer = "l_mpi_oneapi_p_#{node['cluster']['intelmpi']['full_version']}_offline.sh"
+intelmpi_installer_path = "#{node['cluster']['sources_dir']}/#{intelmpi_installer}"
+intelmpi_installer_url = "https://#{node['cluster']['region']}-aws-parallelcluster.s3.#{node['cluster']['region']}.#{aws_domain}/archives/impi/#{intelmpi_installer}"
 
 # fetch intelmpi installer script
 remote_file intelmpi_installer_path do
@@ -28,29 +29,34 @@ remote_file intelmpi_installer_path do
   mode '0744'
   retries 3
   retry_delay 5
-  not_if { ::File.exist?("/opt/intel/impi/#{node['cluster']['intelmpi']['version']}") }
+  not_if { ::File.exist?(intelmpi_installation_path.to_s) }
 end
 
 bash "install intel mpi" do
   cwd node['cluster']['sources_dir']
   code <<-INTELMPI
     set -e
-    tar -xf #{intelmpi_installer_archive}
-    cd l_mpi_#{node['cluster']['intelmpi']['version']}/
-    ./install.sh -s silent.cfg --accept_eula
-    mv rpm/EULA.txt /opt/intel/impi/#{node['cluster']['intelmpi']['version']}
-    cd ..
-    rm -rf l_mpi_#{node['cluster']['intelmpi']['version']}*
+    chmod +x #{intelmpi_installer}
+    ./#{intelmpi_installer} --remove-extracted-files yes -a --silent --eula accept --install-dir /opt/intel
+    rm -f #{intelmpi_installer}
   INTELMPI
-  creates "/opt/intel/impi/#{node['cluster']['intelmpi']['version']}"
+  creates intelmpi_installation_path.to_s
 end
 
 append_if_no_line "append intel modules file dir to modules conf" do
   path node['cluster']['modulepath_config_file']
-  line "/opt/intel/impi/#{node['cluster']['intelmpi']['version']}/intel64/modulefiles/"
+  line "#{intelmpi_installation_path}/modulefiles/"
 end
 
 execute "rename intel mpi modules file name" do
   command "mv #{node['cluster']['intelmpi']['modulefile']} #{intelmpi_modulefile}"
   creates intelmpi_modulefile.to_s
+end
+
+# Add Qt source file
+template "#{intelmpi_installation_path}/qt_source_code.txt" do
+  source 'intel_mpi/qt_source_code.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
 end

--- a/cookbooks/aws-parallelcluster-install/templates/default/intel_mpi/qt_source_code.erb
+++ b/cookbooks/aws-parallelcluster-install/templates/default/intel_mpi/qt_source_code.erb
@@ -1,0 +1,3 @@
+You can get Qt source code here:
+
+https://<%= node['cluster']['region'] %>-aws-parallelcluster.s3.<%= node['cluster']['region'] %>.<%= node['cluster']['aws_domain'] %>/archives/impi/qt-src-<%= node['cluster']['intelmpi']['qt_version'] %>-linux.src.tgz


### PR DESCRIPTION
### Description of changes
Intel MPI is now part of the OneAPI package. The standalone offline installer is available [here](https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#mpi).

Relevant changes:
- The installation path doesn't contain the patch version `.441`
- The EULA file is available in the `/opt/intel/licensing` path
- The base modules folder has been renamed from `impi` to `mpi`
- Installer options have been changed
- Extracted folder can be automatically deleted through the `--remove-extracted-files` flag
- Added Qt source code file to comply with https://www.qt.io/licensing/open-source-lgpl-obligations

### Tests
Integ tests:
* test_efa[sa-east-1-c5n.18xlarge-alinux2-slurm]
* test_efa[us-west-2-c6gn.16xlarge-ubuntu1804-slurm]
* test_efa[us-west-2-c6gn.16xlarge-ubuntu2004-slurm] 
* test_efa[us-west-2-c6gn.16xlarge-alinux2-slurm]
* test_efa[sa-east-1-c5n.18xlarge-alinux2-slurm] 
* test_efa[us-west-2-c6gn.16xlarge-ubuntu1804-slurm]
* test_efa[us-west-2-c6gn.16xlarge-ubuntu2004-slurm] 
* test_efa[us-west-2-c6gn.16xlarge-alinux2-slurm]

Manual tests on Alinux2. Manual execution of the `intel_mpi.rb` recipe then verified modules:
```
$ module avail
...
----------------- /opt/intel/mpi/2021.4.0/modulefiles/ -----------------
intelmpi

$ module load intelmpi
Loading mpi version 2021.4.0
$ mpicc --version
gcc (GCC) 7.3.1 20180712 (Red Hat 7.3.1-13)
Copyright (C) 2017 Free Software Foundation, Inc.
```

### References
* IntelMPI licensing (OneApi section): https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html
* Intel MPI download: https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#mpi
* Modules documentation: https://modules.readthedocs.io/en/latest/module.html

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
