### PR TITLE
2.x: Remove check to verify Intel MPI rpm is installed

### DIFF
--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -305,10 +305,6 @@ if node['conditions']['intel_mpi_supported']
       command "rpm -qa | grep libfabric && rpm -qa | grep efa-"
       user node['cfncluster']['cfn_cluster_user']
     end
-    execute 'check intel mpi installed' do
-      command "rpm -qa | grep intel-mpi"
-      user node['cfncluster']['cfn_cluster_user']
-    end
   when 'ubuntu1804'
     case node['cfncluster']['cfn_node_type']
     when 'MasterServer'


### PR DESCRIPTION
### Description of changes
* This test is not supported by Intel MPI 2021 that is not installed through an rpm.
* This test is useless because we already have another test 'check intel mpi version' to verify Intel MPI is installed and with the right version: [tests.rb#L343](https://github.com/aws/aws-parallelcluster-cookbook/blob/v2.11.4/recipes/tests.rb#L343)

### Tests
* None

### References
* This issue has been introduced with: https://github.com/aws/aws-parallelcluster-cookbook/pull/1293

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
