### PR TITLE
Add timeout of 300 seconds to execute command in cloudwatch_agent.rb recipe

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/cloudwatch_agent.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/cloudwatch_agent.rb
@@ -57,6 +57,7 @@ end
 
 execute "cloudwatch-config-validation" do
   user 'root'
+  timeout 300
   environment(
     'CW_LOGS_CONFIGS_SCHEMA_PATH' => config_schema_path,
     'CW_LOGS_CONFIGS_PATH' => config_data_path
@@ -66,6 +67,7 @@ end
 
 execute "cloudwatch-config-creation" do
   user 'root'
+  timeout 300
   environment(
     'LOG_GROUP_NAME' => node['cluster']['log_group_name'],
     'SCHEDULER' => node['cluster']['scheduler'],
@@ -83,6 +85,7 @@ end
 
 execute "cloudwatch-agent-start" do
   user 'root'
+  timeout 300
   command "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
   not_if do
     system("/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | grep status | grep running") ||


### PR DESCRIPTION
### Description of changes
* Add timeout of 300 seconds to execute command in cloudwatch_agent.rb recipe

### Tests
* Manual tests

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.