### PR TITLE
Add nss_slurm.conf in compute nodes when nss plugin is used

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_compute.rb
@@ -61,4 +61,11 @@ if node['cluster']['enable_nss_slurm'] == 'true'
       sed -i 's/^group: */&slurm /' #{nsswitch_path}
     NSSWITCH
   end
+
+  file '/etc/nss_slurm.conf' do
+    content("NodeName=#{hit_slurm_nodename}")
+    mode '0644'
+    owner 'root'
+    group 'root'
+  end
 end


### PR DESCRIPTION
Signed-off-by: Hanwen <hanwenli@amazon.com>


This conf file is useful for nss plugin when nodename is different from hostname. Even the cluster is running without the conf file, but it is recommended because it potentially reduces the lookups of the nss plugin

When UseEc2Hostname is true, the nodename is different from hostname

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.