### PR TITLE
Add kitchen test for scheduler plugin

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -101,6 +101,28 @@ if node['cluster']['scheduler'] == 'slurm'
     raise "node_type must be HeadNode or ComputeFleet"
   end
 end
+###################
+# Scheduler Plugin
+###################
+if node['cluster']['scheduler'] == 'plugin'
+  if node['cluster']['node_type'] == "HeadNode"
+    execute 'check artifacts are in target_source_path' do
+      command "ls #{node['cluster']['scheduler_plugin']['home']} | grep develop"
+    end
+    execute 'check handler-env.json in path' do
+      command "ls #{node['cluster']['shared_dir']}/handler-env.json"
+    end
+    execute 'check get compute fleet script is executable by plugin user' do
+      command "su #{node['cluster']['scheduler_plugin']['user']} -c 'if [[ ! -x '/usr/local/bin/get-compute-fleet-status.sh' ]]; then exit 1; fi;'"
+    end
+    execute 'check update compute fleet script is executable by plugin user' do
+      command "su #{node['cluster']['scheduler_plugin']['user']} -c 'if [[ ! -x '/usr/local/bin/update-compute-fleet-status.sh' ]]; then exit 1; fi;'"
+    end
+  end
+  execute "check scheduler plugin user doesn't have Sudo Privileges" do
+    command "(su #{node['cluster']['scheduler_plugin']['user']} -c 'sudo -ln') 2>&1 | grep 'a password is required'"
+  end
+end
 
 ###################
 # Amazon Time Sync
@@ -497,4 +519,13 @@ execute 'check supervisord service is enabled' do
 end
 execute 'check ec2blkdev service is enabled' do
   command "systemctl is-enabled ec2blkdev"
+end
+
+###################
+# clusterstatusmgtd
+###################
+if node['cluster']['node_type'] == 'HeadNode' && node['cluster']['scheduler'] != 'awsbatch'
+  execute "check clusterstatusmgtd is configured to be executed by supervisord" do
+    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl status clusterstatusmgtd | grep RUNNING"
+  end
 end


### PR DESCRIPTION
* Test get/update compute fleet script are in the path
* Test artifacts are in target_source_path:“#{node[‘cluster’][‘scheduler_plugin’][‘home’]}/#{source_name}”
* Test scheduler plugin user doesn’t have Sudo Privileges
* Test the existence of source_handler_env = “#{node[‘cluster’][‘shared_dir’]}/handler-env.json for headnode
* check clusterstatusmgtd is configured to be executed by supervisord

Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.