### PR TITLE
[3.2] Backport of Trainium support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 3.2.1
 ------
 
+**ENHANCEMENTS**
+- Add support for AWS Trainium instances.
+
 **CHANGES**
 - Upgrade NVIDIA driver to version 470.141.03.
 - Upgrade NVIDIA Fabric Manager to version 470.141.03.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -477,6 +477,16 @@ default['cluster']['lustre']['client_url'] = value_for_platform(
   }
 )
 
+# Neuron
+default['cluster']['neuron']['repository_name'] = "neuron"
+default['cluster']['neuron']['url_prefix'] = value_for_platform(
+  'default' => 'yum',
+  'ubuntu' => { 'default' => 'apt' }
+)
+default['cluster']['neuron']['base_url'] = "https://#{node['cluster']['neuron']['url_prefix']}.repos.neuron.amazonaws.com"
+default['cluster']['neuron']['public_key'] = "#{node['cluster']['neuron']['base_url']}/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB"
+default['cluster']['neuron']['packages'] = %w(aws-neuronx-dkms)
+
 # Default gc_thresh values for performance at scale
 default['cluster']['sysctl']['ipv4']['gc_thresh1'] = 0
 default['cluster']['sysctl']['ipv4']['gc_thresh2'] = 15_360

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -207,6 +207,9 @@ end
 # Install NVIDIA and CUDA
 include_recipe "aws-parallelcluster-install::nvidia"
 
+# Install Neuron driver
+include_recipe "aws-parallelcluster-install::neuron" unless virtualized?
+
 # Install EFA & Intel MPI
 include_recipe "aws-parallelcluster-install::efa" unless virtualized?
 include_recipe "aws-parallelcluster-install::intel_mpi" unless virtualized?

--- a/cookbooks/aws-parallelcluster-install/recipes/neuron.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/neuron.rb
@@ -22,26 +22,7 @@ return if node['cluster']['base_os'] == 'centos7' || arm_instance?
 return if is_package_installed?("aws-neuronx-dkms") || is_package_installed?("aws-neuron-dkms")
 
 # add neuron repository
-if platform?('amazon')
-  yum_repository "neuron" do
-    description "Neuron YUM Repository"
-    baseurl node['cluster']['neuron']['base_url']
-    gpgkey node['cluster']['neuron']['public_key']
-    retries 3
-    retry_delay 5
-  end
-
-elsif platform?('ubuntu')
-  apt_repository 'neuron' do
-    uri node['cluster']['neuron']['base_url']
-    components ['main']
-    key node['cluster']['neuron']['public_key']
-    retries 3
-    retry_delay 5
-  end
-
-  apt_update
-end
+add_package_repository('neuron', node['cluster']['neuron']['base_url'], node['cluster']['neuron']['public_key'], 'focal', ['main'])
 
 package node['cluster']['neuron']['packages'] do
   retries 10

--- a/cookbooks/aws-parallelcluster-install/recipes/neuron.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/neuron.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster
+# Recipe:: neuron
+#
+# Copyright:: 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+return if node['cluster']['base_os'] == 'centos7' || arm_instance? || neuron_installed?
+
+if platform?('amazon')
+  # add neuron repository
+  yum_repository "neuron" do
+    description "Neuron YUM Repository"
+    baseurl node['cluster']['neuron']['base_url']
+    gpgkey node['cluster']['neuron']['public_key']
+    retries 3
+    retry_delay 5
+  end
+
+elsif platform?('ubuntu')
+
+  apt_repository 'neuron' do
+    uri node['cluster']['neuron']['base_url']
+    components ['main']
+    key node['cluster']['neuron']['public_key']
+    retries 3
+    retry_delay 5
+  end
+
+  apt_update
+end
+
+package node['cluster']['neuron']['packages'] do
+  retries 10
+  retry_delay 5
+end
+
+kernel_module 'neuron'

--- a/cookbooks/aws-parallelcluster-install/recipes/neuron.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/neuron.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-return if node['cluster']['base_os'] == 'centos7' || arm_instance? || neuron_installed?
+return if node['cluster']['base_os'] == 'centos7' || arm_instance? || is_package_installed?("aws-neuronx-dkms")
 
 if platform?('amazon')
   # add neuron repository

--- a/cookbooks/aws-parallelcluster-install/recipes/neuron.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/neuron.rb
@@ -15,10 +15,14 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-return if node['cluster']['base_os'] == 'centos7' || arm_instance? || is_package_installed?("aws-neuronx-dkms")
+return if node['cluster']['base_os'] == 'centos7' || arm_instance?
 
+# Skip installation if Trainium or Inferentia drivers are already installed.
+# Inferentia packages might be installed in old DLAMIs and they will conflict with Neuron packages
+return if is_package_installed?("aws-neuronx-dkms") || is_package_installed?("aws-neuron-dkms")
+
+# add neuron repository
 if platform?('amazon')
-  # add neuron repository
   yum_repository "neuron" do
     description "Neuron YUM Repository"
     baseurl node['cluster']['neuron']['base_url']
@@ -28,7 +32,6 @@ if platform?('amazon')
   end
 
 elsif platform?('ubuntu')
-
   apt_repository 'neuron' do
     uri node['cluster']['neuron']['base_url']
     components ['main']

--- a/cookbooks/aws-parallelcluster-test/recipes/test_neuron.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_neuron.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-test
+# Recipe:: test_neuron
+#
+# Copyright:: 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+ruby_block "Verify Neuron repository is enabled" do
+  block do
+    unless is_repository_enabled?(node['cluster']['neuron']['repository_name'], node['cluster']['neuron']['base_url'])
+      raise "Missing Neuron repository"
+    end
+  end
+end
+
+bash "Check Neuron module" do
+  cwd Chef::Config[:file_cache_path]
+  code <<-TEST
+    lsmod | grep neuron
+    [[ $? == 0 ]] || { echo "ERROR Installed Neuron driver is not working properly: kernel module not loaded"; exit 1; };
+  TEST
+end
+
+if is_neuron_instance?
+  bash "Check Neuron devices" do
+    cwd Chef::Config[:file_cache_path]
+    code <<-TEST
+      ls -l /dev/neuron*
+      [[ $? == 0 ]] || { echo "ERROR Installed Neuron driver is not working properly: device not found"; exit 1; };
+    TEST
+  end
+end

--- a/cookbooks/aws-parallelcluster-test/recipes/test_neuron.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_neuron.rb
@@ -14,6 +14,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+return if node['cluster']['base_os'] == 'centos7' || arm_instance? || node['cluster']['os'].end_with?("-custom")
 
 ruby_block "Verify Neuron repository is enabled" do
   block do

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -22,6 +22,7 @@ include_recipe 'aws-parallelcluster-test::test_imds'
 include_recipe 'aws-parallelcluster-test::test_sudoers'
 include_recipe 'aws-parallelcluster-test::test_openssh'
 include_recipe 'aws-parallelcluster-test::test_nvidia'
+include_recipe 'aws-parallelcluster-test::test_neuron'
 include_recipe 'aws-parallelcluster-test::test_dcv'
 
 ###################

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -533,6 +533,20 @@ def efa_installed?
   dir_exist
 end
 
+def neuron_installed?
+  package_name = "aws-neuronx-dkms"
+  command = value_for_platform(
+  %w(ubuntu debian) => {
+    'default' => "apt list --installed | grep #{package_name}",
+  },
+  'default' => "yum list installed | grep #{package_name}")
+
+  cmd = Mixlib::ShellOut.new(command, timeout: 60)
+  cmd.run_command
+  # Return false if the package is not installed
+  !(cmd.exitstatus != 0)
+end
+
 # load cluster configuration file into node object
 def load_cluster_config
   ruby_block "load cluster configuration" do

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -548,18 +548,19 @@ def efa_installed?
   dir_exist
 end
 
-def neuron_installed?
-  package_name = "aws-neuronx-dkms"
+def is_package_installed?(package_name)
   command = value_for_platform(
-  %w(ubuntu debian) => {
-    'default' => "apt list --installed | grep #{package_name}",
-  },
-  'default' => "yum list installed | grep #{package_name}")
+    %w(ubuntu debian) => {
+      'default' => "apt list --installed | grep #{package_name}",
+    },
+    'default' => "yum list installed | grep #{package_name}"
+  )
 
   cmd = Mixlib::ShellOut.new(command, timeout: 60)
   cmd.run_command
-  # Return false if the package is not installed
-  !(cmd.exitstatus != 0)
+  Chef::Log.info("Checking if #{package_name} is installed...\n#{command}\n#{cmd.stdout.strip}")
+  # Convert return code to boolean
+  cmd.exitstatus.to_i.zero?
 end
 
 def is_neuron_instance?

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -397,6 +397,21 @@ def remove_package_repository(repo_name)
   end
 end
 
+# Check if package repository is enabled
+# NOTE: This helper function defines a Chef resource function to be executed at Converge time
+def is_repository_enabled?(repo_name, base_url)
+  command = value_for_platform(
+  %w(ubuntu debian) => {
+    'default' => "grep -r -E '^deb +#{base_url}' /etc/apt/sources.list*",
+  },
+  'default' => "yum -v repolist #{repo_name} | grep 'Repo-status  : enabled' || exit 1 && yum -v repolist #{repo_name} | grep 'Repo-baseurl : #{base_url}'")
+
+  cmd = Mixlib::ShellOut.new(command, timeout: 60)
+  cmd.run_command
+  # Return false if the repository is not installed
+  cmd.exitstatus.to_i.zero?
+end
+
 # Get number of nv switches
 def get_nvswitches
   # NVSwitch device id is 10de:1af1
@@ -545,6 +560,11 @@ def neuron_installed?
   cmd.run_command
   # Return false if the package is not installed
   !(cmd.exitstatus != 0)
+end
+
+def is_neuron_instance?
+  neuron_filter = ["trn1."]
+  node['ec2']['instance_type'].start_with?(*neuron_filter)
 end
 
 # load cluster configuration file into node object

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -353,7 +353,7 @@ end
 
 # Add an external package repository to the OS's package manager
 # NOTE: This helper function defines a Chef resource function to be executed at Converge time
-def add_package_repository(repo_name, baseurl, gpgkey, distribution)
+def add_package_repository(repo_name, baseurl, gpgkey, distribution, components = [])
   case node['platform_family']
   when 'rhel', 'amazon'
     yum_repository repo_name do
@@ -367,6 +367,7 @@ def add_package_repository(repo_name, baseurl, gpgkey, distribution)
       uri          baseurl
       key          gpgkey
       distribution distribution
+      components components
       retries 3
       retry_delay 5
     end


### PR DESCRIPTION
### Description of changes
* Backport in release-3.2 of the changes needed to:
  * Added the Neuron repository
  * Added installation and load of the kernel module neuron, package aws-neuronx-dkms
  * Skip drivers installation if Inferentia drivers are already installed
    * Inferentia drivers (aws-neuron-dkms) are already installed (and hold) in old DL AMIs and they conflict with new `aws-neuronx-dkms` drivers. Future DL AMIs will have Neuron drivers on them.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1512

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.