### PR TITLE
Configurable slurm nodes bootstrap timeout

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -532,3 +532,6 @@ default['cluster']['head_node_imds_secured'] = 'true'
 default['cluster']['head_node_imds_allowed_users'] = ['root', node['cluster']['cluster_admin_user'], node['cluster']['cluster_user']]
 default['cluster']['head_node_imds_allowed_users'].append('dcv') if node['cluster']['dcv_enabled'] == 'head_node' && platform_supports_dcv?
 default['cluster']['head_node_imds_allowed_users'].append(node['cluster']['scheduler_plugin']['user']) if node['cluster']['scheduler'] == 'plugin'
+
+# Compute nodes bootstrap timeout
+default['cluster']['compute_node_bootstrap_timeout'] = 1800

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/resources/execute_event_handler.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/resources/execute_event_handler.rb
@@ -22,7 +22,6 @@ action :run do
   event_cwd = node['cluster']['scheduler_plugin']['home']
   event_user = node['cluster']['scheduler_plugin']['user']
   event_user_group = node['cluster']['scheduler_plugin']['group']
-  event_timeout = 3600
   event_env = build_env
   event_log_prefix_error = "%Y-%m-%d %H:%M:%S,000 - [#{new_resource.event_name}] - ERROR:"
   event_log_prefix_info = "%Y-%m-%d %H:%M:%S,000 - [#{new_resource.event_name}] - INFO:"
@@ -31,7 +30,7 @@ action :run do
   # switch stderr/stdout with (2>&1 1>&3-), process error (now on stdout), switch back stdout/stderr with (3>&1 1>&2) and then process output
   event_command = Shellwords.escape("set -o pipefail; { (#{new_resource.event_command}) 2>&1 1>&3- | ts '#{event_log_prefix_error}' | tee -a #{event_log_err}; } " \
     "3>&1 1>&2 | ts '#{event_log_prefix_info}' | tee -a #{event_log_out}")
-  cmd = Mixlib::ShellOut.new("/bin/bash -c #{event_command}", user: event_user, group: event_user_group, login: true, env: event_env, cwd: event_cwd, timeout: event_timeout)
+  cmd = Mixlib::ShellOut.new("/bin/bash -c #{event_command}", user: event_user, group: event_user_group, login: true, env: event_env, cwd: event_cwd)
   cmd.run_command
 
   if cmd.error?

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
@@ -31,7 +31,13 @@ class CriticalError(Exception):
 
 
 def generate_slurm_config_files(
-    output_directory, template_directory, input_file, instance_types_data_path, dryrun, no_gpu
+    output_directory,
+    template_directory,
+    input_file,
+    instance_types_data_path,
+    dryrun,
+    no_gpu,
+    compute_node_bootstrap_timeout,
 ):
     """
     Generate Slurm configuration files.
@@ -75,6 +81,7 @@ def generate_slurm_config_files(
             head_node_config,
             cluster_config["Scheduling"]["SlurmSettings"],
             template_name,
+            compute_node_bootstrap_timeout,
             env,
             output_directory,
             dryrun,
@@ -127,13 +134,21 @@ def _generate_queue_config(
 
 
 def _generate_slurm_parallelcluster_configs(
-    queues, head_node_config, scaling_config, template_name, jinja_env, output_dir, dryrun
+    queues,
+    head_node_config,
+    scaling_config,
+    template_name,
+    compute_node_bootstrap_timeout,
+    jinja_env,
+    output_dir,
+    dryrun,
 ):
     log.info("Generating %s", template_name)
     rendered_template = jinja_env.get_template(f"{template_name}").render(
         queues=queues,
         head_node_config=head_node_config,
         scaling_config=scaling_config,
+        compute_node_bootstrap_timeout=compute_node_bootstrap_timeout,
         output_dir=output_dir,
     )
     if not dryrun:
@@ -288,6 +303,13 @@ def main():
             required=False,
             default=False,
         )
+        parser.add_argument(
+            "--compute-node-bootstrap-timeout",
+            type=int,
+            help="Configure ResumeTimeout",
+            required=False,
+            default=1800,
+        )
         args = parser.parse_args()
         generate_slurm_config_files(
             args.output_directory,
@@ -296,6 +318,7 @@ def main():
             args.instance_types_data,
             args.dryrun,
             args.no_gpu,
+            args.compute_node_bootstrap_timeout,
         )
     except Exception as e:
         log.exception("Failed to generate slurm configurations, exception: %s", e)

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster.conf
@@ -5,6 +5,7 @@
 
 SlurmctldHost={{ head_node_config.head_node_hostname }}({{ head_node_config.head_node_ip }})
 SuspendTime={{ scaling_config.ScaledownIdletime * 60 }}
+ResumeTimeout={{ compute_node_bootstrap_timeout }}
 
 {% for queue in queues %}
 include {{ output_dir }}/pcluster/slurm_parallelcluster_{{ queue.Name }}_partition.conf

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -66,7 +66,8 @@ unless virtualized?
   execute "generate_pcluster_slurm_configs" do
     command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_slurm_config_generator.py"\
             " --output-directory /opt/slurm/etc/ --template-directory #{node['cluster']['scripts_dir']}/slurm/templates/"\
-            " --input-file #{node['cluster']['cluster_config_path']}  --instance-types-data #{node['cluster']['instance_types_data_path']} #{no_gpu}"
+            " --input-file #{node['cluster']['cluster_config_path']}  --instance-types-data #{node['cluster']['instance_types_data_path']}"\
+            " --compute-node-bootstrap-timeout #{node['cluster']['compute_node_bootstrap_timeout']} #{no_gpu}"
   end
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -9,3 +9,4 @@ dns_domain = <%= node['cluster']['dns_domain'] %>
 use_private_hostname = <%= node['cluster']['use_private_hostname'] %>
 head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
 head_node_hostname = <%= node['ec2']['local_hostname'] %>
+node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout'] %>

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -36,7 +36,6 @@ SuspendProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_suspend
 ResumeProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_resume
 ResumeFailProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_suspend
 SuspendTimeout=120
-ResumeTimeout=1800
 PrivateData=cloud
 ResumeRate=0
 SuspendRate=0

--- a/system_tests/dna.json
+++ b/system_tests/dna.json
@@ -38,6 +38,7 @@
     "instance_types_data_s3_key": "parallelcluster/3.0.1/clusters/pc3cluster-0000000000000000/configs/instance-types-data.json",
     "custom_node_package": "",
     "custom_awsbatchcli_package": "",
-    "head_node_imds_secured": "true"
+    "head_node_imds_secured": "true",
+    "compute_node_bootstrap_timeout": 1800
   }
 }

--- a/test/unit/slurm/test_slurm_config_generator.py
+++ b/test/unit/slurm/test_slurm_config_generator.py
@@ -20,7 +20,13 @@ def test_generate_slurm_config_files(mocker, test_datadir, tmpdir, no_gpu):
     )
     template_directory = os.path.dirname(slurm.__file__) + "/templates"
     generate_slurm_config_files(
-        tmpdir, template_directory, input_file, instance_types_data, dryrun=False, no_gpu=no_gpu
+        tmpdir,
+        template_directory,
+        input_file,
+        instance_types_data,
+        dryrun=False,
+        no_gpu=no_gpu,
+        compute_node_bootstrap_timeout=1600,
     )
 
     for queue in ["efa", "gpu", "multiple_spot"]:

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files/expected_outputs/slurm_parallelcluster.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files/expected_outputs/slurm_parallelcluster.conf
@@ -4,6 +4,7 @@
 
 SlurmctldHost=ip-1-0-0-0(ip.1.0.0.0)
 SuspendTime=600
+ResumeTimeout=1600
 
 include <DIR>/pcluster/slurm_parallelcluster_multiple_spot_partition.conf
 include <DIR>/pcluster/slurm_parallelcluster_efa_partition.conf


### PR DESCRIPTION
### Description of changes
If DevSettings.Timeouts.ComputeNodeBootstrapTimeout is set for slurm, configure ResumeTimeout for dynamic nodes and node_replacement_timeout for static nodes to be ComputeNodeBootstrapTimeout

### Manually test
```
[ec2-user@ip-192-168-40-194 pcluster]$ cat /etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf
[clustermgtd]
cluster_name = slurm21
region = us-east-1
proxy = NONE
heartbeat_file_path = /opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat
dynamodb_table = parallelcluster-slurm-slurm21
hosted_zone = Z08887381AJSDUII9G6QL
dns_domain = slurm21.pcluster.
use_private_hostname = false
head_node_private_ip = 192.168.40.194
head_node_hostname = ip-192-168-40-194.ec2.internal
node_replacement_timeout = 1201

```

```
[ec2-user@ip-192-168-40-194 pcluster]$ cat /opt/slurm/etc/parallelcluster_slurm.conf
...
ResumeTimeout=1201
...
```
### Integration test
Test the Timeout is configured and update with cluster update in https://github.com/aws/aws-parallelcluster/pull/3753

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.