### PR TITLE
Fix gpg key nvidia fabricmanager for ubuntu 2004 and 1804

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -132,7 +132,7 @@ default['cfncluster']['nvidia']['fabricmanager']['package'] = value_for_platform
 )
 default['cfncluster']['nvidia']['fabricmanager']['repository_key'] = value_for_platform(
   'default' => "D42D0685.pub",
-  'ubuntu' => { 'default' => "7fa2af80.pub" }
+  'ubuntu' => { 'default' => "3bf863cc.pub" }
 )
 default['cfncluster']['nvidia']['fabricmanager']['version'] = value_for_platform(
   'default' => node['cfncluster']['nvidia']['driver_version'],


### PR DESCRIPTION
Signed-off-by: Francesco Giordano <giordafr@amazon.it>

## References
* https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.