### PR TITLE
Make disable_service and is_service_disabled more general setting platform_families default to the current value

### DIFF
--- a/cookbooks/aws-parallelcluster-install/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-install/libraries/helpers.rb
@@ -15,7 +15,7 @@
 #
 # Disable service
 #
-def disable_service(service, platform_families = %i(rhel amazon debian), operations = :disable)
+def disable_service(service, platform_families = node['platform_family'], operations = :disable)
   if platform_family?(platform_families)
     service service do
       action operations

--- a/cookbooks/aws-parallelcluster-test/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-test/libraries/helpers.rb
@@ -228,7 +228,7 @@ end
 #
 # Check if a service is disabled
 #
-def is_service_disabled(service, platform_families = %i(rhel amazon debian))
+def is_service_disabled(service, platform_families = node['platform_family'])
   if platform_family?(platform_families)
     execute "check #{service} service is disabled" do
       command "systemctl is-enabled #{service} && exit 1 || exit 0"


### PR DESCRIPTION
Signed-off-by: Francesco Giordano <giordafr@amazon.it>

### Description of changes
* Make disable_service and is_service_disabled more general setting platform_families default to the current value

### Tests
* Manual tested

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.