### PR TITLE
Add a tool to manually update SSSD property `ldap_default_authtok` ac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **ENHANCEMENTS**
 - Add support for both FQDN and LDAP Distinguished Names in property `DirectoryService.DomainName`.
 
+**CHANGES**
+- Add script to manually update the password used to read from Active Directory,
+  according to the secret stored in AWS Secrets Manager.
+
 **BUG FIXES**
 - Fix `DirectoryService.DomainAddr` conversion to `ldap_uri` SSSD property when it contains multiples domain addresses.
 

--- a/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
@@ -90,6 +90,29 @@ if node['cluster']['node_type'] == 'HeadNode'
     AD
   end
 
+  # Create directory for tools related to the directory service
+  directory_service_scripts_path = "#{node['cluster']['scripts_dir']}/directory_service"
+  directory directory_service_scripts_path do
+    owner 'root'
+    group 'root'
+    mode '0744'
+    recursive true
+  end
+
+  update_directory_service_password_path = "#{directory_service_scripts_path}/update_directory_service_password.sh"
+  template update_directory_service_password_path do
+    source 'directory_service/update_directory_service_password.sh.erb'
+    owner 'root'
+    group 'root'
+    mode '0744'
+    variables(
+      secret_arn: node['cluster']['directory_service']['password_secret_arn'],
+      region: node['cluster']['region'],
+      shared_sssd_conf_path: shared_sssd_conf_path
+    )
+    sensitive true
+  end
+
   sshd_pam_config_path = '/etc/pam.d/sshd'
   generate_ssh_key_path = "#{node['cluster']['scripts_dir']}/generate_ssh_key.sh"
   ssh_key_generator_pam_config_line = "session    optional     pam_exec.so log=/var/log/parallelcluster/pam_ssh_key_generator.log #{generate_ssh_key_path}"
@@ -114,29 +137,6 @@ if node['cluster']['node_type'] == 'HeadNode'
           { after: [sshd_pam_config_regex, ssh_key_generator_pam_config_line, match_to_add_line_after] },
         ]
       )
-    end
-
-    # Create directory for tools related to the directory service
-    directory_service_scripts_path = "#{node['cluster']['scripts_dir']}/directory_service"
-    directory directory_service_scripts_path do
-      owner 'root'
-      group 'root'
-      mode '0744'
-      recursive true
-    end
-
-    update_directory_service_password_path = "#{directory_service_scripts_path}/update_directory_service_password.sh"
-    template update_directory_service_password_path do
-      source 'directory_service/update_directory_service_password.sh.erb'
-      owner 'root'
-      group 'root'
-      mode '0744'
-      variables(
-        secret_arn: node['cluster']['directory_service']['password_secret_arn'],
-        region: node['cluster']['region'],
-        shared_sssd_conf_path: shared_sssd_conf_path
-      )
-      sensitive true
     end
   else
     # Remove script used to generate key if it exists and ensure PAM is not configured to try to call it

--- a/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
@@ -115,6 +115,29 @@ if node['cluster']['node_type'] == 'HeadNode'
         ]
       )
     end
+
+    # Create directory for tools related to the directory service
+    directory_service_scripts_path = "#{node['cluster']['scripts_dir']}/directory_service"
+    directory directory_service_scripts_path do
+      owner 'root'
+      group 'root'
+      mode '0744'
+      recursive true
+    end
+
+    update_directory_service_password_path = "#{directory_service_scripts_path}/update_directory_service_password.sh"
+    template update_directory_service_password_path do
+      source 'directory_service/update_directory_service_password.sh.erb'
+      owner 'root'
+      group 'root'
+      mode '0744'
+      variables(
+        secret_arn: node['cluster']['directory_service']['password_secret_arn'],
+        region: node['cluster']['region'],
+        shared_sssd_conf_path: shared_sssd_conf_path
+      )
+      sensitive true
+    end
   else
     # Remove script used to generate key if it exists and ensure PAM is not configured to try to call it
     file generate_ssh_key_path do

--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/update_directory_service_password.sh.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/update_directory_service_password.sh.erb
@@ -1,0 +1,39 @@
+#!/bin/bash
+# This script updates the password used by SSSD to read from Active Directory, according to the secret stored in
+# AWS Secrets Manager.
+# In particular, it updates the password in /etc/sssd/sssd.conf (ldap_default_authtok) with the one stored
+# in AWS Secrets Manager, if they do not match. The resulting file is then copied to its counterpart shared with compute nodes
+# to make them able to re-sync their local configuration.
+# The script does not require any argument.
+#
+# Usage: ./update_directory_service_password.sh
+# #
+
+set -e
+
+SSSD_CONFIG_FILE="/etc/sssd/sssd.conf"
+SSSD_SHARED_CONFIG_FILE="<%= @shared_sssd_conf_path %>"
+SSSD_SECTION="domain/default"
+SSSD_PROPERTY="ldap_default_authtok"
+SECRET_ARN="<%= @secret_arn %>"
+REGION="<%= @region %>"
+
+PYTHON_CODE_READ_CONFIG="import configparser;file='${SSSD_CONFIG_FILE}';config=configparser.ConfigParser();config.read(file)"
+
+echo "Reading password from ${SSSD_CONFIG_FILE}"
+password_from_sssd_config=$(python3 -c "${PYTHON_CODE_READ_CONFIG}; print(config['${SSSD_SECTION}']['${SSSD_PROPERTY}'])")
+
+echo "Reading password from AWS Secrets Manager: ${SECRET_ARN}"
+password_from_secrets_manager=$(aws secretsmanager get-secret-value --secret-id ${SECRET_ARN} --region ${REGION} --query 'SecretString' --output text)
+
+[ "${password_from_sssd_config}" == "${password_from_secrets_manager}" ] && echo "Password match, skipping update" && exit 0
+
+echo "Writing AWS Secrets Manager password to ${SSSD_CONFIG_FILE}"
+python3 -c "${PYTHON_CODE_READ_CONFIG}; config['${SSSD_SECTION}']['${SSSD_PROPERTY}']='${password_from_secrets_manager}'; config.write(open(file,'w'))"
+echo "Password updated in ${SSSD_CONFIG_FILE}"
+cp ${SSSD_CONFIG_FILE} ${SSSD_SHARED_CONFIG_FILE}
+echo "${SSSD_CONFIG_FILE} copied to ${SSSD_SHARED_CONFIG_FILE}"
+
+echo "Restarting services"
+service sssd restart
+echo "Services restarted"


### PR DESCRIPTION
**CHERRY-PICK from [PR](https://github.com/aws/aws-parallelcluster-cookbook/pull/1389)**

### Description of changes
1. Add the script `/opt/parallelcluster/scripts/directory_service/update_directory_service_password.sh` to update the property `ldap_default_authtok` for `domain/default` in `/etc/sssd/sssd.conf` according to the value stored in the secret in AWS Secrets Manager.

### Tests
Since this is an already tested cherry-pick, we are going to test this PR directly on the dev pipelines. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>