### PR TITLE
Use YAML.safe_load when reading cluster config

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -537,7 +537,7 @@ def load_cluster_config
   ruby_block "load cluster configuration" do
     block do
       require 'yaml'
-      config = YAML.load_file(node['cluster']['cluster_config_path'])
+      config = YAML.safe_load(File.read(node['cluster']['cluster_config_path']))
       Chef::Log.debug("Config read #{config}")
       node.override['cluster']['config'].merge! config
     end


### PR DESCRIPTION
### Description of changes
* Use YAML safe_load when reading cluster config

### References
* https://deepsource.io/blog/ruby-security-pitfalls/

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.