### PR TITLE
Fix bug in IMDS ipv6 lockdown

### DIFF
--- a/cookbooks/aws-parallelcluster-config/files/default/imds/imds-access.sh
+++ b/cookbooks/aws-parallelcluster-config/files/default/imds/imds-access.sh
@@ -35,7 +35,7 @@ EOF
 }
 
 function iptables_delete() {
-  local $iptables_command=$1
+  local iptables_command=$1
   local chain=$2
   local destination=$3
   local jump=$4


### PR DESCRIPTION
This commit fixes bug in https://github.com/aws/aws-parallelcluster-cookbook/pull/1459

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.