### PR TITLE
[DFSM] Add DFSM support for scheduler plugin 

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/fs_mount.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/fs_mount.rb
@@ -15,12 +15,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# generate the shared storages mapping file
-template node['cluster']['shared_storages_mapping_path'] do
-  source 'shared_storages/shared_storages_data.erb'
-  mode '0644'
-end
-
 # Mount EFS directory with manage_efs resource
 manage_efs "mount efs" do
   shared_dir_array node['cluster']['efs_shared_dirs'].split(',')

--- a/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
@@ -15,6 +15,12 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# generate the shared storages mapping file
+template node['cluster']['shared_storages_mapping_path'] do
+  source 'shared_storages/shared_storages_data.erb'
+  mode '0644'
+end
+
 manage_ebs "add ebs" do
   shared_dir_array node['cluster']['ebs_shared_dirs'].split(',')
   vol_array node['cluster']['volume'].split(',')

--- a/cookbooks/aws-parallelcluster-config/recipes/update_shared_storages.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/update_shared_storages.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster-slurm
+# Cookbook:: aws-parallelcluster-config
 # Recipe:: update_shared_storages
 #
 # Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/cookbooks/aws-parallelcluster-config/resources/manage_raid.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_raid.rb
@@ -35,7 +35,7 @@ action :mount do
 
     # Attach RAID EBS volume
     execute "attach_raid_volume_#{index}" do
-      command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python /usr/local/sbin/attachVolume.py --volume-id #{volumeid} --attach"
+      command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volumeid} --attach"
       creates raid_dev_path[index]
     end
 
@@ -176,7 +176,7 @@ action :unmount do
   raid_vol_array.each_with_index do |volumeid, index|
     # Detach RAID EBS volume
     execute "detach_raid_volume_#{index}" do
-      command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python /usr/local/sbin/attachVolume.py --volume-id #{volumeid} --detach"
+      command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volumeid} --detach"
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/update_head_node.rb
@@ -15,6 +15,13 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+ruby_block "update_shared_storages" do
+  block do
+    run_context.include_recipe 'aws-parallelcluster-config::update_shared_storages'
+  end
+  only_if { are_mount_or_unmount_required? }
+end
+
 execute_event_handler 'HeadClusterUpdate' do
   event_command(lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :SchedulerDefinition, :Events, :HeadClusterUpdate, :ExecuteCommand, :Command) })
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -22,7 +22,7 @@ end
 
 ruby_block "update_shared_storages" do
   block do
-    run_context.include_recipe 'aws-parallelcluster-slurm::update_shared_storages'
+    run_context.include_recipe 'aws-parallelcluster-config::update_shared_storages'
   end
   only_if { are_mount_or_unmount_required? }
 end


### PR DESCRIPTION
### Description of changes
* Add DFSM support for scheduler plugin by moving update_shared_storages from aws-parallelcluster-slurm cookbooks to aws-parallelcluster-config cookbooks so it can be used in both update_head_node.rb of slurm and scheduler plugin

### Tests
* Manually test for slurm plugin with update.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.