### PR TITLE
Fix memory cgroup kitchen test

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -104,7 +104,7 @@ if node['cluster']['scheduler'] == 'slurm'
       # subsys_name  hierarchy  num_cgroups  enabled
       # ...
       # memory       <int>      <int>        1
-      command "[[ $(grep memory /proc/cgroups | awk '{print $4}') == 1 ]]"
+      command "test $(grep memory /proc/cgroups | awk '{print $4}') = 1"
     end
   else
     raise "node_type must be HeadNode or ComputeFleet"


### PR DESCRIPTION
Make memory cgroup kitchen test compatible with non-bash shells

Signed-off-by: Jacopo De Amicis <jdamicis@amazon.it>


### Description of changes
* Make memory cgroup kitchen test compatible with non-bash shells

### Tests
* manually tested command syntax

### References
* issue introduced in [PR 1450](https://github.com/aws/aws-parallelcluster-cookbook/pull/1450)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.