### PR TITLE
[develop] Increase retries for gcc sources download

### DIFF
--- a/cookbooks/aws-parallelcluster-install/recipes/arm_pl.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/arm_pl.rb
@@ -65,8 +65,8 @@ gcc_tarball = "#{node['cluster']['sources_dir']}/gcc-#{node['cluster']['armpl'][
 remote_file gcc_tarball do
   source node['cluster']['armpl']['gcc']['url']
   mode '0644'
-  retries 3
-  retry_delay 5
+  retries 5
+  retry_delay 10
   not_if { ::File.exist?(gcc_tarball) }
 end
 


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
This in order to try to reduce likelihood of getting
```
Failed to open TCP connection to ftp.gnu.org:443 (Network is unreachable - connect(2) for "ftp.gnu.org" port 443)

### Tests
* N/A

### References
* N/A

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.