### PR TITLE
Fix update of /etc/hosts files for clusters deployed in VPC without internet access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.1.2
+------
+
+**BUG FIXES**
+- Fix update of `/etc/hosts` files for clusters deployed in VPC without internet access. 
+
 3.1.1
 ------
 

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/prolog
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/prolog
@@ -36,8 +36,8 @@ _log() {
 _log "Adding nodes to /etc/hosts"
 # SLURM_NODE_ALIASES has value like "queue-0-dy-compute-resource-0-1:[192.168.1.2]:ip-192-168-1-2"
 # The following line transforms this line to "192.168.1.2 queue-0-dy-compute-resource ip-192-168-1-2"
-hosts=$(echo "${SLURM_NODE_ALIASES}" | awk 'BEGIN{RS=","; FS=":"}; {gsub(/\[|\]/,"",$2); print $2,$1,$3}')
-lines='#HOSTS_JOB_'"${SLURM_JOB_ID}\n${hosts}\n"'#END_JOB_'"${SLURM_JOB_ID}"
+hosts=$(echo -n "${SLURM_NODE_ALIASES}" | awk 'BEGIN{RS=","; FS=":";ORS="\\n"}; {gsub(/\[|\]/,"",$2); print $2,$1,$3}' )
+lines='#HOSTS_JOB_'"${SLURM_JOB_ID}\n${hosts}"'#END_JOB_'"${SLURM_JOB_ID}"
 if grep -q '^#HOSTS_JOB_.*' /etc/hosts
 then
     # If there is other nodes information in the file, the newest nodes information is inserted before the older ones.


### PR DESCRIPTION
### Description of changes
* Fix prolog script to avoid errors during  the update of `/etc/hosts` with clusters in isolated networks. When `SLURM_NODE_ALIASES` contains more than 1 node `awk` have to use litteral `\n` as record separator.
* https://github.com/aws/aws-parallelcluster/issues/3777

### Tests
* Manual test running jobs on the same node and on 2 nodes, verifying the correct configuration of  `/etc/hosts` ether during the run and after the job execution

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.