### PR TITLE
Set default insufficient_capacity_timeout = 600

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -10,3 +10,4 @@ use_private_hostname = <%= node['cluster']['use_private_hostname'] %>
 head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
 head_node_hostname = <%= node['ec2']['local_hostname'] %>
 node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout'] %>
+insufficient_capacity_timeout = 600


### PR DESCRIPTION
Set default `insufficient_capacity_timeout = 600` in parallelcluster_clustermgtd.conf

Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.