### PR TITLE
Enable `always_set_home` sudoers option for scheduler plugin to set the HOME environment variable to the home directory of root

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/templates/default/scheduler_plugin_user/99-parallelcluster-scheduler-plugin.erb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/templates/default/scheduler_plugin_user/99-parallelcluster-scheduler-plugin.erb
@@ -1,1 +1,2 @@
+Defaults always_set_home
 <%= node['cluster']['scheduler_plugin']['user'] %> ALL = (root) NOPASSWD: ALL


### PR DESCRIPTION
### Description of changes
Enable `always_set_home` sudoers option for scheduler plugin to always set the HOME environment variable to the home directory of the target user
Add the config in order to set $HOME to /root when running chef client when running sudo command for ubuntu18 and ubuntu20.


### Tests
before add `always_set_home`:
```
sudo -E bash -c 'echo $HOME'
/home/ubuntu
```
After adding always_set_home`:
```
sudo -E bash -c 'echo $HOME'
/root
```
Manually tests for PBS plugin and slurm plugin 
### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.