### PR TITLE
3.1.0: Add cluster parameter disabled_on_compute_nodes and disable integration with Ad on compute nodes if it is set to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade CUDA library to version 11.4.3.
 - Upgrade NVIDIA Fabric manager to version 470.82.01.
 - Upgrade Intel MPI Library to 2021.4.0.441.
+- Add cluster parameter `directory_service.disabled_on_compute_nodes` to disable AD integration on compute nodes.
 
 **BUG FIXES**
 - Fix the way ExtraChefAttributes are merged into the final configuration.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -490,6 +490,7 @@ default['cluster']["directory_service"]["ldap_tls_req_cert"] = nil
 default['cluster']["directory_service"]["ldap_access_filter"] = nil
 default['cluster']["directory_service"]["generate_ssh_keys_for_users"] = nil
 default['cluster']['directory_service']['additional_sssd_configs'] = nil
+default['cluster']['directory_service']['disabled_on_compute_nodes'] = nil
 
 # Other ParallelCluster internal variables
 default['cluster']['ddb_table'] = nil

--- a/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
@@ -18,6 +18,7 @@
 require 'uri'
 
 return if node['cluster']["directory_service"]["enabled"] == 'false'
+return if node['cluster']['node_type'] == 'ComputeFleet' && node['cluster']['directory_service']['disabled_on_compute_nodes'] == 'true'
 
 sssd_conf_path = "/etc/sssd/sssd.conf"
 shared_directory_service_dir = "#{node['cluster']['shared_dir']}/directory_service"
@@ -56,10 +57,12 @@ if node['cluster']['node_type'] == 'HeadNode'
     recursive true
   end
 
-  execute 'Copy sssd.conf from head node to the shared folder' do
-    user 'root'
-    command "cp #{sssd_conf_path} #{shared_sssd_conf_path}"
-    sensitive true
+  unless node['cluster']['directory_service']['disabled_on_compute_nodes'] == 'true'
+    execute 'Copy sssd.conf from head node to the shared folder' do
+      user 'root'
+      command "cp #{sssd_conf_path} #{shared_sssd_conf_path}"
+      sensitive true
+    end
   end
 
   bash 'Enable SSH password authentication on head node' do


### PR DESCRIPTION
### Description of changes
1. Allow the customer to disable the AD integration, i.e. SSSD configuration, on compute nodes via `DevSettings.Cookbook.ExtraChefAttributes`. In particular, the configuration below would disable the AD integration. Verified in tests that such disablement would make impossible to any user defined in AD to login to the compute nodes, but without compromising their ability to submit jobs.

```
DevSettings:
  Cookbook:
    ExtraChefAttributes: '{ "cluster" : { "directory_service" : { "disabled_on_compute_nodes": "true" } } }'
```

### Tests
Given the following clusters:

1. Cluster without ExtraChefAttributes
2. Cluster with the following ExtraChefAttributes:
`ExtraChefAttributes: '{ "cluster" : { "directory_service" : { "disabled_on_compute_nodes": "true" } } }'`

The following checks have been executed:

1. [OK] Cluster 1:
    1. [OK] Content of /etc/chef/dna.json is correct
    2. [OK] Content of /etc/sssd/sssd.conf is correct in the head node
    3. [OK] Content of /etc/sssd/sssd.conf is correct in the compute node
    4. [OK] SSH as ec2-user into the head node
    5. [OK] SSH as ec2-user from the head node into the compute node
    6. [OK] SSH with password as AD user into the head node
    7. [OK] SSH without password as AD user from the head node into the compute node
    8. [OK] Home and SSH key for AD user are kept in sync from the head node to the compute node
    9. [OK] SSH with SSH key as AD user into the head node
    10. [OK] Job submission as ec2-user: job succeeded and writes files with correct permissions
    11. [OK] Job submission as AD user: job succeeded and writes files with correct permissions
2. [OK] Cluster 2 (the one with disabled_on_compute_nodes set to true):
    1. [OK] Content of /etc/chef/dna.json is correct
    2. [OK] Content of /etc/sssd/sssd.conf is correct in the head node
    3. [OK] /etc/sssd/sssd.conf is not present in the compute node
    4. [OK] SSH as ec2-user into the head node
    5. [OK] SSH as ec2-user from the head node into the compute node
    6. [OK] SSH with password as AD user into the head node
    7. [OK] SSH without password as AD user from the head node into the compute node, denied as expected
    8. [OK] Home and SSH key for AD user are kept in sync from the head node to the compute node
    9. [OK] SSH with SSH key as AD user into the head node
    10. [OK] Job submission as ec2-user: job succeeded and writes files with correct permissions
    11. [OK] Job submission as AD user: job succeeded and writes files with correct permissions, but within the job the user name cannot be resolved (see details below)


### Further Notes
**What happens when job is executed as AD user an Ad disabled on compute nodes?**

In this case the job is executed as the AD user on compute nodes, but the user name is not resolved, whereas the user id does.

Example:

When running `whoami` from within the job:

```
whoami: cannot find name for user ID 1849401640
```

But when running `id` from within the job:
```
id: uid=1849401640 gid=1849400513 groups=1849400513,1849401637
```

that is the expected user id as it matches the one in the head node (where the Ad integration is enabled):

```
[UserTeamOne@ip-10-0-0-78 ~]$ id
uid=1849401640(UserTeamOne) gid=1849400513(Domain Users) groups=1849400513(Domain Users),1849401637(TeamOne)
```

and that's why the file permissions are correctly set (here `sample-file.txt` is a file written from within the job):

```
[UserTeamOne@ip-10-0-0-78 ~]$ ls -l | grep sample-file
-rw-r--r-- 1 UserTeamOne Domain Users   0 Jan 17 14:50 sample-file.txt
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.