### PR TITLE
3.1: Fix the way extra.json is merged into the final dna.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade NVIDIA Fabric manager to version 470.82.01.
 - Upgrade Intel MPI Library to 2021.4.0.441.
 
+**BUG FIXES**
+- Fix the way ExtraChefAttributes are merged into the final configuration.
+
 3.0.3
 ------
 

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/files/default/event_handler/invoke-scheduler-plugin-event-handler.sh
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/files/default/event_handler/invoke-scheduler-plugin-event-handler.sh
@@ -197,7 +197,7 @@ build_dna_json() {
 }
 EOF
 
-  jq --argfile f1 "${source_dna_json}" --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cluster = $f1.cluster + $f2.cluster' > /tmp/dna.json
+  jq --argfile f1 "${source_dna_json}" --argfile f2 /tmp/extra.json -n '$f1 * $f2' > /tmp/dna.json
   log "Generated dna.json:"
   log "$(cat /tmp/dna.json)"
 }

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -265,7 +265,7 @@ unless node['cluster']['os'].end_with?("-custom")
       export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin"
       echo '{"cluster": {"region": "eu-west-3"}, "run_list": "recipe[aws-parallelcluster::slurm_config]"}' > /tmp/dna.json
       echo '{ "cluster" : { "dcv_enabled" : "head_node" } }' > /tmp/extra.json
-      jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cluster = $f1.cluster + $f2.cluster'
+      jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 * $f2'
     JQMERGE
   end
 end


### PR DESCRIPTION
### Description of changes
Fix the way ExtraChefAttributes are merged into the final /etc/chef/dna.json. In particular, I've replaced the logic based on the simple merge operator (+) with the logic based on the recursive merging operator (*). The simple merge operator was not the correct solution because it overrides the nested elements in the final json rather than merging them. With this fix we can now merge nested elements using ExtraChefAttributes.

This change has been already verified and approved in other part of our code base, see https://github.com/aws/aws-parallelcluster/pull/3664

### Tests
Verified that the `/etc/chef/dna.json` contains the expected json both in head node and compute node in the following cases:
1. No extra json specified
2. Extra json specified, e.g. `ExtraChefAttributes: '{ "cluster" : { "directory_service" : { "something": "true" } } }'`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.