### PR TITLE
[Dependencies] Add NVIDIA GdrCopy 2-3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x.x.x
 - Add new configuration parameter `Scheduling/SlurmSettings/EnableMemoryBasedScheduling` to configure memory-based
   scheduling in Slurm.
   - Move `SelectTypeParameters` and `ConstrainRAMSpace` to the `parallelcluster_slurm*.conf` include files.
+- Add NVIDIA GdrCopy 2.3
 
 **CHANGES**
 - Slurm: Restart `clustermgtd` and `slurmctld` daemons at cluster update time only when `Scheduling` parameters are updated in the cluster configuration.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -201,6 +201,11 @@ default['cluster']['nvidia']['fabricmanager']['repository_uri'] = value_for_plat
   'ubuntu' => { 'default' => "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cluster']['base_os']}/x86_64" }
 )
 
+# NVIDIA GdrCopy
+default['cluster']['nvidia']['gdrcopy']['version'] = '2.3'
+default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrcopy/archive/refs/tags/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"
+default['cluster']['nvidia']['gdrcopy']['sha1'] = '8ee4f0e3c9d0454ff461742c69b0c0ee436e06e1'
+
 # EFA
 default['cluster']['efa']['installer_version'] = '1.15.2'
 default['cluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cluster']['efa']['installer_version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-config/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/nvidia.rb
@@ -22,3 +22,9 @@ if get_nvswitches > 1
     supports status: true
   end
 end
+
+# NVIDIA GdrCopy
+service 'gdrcopy' do
+  action %i(start enable)
+  supports status: true
+end

--- a/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
@@ -128,4 +128,65 @@ if node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['e
 
     remove_package_repository("nvidia-fm-repo")
   end
+
+  # NVIDIA GdrCopy
+  gdrcopy_version = node['cluster']['nvidia']['gdrcopy']['version']
+  gdrcopy_version_extended = "#{node['cluster']['nvidia']['gdrcopy']['version']}-1"
+  gdrcopy_tarball = "#{node['cluster']['sources_dir']}/gdrcopy-#{gdrcopy_version}.tar.gz"
+  gdrcopy_checksum = node['cluster']['nvidia']['gdrcopy']['sha1']
+  gdrcopy_build_dependencies = %w(check check-devel)
+  gdrcopy_service = 'gdrcopy'
+  gdrcopy_verification_commands = %w(copybw)
+
+  remote_file gdrcopy_tarball do
+    source node['cluster']['nvidia']['gdrcopy']['url']
+    mode '0644'
+    retries 3
+    retry_delay 5
+    not_if { ::File.exist?(gdrcopy_tarball) }
+  end
+
+  ruby_block "Validate NVIDIA GdrCopy Tarball Checksum" do
+    block do
+      require 'digest'
+      checksum = Digest::SHA1.file(gdrcopy_tarball).hexdigest # nosemgrep
+      raise "Downloaded NVIDIA GdrCopy Tarball Checksum #{checksum} does not match expected checksum #{gdrcopy_checksum}" if checksum != gdrcopy_checksum
+    end
+  end
+
+  package gdrcopy_build_dependencies do
+    retries 3
+    retry_delay 5
+  end
+
+  bash 'Install NVIDIA GdrCopy' do
+    user 'root'
+    group 'root'
+    cwd Chef::Config[:file_cache_path]
+    code <<-GDRCOPY_INSTALL
+    set -e
+    tar -xf #{gdrcopy_tarball}
+    cd gdrcopy-#{gdrcopy_version}/packages
+    CUDA=/usr/local/cuda ./build-rpm-packages.sh
+    rpm -i gdrcopy-kmod-#{gdrcopy_version_extended}dkms.noarchunknown_distro.rpm    
+    rpm -i gdrcopy-#{gdrcopy_version_extended}.x86_64unknown_distro.rpm 
+    rpm -i gdrcopy-devel-#{gdrcopy_version_extended}.noarchunknown_distro.rpm
+    GDRCOPY_INSTALL
+  end
+
+  gdrcopy_verification_commands.each do |command|
+    bash "Verify NVIDIA GdrCopy: #{command}" do
+      user 'root'
+      group 'root'
+      cwd Chef::Config[:file_cache_path]
+      code <<-GDRCOPY_VERIFY
+      set -e
+      #{command}
+      GDRCOPY_VERIFY
+    end
+  end
+
+  service gdrcopy_service do
+    action %i(disable stop)
+  end
 end

--- a/cookbooks/aws-parallelcluster-test/recipes/test_nvidia.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_nvidia.rb
@@ -37,3 +37,19 @@ bash "check Nvidia drivers" do
     echo "Correctly installed CUDA ${cuda_output}"
   TEST
 end
+
+bash "Check NVIDIA GdrCopy" do
+  cwd Chef::Config[:file_cache_path]
+  code <<-TEST
+    expected_gdrcopy_version="#{node['cluster']['nvidia']['gdrcopy']['version']}"
+
+    echo "Checking NVIDIA GdrCopy version"
+    gdrcopy_version=$(modinfo -F version gdrdrv)
+    [[ "${gdrcopy_version}" != "${expected_gdrcopy_version}" ]] && "ERROR Installed NVIDIA GdrCopy version ${gdrcopy_version} but expected ${expected_gdrcopy_version}" && exit 1
+    echo "Correctly installed NVIDIA GdrCopy ${expected_gdrcopy_version}"
+
+    #echo "Checking NVIDIA GdrCopy installation with copybw"
+    #copybw
+    #[[ $? != 0 ]] && "ERROR Installed NVIDIA GdrCopy is not working properly: copybw test failed" && exit 1
+  TEST
+end


### PR DESCRIPTION
**PLEASE DO NOT MERGE: CRITICAL TESTS STILL PENDING/ONGOING**

### Description of changes
Add NVIDIA GdrCopy 2.3. In particular, the goal is to:
1. Install GdrCopy at AMi build-time;
2. Disable `gdrcopy` service by default at build-time because we want that service to be running only on NVIDIa powered instances.
3. Enable `gdrcopy` service at config-time on NVIDIa powered instances only.

### Tests
1. [PENDING] Verified that there are no breaking changes in the release notes.
1. [PENDING] Built custom AMI.
1. [PENDING] Created a cluster with the above AMI.
1. [PENDING] Checked package versions in the head node.
1. [PENDING] Full kitchen and integration tests will be executed on the development pipeline after the merge.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>