### PR TITLE
Fix how the cluster property `DirectoryService.DomainAddr` is used to set the SSSD property `ldap_uri`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+x.x.x
+------
+
+**BUG FIXES**
+- Fix `DirectoryService.DomainAddr` conversion to `ldap_uri` SSSD property when it contains multiples domain addresses.
+
 3.1.2
 ------
 

--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
@@ -2,7 +2,7 @@
 id_provider = ldap
 cache_credentials = True
 ldap_schema = AD
-ldap_uri = <%=  "#{@domain_addr_prefix}#{node['cluster']['directory_service']['domain_addr']}" %>
+ldap_uri = <%= @ldap_uri %>
 ldap_search_base = <%=  node['cluster']['directory_service']['domain_name'] %>
 ldap_default_bind_dn = <%=  node['cluster']['directory_service']['domain_read_only_user'] %>
 ldap_default_authtok = <%= @ldap_default_authtok %>


### PR DESCRIPTION
### Changes
Fix the way SSSD property `ldap_uri` is configured. 
We want to fix a bug that makes the property `DomainAddr` behave differently w.r.t. what we officially documented.

According to [ParallelCluster official documentation](https://docs.aws.amazon.com/parallelcluster/latest/ug/DirectoryService-v3.html#yaml-DirectoryService-DomainAddr), the property `DomainAddr` accepts the following value:
```
The URI or URIs that point to the AD domain controller that's used as the LDAP server. The URI corresponds to the sssd-ldap parameter that's called ldap_uri. The value can be a comma separated string of URIs. To use LDAP, you must add ldap:// to the beginning of the each URI.

ldap://192.0.2.0,ldap://203.0.113.0          # LDAP
ldaps://192.0.2.0,ldaps://203.0.113.0        # LDAPS without support for certificate verification
ldaps://abcdef01234567890.corp.pcluster.com  # LDAPS with support for certificate verification
192.0.2.0,203.0.113.0                        # AWS ParallelCluster uses LDAPS by default
```

So we may think that  `192.0.2.0,203.0.113.0` would be fine, but it's not because, due to the bug we are fixing here, `ldap_uri` would be set to `ldaps://192.0.2.0,203.0.113.0`, instead of `ldaps://192.0.2.0,ldaps://203.0.113.0`, causing SSSD service start failure and the consequent cluster creation failure.

### Tests
1. Cluster creation succeeded
1. SSSD config is correct
1. SSH login as AD user works, both with password and with SSH key
1. Execution of MPI hello world as AD user succeeds
1. [PENDING] Kitchen tests succeeded
1. [PENDING] Integration tests succeeded


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>