### PR TITLE
[byos] Change permission for the scheduler-plugin python virtual env

### DIFF
--- a/cookbooks/aws-parallelcluster-install/resources/install_pyenv.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/install_pyenv.rb
@@ -20,6 +20,7 @@ action :run do
 
     pyenv_user_install new_resource.python_version do
       user new_resource.user
+      user_prefix new_resource.prefix if new_resource.prefix
     end
   else
     raise "prefix property is required for resource install_pyenv when user_only is set to false" unless new_resource.prefix

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install_python.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install_python.rb
@@ -17,11 +17,14 @@
 #
 
 install_pyenv node['cluster']['scheduler_plugin']['python_version'] do
+  user_only true
+  user node['cluster']['scheduler_plugin']['user']
   prefix node['cluster']['scheduler_plugin']['pyenv_root']
 end
 
 activate_virtual_env node['cluster']['scheduler_plugin']['virtualenv'] do
   pyenv_path node['cluster']['scheduler_plugin']['virtualenv_path']
+  user node['cluster']['scheduler_plugin']['user']
   python_version node['cluster']['scheduler_plugin']['python_version']
   not_if { ::File.exist?("#{node['cluster']['scheduler_plugin']['virtualenv_path']}/bin/activate") }
 end


### PR DESCRIPTION
This to allow scheduler-plugin user to be able to install python packages into the virtual env, without requiring sudo permission

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.