### PR TITLE
Make DirectoryService/AdditionalSssdConfigs be merged into default domain configuration rather than be appended. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ x.x.x
 - Add support for multiple Elastic File Systems.
 - Add support for multiple FSx File System.
 - Slurm: Set `AuthInfo=cred_expire=70` to reduce the time requeued jobs must wait before starting again when nodes are not available.
+- Make `DirectoryService/AdditionalSssdConfigs` be merged into final SSSD configuration rather than be appended.
 
 **CHANGES**
 - Slurm: Restart `clustermgtd` and `slurmctld` daemons at cluster update time only when `Scheduling` parameters are updated in the cluster configuration.

--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
@@ -1,28 +1,7 @@
 [domain/default]
-id_provider = ldap
-cache_credentials = True
-ldap_schema = AD
-ldap_uri = <%= @ldap_uri %>
-ldap_search_base = <%=  @ldap_search_base %>
-ldap_default_bind_dn = <%=  node['cluster']['directory_service']['domain_read_only_user'] %>
-ldap_default_authtok = <%= @ldap_default_authtok %>
-<% if node['cluster']['directory_service']['ldap_tls_ca_cert'] != 'NONE' %>
-ldap_tls_cacert = <%=  node['cluster']['directory_service']['ldap_tls_ca_cert'] %>
-<% end %>
-ldap_tls_reqcert = <%=  node['cluster']['directory_service']['ldap_tls_req_cert'] %>
-ldap_id_mapping = True
-fallback_homedir = /home/%u
-default_shell = /bin/bash
-use_fully_qualified_names = False
-ldap_referrals = False
-<% if node['cluster']['directory_service']['additional_sssd_configs'] %>
-  <% node['cluster']['directory_service']['additional_sssd_configs'].each_pair do |param, value| %>
+<%# Domain properties are added in lexicographic order to make the resulting configuration easier to navigate %>
+<% @domain_properties.sort_by { |key| key }.to_h.each_pair do |param, value| %>
 <%= "#{param} = #{value}" %>
-  <% end %>
-<% end %>
-<% if node['cluster']['directory_service']['ldap_access_filter'] != 'NONE' %>
-access_provider = ldap
-ldap_access_filter = <%= node['cluster']['directory_service']['ldap_access_filter'] %>
 <% end %>
 
 [domain/local]


### PR DESCRIPTION
### Description of changes
1. With this change the properties listed in `DirectoryService/AdditionalSssdConfigs` will be merged into the final SSSD configuration rather than be appended to them. Code has been refactored in a way that is easier to distinguish between mandatory properties that are not meant to be overridden, mandatory properties that are meant to be overridden by cluster properties, and optional properties that can be overridden via `DirectoryService/AdditionalSssdConfigs`.

Example

With the previous append strategy, the following configuration:

```
DirectoryService:
  DomainName: VALUE_1
  AdditionalSssdConfigs:
    ldap_search_base: VALUE_2
```

generated:

```
[domain/default]
ldap_search_base = VALUE_1
ldap_search_base = VALUE_2
```

Whereas the proposed merge strategy will generate:

```
[domain/default]
ldap_search_base = VALUE_2
```


### Tests
1. Integ test (SimpleAD/MsAD with LDAPS) locally launched
3. [ONGOING] Build&Test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>