### PR TITLE
3.1: Fix configuration of LDAP access filter in SSSD

### DIFF
--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
@@ -20,7 +20,7 @@ ldap_referrals = False
 <%= "#{param} = #{value}" %>
   <% end %>
 <% end %>
-<% if node['cluster']['directory_service']['ldap_access_filter'] %>
+<% if node['cluster']['directory_service']['ldap_access_filter'] != 'NONE' %>
 access_provider = ldap
 ldap_access_filter = <%= node['cluster']['directory_service']['ldap_access_filter'] %>
 <% end %>


### PR DESCRIPTION
### Description of changes
Fix a regression causing wrong setting of `ldap_access_filter` in `/etc/sssd/sssd.conf` when `LdapAccessFilter` is omitted in cluster config. The regression has been introduced by https://github.com/aws/aws-parallelcluster-cookbook/pull/1312.

### Tests
1. Created a cluster with `LdapAccessFilter` missing
2. Created a cluster with `LdapAccessFilter` specified
3. Updated from 1 to 2 and back

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.