### PR TITLE
[develop] Fix regex to match Slurm nodenames

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -238,7 +238,8 @@ end
 # Verify if a given node name is a static node or a dynamic one (Slurm only)
 #
 def is_static_node?(nodename)
-  match = nodename.match(/^([a-z0-9\-]+)-(st|dy)-([a-z0-9\-]+)-\d+$/)
+  # Match queue1-st-compute2-1 or queue1-st-compute2-[1-1000] format
+  match = nodename.match(/^([a-z0-9\-]+)-(st|dy)-([a-z0-9\-]+)-\[?\d+[\-\d+]*\]?$/)
   raise "Failed when parsing Compute nodename: #{nodename}" if match.nil?
 
   match[2] == "st"


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Slurm nodenames can be either queue1-st-compute2-1 or queue1-st-compute2-[1-1000]

### Tests
* Manually tested

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.