### PR TITLE
3.0: Disable log4j-cve-2021-44228-hotpatch service on Amazon Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.0.3
+------
+
+**CHANGES**
+- Disable log4j-cve-2021-44228-hotpatch service on Amazon Linux to avoid incurring in potential performance degradation.
+
 3.0.2
 ------
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,9 +101,9 @@ default['cluster']['armpl']['url'] = [
 ].join('/')
 
 # Python packages
-default['cluster']['parallelcluster-version'] = '3.0.2'
-default['cluster']['parallelcluster-cookbook-version'] = '3.0.2'
-default['cluster']['parallelcluster-node-version'] = '3.0.2'
+default['cluster']['parallelcluster-version'] = '3.0.3'
+default['cluster']['parallelcluster-cookbook-version'] = '3.0.3'
+default['cluster']['parallelcluster-node-version'] = '3.0.3'
 default['cluster']['parallelcluster-awsbatch-cli-version'] = '1.0.0'
 
 # URLs to software packages used during install recipes

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ long_description 'Installs/Configures AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
 chef_version '17.2.29'
-version '3.0.2'
+version '3.0.3'
 
 supports 'amazon', '>= 2'
 supports 'centos', '>= 7'

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -17,6 +17,7 @@
 
 include_recipe "aws-parallelcluster::setup_envars"
 include_recipe "aws-parallelcluster::sudoers_install"
+include_recipe "aws-parallelcluster::disable_log4j_patcher"
 
 return if node['conditions']['ami_bootstrapped']
 

--- a/recipes/disable_log4j_patcher.rb
+++ b/recipes/disable_log4j_patcher.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: disable_log4j_patcher
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+if platform_family?('amazon')
+  # masking the service in order to prevent it from being automatically enabled
+  # if not installed yet
+  service 'log4j-cve-2021-44228-hotpatch' do
+    action %i[disable stop mask]
+  end
+end


### PR DESCRIPTION
Backport of https://github.com/aws/aws-parallelcluster-cookbook/pull/1314

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.