### PR TITLE
Use systemctl command to enable GDRCopy service on Ubuntu

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/nvidia.rb
@@ -25,8 +25,12 @@ end
 
 if graphic_instance?
   # NVIDIA GDRCopy
+  execute "enable #{node['cluster']['nvidia']['gdrcopy']['service']} service" do
+    # Using command in place of service resource because of: https://github.com/chef/chef/issues/12053
+    command "systemctl enable #{node['cluster']['nvidia']['gdrcopy']['service']}"
+  end
   service node['cluster']['nvidia']['gdrcopy']['service'] do
-    action %i(start enable)
+    action :start
     supports status: true
   end
 end


### PR DESCRIPTION
### Description of changes
The [service](https://docs.chef.io/resources/service/) resource doesn't enable the service as expected on Ubuntu.
At the end of the recipe execution the service is still disabled, even if changing the order of the start and enable action, because of: https://github.com/chef/chef/issues/12053

### Tests
Recipe execution log (before the change):
```
Recipe: aws-parallelcluster-config::nvidia
  * service[gdrdrv] action start
    - start service service[gdrdrv]
  * service[gdrdrv] action enable (up to date)
...
ubuntu@ip-10-0-0-99:~$ sudo systemctl is-enabled gdrdrv
gdrdrv.service is not a native service, redirecting to systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install is-enabled gdrdrv
disabled
```
Changing the order of the action the service is still disabled
```
  service node['cluster']['nvidia']['gdrcopy']['service'] do
    action %i(enable start)
    supports status: true
  end
...
Recipe: aws-parallelcluster-config::nvidia
  * service[gdrdrv] action enable (up to date)
  * service[gdrdrv] action start
    - start service service[gdrdrv]
...
ubuntu@ip-10-0-0-99:~$ sudo systemctl is-enabled gdrdrv
gdrdrv.service is not a native service, redirecting to systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install is-enabled gdrdrv
disabled
```

So I decided to use an explicit action
``` 
  execute "enable #{node['cluster']['nvidia']['gdrcopy']['service']} service" do
    # Using command in place of service resource because of: https://github.com/chef/chef/issues/12053
    command "systemctl enable #{node['cluster']['nvidia']['gdrcopy']['service']}"
  end
  service node['cluster']['nvidia']['gdrcopy']['service'] do
    action :start
    supports status: true
  end
...
Recipe: aws-parallelcluster-config::nvidia
  * execute[enable gdrdrv service] action run
    - execute systemctl enable gdrdrv
  * service[gdrdrv] action start
    - start service service[gdrdrv]
...
ubuntu@ip-10-0-0-99:~$ sudo systemctl is-enabled gdrdrv
gdrdrv.service is not a native service, redirecting to systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install is-enabled gdrdrv
enabled
```

### References
* Issue related to https://github.com/aws/aws-parallelcluster-cookbook/pull/1462

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.