### PR TITLE
[release-2.11] Disable log4j-cve-2021-44228-hotpatch service on Amazon Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 2.11.5
 -----
 
+**CHANGES**
+- Disable log4j-cve-2021-44228-hotpatch service on Amazon Linux to avoid incurring in potential performance degradation.
+
 **BUG FIXES**
 - Fix DCV connection through browsers.
 

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -17,6 +17,8 @@
 
 return if node['conditions']['ami_bootstrapped']
 
+include_recipe "aws-parallelcluster::disable_log4j_patcher"
+
 case node['platform_family']
 when 'rhel', 'amazon'
   include_recipe 'yum'

--- a/recipes/disable_log4j_patcher.rb
+++ b/recipes/disable_log4j_patcher.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+#
+# Cookbook Name:: aws-parallelcluster
+# Recipe:: disable_log4j_patcher
+#
+# Copyright 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+if platform_family?('amazon')
+  # masking the service in order to prevent it from being automatically enabled
+  # if not installed yet
+  service 'log4j-cve-2021-44228-hotpatch' do
+    action %i[disable stop mask]
+  end
+end

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -743,3 +743,18 @@ bash 'check ipv4 gc_thresh is correctly configured' do
   GC
   user 'root'
 end
+
+##################
+# log4j hotpatch
+##################
+if node['platform_family'] == 'amazon'
+  bash 'verify log4j-cve-2021-44228-hotpatch service is disabled' do
+    code <<-LOG4J
+      set -e
+      systemctl show -p SubState log4j-cve-2021-44228-hotpatch | grep -i -v running
+      echo "log4j-cve-2021-44228-hotpatch service is not running"
+      systemctl show -p LoadState log4j-cve-2021-44228-hotpatch | grep -i "LoadState=masked"
+      echo "log4j-cve-2021-44228-hotpatch service is masked"
+    LOG4J
+  end
+end


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
Disabling log4j-cve-2021-44228-hotpatch service on Amazon Linux by default to avoid incurring in potential performance degradation.

Service is masked so that even if installed at a later stage it won't be able to start automatically.

Run the following to re-enable the service:
```
sudo systemctl unmask log4j-cve-2021-44228-hotpatch
sudo systemctl enable log4j-cve-2021-44228-hotpatch
sudo systemctl start log4j-cve-2021-44228-hotpatch
```

### Tests
* added kitchen tests

### References
* log4j-cve-2021-44228-hotpatch service announcement: https://alas.aws.amazon.com/announcements/2021-001.html

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.