### PR TITLE
Enable slurm_nss plugin

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -515,6 +515,7 @@ default['cluster']['dns_domain'] = nil
 default['cluster']['use_private_hostname'] = 'false'
 default['cluster']['add_node_hostnames_in_hosts_file'] = node['cluster']['use_private_hostname']
 default['cluster']['skip_install_recipes'] = 'yes'
+default['cluster']['enable_nss_slurm'] = node['cluster']['directory_service']['enabled']
 
 # AWS domain
 default['cluster']['aws_domain'] = aws_domain

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_compute.rb
@@ -52,3 +52,13 @@ cookbook_file '/etc/systemd/system/slurmd.service' do
   mode '0644'
   action :create
 end
+
+if node['cluster']['enable_nss_slurm'] == 'true'
+  nsswitch_path = '/etc/nsswitch.conf'
+  bash 'Add Slurm to nsswitch.conf' do
+    code <<-NSSWITCH
+      sed -i 's/^passwd: */&slurm /' #{nsswitch_path}
+      sed -i 's/^group: */&slurm /' #{nsswitch_path}
+    NSSWITCH
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -126,3 +126,8 @@ when 'centos', 'amazon'
     retry_delay 5
   end
 end
+
+file '/etc/ld.so.conf.d/slurm.conf' do
+  content '/opt/slurm/lib/'
+  mode '0744'
+end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -20,6 +20,9 @@ SwitchType=switch/none
 SlurmctldPidFile=/var/run/slurmctld.pid
 SlurmdPidFile=/var/run/slurmd.pid
 ReconfigFlags=KeepPartState
+<% if node['cluster']['enable_nss_slurm'] == 'true' -%>
+LaunchParameters=enable_nss_slurm
+<% end -%>
 #
 # CLOUD CONFIGS OPTIONS
 <% if node['cluster']['use_private_hostname'] == 'true' or node['cluster']['dns_domain'].nil? or node['cluster']['dns_domain'].empty? -%>


### PR DESCRIPTION
The plugin is enabled when directory service is used. It can be turned on manually by setting `enable_nss_slurm` to `true`

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
All tests in pcluster3.yaml have been passed.
test_ad_integration with MicrosoftAD has been passed

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.