### PR TITLE
2.x: Fix string used to verify Intel MPI installation on kitchen tests

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,7 +66,7 @@ default['cfncluster']['intelpython3']['version'] = '2020.2-902'
 default['cfncluster']['intelmpi']['version'] = '2021.4.0'
 default['cfncluster']['intelmpi']['full_version'] = "#{node['cfncluster']['intelmpi']['version']}.441"
 default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/mpi/#{node['cfncluster']['intelmpi']['version']}/modulefiles/mpi"
-default['cfncluster']['intelmpi']['kitchen_test_string'] = 'Version 2021 Update 4'
+default['cfncluster']['intelmpi']['kitchen_test_string'] = 'Version 2021.4'
 default['cfncluster']['intelmpi']['qt_version'] = '5.15.2'
 
 # Arm Performance Library


### PR DESCRIPTION
### Description of changes
* The format of the string has been modified in Intel MPI 2021.

### Tests
```
$ module load intelmpi && mpirun --help | grep 'Version 2021.4'
Loading intelmpi version 2021.4.0
Intel(R) MPI Library, Version 2021.4  Build 20210831 (id: 758087adf)
$ echo $?
0
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
