### PR TITLE
[release-3.2] Add file to disable cron.daily jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Upgrade NVIDIA driver to version 470.141.03.
 - Upgrade NVIDIA Fabric Manager to version 470.141.03.
+- Disable cron job tasks man-db and mlocate, which may have a negative impact on node performance.
 
 3.2.0
 ------

--- a/cookbooks/aws-parallelcluster-install/files/default/cron/jobs.deny
+++ b/cookbooks/aws-parallelcluster-install/files/default/cron/jobs.deny
@@ -1,0 +1,2 @@
+mlocate
+man-db.cron

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -217,6 +217,9 @@ include_recipe "aws-parallelcluster-install::lustre"
 # Install the AWS cloudwatch agent
 include_recipe "aws-parallelcluster-install::cloudwatch_agent"
 
+# Configure cron and anacron
+include_recipe "aws-parallelcluster-install::cron"
+
 # Install Amazon Time Sync
 include_recipe "aws-parallelcluster-install::chrony"
 

--- a/cookbooks/aws-parallelcluster-install/recipes/cron.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/cron.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-install
+# Recipe:: cron
+#
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Disable cron/anacron jobs that may impact performance
+cookbook_file 'cron.jobs.deny' do
+  source 'cron/jobs.deny'
+  path '/etc/cron.daily/jobs.deny'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Add file to be able to disable cron.daily jobs.
The jobs under cron.daily folder are triggered through cron -> anacron

Jobs that have been disabled is because they may have a negative impact on node performance
* man-db to perform maintenance task on man pages
* mlocate to update the database for quick lookup of file names

Resolves
* https://github.com/aws/aws-parallelcluster/issues/4237
* https://github.com/aws/aws-parallelcluster/issues/3869

### Tests
manually tested

### References
* https://github.com/aws/aws-parallelcluster/issues/4237
* https://github.com/aws/aws-parallelcluster/issues/3869

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.