### PR TITLE
Install DCV web viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+2.11.5
+-----
+
+**BUG FIXES**
+- Fix DCV connection through browsers.
+
 2.11.4
 -----
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -195,6 +195,14 @@ default['cfncluster']['dcv']['server'] = value_for_platform( # NICE DCV server p
     'default' => "nice-dcv-server_#{node['cfncluster']['dcv']['server']['version']}_#{node['cfncluster']['dcv']['package_architecture_id']}.#{node['cfncluster']['cfn_base_os']}.deb"
   }
 )
+default['cfncluster']['dcv']['web_viewer']['version'] = '2021.2.11190-1'
+default['cfncluster']['dcv']['web_viewer'] = value_for_platform( # NICE DCV server package
+  'centos' => { '~>7' => "nice-dcv-web-viewer-#{node['cfncluster']['dcv']['web_viewer']['version']}.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },
+  'amazon' => { '2' => "nice-dcv-web-viewer-#{node['cfncluster']['dcv']['web_viewer']['version']}.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },
+  'ubuntu' => {
+    'default' => "nice-dcv-web-viewer_#{node['cfncluster']['dcv']['web_viewer']['version']}_#{node['cfncluster']['dcv']['package_architecture_id']}.#{node['cfncluster']['cfn_base_os']}.deb"
+  }
+)
 default['cfncluster']['dcv']['xdcv']['version'] = '2021.2.411-1'
 default['cfncluster']['dcv']['xdcv'] = value_for_platform( # required to create virtual sessions
   'centos' => { '~>7' => "nice-xdcv-#{node['cfncluster']['dcv']['xdcv']['version']}.el7.#{node['cfncluster']['dcv']['url_architecture_id']}.rpm" },

--- a/recipes/dcv_install.rb
+++ b/recipes/dcv_install.rb
@@ -181,8 +181,8 @@ if node['conditions']['dcv_supported']
       end
     end
 
-    # Install server and xdcv packages
-    dcv_packages = %W[#{node['cfncluster']['dcv']['server']} #{node['cfncluster']['dcv']['xdcv']}]
+    # Install server, xdcv, and web viewer packages
+    dcv_packages = %W[#{node['cfncluster']['dcv']['server']} #{node['cfncluster']['dcv']['xdcv']} #{node['cfncluster']['dcv']['web_viewer']}]
     dcv_packages_path = "#{node['cfncluster']['sources_dir']}/#{node['cfncluster']['dcv']['package']}/"
     # Rewrite dcv_packages object by cycling each package file name and appending the path to them
     dcv_packages.map! { |package| dcv_packages_path + package }


### PR DESCRIPTION
Starting from [DCV release 2021.2-11048](https://docs.aws.amazon.com/dcv/latest/adminguide/doc-history-release-notes.html#dcv-2021-2-11048), the NICE DCV web viewer is distributed as a stand-alone package on Linux, and is no longer included in the DCV server bundle. We need to install the package to enable DCV session using browsers

This commit is related to [this Wiki](https://github.com/aws/aws-parallelcluster/wiki/DCV-Connection-Through-Web-Browsers-Does-Not-Work)

Signed-off-by: Hanwen <hanwenli@amazon.com>


### Tests
* Describe the automated and/or manual tests executed to validate the patch.
test_dcv_configuration has been passed

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.