### PR TITLE
Force file override when copying plugin configurations

### DIFF
--- a/cookbooks/aws-parallelcluster-config/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/fetch_config.rb
@@ -14,7 +14,7 @@ action :run do
   unless virtualized?
     if new_resource.update
       Chef::Log.info("Backing up old configuration from (#{node['cluster']['cluster_config_path']}) to (#{node['cluster']['previous_cluster_config_path']})")
-      ::FileUtils.cp(node['cluster']['cluster_config_path'], node['cluster']['previous_cluster_config_path'])
+      ::FileUtils.cp_r(node['cluster']['cluster_config_path'], node['cluster']['previous_cluster_config_path'], remove_destination: true)
       fetch_cluster_config(node['cluster']['cluster_config_path'])
       fetch_instance_type_data unless ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path'])
     else

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/resources/execute_event_handler.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/resources/execute_event_handler.rb
@@ -128,7 +128,7 @@ action_class do # rubocop:disable Metrics/BlockLength
     raise "Expected #{config_type} file not found in (#{source_config})" unless ::File.exist?(source_config)
 
     Chef::Log.info("Copying #{config_type} file from (#{source_config}) to (#{target_config})")
-    FileUtils.cp(source_config, target_config)
+    FileUtils.cp_r(source_config, target_config, remove_destination: true)
     FileUtils.chown(node['cluster']['scheduler_plugin']['user'], node['cluster']['scheduler_plugin']['group'], target_config)
   end
 


### PR DESCRIPTION
### Description of changes
* Not forcing an override would cause the copy to follow symlinks and opens up the possibility to privilege escalation

### References
* https://ruby-doc.org/stdlib-2.4.1/libdoc/fileutils/rdoc/FileUtils.html
* This is caused because ruby copies the content of the file by default:  https://github.com/ruby/ruby/blob/5827d8e887d881eb3a6e6ea7410590261c90545f/lib/fileutils.rb#L1391-L1397

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.