### PR TITLE
[release-3.1] Fix DCV not loading user profile at session start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Fix the configuration parameter `DirectoryService/DomainAddr` conversion to `ldap_uri` SSSD property when it contains multiples domain addresses.
+- Fix DCV not loading user profile at session start. The user's PATH was not correctly set at DCV session connection.  
 
 3.1.2
 ------

--- a/cookbooks/aws-parallelcluster-config/templates/default/dcv/dcv.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/dcv/dcv.conf.erb
@@ -43,6 +43,13 @@
 # If not specified, the default value is 'default-on'.
 #enable-gl-in-virtual-sessions = "default-on"
 
+# Property "virtual-session-source-profile" specifies whether the shell that
+# runs the session starter script should source the user profile.
+# Allowed values: 'false', 'true'.
+# If not specified, the default value is 'false' and DCV will run the session
+# starter script with "bash --noprofile --norc"
+virtual-session-source-profile = true
+
 ###############################################################################
 ## Section "session-management/defaults" contains the default properties of DCV sessions
 ###############################################################################


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
The user's PATH was not correctly set at DCV session connection.

This change was introduced in DCV 2021.3-11591, see doc https://docs.aws.amazon.com/en_us/dcv/latest/adminguide/config-param-ref.html#session_management

### Tests
* manually tested creating dcv session with the modified dcv.conf

### References

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.