### PR TITLE
3.x: Restart clustermgtd and slurmctld only when queue parameters update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ x.x.x
 - Add support for multiple Elastic File Systems.
 - Add support for multiple FSx File System.
 
+**CHANGES**
+- Slurm: Restart `clustermgtd` and `slurmctld` daemons at cluster update time only when `Scheduling` parameters are updated in the cluster configuration.
+
 3.1.3
 ------
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -23,12 +23,12 @@ execute "generate_pcluster_slurm_configs" do
           " --instance-types-data #{node['cluster']['instance_types_data_path']}" \
           " --compute-node-bootstrap-timeout #{node['cluster']['compute_node_bootstrap_timeout']}" \
           " #{nvidia_installed? ? '' : '--no-gpu'}"
-  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path']) }
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? }
 end
 
 execute 'stop clustermgtd' do
   command "#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl stop clustermgtd"
-  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path']) }
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? }
 end
 
 replace_or_add "update node replacement timeout" do
@@ -40,17 +40,17 @@ end
 
 service 'slurmctld' do
   action :restart
-  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path']) }
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? }
 end
 
 execute 'reload config for running nodes' do
   command "/opt/slurm/bin/scontrol reconfigure && sleep 15"
   retries 3
   retry_delay 5
-  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path']) }
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? }
 end
 
 execute 'start clustermgtd' do
   command "#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl start clustermgtd"
-  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path']) }
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? }
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -552,3 +552,19 @@ def raise_and_write_chef_error(raise_message, chef_error = nil)
   Mixlib::ShellOut.new("echo '#{chef_error}' > /var/log/parallelcluster/chef_error_msg").run_command
   raise raise_message
 end
+
+# Verify if Scheduling section of cluster configuration and compute node bootstrap_timeout have been updated
+def are_queues_updated?
+  require 'yaml'
+  config = YAML.safe_load(File.read(node['cluster']['cluster_config_path']))
+  previous_config = YAML.safe_load(File.read(node['cluster']['previous_cluster_config_path']))
+  config["Scheduling"] != previous_config["Scheduling"] or is_compute_node_bootstrap_timeout_updated?(previous_config, config)
+end
+
+def evaluate_compute_bootstrap_timeout(config)
+  config.dig("DevSettings", "Timeouts", "ComputeNodeBootstrapTimeout") or 1800
+end
+
+def is_compute_node_bootstrap_timeout_updated?(previous_config, config)
+  evaluate_compute_bootstrap_timeout(previous_config) != evaluate_compute_bootstrap_timeout(config)
+end


### PR DESCRIPTION
### Description of changes
* Only restart clustermgtd and slurmctld when Scheduling parameters update or ComputeNodeBootstrapTimeouts update

### Tests
* Update on headnode paramter: clustermgtd and slurmctld not update
* Update MaxCount:  clustermgtd and slurmctld update
* Update ComputeNodeBootstrapTimeouts:  clustermgtd and slurmctld update

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.