### PR TITLE
Make DirectoryService/AdditionalSssdConfigs be merged into default domain configuration rather than be appended.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Add support for both FQDN and LDAP Distinguished Names in the configuration parameter `DirectoryService/DomainName`. The new validator now checks both the syntaxes.
 - New `update_directory_service_password.sh` script deployed on the head node supports the manual update of the Active Directory password in the SSSD configuration.
   The password is retrieved by the AWS Secrets Manager as from the cluster configuration.
+- Make `DirectoryService/AdditionalSssdConfigs` be merged into final SSSD configuration rather than be appended.
 
 **CHANGES**
 - Disable deeper C-States in x86_64 official AMIs and AMIs created through `build-image` command, to guarantee high performance and low latency.

--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
@@ -1,28 +1,7 @@
 [domain/default]
-id_provider = ldap
-cache_credentials = True
-ldap_schema = AD
-ldap_uri = <%= @ldap_uri %>
-ldap_search_base = <%=  @ldap_search_base %>
-ldap_default_bind_dn = <%=  node['cluster']['directory_service']['domain_read_only_user'] %>
-ldap_default_authtok = <%= @ldap_default_authtok %>
-<% if node['cluster']['directory_service']['ldap_tls_ca_cert'] != 'NONE' %>
-ldap_tls_cacert = <%=  node['cluster']['directory_service']['ldap_tls_ca_cert'] %>
-<% end %>
-ldap_tls_reqcert = <%=  node['cluster']['directory_service']['ldap_tls_req_cert'] %>
-ldap_id_mapping = True
-fallback_homedir = /home/%u
-default_shell = /bin/bash
-use_fully_qualified_names = False
-ldap_referrals = False
-<% if node['cluster']['directory_service']['additional_sssd_configs'] %>
-  <% node['cluster']['directory_service']['additional_sssd_configs'].each_pair do |param, value| %>
+<%# Domain properties are added in lexicographic order to make the resulting configuration easier to navigate %>
+<% @domain_properties.sort_by { |key| key }.to_h.each_pair do |param, value| %>
 <%= "#{param} = #{value}" %>
-  <% end %>
-<% end %>
-<% if node['cluster']['directory_service']['ldap_access_filter'] != 'NONE' %>
-access_provider = ldap
-ldap_access_filter = <%= node['cluster']['directory_service']['ldap_access_filter'] %>
 <% end %>
 
 [domain/local]


### PR DESCRIPTION
**CHERRY-PICKED FROM https://github.com/aws/aws-parallelcluster-cookbook/pull/1413**

### Description of changes
1. With this change the properties listed in `DirectoryService/AdditionalSssdConfigs` will be merged into the final SSSD configuration rather than be appended to them. Code has been refactored in a way that is easier to distinguish between mandatory properties that are not meant to be overridden, mandatory properties that are meant to be overridden by cluster properties, and optional properties that can be overridden via `DirectoryService/AdditionalSssdConfigs`.

Example

With the previous append strategy, the following configuration:

```
DirectoryService:
  DomainName: VALUE_1
  AdditionalSssdConfigs:
    ldap_search_base: VALUE_2
```

generated:

```
[domain/default]
ldap_search_base = VALUE_1
ldap_search_base = VALUE_2
```

Whereas the proposed merge strategy will generate:

```
[domain/default]
ldap_search_base = VALUE_2
```

### Tests
1. The change has been tested in the original PR, btw I will execute a build&test before merging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>