### PR TITLE
Do not grant system users sudo privileges in case GrantSudoPrivileges is set to false

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/init_user.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/init_user.rb
@@ -18,6 +18,7 @@
 # create scheduler plugin users in config file
 create_user 'Create scheduler plugin users' do
   system_users(lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :SchedulerDefinition, :SystemUsers) })
+  grant_sudo_privileges(lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :GrantSudoPrivileges) })
 end
 
 # set sudo privileges for scheduler plugin user

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/resources/create_user.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/resources/create_user.rb
@@ -18,6 +18,9 @@ property :system_users, Array, required: false
 property :force_creation, [true, false],
          default: false,
          description: 'force creation if uid/gid already exists'
+property :grant_sudo_privileges, [true, false],
+         default: false,
+         description: 'flag to set sudo privileges'
 
 default_action :run
 
@@ -57,7 +60,7 @@ action :run do
         node.default['cluster']['head_node_imds_allowed_users'].append(name)
       end
 
-      if sudoer_configuration && !sudoer_configuration.empty?  # rubocop:disable Style/Next
+      if sudoer_configuration && !sudoer_configuration.empty? && new_resource.grant_sudo_privileges # rubocop:disable Style/Next
         template "/etc/sudoers.d/99-parallelcluster-scheduler-plugin-#{name}" do
           source 'scheduler_plugin_user/99-parallelcluster-scheduler-plugin-sudoer-configuration.erb'
           variables(sudoer_configuration: sudoer_configuration, user: name)


### PR DESCRIPTION
In case CLI validator is suppressed, skip sudoer configuration of system users
Manually test with:
Not setting: GrantSudoPrivileges(So it is default to false)
Set 
```
      SystemUsers:
        - Name: user1
          EnableImds: true
          SudoerConfiguration:
            - Commands: ALL
              RunAs: root
```
I am blocked by the validator. After the validator is surpressed, cluster creation is successful without 99-parallelcluster-scheduler-plugin-user1 under `/etc/sudoers.d`, while without this change, there is /etc/sudoers.d99-parallelcluster-scheduler-plugin-user1