### PR TITLE
[develop] Remove check on EFA GDR

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -276,11 +276,6 @@ if node['conditions']['efa_supported']
         grep "EFA installer version: #{node['cluster']['efa']['installer_version']}" /opt/amazon/efa_installed_packages
       EFA
     end
-    # GDR (GPUDirect RDMA)
-    execute 'check efa gdr installed' do
-      command "modinfo efa | grep 'gdr:\ *Y'"
-      user node['cluster']['cluster_user']
-    end
   end
 end
 


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
GDR is enabled by default since EFA driver version 1.14.0, but since version 1.16.0 the GDR flag `Y` was removed from driver info, retrievable with `modinfo efa`


### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.