### PR TITLE
3.x Upgrade Python from v3.7.10 to v3.7.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Add support for generating Slurm Configuration files for Compute Resources with Multiple Instance Types.
 - Reduce timeout from 50 to a maximum of 5min in case of DynamoDB connection issues at compute node bootstrap.
 - Change the logic to number the routing tables when an instance have multiple NICs.
+- Upgrade Python from 3.7.10 to 3.7.13 in response to this [security risk](https://nvd.nist.gov/vuln/detail/CVE-2021-3737).
 
 3.2.0
 ------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,7 +38,7 @@ default['cluster']['computefleet_status_path'] = "#{node['cluster']['shared_dir'
 default['cluster']['reserved_base_uid'] = 400
 
 # Python Version
-default['cluster']['python-version'] = '3.7.10'
+default['cluster']['python-version'] = '3.7.13'
 # plcuster-specific pyenv system installation root
 default['cluster']['system_pyenv_root'] = "#{node['cluster']['base_dir']}/pyenv"
 # Virtualenv Cookbook Name


### PR DESCRIPTION
This change is to fix https://nvd.nist.gov/vuln/detail/CVE-2021-3737 which was
present in Python versions up through v3.7.10


### Description of changes
* Upgraded Python to version 3.7.13
* [Issue](https://nvd.nist.gov/vuln/detail/CVE-2021-3737)

### Tests
* Manually created a cluster with built AMI and ran 'srun hostname' from the head node.
* Kitchen Tests
* Subset of integration tests.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.