### PR TITLE
[develop] Simplify way to configure additional prolog/epilog scripts

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -186,14 +186,26 @@ template '/etc/systemd/system/slurmctld.service' do
 end
 
 if node['cluster']['add_node_hostnames_in_hosts_file'] == "true"
-  cookbook_file "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/prolog" do
+  directory "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/prolog.d" do
+    user 'root'
+    group 'root'
+    mode '0755'
+  end
+
+  cookbook_file "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/prolog.d/pcluster_prolog" do
     source 'head_node_slurm/prolog'
     owner node['cluster']['slurm']['user']
     group node['cluster']['slurm']['group']
     mode '0744'
   end
 
-  cookbook_file "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/epilog" do
+  directory "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/epilog.d" do
+    user 'root'
+    group 'root'
+    mode '0755'
+  end
+
+  cookbook_file "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/epilog.d/pcluster_epilog" do
     source 'head_node_slurm/epilog'
     owner node['cluster']['slurm']['user']
     group node['cluster']['slurm']['group']

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -47,8 +47,8 @@ SuspendRate=0
 # PrologFlags specifies the prolog is executed at job allocation and prologs and epilogs are of different jobs are executed serially
 # SchedulerParameters allows jobs to be requeued to other nodes if prolog error exits.
 # Note the error exit of prolog drains a node, because the error of prolog is considered as a node error.
-Epilog=<%= node['cluster']['slurm']['install_dir'] %>/etc/pcluster/epilog
-Prolog=<%= node['cluster']['slurm']['install_dir'] %>/etc/pcluster/prolog
+Epilog=<%= node['cluster']['slurm']['install_dir'] %>/etc/pcluster/epilog.d/*
+Prolog=<%= node['cluster']['slurm']['install_dir'] %>/etc/pcluster/prolog.d/*
 PrologFlags=alloc,serial
 SchedulerParameters=nohold_on_prolog_fail
 <% end -%>


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
Put official pcluster prolog/epilog scripts under a folder and have slurm loads all files under that folder using the * glob pattern, see official Slurm doc https://slurm.schedmd.com/slurm.conf.html#OPT_Prolog.

In this way, additional prolog/epilog scripts can be easily added by putting a custom script in that folder.
NB. pcluster prolog/epilog scripts are configured only when using a private subnet setup.

### Tests
* covered by integration tests

### References
* n/a
### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.