### PR TITLE
3.x: Set AuthInfo=cred_expire=70 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ x.x.x
 **ENHANCEMENTS**
 - Add support for multiple Elastic File Systems.
 - Add support for multiple FSx File System.
+- Slurm: Set `AuthInfo=cred_expire=70` to reduce the time requeued jobs must wait before starting again when nodes are not available.
 
 3.1.3
 ------

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -62,6 +62,7 @@ MinJobAge=300
 KillWait=30
 Waittime=0
 MessageTimeout=60
+AuthInfo=cred_expire=70
 #
 # SCHEDULING, JOB, AND NODE SETTINGS
 EnforcePartLimits=ALL


### PR DESCRIPTION
### Description of changes
* The default value is 120 seconds, reduce AuthInfo=cred_expire=70 to allow job faster requeue when nodes are not available. The choice of 70 seconds is justified by the clustermgtd wake up time (60 secs) + 2 times an average loop time (5 seconds). This changes with the number of nodes, anyway in the worst case scenario that the clustermgtd hasn't finished yet, the job will get rescheduled to the same compute resource and the fail over will happen at the next iteration.

### Tests
* Test with insufficient capacity nodes with fast capacity fail-over enabled. Jobs will be allocated to another compute resources after one compute resources ICE

### References
* https://slurm.schedmd.com/slurm.conf.html#OPT_cred_expire
* https://github.com/aws/aws-parallelcluster-node/pull/398

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.