### PR TITLE
Add kitchen test to verify Nvidia drivers and DCV GL

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/test_dcv.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_dcv.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-test
+# Recipe:: test_dcv
+#
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+return unless node['cluster']['node_type'] == "HeadNode" && node['conditions']['dcv_supported'] && graphic_instance? && nvidia_installed? && dcv_gpu_accel_supported?
+
+bash "check nice-dcv-gl installation" do
+  cwd Chef::Config[:file_cache_path]
+  code <<-TEST
+    package_name="nice-dcv-gl"
+    expected_package_version="#{node['cluster']['dcv']['gl']['version']}"
+
+    echo "Testing nice-dcv-gl installation"
+    if [[ "#{node['platform_family']}" == "rhel" || "#{node['platform_family']}" == "amazon" ]]; then
+      yum list installed | grep ${package_name} | grep ${expected_package_version} || exit 1
+    else
+      apt list --installed | grep ${package_name} | grep ${expected_package_version} || exit 1
+    fi
+    echo "nice-dcv-gl test passed: the package is installed with the expected version ${expected_package_version}"
+  TEST
+end

--- a/cookbooks/aws-parallelcluster-test/recipes/test_nvidia.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_nvidia.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-test
+# Recipe:: test_nvidia
+#
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+bash "check Nvidia drivers" do
+  cwd Chef::Config[:file_cache_path]
+  code <<-TEST
+    expected_nvidia_driver_version="#{node['cluster']['nvidia']['driver_version']}"
+    export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin"
+
+    echo "Testing Nvidia driver version"
+    nvidia_driver_version=$(modinfo -F version nvidia)
+    [[ "${nvidia_driver_version}" != "${expected_nvidia_driver_ver}" ]] && "ERROR Installed Nvidia driver version ${nvidia_driver_version} but expected ${expected_nvidia_driver_version}" && exit 1
+    echo "Correctly installed Nvidia ${nvidia_driver_version}"
+
+    echo "Testing CUDA installation with nvcc"
+    cuda_ver="#{node['cluster']['nvidia']['cuda_version']}"
+    export PATH=/usr/local/cuda-${cuda_ver}/bin:${PATH}
+    export LD_LIBRARY_PATH=/usr/local/cuda-${cuda_ver}/lib64:${LD_LIBRARY_PATH}
+    cuda_output=$(nvcc -V | grep -E -o "release [0-9]+.[0-9]+")
+    [[ "${cuda_output}" != "release ${cuda_ver}" ]] && echo "ERROR Installed version ${cuda_output} but expected ${cuda_ver}" && exit 1
+    echo "Correctly installed CUDA ${cuda_output}"
+  TEST
+end

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -21,6 +21,8 @@ include_recipe 'aws-parallelcluster-test::test_processes'
 include_recipe 'aws-parallelcluster-test::test_imds'
 include_recipe 'aws-parallelcluster-test::test_sudoers'
 include_recipe 'aws-parallelcluster-test::test_openssh'
+include_recipe 'aws-parallelcluster-test::test_nvidia'
+include_recipe 'aws-parallelcluster-test::test_dcv'
 
 ###################
 # AWS Cli


### PR DESCRIPTION
### Description of changes
Add kitchen test to verify Nvidia drivers and DCV GL.
In particular, we want here to execute for Nvidia drivers the same tests executed during image build validation [here](https://github.com/aws/aws-parallelcluster/blob/98c53c241f5250ff4475e0b35eedbf7627322634/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml#L250-L304).


### Tests
1. Manual execution of the test recipe on both an instance with GPU (g3.4xlarge) and without (t2.micro).
1. Build&Test (only on x64)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>