### PR TITLE
Added support for rebooting compute nodes via Slurm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ x.x.x
   scheduling in Slurm.
   - Move `SelectTypeParameters` and `ConstrainRAMSpace` to the `parallelcluster_slurm*.conf` include files.
   - Add new configuration parameter to override default value of schedulable memory on compute nodes.
+- Add support for rebooting compute nodes via Slurm.
 
 **CHANGES**
 - Slurm: Restart `clustermgtd` and `slurmctld` daemons at cluster update time only when `Scheduling` parameters are updated in the cluster configuration.

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -35,6 +35,7 @@ CommunicationParameters=NoAddrCache
 SuspendProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_suspend
 ResumeProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_resume
 ResumeFailProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_suspend
+RebootProgram=/sbin/reboot
 SuspendTimeout=120
 PrivateData=cloud
 ResumeRate=0


### PR DESCRIPTION
### Description of changes
* Added support for rebooting compute nodes via Slurm without having clustermgtd marking nodes as unhealthy during the reboot.

### Tests
* Manual tests with `scontrol reboot` and `scontrol reboot asap` with both static and dynamic nodes.
* Manual tests with `scontrol update Node=<> State=POWER_DOWN_ASAP`.

### References
* https://github.com/aws/aws-parallelcluster/pull/4133
* https://github.com/aws/aws-parallelcluster-node/pull/416

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.