### PR TITLE
Move SSH key generation script from pam.d to /etc/profile (3.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Change the logic to number the routing tables when an instance have multiple NICs.
 - Upgrade Python from 3.7.13 to 3.9.13.
 - Upgrade Slurm to version 22.05.3.
+- Move SSH key generation from pam.d to /etc/profile to enable root_squash'd FSx
 
 3.2.0
 ------

--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/generate_ssh_key.sh.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/generate_ssh_key.sh.erb
@@ -3,16 +3,11 @@ set -ex
 env
 
 # Root does not need SSH key generation
-[ ${PAM_USER} == "root" ] && exit 0
-
-# The home directory for every user must be determined in the most generic way because
-# we should not assume that every user has its home directory in /home/$USER.
-user_home_dir="$(getent passwd ${PAM_USER} | cut -d ':' -f 6)"
-[ ! -d "${user_home_dir}" ] && echo "ERROR Cannot create SSH key for user ${PAM_USER} if its home directory is not found" && exit 1
+[ ${USER} == "root" ] && exit 0
 
 # Skip SSH key creation if the SSH has been already configured for the user.
 # We assume that SSH has been already configured if the directory .ssh already exists in the user home.
-user_ssh_dir="${user_home_dir}/.ssh"
+user_ssh_dir="${HOME}/.ssh"
 [ -d "${user_ssh_dir}" ] && exit 0
 
 mkdir -m 0700 "${user_ssh_dir}"
@@ -22,4 +17,4 @@ cat "${user_ssh_dir}/id_rsa.pub" >> "${user_ssh_dir}/authorized_keys"
 chmod 0600 "${user_ssh_dir}/authorized_keys"
 ssh-keyscan <%=  node['hostname'] %> > "${user_ssh_dir}/known_hosts"
 chmod 0600 "${user_ssh_dir}/known_hosts"
-chown ${PAM_USER}:$(id -g ${PAM_USER}) -R "${user_ssh_dir}"
+chown ${USER}:$(id -g ${USER}) -R "${user_ssh_dir}"


### PR DESCRIPTION
### Description of changes

When FSx Lustre is configured with the new root_squash feature, and ParallelCluster is configured with Active Directory with home folders within the FSx mount, pam_exec.so is unable to properly run the SSH key generation script. This is because pam_exec.so runs the script as root, but root does not have access to any home folders to manipulate the files due to the fact that root is regarded as nobody/nogroup within the root_squash'd FSx mount point.

Using su in the generation script to impersonate the user does not work around the problem, as su itself would trigger pam_exec.so, and trigger a loop, which doesn't look trivial to avoid to me.

Instead, I suggest moving the key generation to /etc/profile, which is executed by default for every interactive shells, by the connecting user, and serves the purpose.

### Tests

I have performed the Parallel Cluster initialization & successfully  logged in with an AD user, with its SSH key material properly generated upon login. 

### References
- Case ID 10861640911

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Check if documentation is impacted by this change.

It is my first interaction with this repository, and my first few days with ParallelCluster as a whole - testing has been a bit of a journey between building/uploading a new pcluster, node tool, image, and cookbooks - been bumping into the version checks in various places for quite a while as the versions feeding into the checks appear to be coming from different places, between the AMI baked "bootstrap" version, the userdata generated by pcluster, `b1` not being tolerated by Berks, ... But at last, the solution works for my cluster - and actually initially wrote the change purely in Ansible, but I was bumping another provisioning issue breaking Cloudformation's initial rollout (see `Other issue` below) so decided to start editing the cookbook anyways.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Other issue

With Parallel Cluster v3.2, root_squash was also broken during provisioning due to something else (see case / see logs below), but that issue seems to have been already resolved, although I am not 100% sure why by just glancing over the code.

```
    - mount fs-XXXX.fsx.us-east-1.amazonaws.com@tcp:/jwpx5bev to /data
  * mount[/data] action enable[2022-09-26T20:46:46+00:00] INFO: Processing mount[/data] 
action enable (aws-parallelcluster-config::fsx_mount line 57)
[2022-09-26T20:46:46+00:00] INFO: mount[/data] enabled

    - enable fs-XXXX.fsx.us-east-1.amazonaws.com@tcp:/jwpx5bev
  * directory[/data] action create[2022-09-26T20:46:46+00:00] INFO: Processing 
directory[/data] action create (aws-parallelcluster-config::fsx_mount line 94)

    ================================================================================
    Error executing action `create` on resource 'directory[/data]'
    ================================================================================

    Errno::EPERM
    ------------
    Operation not permitted @ apply2files - /data

    Resource Declaration:
    ---------------------
    # In 
/etc/chef/local-mode-cache/cache/cookbooks/aws-parallelcluster-config/recipes/fsx_mount.rb

     94:   directory fsx_shared_dir do
     95:     owner 'root'
     96:     group 'root'
     97:     mode '1777'
     98:   end
     99: end

    Compiled Resource:
    ------------------
    # Declared in 
/etc/chef/local-mode-cache/cache/cookbooks/aws-parallelcluster-config/recipes/fsx_mount.rb:94:in 
`block in from_file'

    directory("/data") do
      action [:create]
      default_guard_interpreter :default
      declared_type :directory
      cookbook_name "aws-parallelcluster-config"
      recipe_name "fsx_mount"
      mode "1777"
      owner "root"
      group "root"
      path "/data"
    end
```