### PR TITLE
Add flush_cache before package installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **BUG FIXES**
 - Do not configure GPUs in Slurm when NVIDIA driver is not installed.
 - Fix the way `ExtraChefAttributes` are merged into the final configuration.
+- Fix sporadic failure of build-image due to missing package
 
 3.0.3
 ------

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -25,6 +25,10 @@ when 'rhel', 'amazon'
   include_recipe 'yum'
   if platform_family?('amazon')
     alinux_extras_topic 'epel'
+    # In the case of AL2, there are more packages to install via extras
+    node['cluster']['alinux_extras']&.each do |topic|
+      alinux_extras_topic topic
+    end
   elsif platform?('centos')
     include_recipe "yum-epel"
   end
@@ -67,14 +71,11 @@ build_essential
 include_recipe "aws-parallelcluster-install::python"
 
 # Install lots of packages
+
 package node['cluster']['base_packages'] do
   retries 10
   retry_delay 5
-end
-
-# In the case of AL2, there are more packages to install via extras
-node['cluster']['alinux_extras']&.each do |topic|
-  alinux_extras_topic topic
+  flush_cache({ before: true }) if platform_family?('rhel', 'amazon')
 end
 
 unless virtualized?


### PR DESCRIPTION
### Description of changes
* This patch addresses sporadic error regarding moreutils installation due to out-of-sync of Chef yum cache. The parameter flush_cache allows to flush the internal yum cache of Chef preventing the out-of-sync. The parameter is not supported by apt_package. Moved alinux_extras installation before the flush_cache to be sure that every repository change is made before the flush.

### Tests
* Executed kitchen tests with c5.4xlarge and m6g.xlarge
* Executed build of all OSes

### References
* [Package documentation](https://docs.chef.io/resources/package/).

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.