### PR TITLE
[EFA] Upgrade EFA from 1.17.2 to 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade third-party cookbook dependencies:
   - selinux-6.0.5 (from selinux-6.0.4)
   - nfs-5.0.0 (from nfs-2.6.4)
+- Upgrade EFA installer to `1.18.0`
+  - Efa-driver: `efa-1.16.0-1`
+  - Efa-config: `efa-config-1.11-1`
+  - Efa-profile: `efa-profile-1.5-1`
+  - Libfabric-aws: `libfabric-aws-1.16.0~amzn4.0-1`
+  - Rdma-core: `rdma-core-41.0-2`
+  - Open MPI: `openmpi40-aws-4.1.4-2`
 
 **CHANGES**
 - Upgrade NVIDIA driver to version 470.141.03.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -256,7 +256,7 @@ else
 end
 
 # EFA
-default['cluster']['efa']['installer_version'] = '1.17.2'
+default['cluster']['efa']['installer_version'] = '1.18.0'
 default['cluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cluster']['efa']['installer_version']}.tar.gz"
 default['cluster']['efa']['unsupported_aarch64_oses'] = %w(centos7)
 


### PR DESCRIPTION
### Description of changes
Upgrades EFA installer from 1.17.2 to 1.18.0
- Efa-driver: `efa-1.16.0-1`
- Efa-config: `efa-config-1.11-1`
- Efa-profile: `efa-profile-1.5-1`
- Libfabric-aws: `libfabric-aws-1.16.0~amzn4.0-1`
- Rdma-core: `rdma-core-41.0-2`
- Open MPI: `openmpi40-aws-4.1.4-2`

### Tests
* Created a Custom AMI with the cookbook changes and confirm EFA (`1.18.0`) was successfully installed

### References
* [EFA installer](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-verify.html)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.