### PR TITLE
2.x: Move Intel MPI change in the right version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade NVIDIA driver to version 470.103.01.
 - Upgrade CUDA library to version 11.4.4.
 - Upgrade NVIDIA Fabric manager to version 470.103.01.
+- Upgrade Intel MPI Library to 2021.4.0.441.
 
 **BUG FIXES**
 - Fix DCV connection through browsers.
@@ -26,7 +27,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade NVIDIA driver to version 470.82.01.
 - Upgrade CUDA library to version 11.4.3.
 - Upgrade NVIDIA Fabric manager to 470.82.01.
-- Upgrade Intel MPI Library to 2021.4.0.441.
 - Disable unattended packages update on Ubuntu.
 - Install Python 3 version of `aws-cfn-bootstrap` scripts on CentOS 7 and Ubuntu 18.04, aligning with Ubuntu 20.04 and Amazon Linux 2.
 


### PR DESCRIPTION
I wrongly included Intel MPI in the 2.11.4 section.
