### PR TITLE
Fix GDRCopy kitchen test logic

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/test_nvidia.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_nvidia.rb
@@ -61,21 +61,19 @@ if graphic_instance?
     code <<-TEST
       echo "Checking NVIDIA GDRCopy is working with sanity"
       sanity
-      [[ $? != 0 ]] && echo "ERROR NVIDIA GDRCopy is not working properly: sanity test failed." && exit 1
+      [[ $? == 0 ]] || { echo "ERROR Installed NVIDIA GDRCopy is not working properly: sanity test failed"; exit 1; };
 
       echo "Checking NVIDIA GDRCopy is working with copybw"
       copybw
-      [[ $? != 0 ]] && "ERROR Installed NVIDIA GDRCopy is not working properly: copybw test failed" && exit 1
+      [[ $? == 0 ]] || { echo "ERROR Installed NVIDIA GDRCopy is not working properly: copybw test failed"; exit 1; };
 
       echo "Checking NVIDIA GDRCopy is working with copylat"
       copylat
-      [[ $? != 0 ]] && "ERROR Installed NVIDIA GDRCopy is not working properly: copylat test failed" && exit 1
+      [[ $? == 0 ]] || { echo "ERROR Installed NVIDIA GDRCopy is not working properly: copylat test failed"; exit 1; };
 
-      # The following test is disabled because some assertions in the apiperf code are failing.
-      # https://github.com/NVIDIA/gdrcopy/blob/master/tests/apiperf.cpp
-      #echo "Checking NVIDIA GDRCopy is working with apiperf"
-      #apiperf -s 8
-      #[[ $? != 0 ]] && "ERROR Installed NVIDIA GDRCopy is not working properly: apiperf test failed" && exit 1
+      echo "Checking NVIDIA GDRCopy is working with apiperf"
+      apiperf -s 8
+      [[ $? == 0 ]] || { echo "ERROR Installed NVIDIA GDRCopy is not working properly: apiperf test failed"; exit 1; };
     TEST
   end
 else


### PR DESCRIPTION
### Description of changes
Previously the test was returning 1 even if there were no failures in the executed commands.

### Tests
Manually tested.
```
[ec2-user@ip-10-0-0-188 ~]$ cat test.sh
echo "Checking NVIDIA GDRCopy is working with sanity"
sanity
[[ $? == 0 ]] || { echo "ERROR Installed NVIDIA GDRCopy is not working properly: sanity test failed"; exit 1; };

echo "Checking NVIDIA GDRCopy is working with copybw"
copybw
[[ $? == 0 ]] || { echo "ERROR Installed NVIDIA GDRCopy is not working properly: copybw test failed"; exit 1; };

echo "Checking NVIDIA GDRCopy is working with copylat"
copylat
[[ $? == 0 ]] || { echo "ERROR Installed NVIDIA GDRCopy is not working properly: copylat test failed"; exit 1; };

echo "Checking NVIDIA GDRCopy is working with apiperf"
apiperf -s 8
[[ $? == 0 ]] || { echo "ERROR Installed NVIDIA GDRCopy is not working properly: apiperf test failed"; exit 1; };


[ec2-user@ip-10-0-0-188 ~]$ bash test.sh
Checking NVIDIA GDRCopy is working with sanity
Running suite(s): Sanity
100%: Checks: 27, Failures: 0, Errors: 0
...
closing gdrdrv


[ec2-user@ip-10-0-0-188 ~]$ echo $?
0
```

### References
* Related to https://github.com/aws/aws-parallelcluster-cookbook/pull/1462

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.