### PR TITLE
Add is_service_installed? helper to enable and run gdrcopy service only when the service is present

### DIFF
--- a/cookbooks/aws-parallelcluster-config/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-config/libraries/helpers.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright:: 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+#
+# Check if a service is installed in the instance and in the specific platform
+#
+def is_service_installed?(service, platform_families = node['platform_family'])
+  if platform_family?(platform_families)
+    service_check = Mixlib::ShellOut.new("systemctl daemon-reload && systemctl list-unit-files --all | grep #{service}")
+    service_check.run_command
+    # convert return code in boolean
+    service_check.exitstatus.to_i.zero?
+  else
+    # in case of different platform return false
+    false
+  end
+end

--- a/cookbooks/aws-parallelcluster-config/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/nvidia.rb
@@ -23,7 +23,7 @@ if get_nvswitches > 1
   end
 end
 
-if graphic_instance?
+if graphic_instance? && is_service_installed?(node['cluster']['nvidia']['gdrcopy']['service'])
   # NVIDIA GDRCopy
   execute "enable #{node['cluster']['nvidia']['gdrcopy']['service']} service" do
     # Using command in place of service resource because of: https://github.com/chef/chef/issues/12053


### PR DESCRIPTION
Signed-off-by: Francesco Giordano <giordafr@amazon.it>

### Description of changes
* Add is_service_installed? helper to enable and run gdrcopy service only when the service is present

### Tests
* Manually tested

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.