### PR TITLE
`[libjwt]` Add support for building libjwt before compiling Slurm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ x.x.x
 ------
 
 **ENHANCEMENTS**
+- Add support for enabling JWT authentication Slurm.
 - Add support for multiple Elastic File Systems.
 - Add support for multiple FSx File System.
 - Slurm: Set `AuthInfo=cred_expire=70` to reduce the time requeued jobs must wait before starting again when nodes are not available.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -163,6 +163,10 @@ default['cluster']['munge']['user'] = 'munge'
 default['cluster']['munge']['user_id'] = node['cluster']['reserved_base_uid'] + 2
 default['cluster']['munge']['group'] = node['cluster']['munge']['user']
 default['cluster']['munge']['group_id'] = node['cluster']['munge']['user_id']
+# JWT
+default['cluster']['jwt']['version'] = '1.12.0'
+default['cluster']['jwt']['url'] = "https://github.com/benmcollins/libjwt/archive/refs/tags/v#{node['cluster']['jwt']['version']}.tar.gz"
+default['cluster']['jwt']['sha1'] = '1c6fec984a8e0ca1122bfc3552a49f45bdb0c4e8'
 
 # NVIDIA
 default['cluster']['nvidia']['enabled'] = 'no'

--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -33,9 +33,11 @@ service "setup-ephemeral" do
 end
 
 # Execution timeout 3600 seconds
-execute "Setup of ephemeral drivers" do
-  user "root"
-  command "/usr/local/sbin/setup-ephemeral-drives.sh"
+unless virtualized?
+  execute "Setup of ephemeral drivers" do
+    user "root"
+    command "/usr/local/sbin/setup-ephemeral-drives.sh"
+  end
 end
 
 # Increase somaxconn and tcp_max_syn_backlog for large scale setting

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_jwt.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_jwt.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-slurm
+# Recipe:: install_jwt
+#
+# Copyright:: Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+jwt_version = node['cluster']['jwt']['version']
+jwt_tarball = "#{node['cluster']['sources_dir']}/libjwt-#{jwt_version}.tar.gz"
+
+remote_file jwt_tarball do
+  source node['cluster']['jwt']['url']
+  mode '0644'
+  retries 3
+  retry_delay 5
+  not_if { ::File.exist?(jwt_tarball) }
+end
+
+ruby_block "Validate libjwt Tarball Checksum" do
+  block do
+    require 'digest'
+    checksum = Digest::SHA1.file(jwt_tarball).hexdigest # nosemgrep
+    raise "Downloaded Tarball Checksum #{checksum} does not match expected checksum #{node['cluster']['jwt']['sha1']}" if checksum != node['cluster']['jwt']['sha1']
+  end
+end
+
+jwt_build_deps = value_for_platform(
+  'ubuntu' => {
+    'default' => 'libjansson-dev',
+  },
+  'default' => 'jansson-devel'
+)
+
+package jwt_build_deps do
+  retries 3
+  retry_delay 5
+end
+
+bash 'libjwt' do
+  user 'root'
+  group 'root'
+  cwd Chef::Config[:file_cache_path]
+  code <<-LIBJWT
+    set -e
+    tar xf #{jwt_tarball}
+    cd libjwt-#{jwt_version}
+    autoreconf --force --install
+    ./configure --prefix=/opt/libjwt
+    CORES=$(grep processor /proc/cpuinfo | wc -l)
+    make -j $CORES
+    sudo make install
+  LIBJWT
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -50,6 +50,8 @@ user node['cluster']['slurm']['user'] do
   shell '/bin/bash'
 end
 
+include_recipe 'aws-parallelcluster-slurm::install_jwt'
+
 slurm_tarball = "#{node['cluster']['sources_dir']}/slurm-#{node['cluster']['slurm']['version']}.tar.gz"
 
 # Get slurm tarball
@@ -83,7 +85,7 @@ bash 'make install' do
 
     tar xf #{slurm_tarball}
     cd slurm-slurm-#{node['cluster']['slurm']['version']}
-    ./configure --prefix=/opt/slurm --with-pmix=/opt/pmix --enable-slurmrestd
+    ./configure --prefix=/opt/slurm --with-pmix=/opt/pmix --with-jwt=/opt/libjwt --enable-slurmrestd
     CORES=$(grep processor /proc/cpuinfo | wc -l)
     make -j $CORES
     make install

--- a/system_tests/bootstrap.sh
+++ b/system_tests/bootstrap.sh
@@ -53,12 +53,12 @@ cp system_tests/systemctl /bin/systemctl
 
 echo "cookbook_path [\"/etc/chef/cookbooks\"]" > /etc/chef/client.rb
 
-mkdir -p /lib/modules/`uname -r`
+mkdir -p /lib/modules/${KERNEL_RELEASE}
 
 platform=$(cat /etc/*-release | grep ID_LIKE | sed 's/.*=//')
 
 if [ "$platform" == "debian" ]; then
-    apt install -y linux-modules-`uname -r`
+    apt install -y linux-modules-${KERNEL_RELEASE}
 else
     yum install -y kernel-modules
 fi

--- a/system_tests/systemd
+++ b/system_tests/systemd
@@ -35,7 +35,7 @@ mkdir -p /home/ubuntu/.ssh
 chown -R ubuntu:ubuntu /home/ubuntu/.ssh
 
 mkdir -p /opt/parallelcluster
-echo "aws-parallelcluster-cookbook-3.0.1" > /opt/parallelcluster/.bootstrapped
+echo "aws-parallelcluster-cookbook-3.2.0" > /opt/parallelcluster/.bootstrapped
 
 mkdir -p /opt/parallelcluster/scripts
 mkdir -p /etc/parallelcluster


### PR DESCRIPTION
### Description of changes
* Add support for building `libjwt` before compiling slurm as this is required to enable the standard JWT authentication mechanism for `slurmrestd`. 
* https://github.com/aws/aws-parallelcluster/issues/3865

### Tests
* The SystemTests were run for both `ubuntu` and `centos7` to validate the build process for apt and yum based distributions.

### References
* Relevant documentation from Slurm about building JWT from source: https://slurm.schedmd.com/download.html#jwt

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.