### PR TITLE
[Networking] Preserve iptables for IPv6 on head node reboot

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/imds.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/imds.rb
@@ -57,12 +57,21 @@ if node['cluster']['node_type'] == 'HeadNode'
     command "mkdir -p $(dirname #{iptables_rules_file}) && iptables-save > #{iptables_rules_file}"
   end
 
+  ip6tables_rules_file = '/etc/parallelcluster/sysconfig/ip6tables.rules'
+
+  execute "Save ip6tables rules" do
+    command "mkdir -p $(dirname #{ip6tables_rules_file}) && ip6tables-save > #{ip6tables_rules_file}"
+  end
+
   template '/etc/init.d/parallelcluster-iptables' do
     source 'imds/parallelcluster-iptables.erb'
     user 'root'
     group 'root'
     mode '0744'
-    variables(iptables_rules_file: iptables_rules_file)
+    variables(
+      iptables_rules_file: iptables_rules_file,
+      ip6tables_rules_file: ip6tables_rules_file
+    )
   end
 
   service "parallelcluster-iptables" do

--- a/cookbooks/aws-parallelcluster-config/templates/default/imds/parallelcluster-iptables.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/imds/parallelcluster-iptables.erb
@@ -3,7 +3,7 @@
 # parallelcluster-iptables
 #
 # chkconfig: 12345 99 99
-# description: Backup and restore iptables rules
+# description: Backup and restore iptables rules (both for IPv4 and IPv6)
 
 ### BEGIN INIT INFO
 # Provides: $parallelcluster-iptables
@@ -16,21 +16,36 @@
 ### END INIT INFO
 
 IPTABLES_RULES_FILE="<%= @iptables_rules_file %>"
+IP6TABLES_RULES_FILE="<%= @ip6tables_rules_file %>"
 
-function start() {
-  if [[ -f $IPTABLES_RULES_FILE ]]; then
-    iptables-restore < $IPTABLES_RULES_FILE
-    echo "iptables rules restored from file: $IPTABLES_RULES_FILE"
+function save_tables() {
+  local iptables_command=$1
+  local iptables_file=$2
+  echo "saving iptables rules to file: $iptables_file"
+  mkdir -p $(dirname $iptables_file)
+  $iptables_command > $iptables_file
+  echo "iptables rules saved to file: $iptables_file"
+}
+
+function restore_tables() {
+  local iptables_command=$1
+  local iptables_file=$2
+  if [[ -f $iptables_file ]]; then
+    $iptables_command < $iptables_file
+    echo "iptables rules restored from file: $iptables_file"
   else
-    echo "iptables rules left unchanged as file was not found: $IPTABLES_RULES_FILE"
+    echo "iptables rules left unchanged as file was not found: $iptables_file"
   fi
 }
 
+function start() {
+  restore_tables iptables-restore $IPTABLES_RULES_FILE
+  restore_tables ip6tables-restore $IP6TABLES_RULES_FILE
+}
+
 function stop() {
-  echo "saving iptables rules to file: $IPTABLES_RULES_FILE"
-  mkdir -p $(dirname $IPTABLES_RULES_FILE)
-  iptables-save > $IPTABLES_RULES_FILE
-  echo "iptables rules saved to file: $IPTABLES_RULES_FILE"
+  save_tables iptables-save $IPTABLES_RULES_FILE
+  save_tables ip6tables-save $IP6TABLES_RULES_FILE
 }
 
 case "$1" in


### PR DESCRIPTION
### Description of changes
Preserve iptables for IPv6 on head node reboot

### Tests
1. Built custom AMI with the changes.
2. Created a cluster with the above custom AMI.
3. Verified that iptables for IPv4 are restored after head node reboot.
4. Verified that iptables for IPv6 are restored after head node reboot.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>