### PR TITLE
Force synchronous execution of setup-ephemeral-drives.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **BUG FIXES**
-- Fix update of `/etc/hosts` files for clusters deployed in VPC without internet access. 
+- Fix update of `/etc/hosts` files for clusters deployed in VPC without internet access.
+- Wait for ephemeral drives setup before having a compute node join the scheduler.
 
 3.1.1
 ------

--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -29,7 +29,13 @@ include_recipe 'aws-parallelcluster-config::nfs' unless virtualized?
 
 service "setup-ephemeral" do
   supports restart: false
-  action %i(enable start)
+  action :enable
+end
+
+# Execution timeout 3600 seconds
+execute "Setup of ephemeral drivers" do
+  user "root"
+  command "/usr/local/sbin/setup-ephemeral-drives.sh"
 end
 
 # Increase somaxconn and tcp_max_syn_backlog for large scale setting


### PR DESCRIPTION
### Description of changes
* Run setup-ephemeral-drives.sh explicitly to ensure execution on first node startup 

### Tests
* Tested manually on running Amazon Linux 2, then reboot to check if the service will start

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.