### PR TITLE
[develop] Mock cluster stack arn for kitchen test run

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/tests_mock.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests_mock.rb
@@ -17,6 +17,9 @@
 
 # Recipe used to mock node environment before the execution of kitchen tests
 
+# mock cluster stack arn
+node.override['cluster']['stack_arn'] = "arn:aws:cloudformation:eu-west-1:1234567890:stack/fake-stack/07684870-8b1d-11ec-b57f-0a6d1e873bc9"
+
 # mock launch templates config content
 file node['cluster']['launch_templates_config_path'] do
   content <<-LAUNCH_TEMPLATE_DATA


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
* Mock cluster stack arn for kitchen test run
Stack arn value is used by event handler when building handler static environment

### Tests

### References

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.