### PR TITLE
Fix python version for cfn_bootstrap_virtualenv to 3.7.14 for a bug in aws-cfn-bootstrap-py3-latest.tar.gz

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,6 +39,8 @@ default['cluster']['reserved_base_uid'] = 400
 
 # Python Version
 default['cluster']['python-version'] = '3.9.13'
+# FIXME: Python Version cfn_bootstrap_virtualenv due to a bug with cfn-hup
+default['cluster']['python-version-cfn_bootstrap_virtualenv'] = '3.7.14'
 # plcuster-specific pyenv system installation root
 default['cluster']['system_pyenv_root'] = "#{node['cluster']['base_dir']}/pyenv"
 # Virtualenv Cookbook Name
@@ -56,7 +58,7 @@ default['cluster']['node_virtualenv_path'] = "#{node['cluster']['system_pyenv_ro
 # AWSBatch Virtualenv Path
 default['cluster']['awsbatch_virtualenv_path'] = "#{node['cluster']['system_pyenv_root']}/versions/#{node['cluster']['python-version']}/envs/#{node['cluster']['awsbatch_virtualenv']}"
 # cfn-bootstrap Virtualenv Path
-default['cluster']['cfn_bootstrap_virtualenv_path'] = "#{node['cluster']['system_pyenv_root']}/versions/#{node['cluster']['python-version']}/envs/#{node['cluster']['cfn_bootstrap_virtualenv']}"
+default['cluster']['cfn_bootstrap_virtualenv_path'] = "#{node['cluster']['system_pyenv_root']}/versions/#{node['cluster']['python-version-cfn_bootstrap_virtualenv']}/envs/#{node['cluster']['cfn_bootstrap_virtualenv']}"
 
 # Intel Packages
 default['cluster']['psxe']['version'] = '2020.4-17'

--- a/cookbooks/aws-parallelcluster-install/recipes/python.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/python.rb
@@ -19,6 +19,11 @@ install_pyenv node['cluster']['python-version'] do
   prefix node['cluster']['system_pyenv_root']
 end
 
+# FIXME: Python install for cfn_bootstrap_virtualenv due to a bug with cfn-hup
+install_pyenv node['cluster']['python-version-cfn_bootstrap_virtualenv'] do
+  prefix node['cluster']['system_pyenv_root']
+end
+
 activate_virtual_env node['cluster']['cookbook_virtualenv'] do
   pyenv_path node['cluster']['cookbook_virtualenv_path']
   python_version node['cluster']['python-version']
@@ -42,7 +47,7 @@ end
 # Install cfn_bootstrap virtualenv
 activate_virtual_env node['cluster']['cfn_bootstrap_virtualenv'] do
   pyenv_path node['cluster']['cfn_bootstrap_virtualenv_path']
-  python_version node['cluster']['python-version']
+  python_version node['cluster']['python-version-cfn_bootstrap_virtualenv']
   not_if { ::File.exist?("#{node['cluster']['cfn_bootstrap_virtualenv_path']}/bin/activate") }
 end
 


### PR DESCRIPTION
When the bug has been solved the version can be realigned to the `python-version`.

Signed-off-by: Francesco Giordano <giordafr@amazon.it>
### Description of change
* Install python 3.7.14 version in pyenv
* Create cfn_bootstrap_virtualenv with version 3.7.14

### Tests
* Manual tested

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.