### PR TITLE
[develop] Avoid sending POWER_DOWN_ASAP to static node

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize_compute.rb
@@ -46,5 +46,5 @@ execute 'resume_node' do
   command(lazy { "#{node['cluster']['slurm']['install_dir']}/bin/scontrol update nodename=#{node.run_state['slurm_compute_nodename']} state=resume reason='Node start up'" })
   ignore_failure true
   # Only resume static nodes
-  only_if { hit_is_static_node?(node.run_state['slurm_compute_nodename']) }
+  only_if { is_static_node?(node.run_state['slurm_compute_nodename']) }
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -235,9 +235,9 @@ def hit_dynamodb_info
 end
 
 #
-# Verify if a given node name is a static node or a dynamic one (HIT only)
+# Verify if a given node name is a static node or a dynamic one (Slurm only)
 #
-def hit_is_static_node?(nodename)
+def is_static_node?(nodename)
   match = nodename.match(/^([a-z0-9\-]+)-(st|dy)-([a-z0-9\-]+)-\d+$/)
   raise "Failed when parsing Compute nodename: #{nodename}" if match.nil?
 


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Since static node are managed by clustermgtd, avoid sending POWER_DOWN_ASAP to static nodes, but instead put those nodes into DRAIN.
This would allow to keep clustermgtd in charge on managing static nodes lifecycle and will avoid Slurm to call the resume program on those static nodes.

### Tests
* Tested manually performing cluster update
* Integration tests will follow up in CLI code

### References
* CLI changes https://github.com/aws/aws-parallelcluster/pull/3976
* cookbook changes https://github.com/aws/aws-parallelcluster-cookbook/pull/1422

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.