### PR TITLE
Add support for both FQDN and LDAP Distinguished Names in property DirectoryService.DomainName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 x.x.x
 ------
 
+**ENHANCEMENTS**
+- Add support for both FQDN and LDAP Distinguished Names in property `DirectoryService.DomainName`.
+
 **BUG FIXES**
 - Fix `DirectoryService.DomainAddr` conversion to `ldap_uri` SSSD property when it contains multiples domain addresses.
 
-- **CHANGES**
+**CHANGES**
 - Disable deeper C-States in x86_64 official AMIs and AMIs created through `build-image` command, to guarantee high performance and low latency.
 - Add script to manually update the password used to read from Active Directory,
   according to the secret stored in AWS Secrets Manager.

--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
@@ -3,7 +3,7 @@ id_provider = ldap
 cache_credentials = True
 ldap_schema = AD
 ldap_uri = <%= @ldap_uri %>
-ldap_search_base = <%=  node['cluster']['directory_service']['domain_name'] %>
+ldap_search_base = <%=  @ldap_search_base %>
 ldap_default_bind_dn = <%=  node['cluster']['directory_service']['domain_read_only_user'] %>
 ldap_default_authtok = <%= @ldap_default_authtok %>
 <% if node['cluster']['directory_service']['ldap_tls_ca_cert'] != 'NONE' %>


### PR DESCRIPTION
### Description of changes
Add support for both FQDN and LDAP Distinguished Names in property DirectoryService.DomainName.
In particular:
1. when the property `DirectoryService.DomainName` is a FQDN string, it will be converted into a LDAP Distinguished Name to be written into `/etc/sssd/sssd.conf` in property `ldap_search_base `.
2. otherwise, the provided value is written.

Notice that only FQDN or LDAP DN values can be received as input because the CLI only accepts those formats.

Examples:
```sh
# FQDN
corp.example.com

# LDAP DN
DC=corp,DC=example,DC=com
```

### Tests
1. Cluster creation with DomainName as FQDN + SSH login and job submission as AD user
2. Cluster update with DomainName as LDAP DN + SSH login and job submission as AD user
5. Build&Test in Jenkins

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>