### PR TITLE
[FIT] Generate API field to discriminate create-fleet API usage and save fleet config file into local folder

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,7 +35,6 @@ default['cluster']['change_set_path'] = "#{node['cluster']['shared_dir']}/change
 default['cluster']['launch_templates_config_path'] = "#{node['cluster']['shared_dir']}/launch-templates-config.json"
 default['cluster']['instance_types_data_path'] = "#{node['cluster']['shared_dir']}/instance-types-data.json"
 default['cluster']['computefleet_status_path'] = "#{node['cluster']['shared_dir']}/computefleet-status.json"
-default['cluster']['fleet_config_path'] = "#{node['cluster']['shared_dir']}/fleet-config.json"
 default['cluster']['reserved_base_uid'] = 400
 
 # Python Version
@@ -131,6 +130,8 @@ default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 
 default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']
 default['cluster']['slurm']['group_id'] = node['cluster']['slurm']['user_id']
 default['cluster']['slurm']['install_dir'] = "/opt/slurm"
+default['cluster']['slurm']['fleet_config_path'] = "#{node['cluster']['slurm_plugin_dir']}/fleet-config.json"
+
 # Scheduler plugin Configuration
 default['cluster']['scheduler_plugin']['name'] = 'pcluster-scheduler-plugin'
 default['cluster']['scheduler_plugin']['user'] = default['cluster']['scheduler_plugin']['name']

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
@@ -31,8 +31,9 @@ def generate_fleet_config_file(output_file, input_file):
 
     Generate fleet-config.json
     {
-        "my-create-fleet-queue": {
-            "my-compute-resource": {
+        "my-queue": {
+            "fleet-compute-resource": {
+                "Api": "create-fleet",
                 "CapacityType": "on-demand|spot",
                 "AllocationStrategy": "lowest-price"
                 "InstanceTypeList": [
@@ -40,13 +41,11 @@ def generate_fleet_config_file(output_file, input_file):
                 ],
                 "MaxPrice": ...
             }
-        },
-        "my-run-instances-queue": {
-            "my-compute-resource": {
-                "CapacityType": "on-demand|spot",
-                "AllocationStrategy": "lowest-price"
-                "InstanceType": ...,
-                "MaxPrice": ...
+            "single-compute-resource": {
+                "Api": "run-instances",
+                "InstanceTypeList": [
+                    { "InstanceType": ... }
+                ],
             }
         }
     }
@@ -67,6 +66,7 @@ def generate_fleet_config_file(output_file, input_file):
 
                 if compute_resource_config.get("InstanceTypeList"):
                     fleet_config[queue][compute_resource] = {
+                        "Api": "create-fleet",
                         "CapacityType": capacity_type,
                         "AllocationStrategy": allocation_strategy,
                         "InstanceTypeList": copy.deepcopy(compute_resource_config["InstanceTypeList"]),
@@ -75,7 +75,10 @@ def generate_fleet_config_file(output_file, input_file):
                         fleet_config[queue][compute_resource]["MaxPrice"] = compute_resource_config["SpotPrice"]
 
                 elif compute_resource_config.get("InstanceType"):
-                    fleet_config[queue][compute_resource]["InstanceType"] = compute_resource_config["InstanceType"]
+                    fleet_config[queue][compute_resource] = {
+                        "Api": "run-instances",
+                        "InstanceTypeList": [{"InstanceType": compute_resource_config["InstanceType"]}],
+                    }
 
                 else:
                     raise Exception(

--- a/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/expected_outputs/fleet-config.json
+++ b/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/expected_outputs/fleet-config.json
@@ -1,9 +1,15 @@
 {
     "ondemand-mixed": {
         "single": {
-            "InstanceType": "c5n.4xlarge"
+            "Api": "run-instances",
+            "InstanceTypeList": [
+                {
+                    "InstanceType": "c5n.4xlarge"
+                }
+            ]
         },
         "fleet": {
+            "Api": "create-fleet",
             "CapacityType": "on-demand",
             "AllocationStrategy": "lowest-price",
             "InstanceTypeList": [
@@ -21,9 +27,15 @@
     },
     "spot-mixed": {
         "single": {
-            "InstanceType": "c5n.18xlarge"
+            "Api": "run-instances",
+            "InstanceTypeList": [
+                {
+                    "InstanceType": "c5n.18xlarge"
+                }
+            ]
         },
         "fleet-price": {
+            "Api": "create-fleet",
             "CapacityType": "spot",
             "AllocationStrategy": "capacity-optimized",
             "InstanceTypeList": [
@@ -34,6 +46,7 @@
             "MaxPrice": 10
         },
         "fleet-noprice": {
+            "Api": "create-fleet",
             "CapacityType": "spot",
             "AllocationStrategy": "capacity-optimized",
             "InstanceTypeList": [


### PR DESCRIPTION
### Description of changes
#### 1. Generate new "API" field to discriminate compute resources with single and multiple instance types
Note: currently run-instances compute resources don't have all the information required for fleet
so it will be possible to force usage of run-instances API for "fleet" compute resources but
not the opposite.

To be able to use "create-fleet" API for all of them we need to propagate all the information
required for create-fleet API but this requires a change in the CLI.

Cluster config with default values don't contain for example AllocationStrategy info
for queues without InstanceTypeList.

#### 2. Move fleet config file into a local folder

The file doesn't need to be shared.


### References
* https://github.com/aws/aws-parallelcluster-node/pull/436

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.