### PR TITLE
Fix device_number to be set as an incremental counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Disable cron job tasks man-db and mlocate, which may have a negative impact on node performance.
 - Add support for generating Slurm Configuration files for Compute Resources with Multiple Instance Types.
 - Reduce timeout from 50 to a maximum of 5min in case of DynamoDB connection issues at compute node bootstrap.
+- Change the logic to number the routing tables when an instance have multiple NICs.
 
 3.2.0
 ------

--- a/cookbooks/aws-parallelcluster-config/files/default/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-config/files/default/network_interfaces/configure_nw_interface.sh
@@ -22,6 +22,8 @@ fi
 
 ROUTE_TABLE="100${DEVICE_NUMBER}"
 
+echo "Configuring ${DEVICE_NAME} with IP:${DEVICE_IP_ADDRESS} CIDR_PREFIX:${CIDR_PREFIX_LENGTH} NETMASK:${NETMASK} GW:${GW_IP_ADDRESS} ROUTING_TABLE:${ROUTE_TABLE}"
+
 # config file
 FILE="/etc/sysconfig/network-scripts/ifcfg-${DEVICE_NAME}"
 if [ ! -f "$FILE" ]; then

--- a/cookbooks/aws-parallelcluster-config/files/ubuntu/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-config/files/ubuntu/network_interfaces/configure_nw_interface.sh
@@ -31,14 +31,18 @@ END
 # NOTE: In Ubuntu 20.04 all network interfaces are already configured in 50-cloud-init.yaml with dhcp4 enabled.
 # However, the specific configuration files created below (in the same way of Ubuntu 18) will override these initial
 # settings, as can be verified with the command `netplan get`
-if [ "${DEVICE_NUMBER}" = "0" ]
+grep "${DEVICE_NAME}:" /etc/netplan/50-cloud-init.yaml 1>/dev/null && STATIC_IP_CONFIG=""
+if [ "${STATIC_IP_CONFIG}" = "" ]
   then
-    echo "Device 0 is dhcp managed in current plaform"
-    STATIC_IP_CONFIG=""
+    echo "Device ${DEVICE_NAME} is dhcp managed in current platform"
+  else
+    echo "Device ${DEVICE_NAME} IP address will be set to ${DEVICE_IP_ADDRESS}"
 fi
 
 FILE="/etc/netplan/${DEVICE_NAME}.yaml"
 ROUTE_TABLE="100${DEVICE_NUMBER}"
+
+echo "Configuring ${DEVICE_NAME} with IP:${DEVICE_IP_ADDRESS} CIDR_PREFIX:${CIDR_PREFIX_LENGTH} NETMASK:${NETMASK} GW:${GW_IP_ADDRESS} ROUTING_TABLE:${ROUTE_TABLE}"
 
 /bin/cat <<EOF >${FILE}
 network:

--- a/cookbooks/aws-parallelcluster-config/recipes/network_interfaces.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/network_interfaces.rb
@@ -27,11 +27,6 @@ def device_name(mac)
   cmd.stdout.delete("\n")
 end
 
-def device_number(mac, token)
-  uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{mac}/device-number")
-  get_metadata_with_token(token, uri)
-end
-
 def device_ip(mac, token)
   uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{mac}/local-ipv4s")
   get_metadata_with_token(token, uri)
@@ -73,9 +68,8 @@ if macs.length > 1
   end
 
   # Configure nw interfaces
-  macs.each do |mac|
+  macs.each_with_index do |mac, device_number|
     device_name = device_name(mac)
-    device_number = device_number(mac, token)
     gw_ip_address = gateway_address
     device_ip_address = device_ip(mac, token)
     cidr_prefix_length = cidr_prefix_length(mac, token)
@@ -88,7 +82,7 @@ if macs.length > 1
       cwd "/tmp"
       environment(
         'DEVICE_NAME' => device_name,
-        'DEVICE_NUMBER' => device_number,
+        'DEVICE_NUMBER' => "#{device_number}",
         'GW_IP_ADDRESS' => gw_ip_address,
         'DEVICE_IP_ADDRESS' => device_ip_address,
         'CIDR_PREFIX_LENGTH' => cidr_prefix_length,


### PR DESCRIPTION
The change handles the situation when multiple device have
the same DeviceIndex, avoiding pointing all the network
interfaces to the same routing table causing asymmetric
routing.

Signed-off-by: Francesco Giordano <giordafr@amazon.it>

### Tests
* Manual tested with p4d.

### References
* fix bug introduced with https://github.com/aws/aws-parallelcluster/pull/4278

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.