### PR TITLE
Set SSH key generation at SSH login, switch-user and run-as-user.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **ENHANCEMENTS**
+- Execute SSH key creation alongside with the creation of HOME directory, i.e.
+  during SSH login, when switching to another user and when executing a command as another user.
 - Add support for both FQDN and LDAP Distinguished Names in property `DirectoryService.DomainName`.
+- Add script to manually update the password used to read from Active Directory,
+  according to the secret stored in AWS Secrets Manager.
+
+**CHANGES**
+- Disable deeper C-States in x86_64 official AMIs and AMIs created through `build-image` command, to guarantee high performance and low latency.
 
 **CHANGES**
 - Add script to manually update the password used to read from Active Directory,

--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/generate_ssh_key.sh.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/generate_ssh_key.sh.erb
@@ -1,14 +1,25 @@
 #!/bin/bash
 set -ex
 env
-if [ ! -d /home/${PAM_USER}/.ssh ] ; then
-    mkdir /home/${PAM_USER}/.ssh
-    ssh-keygen -q -t rsa -f /home/${PAM_USER}/.ssh/id_rsa -N ''
-    cat /home/${PAM_USER}/.ssh/id_rsa.pub >> /home/${PAM_USER}/.ssh/authorized_keys
-    chmod 0600 /home/${PAM_USER}/.ssh/authorized_keys
-    ssh-keyscan <%=  node['hostname'] %> > /home/${PAM_USER}/.ssh/known_hosts
-    chmod 0600 /home/${PAM_USER}/.ssh/known_hosts
-    chown ${PAM_USER}:$(id -g ${PAM_USER}) -R /home/${PAM_USER}/.ssh
-else
-    exit 0
-fi
+
+# Root does not need SSH key generation
+[ ${PAM_USER} == "root" ] && exit 0
+
+# The home directory for every user must be determined in the most generic way because
+# we should not assume that every user has its home directory in /home/$USER.
+user_home_dir="$(getent passwd ${PAM_USER} | cut -d ':' -f 6)"
+[ ! -d "${user_home_dir}" ] && echo "ERROR Cannot create SSH key for user ${PAM_USER} if its home directory is not found" && exit 1
+
+# Skip SSH key creation if the SSH has been already configured for the user.
+# We assume that SSH has been already configured if the directory .ssh already exists in the user home.
+user_ssh_dir="${user_home_dir}/.ssh"
+[ -d "${user_ssh_dir}" ] && exit 0
+
+mkdir -m 0700 "${user_ssh_dir}"
+
+ssh-keygen -q -t rsa -f "${user_ssh_dir}/id_rsa" -N ''
+cat "${user_ssh_dir}/id_rsa.pub" >> "${user_ssh_dir}/authorized_keys"
+chmod 0600 "${user_ssh_dir}/authorized_keys"
+ssh-keyscan <%=  node['hostname'] %> > "${user_ssh_dir}/known_hosts"
+chmod 0600 "${user_ssh_dir}/known_hosts"
+chown ${PAM_USER}:$(id -g ${PAM_USER}) -R "${user_ssh_dir}"


### PR DESCRIPTION
**CHERRY-PICK from [PR](https://github.com/aws/aws-parallelcluster-cookbook/pull/1385)**

### Description of changes
1. Set SSH key generation at SSH login, switch-user and run-as-user.
2. Made improvements to the script that generates SSH keys.
3. Updated changelog. 

### Tests
1. Launched integration tests locally
This is a cherry-pick from an approved change, so extensive manual tests will be skipped.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>