### PR TITLE
Generate new configuration file to share compute resource info required to create fleet API

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default['cluster']['change_set_path'] = "#{node['cluster']['shared_dir']}/change
 default['cluster']['launch_templates_config_path'] = "#{node['cluster']['shared_dir']}/launch-templates-config.json"
 default['cluster']['instance_types_data_path'] = "#{node['cluster']['shared_dir']}/instance-types-data.json"
 default['cluster']['computefleet_status_path'] = "#{node['cluster']['shared_dir']}/computefleet-status.json"
+default['cluster']['fleet_config_path'] = "#{node['cluster']['shared_dir']}/fleet-config.json"
 default['cluster']['reserved_base_uid'] = 400
 
 # Python Version

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
@@ -1,0 +1,127 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import argparse
+import copy
+import json
+import logging
+
+import yaml
+
+log = logging.getLogger()
+
+
+class CriticalError(Exception):
+    """Critical error for the script."""
+
+    pass
+
+
+def generate_fleet_config_file(output_file, input_file):
+    """
+    Generate configuration file used by Fleet Manager in node daemon package.
+
+    Generate fleet-config.json
+    {
+        "my-create-fleet-queue": {
+            "my-compute-resource": {
+                "CapacityType": "on-demand|spot",
+                "AllocationStrategy": "lowest-price"
+                "InstanceTypeList": [
+                    { "InstanceType": ... }
+                ],
+                "MaxPrice": ...
+            }
+        },
+        "my-run-instances-queue": {
+            "my-compute-resource": {
+                "CapacityType": "on-demand|spot",
+                "AllocationStrategy": "lowest-price"
+                "InstanceType": ...,
+                "MaxPrice": ...
+            }
+        }
+    }
+    """
+    cluster_config = _load_cluster_config(input_file)
+    queue, compute_resource = None, None
+    try:
+        fleet_config = {}
+        for queue_config in cluster_config["Scheduling"]["SlurmQueues"]:
+            queue = queue_config["Name"]
+            capacity_type = "on-demand" if queue_config["CapacityType"] == "ONDEMAND" else "spot"
+            allocation_strategy = queue_config.get("AllocationStrategy", "lowest-price")
+            fleet_config[queue] = {}
+
+            for compute_resource_config in queue_config["ComputeResources"]:
+                compute_resource = compute_resource_config["Name"]
+                fleet_config[queue][compute_resource] = {}
+
+                if compute_resource_config.get("InstanceTypeList"):
+                    fleet_config[queue][compute_resource] = {
+                        "CapacityType": capacity_type,
+                        "AllocationStrategy": allocation_strategy,
+                        "InstanceTypeList": copy.deepcopy(compute_resource_config["InstanceTypeList"]),
+                    }
+                    if capacity_type == "spot" and compute_resource_config["SpotPrice"]:
+                        fleet_config[queue][compute_resource]["MaxPrice"] = compute_resource_config["SpotPrice"]
+
+                elif compute_resource_config.get("InstanceType"):
+                    fleet_config[queue][compute_resource]["InstanceType"] = compute_resource_config["InstanceType"]
+
+                else:
+                    raise Exception(
+                        "InstanceTypeList or InstanceType field not found "
+                        f"in queue: {queue}, compute resource: {compute_resource} configuration"
+                    )
+    except KeyError as e:
+        message = f"Unable to find key {e} in the configuration"
+        message += f" of queue: {queue}" if queue else " file"
+        message += f", compute resource: {compute_resource}" if compute_resource else ""
+
+        log.error(message)
+        raise CriticalError(message)
+
+    log.info("Generating %s", output_file)
+    with open(output_file, "w") as output:
+        output.write(json.dumps(fleet_config, indent=4))
+
+    log.info("Finished.")
+
+
+def _load_cluster_config(input_file_path):
+    """Load cluster config file."""
+    with open(input_file_path) as input_file:
+        return yaml.load(input_file, Loader=yaml.SafeLoader)
+
+
+def main():
+    try:
+        logging.basicConfig(
+            level=logging.INFO, format="%(asctime)s - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s"
+        )
+        log.info("Running ParallelCluster Fleet Config Generator")
+        parser = argparse.ArgumentParser(description="Take in fleet configuration generator related parameters")
+        parser.add_argument("--output-file", help="The output file for generated json fleet config", required=True)
+        parser.add_argument(
+            "--input-file",
+            help="Yaml file containing pcluster CLI configuration file with default values",
+            required=True,
+        )
+        args = parser.parse_args()
+        generate_fleet_config_file(args.output_file, args.input_file)
+    except Exception as e:
+        log.exception("Failed to generate Fleet configuration, exception: %s", e)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
@@ -27,7 +27,7 @@ instance_types_data = {}
 
 
 class CriticalError(Exception):
-    """Critical error for the daemon."""
+    """Critical error for the script."""
 
     pass
 
@@ -100,8 +100,6 @@ def generate_slurm_config_files(
             output_directory,
             dryrun,
         )
-
-    generate_instance_type_mapping_file(pcluster_subdirectory, queues)
 
     log.info("Finished.")
 
@@ -282,23 +280,6 @@ def _setup_logger():
     )
 
 
-def generate_instance_type_mapping_file(output_dir, queues):
-    """Generate a mapping file to retrieve the Instance Type related to the instance key used in the slurm nodename."""
-    instance_name_type_mapping = {}
-    for queue in queues:
-        instance_name_type_mapping[queue["Name"]] = {}
-        compute_resources = queue["ComputeResources"]
-        for compute_resource in compute_resources:
-            instance_type = compute_resource.get("InstanceType")
-            # Remove all characters excepts letters and numbers
-            instance_name_type_mapping[queue["Name"]][compute_resource["Name"]] = instance_type
-
-    filename = f"{output_dir}/instance_name_type_mappings.json"
-    log.info("Generating %s", filename)
-    with open(filename, "w") as output_file:
-        output_file.write(json.dumps(instance_name_type_mapping, indent=4))
-
-
 def _get_metadata(metadata_path):
     """
     Get EC2 instance metadata.
@@ -347,23 +328,11 @@ def main():
         log.info("Running ParallelCluster Slurm Config Generator")
         parser = argparse.ArgumentParser(description="Take in slurm configuration generator related parameters")
         parser.add_argument(
-            "--output-directory", type=str, help="The output directory for generated slurm configs", required=True
+            "--output-directory", help="The output directory for generated slurm configs", required=True
         )
-        parser.add_argument(
-            "--template-directory", type=str, help="The directory storing slurm config templates", required=True
-        )
-        parser.add_argument(
-            "--input-file",
-            type=str,
-            # Todo: is the default necessary?
-            default="/opt/parallelcluster/slurm_config.json",
-            help="Yaml file containing pcluster configuration file",
-        )
-        parser.add_argument(
-            "--instance-types-data",
-            type=str,
-            help="JSON file containing info about instance types",
-        )
+        parser.add_argument("--template-directory", help="The directory storing slurm config templates", required=True)
+        parser.add_argument("--input-file", help="Yaml file containing pcluster configuration file", required=True)
+        parser.add_argument("--instance-types-data", help="JSON file containing info about instance types")
         parser.add_argument(
             "--dryrun",
             action="store_true",

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -70,6 +70,12 @@ unless virtualized?
             " --compute-node-bootstrap-timeout #{node['cluster']['compute_node_bootstrap_timeout']} #{no_gpu}"\
             " --realmemory-to-ec2memory-ratio #{node['cluster']['realmemory_to_ec2memory_ratio']}"
   end
+
+  # Generate pcluster fleet config
+  execute "generate_pcluster_fleet_config" do
+    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_fleet_config_generator.py"\
+            " --output-file #{node['cluster']['fleet_config_path']} --input-file #{node['cluster']['cluster_config_path']}"
+  end
 end
 
 # all other OSs use /sys/fs/cgroup, which is the default

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -136,6 +136,12 @@ execute "generate_pcluster_slurm_configs" do
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? }
 end
 
+execute "generate_pcluster_fleet_config" do
+  command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_fleet_config_generator.py"\
+          " --output-file #{node['cluster']['fleet_config_path']} --input-file #{node['cluster']['cluster_config_path']}"
+  not_if { ::File.exist?(node['cluster']['fleet_config_path']) && !are_queues_updated? }
+end
+
 replace_or_add "update node replacement timeout" do
   path "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
   pattern "node_replacement_timeout*"

--- a/test/unit/slurm/test_fleet_config_generator.py
+++ b/test/unit/slurm/test_fleet_config_generator.py
@@ -1,0 +1,134 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import pytest
+from assertpy import assert_that
+from slurm.pcluster_fleet_config_generator import generate_fleet_config_file
+
+
+@pytest.mark.parametrize(
+    "cluster_config, expected_message",
+    [
+        ({}, "Unable to find key 'Scheduling' in the configuration file"),
+        ({"Scheduling": {}}, "Unable to find key 'SlurmQueues' in the configuration file"),
+        ({"Scheduling": {"SlurmQueues": []}}, None),
+        (
+            {"Scheduling": {"SlurmQueues": [{"ComputeResources": []}]}},
+            "Unable to find key 'Name' in the configuration file",
+        ),
+        (
+            {"Scheduling": {"SlurmQueues": [{"Name": "q1"}]}},
+            "Unable to find key 'CapacityType' in the configuration of queue: q1",
+        ),
+        (
+            {"Scheduling": {"SlurmQueues": [{"Name": "q1", "CapacityType": "ONDEMAND"}]}},
+            "Unable to find key 'ComputeResources' in the configuration of queue: q1",
+        ),
+        ({"Scheduling": {"SlurmQueues": [{"Name": "q1", "CapacityType": "SPOT", "ComputeResources": []}]}}, None),
+        (
+            {
+                "Scheduling": {
+                    "SlurmQueues": [
+                        {"Name": "q1", "CapacityType": "SPOT", "ComputeResources": [{"InstanceTypeList": []}]}
+                    ]
+                }
+            },
+            "Unable to find key 'Name' in the configuration of queue: q1",
+        ),
+        (
+            {
+                "Scheduling": {
+                    "SlurmQueues": [
+                        {
+                            "Name": "q1",
+                            "CapacityType": "ONDEMAND",
+                            "ComputeResources": [{"Name": "cr1", "InstanceTypeList": []}],
+                        }
+                    ]
+                }
+            },
+            "InstanceTypeList or InstanceType field not found in queue: q1, compute resource: cr1 configuration",
+        ),
+        (
+            {
+                "Scheduling": {
+                    "SlurmQueues": [
+                        {
+                            "Name": "q1",
+                            "CapacityType": "ONDEMAND",
+                            "ComputeResources": [
+                                {"Name": "cr1", "InstanceTypeList": [{"InstanceType": "test"}]},
+                                {"Name": "cr2", "InstanceType": "test"},
+                            ],
+                        }
+                    ]
+                }
+            },
+            None,
+        ),
+        (
+            {
+                "Scheduling": {
+                    "SlurmQueues": [
+                        {
+                            "Name": "q1",
+                            "CapacityType": "SPOT",
+                            "ComputeResources": [{"Name": "cr1", "InstanceTypeList": [{"InstanceType": "test"}]}],
+                        }
+                    ]
+                }
+            },
+            "Unable to find key 'SpotPrice' in the configuration of queue: q1, compute resource: cr1",
+        ),
+        (
+            {
+                "Scheduling": {
+                    "SlurmQueues": [
+                        {
+                            "Name": "q1",
+                            "CapacityType": "SPOT",
+                            "ComputeResources": [
+                                {"Name": "cr1", "InstanceTypeList": [{"InstanceType": "test"}], "SpotPrice": 10}
+                            ],
+                        }
+                    ]
+                }
+            },
+            None,
+        ),
+    ],
+)
+def test_generate_fleet_config_file_error_cases(mocker, tmpdir, cluster_config, expected_message, caplog):
+    mocker.patch("slurm.pcluster_fleet_config_generator._load_cluster_config", return_value=cluster_config)
+    output_file = f"{tmpdir}/fleet-config.json"
+
+    if expected_message:
+        with pytest.raises(Exception, match=expected_message):
+            generate_fleet_config_file(output_file, input_file="fake")
+    else:
+        generate_fleet_config_file(output_file, input_file="fake")
+
+
+def test_generate_fleet_config_file(test_datadir, tmpdir):
+    input_file = os.path.join(test_datadir, "sample_input.yaml")
+    file_name = "fleet-config.json"
+    output_file = f"{tmpdir}/{file_name}"
+
+    generate_fleet_config_file(output_file, input_file)
+    _assert_files_are_equal(tmpdir / file_name, test_datadir / "expected_outputs" / file_name)
+
+
+def _assert_files_are_equal(file, expected_file):
+    with open(file, "r") as f, open(expected_file, "r") as exp_f:
+        expected_file_content = exp_f.read()
+        expected_file_content = expected_file_content.replace("<DIR>", os.path.dirname(file))
+        assert_that(f.read()).is_equal_to(expected_file_content)

--- a/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/expected_outputs/fleet-config.json
+++ b/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/expected_outputs/fleet-config.json
@@ -1,0 +1,46 @@
+{
+    "ondemand-mixed": {
+        "single": {
+            "InstanceType": "c5n.4xlarge"
+        },
+        "fleet": {
+            "CapacityType": "on-demand",
+            "AllocationStrategy": "lowest-price",
+            "InstanceTypeList": [
+                {
+                    "InstanceType": "c5n.4xlarge"
+                },
+                {
+                    "InstanceType": "r5.4xlarge"
+                },
+                {
+                    "InstanceType": "r5n.4xlarge"
+                }
+            ]
+        }
+    },
+    "spot-mixed": {
+        "single": {
+            "InstanceType": "c5n.18xlarge"
+        },
+        "fleet-price": {
+            "CapacityType": "spot",
+            "AllocationStrategy": "capacity-optimized",
+            "InstanceTypeList": [
+                {
+                    "InstanceType": "c5n.18xlarge"
+                }
+            ],
+            "MaxPrice": 10
+        },
+        "fleet-noprice": {
+            "CapacityType": "spot",
+            "AllocationStrategy": "capacity-optimized",
+            "InstanceTypeList": [
+                {
+                    "InstanceType": "c5n.18xlarge"
+                }
+            ]
+        }
+    }
+}

--- a/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/sample_input.yaml
+++ b/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/sample_input.yaml
@@ -1,0 +1,126 @@
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - AllocationStrategy: lowest-price
+    CapacityType: ONDEMAND
+    ComputeResources:
+    - DisableSimultaneousMultithreading: false
+      Efa:
+        Enabled: false
+        GdrSupport: false
+      InstanceType: c5n.4xlarge
+      MaxCount: 10
+      MinCount: 0
+      Name: single
+      SchedulableMemory: null
+      SpotPrice: null
+    - DisableSimultaneousMultithreading: false
+      Efa:
+        Enabled: true
+        GdrSupport: false
+      InstanceTypeList:
+        - InstanceType: c5n.4xlarge
+        - InstanceType: r5.4xlarge
+        - InstanceType: r5n.4xlarge
+      MaxCount: 10
+      MinCount: 1
+      Name: fleet
+      SchedulableMemory: null
+      SpotPrice: null
+    ComputeSettings:
+      LocalStorage:
+        EphemeralVolume: null
+        RootVolume:
+          Encrypted: true
+          Iops: 3000
+          Size: null
+          Throughput: 125
+          VolumeType: gp3
+    CustomActions: null
+    Iam:
+      AdditionalIamPolicies: []
+      InstanceProfile: null
+      InstanceRole: null
+      S3Access: null
+    Image: null
+    Name: ondemand-mixed
+    Networking:
+      AdditionalSecurityGroups: null
+      AssignPublicIp: null
+      PlacementGroup:
+        Enabled: true
+        Id: null
+      Proxy: null
+      SecurityGroups: null
+      SubnetIds:
+      - subnet-0230367ab0e5123a4
+  - AllocationStrategy: capacity-optimized
+    CapacityType: SPOT
+    ComputeResources:
+    - DisableSimultaneousMultithreading: false
+      Efa:
+        Enabled: true
+        GdrSupport: false
+      InstanceType: c5n.18xlarge
+      MaxCount: 10
+      MinCount: 1
+      Name: single
+      SchedulableMemory: null
+      SpotPrice: null
+    - DisableSimultaneousMultithreading: false
+      Efa:
+        Enabled: true
+        GdrSupport: false
+      InstanceTypeList:
+        - InstanceType: c5n.18xlarge
+      MaxCount: 10
+      MinCount: 1
+      Name: fleet-price
+      SchedulableMemory: null
+      SpotPrice: 10
+    - DisableSimultaneousMultithreading: false
+      Efa:
+        Enabled: true
+        GdrSupport: false
+      InstanceTypeList:
+        - InstanceType: c5n.18xlarge
+      MaxCount: 10
+      MinCount: 1
+      Name: fleet-noprice
+      SchedulableMemory: null
+      SpotPrice: null
+    ComputeSettings:
+      LocalStorage:
+        EphemeralVolume: null
+        RootVolume:
+          Encrypted: true
+          Iops: 3000
+          Size: null
+          Throughput: 125
+          VolumeType: gp3
+    CustomActions: null
+    Iam:
+      AdditionalIamPolicies: []
+      InstanceProfile: null
+      InstanceRole: null
+      S3Access: null
+    Image: null
+    Name: spot-mixed
+    Networking:
+      AdditionalSecurityGroups: null
+      AssignPublicIp: null
+      PlacementGroup:
+        Enabled: true
+        Id: null
+      Proxy: null
+      SecurityGroups: null
+      SubnetIds:
+      - subnet-0230367ab0e5123a4
+  SlurmSettings:
+    Dns:
+      DisableManagedDns: false
+      HostedZoneId: null
+      UseEc2Hostnames: false
+    EnableMemoryBasedScheduling: false
+    QueueUpdateStrategy: COMPUTE_FLEET_STOP
+    ScaledownIdletime: 10

--- a/test/unit/slurm/test_slurm_config_generator.py
+++ b/test/unit/slurm/test_slurm_config_generator.py
@@ -41,11 +41,6 @@ def test_generate_slurm_config_files_nogpu(mocker, test_datadir, tmpdir, no_gpu)
         output_file_name = f"slurm_parallelcluster{file_type}.conf"
         _assert_files_are_equal(tmpdir / output_file_name, test_datadir / "expected_outputs" / output_file_name)
 
-    _assert_files_are_equal(
-        tmpdir / "pcluster/instance_name_type_mappings.json",
-        test_datadir / "expected_outputs/pcluster/instance_name_type_mappings.json",
-    )
-
 
 @pytest.mark.parametrize(
     "memory_scheduling,realmemory_to_ec2memory_ratio",
@@ -89,11 +84,6 @@ def test_generate_slurm_config_files_memory_scheduling(
         mem_sched = "_mem_sched" if memory_scheduling else ""
         output_file_name = f"slurm_parallelcluster{file_type}{mem_sched}.conf"
         _assert_files_are_equal(tmpdir / file_name, test_datadir / "expected_outputs" / output_file_name)
-
-    _assert_files_are_equal(
-        tmpdir / "pcluster/instance_name_type_mappings.json",
-        test_datadir / "expected_outputs/pcluster/instance_name_type_mappings.json",
-    )
 
 
 def test_generating_slurm_config_flexible_instance_types(mocker, test_datadir, tmpdir):


### PR DESCRIPTION
### Description of changes

We were using the `cluster-config.yaml` file to pass the queue/compute-resource configuration parameters
to the create-fleet api. With this patch we're using a new json configuration file.

The new `/opt/parallelcluster/shared/fleet-config.json` file contains info for all the compute resources
(both run-instances and create-fleet compute resources) and has the following structure:
```
{
    "my-create-fleet-queue": {
        "my-compute-resource": {
            "CapacityType": "on-demand|spot",
            "AllocationStrategy": "lowest-price"
            "InstanceTypeList": [
                { "InstanceType": ... }
            ],
            "MaxPrice": ...
        }
    },
    "my-run-instances-queue": {
        "my-compute-resource": {
            "CapacityType": "on-demand|spot",
            "AllocationStrategy": "lowest-price"
            "InstanceType": ...,
            "MaxPrice": ...
        }
    }
}
```
All the information are stored at compute resource level and the node
code will use them only if `InstanceTypeList` is present in the compute resource.

The `pcluster_fleet_config_generator.py` generates it
by moving all the required info from cluster config file.

#### Instance types mapping
Removed instance type mapping usage. This was used in past when we were using
sanitized instance type in the node name.
This approach has been already modified to use compute resource name instead.
This means this mapping file was useless.

### Tests
Manually tested by running the cluster configurator in a running cluster with a mix of spot/ondemand single/multi instance types, verifying generated config and submitting a new job.

### Integration tests
Executed a small set of tests, to be sure previous behaviour is working. We still have to add new tests using flexible instance types.
* test_awsbatch[eu-west-1-c5.xlarge-alinux2-awsbatch] – schedulers.test_awsbatch
* test_mpi[eu-west-1-c5.xlarge-ubuntu2004-slurm] – scaling.test_mpi
* test_mpi[eu-west-1-c5.xlarge-centos7-slurm] – scaling.test_mpi
* test_mpi[eu-west-1-c5.xlarge-alinux2-slurm] – scaling.test_mpi
* test_mpi[eu-west-1-c5.xlarge-ubuntu1804-slurm] – scaling.test_mpi

#### Unit tests
* Added unit tests for all the case of errors, when parsing the cluster configuration file.
* Added unit tests to check the correctness of the generated file with mixed run-instances/create-fleet compute resources.
* Modified tests to use the new file format

### References
* https://github.com/aws/aws-parallelcluster-node/pull/435

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.