### PR TITLE
[Dependencies] Add NVIDIA GDRCopy 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ x.x.x
 - Add support for multiple Elastic File Systems.
 - Add support for multiple FSx File System.
 - Add support for attaching existing FSx for Ontap and FSx for OpenZFS File Systems.
+- Install NVIDIA GDRCopy 2.3 to enable low-latency GPU memory copy on supported instance types.
 - Slurm: Set `AuthInfo=cred_expire=70` to reduce the time requeued jobs must wait before starting again when nodes are not available.
 - Make `DirectoryService/AdditionalSssdConfigs` be merged into final SSSD configuration rather than be appended.
 - During cluster update set Slurm nodes state accordingly to strategy set through QueueUpdateStrategy parameter.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@
 # Cookbook:: aws-parallelcluster
 # Attributes:: default
 #
-# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -205,6 +205,14 @@ default['cluster']['nvidia']['fabricmanager']['repository_uri'] = value_for_plat
   'ubuntu' => { 'default' => "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cluster']['base_os']}/x86_64" }
 )
 
+# NVIDIA GDRCopy
+default['cluster']['nvidia']['gdrcopy']['version'] = '2.3'
+default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrcopy/archive/refs/tags/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"
+default['cluster']['nvidia']['gdrcopy']['sha1'] = '8ee4f0e3c9d0454ff461742c69b0c0ee436e06e1'
+default['cluster']['nvidia']['gdrcopy']['service'] = value_for_platform(
+  'ubuntu' => { 'default' => 'gdrdrv' },
+  'default' => 'gdrcopy'
+)
 # EFA
 default['cluster']['efa']['installer_version'] = '1.16.0'
 default['cluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cluster']['efa']['installer_version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-config/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/nvidia.rb
@@ -4,7 +4,7 @@
 # Cookbook:: aws-parallelcluster
 # Recipe:: nvidia
 #
-# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -18,6 +18,14 @@
 # Start nvidia fabric manager on NVSwitch enabled systems
 if get_nvswitches > 1
   service 'nvidia-fabricmanager' do
+    action %i(start enable)
+    supports status: true
+  end
+end
+
+if graphic_instance?
+  # NVIDIA GDRCopy
+  service node['cluster']['nvidia']['gdrcopy']['service'] do
     action %i(start enable)
     supports status: true
   end

--- a/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
@@ -4,7 +4,7 @@
 # Cookbook:: aws-parallelcluster
 # Recipe:: nvidia
 #
-# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -127,5 +127,98 @@ if node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['e
     end
 
     remove_package_repository("nvidia-fm-repo")
+  end
+
+  # NVIDIA GDRCopy
+  gdrcopy_version = node['cluster']['nvidia']['gdrcopy']['version']
+  gdrcopy_version_extended = "#{node['cluster']['nvidia']['gdrcopy']['version']}-1"
+  gdrcopy_tarball = "#{node['cluster']['sources_dir']}/gdrcopy-#{gdrcopy_version}.tar.gz"
+  gdrcopy_checksum = node['cluster']['nvidia']['gdrcopy']['sha1']
+  gdrcopy_build_dependencies = value_for_platform(
+    'ubuntu' => {
+      'default' => %w(build-essential devscripts debhelper check libsubunit-dev fakeroot pkg-config dkms),
+    },
+    'default' => %w(dkms rpm-build make check check-devel subunit subunit-devel)
+  )
+  gdrcopy_verification_commands = %w(copybw)
+
+  remote_file gdrcopy_tarball do
+    source node['cluster']['nvidia']['gdrcopy']['url']
+    mode '0644'
+    retries 3
+    retry_delay 5
+    not_if { ::File.exist?(gdrcopy_tarball) }
+  end
+
+  ruby_block "Validate NVIDIA GDRCopy Tarball Checksum" do
+    block do
+      require 'digest'
+      checksum = Digest::SHA1.file(gdrcopy_tarball).hexdigest # nosemgrep
+      raise "Downloaded NVIDIA GDRCopy Tarball Checksum #{checksum} does not match expected checksum #{gdrcopy_checksum}" if checksum != gdrcopy_checksum
+    end
+  end
+
+  package gdrcopy_build_dependencies do
+    retries 3
+    retry_delay 5
+  end
+
+  platform = value_for_platform(
+    'ubuntu' => {
+      '18.04' => 'Ubuntu18_04',
+      '20.04' => 'Ubuntu20_04',
+    },
+    'amazon' => { 'default' => 'unknown_distro' },
+    'default' => '.el7'
+  )
+  arch = value_for_platform(
+    'ubuntu' => { 'default' => arm_instance? ? 'arm64' : 'amd64' },
+    'amazon' => { 'default' => arm_instance? ? 'aarch64' : 'x86_64' },
+    'default' => arm_instance? ? 'arm64' : 'x86_64'
+  )
+  installation_code = value_for_platform(
+    'ubuntu' => {
+      'default' => <<~COMMAND,
+        CUDA=/usr/local/cuda ./build-deb-packages.sh
+        dpkg -i gdrdrv-dkms_#{gdrcopy_version_extended}_#{arch}.#{platform}.deb
+        dpkg -i libgdrapi_#{gdrcopy_version_extended}_#{arch}.#{platform}.deb
+        dpkg -i gdrcopy-tests_#{gdrcopy_version_extended}_#{arch}.#{platform}.deb
+        dpkg -i gdrcopy_#{gdrcopy_version_extended}_#{arch}.#{platform}.deb
+        COMMAND
+    },
+    'default' => <<~COMMAND
+      CUDA=/usr/local/cuda ./build-rpm-packages.sh
+      rpm -i gdrcopy-kmod-#{gdrcopy_version_extended}dkms.noarch#{platform}.rpm
+      rpm -i gdrcopy-#{gdrcopy_version_extended}.#{arch}#{platform}.rpm
+      rpm -i gdrcopy-devel-#{gdrcopy_version_extended}.noarch#{platform}.rpm
+      COMMAND
+  )
+
+  bash 'Install NVIDIA GDRCopy' do
+    user 'root'
+    group 'root'
+    cwd Chef::Config[:file_cache_path]
+    code <<-GDRCOPY_INSTALL
+    set -e
+    tar -xf #{gdrcopy_tarball}
+    cd gdrcopy-#{gdrcopy_version}/packages
+    #{installation_code}
+    GDRCOPY_INSTALL
+  end
+
+  gdrcopy_verification_commands.each do |command|
+    bash "Verify NVIDIA GDRCopy: #{command}" do
+      user 'root'
+      group 'root'
+      cwd Chef::Config[:file_cache_path]
+      code <<-GDRCOPY_VERIFY
+      set -e
+      #{command}
+      GDRCOPY_VERIFY
+    end
+  end
+
+  service node['cluster']['nvidia']['gdrcopy']['service'] do
+    action %i(disable stop)
   end
 end


### PR DESCRIPTION
### Description of changes
GDRCopy is a low-latency GPU memory copy library based on NVIDIA GPUDirect RDMA technology.

With this patch we're installing NVIDIA GDRCopy 2.3 at AMI build time.
The `gdrcopy` service will be disabled by default at build-time because we want that service to be running only on NVIDIA powered instances.

### Tests
* Built custom AMI for ubuntu20 and alinux2
* Executed build AMI process for all the supported OSes and architectures + deep learning AMIs
* Created a cluster with all the OSes and tested submission on different instance types (i.e. c5n, g4dn, g3)
* Added kitchen tests execute the full set of tests suggested in the official doc: https://github.com/NVIDIA/gdrcopy#tests
* Added kitchen test to verify service is enabled on graphic instances and disabled on non-graphic instances.
* Full kitchen and integration tests will be executed on the development pipeline after the merge.

### References
* https://github.com/NVIDIA/gdrcopy
* Created starting from: https://github.com/aws/aws-parallelcluster-cookbook/pull/1458 plus the following changes:
   * Ubuntu support
   * arm64 support
   * check to enable the service only in instances with gpu drivers
   * reordered start and enable for the service in the config recipe
   * additional tests from official doc

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.