### PR TITLE
[byos] Install scheduler plugin python virtual into a shared path

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -140,10 +140,10 @@ default['cluster']['scheduler_plugin']['local_dir'] = "#{node['cluster']['base_d
 default['cluster']['scheduler_plugin']['handler_dir'] = "#{node['cluster']['scheduler_plugin']['local_dir']}/.configs"
 default['cluster']['scheduler_plugin']['scheduler_plugin_substack_outputs_path'] = "#{node['cluster']['shared_dir']}/scheduler-plugin-substack-outputs.json"
 default['cluster']['scheduler_plugin']['python_version'] = '3.9.9'
+default['cluster']['scheduler_plugin']['pyenv_root'] = "#{node['cluster']['scheduler_plugin']['shared_dir']}/pyenv"
 default['cluster']['scheduler_plugin']['virtualenv'] = 'scheduler_plugin_virtualenv'
 default['cluster']['scheduler_plugin']['virtualenv_path'] = [
-  node['cluster']['scheduler_plugin']['home'],
-  '.pyenv',
+  node['cluster']['scheduler_plugin']['pyenv_root'],
   'versions',
   node['cluster']['scheduler_plugin']['python_version'],
   'envs',

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install.rb
@@ -17,8 +17,6 @@
 
 # setup the user accounts
 include_recipe "aws-parallelcluster-scheduler-plugin::install_user"
-# setup Pyenv and Virtualenv
-include_recipe "aws-parallelcluster-scheduler-plugin::install_python"
 
 directory node['cluster']['scheduler_plugin']['local_dir'] do
   owner node['cluster']['scheduler_plugin']['user']
@@ -40,6 +38,9 @@ directory node['cluster']['scheduler_plugin']['shared_dir'] do
   mode '0755'
   action :create
 end
+
+# setup Pyenv and Virtualenv under node['cluster']['scheduler_plugin']['shared_dir']
+include_recipe "aws-parallelcluster-scheduler-plugin::install_python"
 
 cookbook_file '/usr/local/sbin/invoke-scheduler-plugin-event-handler.sh' do
   source 'event_handler/invoke-scheduler-plugin-event-handler.sh'

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install_python.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install_python.rb
@@ -17,13 +17,11 @@
 #
 
 install_pyenv node['cluster']['scheduler_plugin']['python_version'] do
-  user_only true
-  user node['cluster']['scheduler_plugin']['user']
+  prefix node['cluster']['scheduler_plugin']['pyenv_root']
 end
 
 activate_virtual_env node['cluster']['scheduler_plugin']['virtualenv'] do
   pyenv_path node['cluster']['scheduler_plugin']['virtualenv_path']
-  user node['cluster']['scheduler_plugin']['user']
   python_version node['cluster']['scheduler_plugin']['python_version']
   not_if { ::File.exist?("#{node['cluster']['scheduler_plugin']['virtualenv_path']}/bin/activate") }
 end


### PR DESCRIPTION
This to allow other users (different from scheduler-plugin) to be able to access the virtualenv and activate it

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.