### PR TITLE
[develop] Fix format for dummy compute fleet status

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/files/default/event_handler/invoke-scheduler-plugin-event-handler.sh
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/files/default/event_handler/invoke-scheduler-plugin-event-handler.sh
@@ -177,8 +177,8 @@ build_dummy_computefleet_status_json() {
   log "Building dummy computefleet-status.json in (${DUMMY_COMPUTEFLEET_STATUS})"
   cat << EOF > "${DUMMY_COMPUTEFLEET_STATUS}"
 {
-  "Status": "${computefleet_status}",
-  "LastUpdatedTime": "$(date "+%Y-%m-%d %H:%M:%S.%N%:z")"
+  "status": "${computefleet_status}",
+  "lastStatusUpdatedTime": "$(date "+%Y-%m-%d %H:%M:%S.%N%:z")"
 }
 EOF
 }


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Compute fleet status format is defined in the class JsonComputeFleetStatusManager, see
https://github.com/aws/aws-parallelcluster/blob/develop/cli/src/pcluster/models/compute_fleet_status_manager.py#L159

### Tests
* This will be covered by https://github.com/aws/aws-parallelcluster/pull/3771

### References

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.