### PR TITLE
Kitchen tests mock environment

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -97,6 +97,7 @@ suites:
 
   - name: scheduler_plugin_config_HeadNode_x86_64
     run_list: &run_lists_scheduler_plugin_config_HeadNode
+      - recipe[aws-parallelcluster::tests_mock]
       - recipe[aws-parallelcluster::init]
       - recipe[aws-parallelcluster::config]
       - recipe[aws-parallelcluster::finalize]
@@ -205,6 +206,7 @@ suites:
 
   - name: scheduler_plugin_config_ComputeFleet_x86_64
     run_list: &run_lists_scheduler_plugin_config_ComputeFleet
+      - recipe[aws-parallelcluster::tests_mock]
       - recipe[aws-parallelcluster::init]
       - recipe[aws-parallelcluster::config]
       - recipe[aws-parallelcluster::finalize]

--- a/cookbooks/aws-parallelcluster-test/recipes/test_envars.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_envars.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
+# Cookbook:: aws-parallelcluster-test
 # Recipe:: test_envars
 #
 # Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/cookbooks/aws-parallelcluster-test/recipes/test_imds.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_imds.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
+# Cookbook:: aws-parallelcluster-test
 # Recipe:: test_imds
 #
 # Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/cookbooks/aws-parallelcluster-test/recipes/test_openssh.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_openssh.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
+# Cookbook:: aws-parallelcluster-test
 # Recipe:: test_openssh
 #
 # Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/cookbooks/aws-parallelcluster-test/recipes/test_processes.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_processes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
+# Cookbook:: aws-parallelcluster-test
 # Recipe:: tests_processes
 #
 # Copyright:: 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/cookbooks/aws-parallelcluster-test/recipes/test_sudoers.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_sudoers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
+# Cookbook:: aws-parallelcluster-test
 # Recipe:: test_sudoers
 #
 # Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/cookbooks/aws-parallelcluster-test/recipes/test_users.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_users.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
+# Cookbook:: aws-parallelcluster-test
 # Recipe:: tests_users
 #
 # Copyright:: 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
+# Cookbook:: aws-parallelcluster-test
 # Recipe:: tests
 #
 # Copyright:: 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/cookbooks/aws-parallelcluster-test/recipes/tests_mock.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests_mock.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-test
+# Recipe:: tests_mock
+#
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Recipe used to mock node environment before the execution of kitchen tests
+
+# mock launch templates config content
+file node['cluster']['launch_templates_config_path'] do
+  content <<-LAUNCH_TEMPLATE_DATA
+{
+  "Queues": {
+    "queue1": {
+      "ComputeResources": {
+        "computeresource1": {
+          "LaunchTemplate": {
+            "Version": "1",
+            "Id": "lt-1234567890abcd"
+          }
+        }
+      }
+    },
+    "queue2": {
+      "ComputeResources": {
+        "computeresource1": {
+          "LaunchTemplate": {
+            "Version": "1",
+            "Id": "lt-dcba0987654321"
+          }
+        }
+      }
+    }
+  }
+}
+LAUNCH_TEMPLATE_DATA
+  mode '0644'
+  owner 'root'
+  group 'root'
+end

--- a/recipes/tests_mock.rb
+++ b/recipes/tests_mock.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster
+# Recipe:: tests_mock
+#
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_recipe 'aws-parallelcluster-test::tests_mock'


### PR DESCRIPTION
### Description of changes
* Add recipe to mock environment during kitchen tests run
The recipe is called at the beginning of the recipes run_list.
Within this commit, the mock recipe creates a fake launch template configuration file

* Fix cookbook name

### Tests
N/A

### References

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.