### PR TITLE
Change fqdn in file /etc/hosts to be stripped of the trailing dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - yum-epel-4.5.0 (from yum-epel-4.1.2)
 - Disable `aws-ubuntu-eni-helper` service, available in Deep Learning AMIs, to avoid conflicts with `configure_nw_interface.sh` when configuring instances with multiple network cards.
 - Set MTU to 9001 for all the network interfaces when configuring instances with multiple network cards.
+- Remove the trailing dot when configuring the compute node FQDN.
 
 3.1.4
 ------

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
@@ -97,6 +97,6 @@ end
 replace_or_add "set fqdn in the /etc/hosts" do
   path "/etc/hosts"
   pattern "^#{node['ec2']['local_ipv4']}\s+"
-  line(lazy { "#{node['ec2']['local_ipv4']} #{node['cluster']['assigned_hostname']} #{node['cluster']['assigned_short_hostname']}" })
+  line(lazy { "#{node['ec2']['local_ipv4']} #{node['cluster']['assigned_hostname'].chomp('.')} #{node['cluster']['assigned_short_hostname']}" })
   notifies :reload, "ohai[reload_hostname]"
 end


### PR DESCRIPTION
Signed-off-by: Francesco Giordano <giordafr@amazon.it>


### Description of changes
* Change fqdn in file /etc/hosts to be stripped of the last dot
* In some case the absolute FQDN is not accepted by the application - http://www.dns-sd.org/trailingdotsindomainnames.html

### Tests
* Manual tested
* Create a cluster with custom cookbook with user provided hosted zone

### References
* https://ruby-doc.org/core-3.1.2/String.html#method-i-chomp

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.