### PR TITLE
[develop] Upgrade NVIDIA drivers, CUDA and Fabric Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Upgrade Slurm to version 21.08.5.
 - Upgrade NICE DCV to version 2021.3-11591.
-- Upgrade NVIDIA driver to version 470.82.01.
-- Upgrade CUDA library to version 11.4.3.
-- Upgrade NVIDIA Fabric manager to version 470.82.01.
+- Upgrade NVIDIA driver to version 470.103.01.
+- Upgrade CUDA library to version 11.4.4.
+- Upgrade NVIDIA Fabric manager to version 470.103.01.
 - Upgrade Intel MPI Library to 2021.4.0.441.
 - Upgrade PMIx to version 3.2.3.
 - Move the configure/install recipes to separate cookbooks that are called from the main one. Existing entrypoints are maintained and backwards compatible.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -166,12 +166,12 @@ default['cluster']['munge']['group_id'] = node['cluster']['munge']['user_id']
 
 # NVIDIA
 default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '470.82.01'
+default['cluster']['nvidia']['driver_version'] = '470.103.01'
 default['cluster']['nvidia']['cuda_version'] = '11.4'
 default['cluster']['nvidia']['driver_url_architecture_id'] = arm_instance? ? 'aarch64' : 'x86_64'
 default['cluster']['nvidia']['cuda_url_architecture_id'] = arm_instance? ? 'linux_sbsa' : 'linux'
 default['cluster']['nvidia']['driver_url'] = "https://us.download.nvidia.com/tesla/#{node['cluster']['nvidia']['driver_version']}/NVIDIA-Linux-#{node['cluster']['nvidia']['driver_url_architecture_id']}-#{node['cluster']['nvidia']['driver_version']}.run"
-default['cluster']['nvidia']['cuda_url'] = "https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_470.82.01_#{node['cluster']['nvidia']['cuda_url_architecture_id']}.run"
+default['cluster']['nvidia']['cuda_url'] = "https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_#{node['cluster']['nvidia']['cuda_url_architecture_id']}.run"
 
 # NVIDIA fabric-manager
 # The package name of Fabric Manager for alinux2 and centos7 is nvidia-fabric-manager-version


### PR DESCRIPTION
NVIDIA drivers from 470.82.01 to 470.103.01
CUDA from 11.4.3 to 11.4.4
Fabric Manager from 470.82.01 to 470.103.01

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.