### PR TITLE
[Versioning] Bump version to 3.3.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -119,9 +119,9 @@ default['cluster']['armpl']['url'] = [
 ].join('/')
 
 # Python packages
-default['cluster']['parallelcluster-version'] = '3.3.0b1'
-default['cluster']['parallelcluster-cookbook-version'] = '3.3.0b1'
-default['cluster']['parallelcluster-node-version'] = '3.3.0b1'
+default['cluster']['parallelcluster-version'] = '3.3.0'
+default['cluster']['parallelcluster-cookbook-version'] = '3.3.0'
+default['cluster']['parallelcluster-node-version'] = '3.3.0'
 default['cluster']['parallelcluster-awsbatch-cli-version'] = '1.0.0'
 
 # URLs to software packages used during install recipes


### PR DESCRIPTION
### Changes
Version bumped to 3.3.0 using version bumping tool.

### Tests
Not needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>