### PR TITLE
2.x: Add force to mkfs.ext4 in encrypted ephemeral

### DIFF
--- a/files/default/setup-ephemeral-drives.sh
+++ b/files/default/setup-ephemeral-drives.sh
@@ -119,7 +119,7 @@ function setup_ephemeral_drives () {
       chmod 0400 /root/keystore/keyfile || RC=1
       cryptsetup -q luksFormat /dev/vg.01/lv_ephemeral /root/keystore/keyfile || RC=1
       cryptsetup -d /root/keystore/keyfile luksOpen /dev/vg.01/lv_ephemeral ephemeral_luks || RC=1
-      mkfs.ext4 /dev/mapper/ephemeral_luks || RC=1
+      mkfs.ext4 -F /dev/mapper/ephemeral_luks || RC=1
       mount -v -t ext4 -o noatime,nodiratime /dev/mapper/ephemeral_luks ${cfn_ephemeral_dir} || RC=1
     else
       mkfs.ext4 /dev/vg.01/lv_ephemeral || RC=1


### PR DESCRIPTION
### Description of changes
To avoid errors caused by the detection of a partition when formatting ephemeral drive
**Note**
With this patch the creation of the filesystem is made without checking the existence of a previous filesystem. If to the mkfs.ext4 is passed the wrong block device it could be dangerous.
```
mke2fs 1.45.5 (07-Jan-2020)
Found a atari partition table in /dev/mapper/ephemeral_luks
```

### Tests
* Teste with automated integration and kitchen test 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.