### PR TITLE
Add validator for MemoryInfo from EC2 API

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
@@ -222,8 +222,10 @@ def _realmemory(compute_resource) -> int:
     """Get the RealMemory parameter to be added to the Slurm compute node configuration."""
     instance_type = compute_resource["InstanceType"]
     instance_type_info = instance_types_data[instance_type]
-    memory_info = instance_type_info.get("MemoryInfo", {})
-    ec2_memory = memory_info.get("SizeInMiB")
+    # These are protections against potentially missing elements in the instance description json.
+    # In case of missing MemoryInfo or SizeInMiB, the following evaluations will fail with KeyError.
+    memory_info = instance_type_info["MemoryInfo"]
+    ec2_memory = memory_info["SizeInMiB"]
     realmemory = math.floor(ec2_memory * 0.95)
     return realmemory
 


### PR DESCRIPTION
Prevent cluster creation/update if memory information is not available from EC2 API

Signed-off-by: Jacopo De Amicis <jdamicis@amazon.it>


### Description of changes
* Add validator to throw error in case EC2 does not provide the instance memory information when Slurm memory-based scheduling is enabled.

### Tests
* Manually tested validator at cluster creation and cluster update time.

### References
* https://github.com/aws/aws-parallelcluster/pull/4107

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.