### PR TITLE
3.x [Dependencies] Upgrade Intel MPI to version 2021.6.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -81,10 +81,10 @@ default['cluster']['intelpython2']['version'] = '2019.4-088'
 default['cluster']['intelpython3']['version'] = '2020.2-902'
 
 # Intel MPI
-default['cluster']['intelmpi']['version'] = '2021.4.0'
-default['cluster']['intelmpi']['full_version'] = "#{node['cluster']['intelmpi']['version']}.441"
+default['cluster']['intelmpi']['version'] = '2021.6.0'
+default['cluster']['intelmpi']['full_version'] = "#{node['cluster']['intelmpi']['version']}.602"
 default['cluster']['intelmpi']['modulefile'] = "/opt/intel/mpi/#{node['cluster']['intelmpi']['version']}/modulefiles/mpi"
-default['cluster']['intelmpi']['kitchen_test_string'] = 'Version 2021.4'
+default['cluster']['intelmpi']['kitchen_test_string'] = 'Version 2021.6'
 default['cluster']['intelmpi']['qt_version'] = '5.15.2'
 
 # Arm Performance Library


### PR DESCRIPTION
Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
Tests in https://github.com/aws/aws-parallelcluster/blob/develop/tests/integration-tests/configs/pcluster3.yaml have been passed

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.