### PR TITLE
Add recipe and kitchen test to disable and check deeper C states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   according to the secret stored in AWS Secrets Manager.
 
 **CHANGES**
-- Disable deeper C-States in x86_64 official AMIs and AMIs created through `build-image` command, to guarantee high performance and low latency.
-
-**CHANGES**
 - Add script to manually update the password used to read from Active Directory,
   according to the secret stored in AWS Secrets Manager.
+- Disable deeper C-States in x86_64 official AMIs and AMIs created through `build-image` command, to guarantee high performance and low latency.
 
 **BUG FIXES**
 - Fix `DirectoryService.DomainAddr` conversion to `ldap_uri` SSSD property when it contains multiples domain addresses.

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -221,3 +221,6 @@ include_recipe "aws-parallelcluster-install::chrony"
 
 # Install ARM Performance Library
 include_recipe "aws-parallelcluster-install::arm_pl"
+
+# Disable x86_64 C states
+include_recipe "aws-parallelcluster-install::c_states" unless virtualized?

--- a/cookbooks/aws-parallelcluster-install/recipes/c_states.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/c_states.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-install
+# Recipe:: c_states
+#
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# EC2 C states documentation - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/processor_state_control.html#c-states
+
+return unless node['kernel']['machine'] == 'x86_64'
+
+regen_grub_command = value_for_platform(
+  %w(centos amazon) => { 'default' => '/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg' },
+  'ubuntu' => { 'default' => '/usr/sbin/update-grub' }
+)
+
+# Utility function to add an attribute in GRUB_CMDLINE_LINUX_DEFAULT if it is not present
+def append_if_not_present_grub_cmdline(attributes)
+  grub_variable = value_for_platform(
+    %w(centos amazon) => { 'default' => 'GRUB_CMDLINE_LINUX_DEFAULT' },
+    'ubuntu' => { 'default' => 'GRUB_CMDLINE_LINUX' }
+  )
+
+  grep_grub_cmdline = 'grep "^' + grub_variable + '=" /etc/default/grub'
+
+  ruby_block "Append #{grub_variable} if it do not exist in /etc/default/grub" do
+    block do
+      if shell_out(grep_grub_cmdline).stdout.include? "#{grub_variable}="
+        Chef::Log.debug("Found #{grub_variable} line")
+      else
+        Chef::Log.warn("#{grub_variable} not found - Adding")
+        shell_out('echo \'' + grub_variable + '=""\' >> /etc/default/grub')
+        Chef::Log.info("Added #{grub_variable} line")
+      end
+    end
+    action :run
+  end
+  attributes.each do |attribute, properties|
+    ruby_block "Add #{attribute} with value #{properties['value']} to /etc/default/grub in line #{grub_variable} if it is not present" do
+      block do
+        command_out = shell_out(grep_grub_cmdline).stdout
+        if command_out.include? "#{attribute}"
+          Chef::Log.warn("Found #{attribute} in #{grub_variable} - #{grub_variable} value: #{command_out}")
+        else
+          Chef::Log.info("#{attribute} not found - Adding")
+          shell_out('sed -i \'s/^\(' + grub_variable + '=".*\)"$/\1 ' + attribute + '=' + properties['value'] + '"/g\' /etc/default/grub')
+          Chef::Log.info("Added #{attribute}=#{properties['value']} to #{grub_variable}")
+        end
+      end
+      action :run
+    end
+  end
+end
+
+grub_cmdline_attributes = {
+  "processor.max_cstate" => { "value" => "1" },
+  "intel_idle.max_cstate" => { "value" => "1" },
+}
+
+append_if_not_present_grub_cmdline(grub_cmdline_attributes)
+
+execute "Regenerate grub boot menu" do
+  command regen_grub_command
+end

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
+# Cookbook:: aws-parallelcluster-test
 # Recipe:: tests
 #
 # Copyright:: 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -497,4 +497,13 @@ execute 'check supervisord service is enabled' do
 end
 execute 'check ec2blkdev service is enabled' do
   command "systemctl is-enabled ec2blkdev"
+end
+
+###################
+# Verify C-states are disabled
+###################
+if node['kernel']['machine'] == 'x86_64'
+  execute 'Verify C-states are disabled' do
+    command 'test "$(cat /sys/module/intel_idle/parameters/max_cstate)" = "1"'
+  end
 end


### PR DESCRIPTION
CHERRY-PICK from [PR](https://github.com/aws/aws-parallelcluster-cookbook/pull/1386)

### Description of changes
* Disable deeper C states to guarantee high performance and lower latency as stated in [EC2 documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/processor_state_control.html#c-states)
* If there is already a value set for max_cstate in `GRUB_CMDLINE_LINUX_DEFAULT` variable, the value is not modified

### Tests
Manual test whit OS: Amazon Linux 2, Ubuntu 1804, Ubuntu 2004 and Centos 7 with Intel, AMD and Arm instances.

Automated tests included:
1. Xeon E5-2666 v3 (Haswell) → c4.xlarge
2. 2nd generation AMD EPYC 7002 series → c5a.xlarge
3. Xeon Scalable Processors (Cascade Lake) → c5.12xlarge
4. 1st generation Intel Xeon Platinum 8000 series (Skylake-SP) → c5.2xlarge
5. 3rd generation AMD EPYC 7003 series → hpc6a.48xlarge
6. 3rd generation Intel Xeon Scalable processors → c6i.xlarge
7. Arm im4gn.xlarge
8. Arm c6g.2xlarge
9. Arm c6g.xlarge
10. Arm r6g.xlarge
11. Arm m6g.xlarge
12. Arm t4g.xlarge

Added kitchen test to verify that there is only 1 sleep state

### References
* [EC2 documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/processor_state_control.html#c-states)
* [C states](https://wiki.bu.ost.ch/infoportal/_media/embedded_systems/ethercat/controlling_processor_c-state_usage_in_linux_v1.1_nov2013.pdf)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.