### PR TITLE
Disable log4j-cve-2021-44228-hotpatch service on Amazon Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade NVIDIA driver to version 470.82.01.
 - Upgrade CUDA library to version 11.4.3.
 - Upgrade NVIDIA Fabric manager to version 470.82.01.
+- Disable log4j-cve-2021-44228-hotpatch service on Amazon Linux to avoid incurring in potential performance degradation.
 
 
 3.0.2

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -18,6 +18,7 @@
 include_recipe "aws-parallelcluster::setup_envars"
 include_recipe "aws-parallelcluster-install::sudoers"
 include_recipe "aws-parallelcluster-install::cluster_admin_user"
+include_recipe "aws-parallelcluster-install::disable_log4j_patcher"
 
 case node['platform_family']
 when 'rhel', 'amazon'

--- a/cookbooks/aws-parallelcluster-install/recipes/disable_log4j_patcher.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/disable_log4j_patcher.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster
+# Recipe:: disable_log4j_patcher
+#
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# default openmpi installation conflicts with new install
+# new one is installed in /opt/amazon/efa/bin/
+
+if platform_family?('amazon')
+  # masking the service in order to prevent it from being automatically enabled
+  # if not installed yet
+  service 'log4j-cve-2021-44228-hotpatch' do
+    action %i(disable stop mask)
+  end
+end


### PR DESCRIPTION
### Description of changes
Disabling log4j-cve-2021-44228-hotpatch service on Amazon Linux by default to avoid incurring in potential performance degradation.

Service is masked so that even if installed at a later stage it won't be able to start automatically.

Run the following to re-enable the service:
```
sudo systemctl unmask log4j-cve-2021-44228-hotpatch
sudo systemctl enable log4j-cve-2021-44228-hotpatch
sudo systemctl start log4j-cve-2021-44228-hotpatch
```

### Tests
* Tested manually by executing the new recipe in the following cases:
  * log4j-cve-2021-44228-hotpatch installed and running
  * log4j-cve-2021-44228-hotpatch installed after running the recipe
* Added build time tests as part of https://github.com/aws/aws-parallelcluster/pull/3657 

### References
* log4j-cve-2021-44228-hotpatch service announcement: https://alas.aws.amazon.com/announcements/2021-001.html

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.