### PR TITLE
Always configure slurmdbd CloudWatch log on head

### DIFF
--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
@@ -273,16 +273,7 @@
       "node_roles": [
         "HeadNode"
       ],
-      "feature_conditions": [
-        {
-          "dna_key": [
-            "slurm",
-            "database",
-            "enabled"
-          ],
-          "satisfying_values": ["true", "yes"]
-        }
-      ]
+      "feature_conditions": []
     },
     {
       "timestamp_format_key": "default",


### PR DESCRIPTION


### Description of changes
* Removed restriction to only configure slurmdbd CloudWatch logging if Slurm Accounting was enabled.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.