### PR TITLE
Fix variable used for fleet config path

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -74,7 +74,7 @@ unless virtualized?
   # Generate pcluster fleet config
   execute "generate_pcluster_fleet_config" do
     command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_fleet_config_generator.py"\
-            " --output-file #{node['cluster']['fleet_config_path']} --input-file #{node['cluster']['cluster_config_path']}"
+            " --output-file #{node['cluster']['slurm']['fleet_config_path']} --input-file #{node['cluster']['cluster_config_path']}"
   end
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -138,8 +138,8 @@ end
 
 execute "generate_pcluster_fleet_config" do
   command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_fleet_config_generator.py"\
-          " --output-file #{node['cluster']['fleet_config_path']} --input-file #{node['cluster']['cluster_config_path']}"
-  not_if { ::File.exist?(node['cluster']['fleet_config_path']) && !are_queues_updated? }
+          " --output-file #{node['cluster']['slurm']['fleet_config_path']} --input-file #{node['cluster']['cluster_config_path']}"
+  not_if { ::File.exist?(node['cluster']['slurm']['fleet_config_path']) && !are_queues_updated? }
 end
 
 replace_or_add "update node replacement timeout" do


### PR DESCRIPTION
### Description of changes
Variable has been renamed as part of https://github.com/aws/aws-parallelcluster-cookbook/pull/1508 but we missed to update recipes.

### Tests
Tests were failing with: 
``` 
pcluster_fleet_config_generator.py: error: argument --output-file: expected one argument
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.