### PR TITLE
[byos] Fix invoke handler script syntax for HeadComputeFleetUpdate

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/files/default/event_handler/invoke-scheduler-plugin-event-handler.sh
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/files/default/event_handler/invoke-scheduler-plugin-event-handler.sh
@@ -20,18 +20,33 @@ DUMMY_COMPUTEFLEET_STATUS="${DUMMY_DIR}/${COMPUTEFLEET_STATUS_FILE}"
 
 syntax() {
   echo
-  echo "Syntax: $0 [--help] [--debug] [--launch-templates-config <launch templates config> --instance-types-data <instance types data> --scheduler-plugin-stack-outputs <scheduler plugin substack outputs>] --cluster-configuration <cluster configuration> --event-name <event name>"
-  echo "options:"
-  echo "--help                                Print this help."
-  echo "--debug                               Exec in debug mode (with set -x)."
-  echo "--event-name                          The name of the event to trigger, possible values are:"
-  echo "                                          HeadInit, HeadConfigure, HeadFinalize, ComputeInit, ComputeConfigure, ComputeFinalize, HeadClusterUpdate or HeadComputeFleetUpdate."
-  echo "--cluster-configuration               Required local path to cluster configuration file, in YAML format."
-  echo "--previous-cluster-configuration      Required for the HeadClusterUpdate event. Local path to previous cluster configuration file, in YAML format."
-  echo "--computefleet-status                 Required for the HeadComputeFleetUpdate. Can be one between STOP_REQUESTED or START_REQUESTED"
-  echo "--launch-templates-config             Local path to launch templates config file, in JSON format. When not set, if instance is not created by cluster creation, dummy launch templates config is created, otherwise the one retrieved from cluster will be used"
-  echo "--instance-types-data                 Local path to instance types data file, in JSON format. When not set, if instance is not created by cluster creation, dummy instance types data is created, otherwise the one retrieved from cluster will be used"
-  echo "--scheduler-plugin-substack-outputs   Local path to scheduler plugin substack outputs file, in JSON format. When not set, if instance is not created by cluster creation, dummy scheduler plugin substack outputs is created, otherwise the one retrieved from cluster will be used"
+  echo "Syntax: $0 [--help] [--debug] [--launch-templates-config <launch templates config>]
+    [--instance-types-data <instance types data>] [--scheduler-plugin-stack-outputs <scheduler plugin substack outputs>]
+    [--previous-cluster-configuration <previous cluster configuration>] [--computefleet-status <compute fleet status>]
+    --cluster-configuration <cluster configuration> --event-name <event name>"
+  echo
+  echo "Options:"
+  echo " --help                                Print this help."
+  echo " --debug                               Exec in debug mode (with set -x)."
+  echo " --event-name                          The name of the event to trigger, possible values are:
+                                               HeadInit, HeadConfigure, HeadFinalize, ComputeInit, ComputeConfigure,
+                                               ComputeFinalize, HeadClusterUpdate or HeadComputeFleetUpdate."
+  echo " --cluster-configuration               Required local path to cluster configuration file, in YAML format."
+  echo " --previous-cluster-configuration      Required for the HeadClusterUpdate event. Local path to previous cluster
+                                               configuration file, in YAML format."
+  echo " --computefleet-status                 Required for the HeadComputeFleetUpdate. Can be one between
+                                               STOP_REQUESTED or START_REQUESTED"
+  echo " --launch-templates-config             Local path to launch templates config file, in JSON format.
+                                               When not set, if instance is not created by cluster creation,
+                                               dummy launch templates config is created, otherwise the one retrieved
+                                               from cluster will be used"
+  echo " --instance-types-data                 Local path to instance types data file, in JSON format. When not set,
+                                               if instance is not created by cluster creation, dummy instance types
+                                               data is created, otherwise the one retrieved from cluster will be used"
+  echo " --scheduler-plugin-substack-outputs   Local path to scheduler plugin substack outputs file, in JSON format.
+                                               When not set, if instance is not created by cluster creation,
+                                               dummy scheduler plugin substack outputs is created, otherwise the one
+                                               retrieved from cluster will be used"
   echo
 }
 
@@ -147,7 +162,7 @@ if [[ "${event_name}" == "HeadComputeFleetUpdate" ]] && [[ -z ${computefleet_sta
   fail "Option --computefleet-status is required when event name is (${event_name})"
 fi
 
-if [[ ! "${computefleet_status}" =~ ^(STOP_REQUESTED|START_REQUESTED)$ ]]; then
+if [[ "${event_name}" == "HeadComputeFleetUpdate" ]] && [[ ! "${computefleet_status}" =~ ^(STOP_REQUESTED|START_REQUESTED)$ ]]; then
   fail "Requested status ${computefleet_status} not supported. Supported status are STOP_REQUESTED or START_REQUESTED"
 fi
 


### PR DESCRIPTION
Also reformatting help

```
# invoke-scheduler-plugin-event-handler.sh --help
Utility to call ParallelCluster scheduler plugin event handler for development/debugging purposes

Syntax: /usr/local/sbin/invoke-scheduler-plugin-event-handler.sh [--help] [--debug] [--launch-templates-config <launch templates config>]
    [--instance-types-data <instance types data>] [--scheduler-plugin-stack-outputs <scheduler plugin substack outputs>]
    [--previous-cluster-configuration <previous cluster configuration>] [--computefleet-status <compute fleet status>]
    --cluster-configuration <cluster configuration> --event-name <event name>

Options:
 --help                                Print this help.
 --debug                               Exec in debug mode (with set -x).
 --event-name                          The name of the event to trigger, possible values are:
                                               HeadInit, HeadConfigure, HeadFinalize, ComputeInit, ComputeConfigure,
                                               ComputeFinalize, HeadClusterUpdate or HeadComputeFleetUpdate.
 --cluster-configuration               Required local path to cluster configuration file, in YAML format.
 --previous-cluster-configuration      Required for the HeadClusterUpdate event. Local path to previous cluster
                                               configuration file, in YAML format.
 --computefleet-status                 Required for the HeadComputeFleetUpdate. Can be one between
                                               STOP_REQUESTED or START_REQUESTED
 --launch-templates-config             Local path to launch templates config file, in JSON format.
                                               When not set, if instance is not created by cluster creation,
                                               dummy launch templates config is created, otherwise the one retrieved
                                               from cluster will be used
 --instance-types-data                 Local path to instance types data file, in JSON format. When not set,
                                               if instance is not created by cluster creation, dummy instance types
                                               data is created, otherwise the one retrieved from cluster will be used
 --scheduler-plugin-substack-outputs   Local path to scheduler plugin substack outputs file, in JSON format.
                                               When not set, if instance is not created by cluster creation,
                                               dummy scheduler plugin substack outputs is created, otherwise the one
                                               retrieved from cluster will be used

```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.