### PR TITLE
Upgrade Slurm to version 21.08.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ x.x.x
 
 **CHANGES**
 - Slurm: Restart `clustermgtd` and `slurmctld` daemons at cluster update time only when `Scheduling` parameters are updated in the cluster configuration.
+- Upgrade Slurm to version 21.08.7.
 
 **BUG FIXES**
 - Fix DCV not loading user profile at session start. The user's PATH was not correctly set at DCV session connection.  

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -116,9 +116,9 @@ default['cluster']['parallelcluster-awsbatch-cli-version'] = '1.0.0'
 # URLs to software packages used during install recipes
 # Slurm software
 default['cluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
-default['cluster']['slurm']['version'] = '21-08-6-1'
+default['cluster']['slurm']['version'] = '21-08-7-1'
 default['cluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['cluster']['slurm']['version']}.tar.gz"
-default['cluster']['slurm']['sha1'] = '61c24d0dc89981112710cca571fcd0a2bdefb879'
+default['cluster']['slurm']['sha1'] = '318c261d40dd6d946b150d557e9f107e32b0b8a4'
 default['cluster']['slurm']['user'] = 'slurm'
 default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1
 default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']


### PR DESCRIPTION
### Description of changes
Upgrade Slurm to version 21.08.7

### Tests
1. Image built with the new version
2. Manually tested a job submission 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.