### PR TITLE
[Dependencies] Upgrade NVIDIA driver to version 470.129.06. Upgrade NVIDIA Fabric Manager to version 470.129.06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ x.x.x
 - Slurm: Restart `clustermgtd` and `slurmctld` daemons at cluster update time only when `Scheduling` parameters are updated in the cluster configuration.
 - Update slurmctld and slurmd systemd service files.
 - Upgrade NICE DCV to version 2022.0-12760.
+- Upgrade NVIDIA driver to version 470.129.06.
+- Upgrade NVIDIA Fabric Manager to version 470.129.06.
 - Upgrade EFA installer to version 1.15.2.
   - EFA driver: ``efa-1.16.0-1``
   - EFA configuration: ``efa-config-1.9-1``

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -173,7 +173,7 @@ default['cluster']['jwt']['sha1'] = '1c6fec984a8e0ca1122bfc3552a49f45bdb0c4e8'
 
 # NVIDIA
 default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '470.103.01'
+default['cluster']['nvidia']['driver_version'] = '470.129.06'
 default['cluster']['nvidia']['cuda_version'] = '11.4'
 default['cluster']['nvidia']['driver_url_architecture_id'] = arm_instance? ? 'aarch64' : 'x86_64'
 default['cluster']['nvidia']['cuda_url_architecture_id'] = arm_instance? ? 'linux_sbsa' : 'linux'


### PR DESCRIPTION
### Description of changes
1. Upgrade NVIDIA driver to version 470.129.06. 
2. Upgrade NVIDIA Fabric Manager to version 470.129.06.

See release notes: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-470-129-06/index.html

### Tests
1. Verified that there are no breaking changes in the release notes.
2. Verified that there are no diffs in licenses w.r.t to the currently shipped releases.
3. Built custom AMI.
4. Created a cluster with the above AMI.
5. Checked package versions in the head node.
6. Full kitchen and integration tests will be executed on the development pipeline after the merge. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>