### PR TITLE
Prevent mountpoint collision between ephemeral drive and shared drives

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -27,7 +27,7 @@ end
 
 include_recipe 'aws-parallelcluster-config::nfs' unless virtualized?
 
-# Disable mounting of ephemeral drive under /scratch if /scratch is used by another device
+# Mount the ephemeral drive unless there is a mountpoint collision with shared drives
 shared_dir_array = node['cluster']['ebs_shared_dirs'].split(',') + \
                    node['cluster']['efs_shared_dirs'].split(',') + \
                    node['cluster']['fsx_shared_dirs'].split(',') + \

--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -27,16 +27,23 @@ end
 
 include_recipe 'aws-parallelcluster-config::nfs' unless virtualized?
 
-service "setup-ephemeral" do
-  supports restart: false
-  action :enable
-end
+# Disable mounting of ephemeral drive under /scratch if /scratch is used by another device
+shared_dir_array = node['cluster']['ebs_shared_dirs'].split(',') + \
+                   node['cluster']['efs_shared_dirs'].split(',') + \
+                   node['cluster']['fsx_shared_dirs'].split(',') + \
+                   [ node['cluster']['raid_shared_dir'] ]
+unless shared_dir_array.include? node['cluster']['ephemeral_dir']
+  service "setup-ephemeral" do
+    supports restart: false
+    action :enable
+  end
 
-# Execution timeout 3600 seconds
-unless virtualized?
-  execute "Setup of ephemeral drivers" do
-    user "root"
-    command "/usr/local/sbin/setup-ephemeral-drives.sh"
+  # Execution timeout 3600 seconds
+  unless virtualized?
+    execute "Setup of ephemeral drives" do
+      user "root"
+      command "/usr/local/sbin/setup-ephemeral-drives.sh"
+    end
   end
 end
 

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -373,8 +373,8 @@ if ebs_shared_dirs_array.include? node['cluster']['ephemeral_dir']
     cwd Chef::Config[:file_cache_path]
     user node['cluster']['cluster_user']
     code <<-COLLISION
-      systemctl show setup-ephemeral.service | grep "ActiveState=inactive"
-      systemctl show setup-ephemeral.service | grep "UnitFileState=disabled"
+      systemctl show setup-ephemeral.service -p ActiveState | grep "=inactive"
+      systemctl show setup-ephemeral.service -p UnitFileState | grep "=disabled"
     COLLISION
   end
 else

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -363,9 +363,25 @@ end
 ###################
 # instance store
 ###################
-bash 'test instance store' do
-  cwd Chef::Config[:file_cache_path]
-  code <<-EPHEMERAL
+
+ebs_shared_dirs_array = node['cluster']['ebs_shared_dirs'].split(',')
+
+if ebs_shared_dirs_array.include? node['cluster']['ephemeral_dir']
+  # In this case the ephemeral storage should not be mounted because the mountpoint
+  # clashes with the mountpoint coming from t
+  bash 'test instance store mountpoint collision' do
+    cwd Chef::Config[:file_cache_path]
+    user node['cluster']['cluster_user']
+    code <<-COLLISION
+      systemctl show setup-ephemeral.service | grep "ActiveState=inactive"
+      systemctl show setup-ephemeral.service | grep "UnitFileState=disabled"
+    COLLISION
+  end
+else
+  bash 'test instance store' do
+    cwd Chef::Config[:file_cache_path]
+    user node['cluster']['cluster_user']
+    code <<-EPHEMERAL
       set -xe
       EPHEMERAL_DIR="#{node['cluster']['ephemeral_dir']}"
 
@@ -418,11 +434,11 @@ bash 'test instance store' do
         mkdir -p ${EPHEMERAL_DIR}/test_dir
         touch ${EPHEMERAL_DIR}/test_dir/test_file
       fi
-  EPHEMERAL
-  user node['cluster']['cluster_user']
-end
-execute 'check setup-ephemeral service is enabled' do
-  command "systemctl is-enabled setup-ephemeral"
+    EPHEMERAL
+  end
+  execute 'check setup-ephemeral service is enabled' do
+    command "systemctl is-enabled setup-ephemeral"
+  end
 end
 
 ###################


### PR DESCRIPTION
### Description of changes
* Prevent automatic mounting of ephemeral drives in case of a mountpoint collision between ephemeral drive and other shared storage devices.

### Tests
* Manually created clusters with and without colliding `/scratch` mount point with:
    * EBS
    * EFS
    * FSX
    * EBS-RAID

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.