### PR TITLE
Upgrade slurm on existing cluster

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/upgrade_slurm.sh
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/upgrade_slurm.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+if /opt/slurm/bin/scontrol show partitions | grep -E "State=(UP|DOWN|DRAIN)"
+then
+  echo "There are partitions in UP, DOWN, DRAIN state. Please execute 'pcluster update-compute-fleet --cluster-name CLUSTER_NAME --status STOP_REQUESTED' to stop the cluster before upgrading Slurm."
+  exit 1
+fi
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit 1
+fi
+
+echo "Stopping ParallelCluster daemons"
+systemctl stop supervisord
+
+echo "Stopping Slurm controller"
+systemctl stop slurmctld
+
+echo "Backing up previous Slurm installation"
+mv /opt/slurm /opt/slurm.bak
+
+cd /etc/chef
+cat > cookbooks/aws-parallelcluster/recipes/upgrade_slurm.rb << EOF
+node.default['cluster']['slurm']['version'] = '21-08-8-2'
+node.default['cluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['cluster']['slurm']['version']}.tar.gz"
+node.default['cluster']['slurm']['sha1'] = 'f7687c11f024fbbe5399b93906d1179adc5c3fb6'
+include_recipe 'aws-parallelcluster-slurm::install_slurm'
+
+EOF
+cinc-client -z -o aws-parallelcluster::upgrade_slurm
+
+echo "Copy Slurm config to the new installation"
+cp -Rp /opt/slurm.bak/etc /opt/slurm/etc
+
+echo "Starting Slurm controller"
+systemctl start slurmctld
+
+echo "Starting ParallelCluster daemons"
+systemctl start supervisord


### PR DESCRIPTION
Note this approach requires head node access to github. e.g. cluster in a subnet without Internet cannot use this approach

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
Manually ran the script on a existing cluster. Slurm was successfully upgraded.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.