### PR TITLE
Small changes for Slurm Accounting configurations

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -134,8 +134,12 @@ default['cluster']['slurm']['user'] = 'slurm'
 default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1
 default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']
 default['cluster']['slurm']['group_id'] = node['cluster']['slurm']['user_id']
-default['cluster']['slurm']['dbduser'] = 'slurmdbd'
-default['cluster']['slurm']['dbduser_id'] = node['cluster']['reserved_base_uid'] + 5
+default['cluster']['slurm']['dbduser'] = 'slurm'
+default['cluster']['slurm']['dbduser_id'] = if node['cluster']['slurm']['dbduser'].eql?(node['cluster']['slurm']['user'])
+                                              default['cluster']['slurm']['user_id']
+                                            else
+                                              node['cluster']['reserved_base_uid'] + 5
+                                            end
 default['cluster']['slurm']['dbdgroup'] = node['cluster']['slurm']['dbduser']
 default['cluster']['slurm']['dbdgroup_id'] = node['cluster']['slurm']['dbduser_id']
 default['cluster']['slurm']['install_dir'] = "/opt/slurm"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -134,14 +134,6 @@ default['cluster']['slurm']['user'] = 'slurm'
 default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1
 default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']
 default['cluster']['slurm']['group_id'] = node['cluster']['slurm']['user_id']
-default['cluster']['slurm']['dbduser'] = 'slurm'
-default['cluster']['slurm']['dbduser_id'] = if node['cluster']['slurm']['dbduser'].eql?(node['cluster']['slurm']['user'])
-                                              default['cluster']['slurm']['user_id']
-                                            else
-                                              node['cluster']['reserved_base_uid'] + 5
-                                            end
-default['cluster']['slurm']['dbdgroup'] = node['cluster']['slurm']['dbduser']
-default['cluster']['slurm']['dbdgroup_id'] = node['cluster']['slurm']['dbduser_id']
 default['cluster']['slurm']['install_dir'] = "/opt/slurm"
 default['cluster']['slurm']['fleet_config_path'] = "#{node['cluster']['slurm_plugin_dir']}/fleet-config.json"
 

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
@@ -45,6 +45,7 @@ def generate_slurm_config_files(
     compute_node_bootstrap_timeout,
     realmemory_to_ec2memory_ratio,
     slurmdbd_user,
+    cluster_name,
 ):
     """
     Generate Slurm configuration files.
@@ -67,7 +68,6 @@ def generate_slurm_config_files(
     cluster_config = _load_cluster_config(input_file)
     head_node_config = _get_head_node_config()
     queues = cluster_config["Scheduling"]["SlurmQueues"]
-    cluster_name = _get_cluster_name()
 
     global instance_types_data
     with open(instance_types_data_path) as input_file:
@@ -132,11 +132,6 @@ def _get_head_node_config():
 def _get_head_node_private_ip():
     """Get head node private ip from EC2 metadata."""
     return _get_metadata("local-ipv4")
-
-
-def _get_cluster_name():
-    with open("/etc/parallelcluster/cfnconfig") as f:
-        return [line.rstrip().split(sep="=")[1] for line in f.readlines() if line.startswith("stack_name=")][0]
 
 
 def _generate_queue_config(
@@ -450,6 +445,7 @@ def main():
             required=True,
         )
         parser.add_argument("--slurmdbd-user", help="User for the slurmdbd service.", required=True)
+        parser.add_argument("--cluster-name", help="Name of the cluster.", required=True)
         args = parser.parse_args()
         generate_slurm_config_files(
             args.output_directory,
@@ -461,6 +457,7 @@ def main():
             args.compute_node_bootstrap_timeout,
             args.realmemory_to_ec2memory_ratio,
             args.slurmdbd_user,
+            args.cluster_name,
         )
     except Exception as e:
         log.exception("Failed to generate slurm configurations, exception: %s", e)

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
@@ -67,7 +67,7 @@ def generate_slurm_config_files(
     cluster_config = _load_cluster_config(input_file)
     head_node_config = _get_head_node_config()
     queues = cluster_config["Scheduling"]["SlurmQueues"]
-    cluster_name = next(tag["Value"] for tag in cluster_config["Tags"] if tag["Key"] == "parallelcluster:cluster-name")
+    cluster_name = _get_cluster_name()
 
     global instance_types_data
     with open(instance_types_data_path) as input_file:
@@ -132,6 +132,11 @@ def _get_head_node_config():
 def _get_head_node_private_ip():
     """Get head node private ip from EC2 metadata."""
     return _get_metadata("local-ipv4")
+
+
+def _get_cluster_name():
+    with open("/etc/parallelcluster/cfnconfig") as f:
+        return [line.rstrip().split(sep="=")[1] for line in f.readlines() if line.startswith("stack_name=")][0]
 
 
 def _generate_queue_config(

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -69,7 +69,7 @@ unless virtualized?
             " --input-file #{node['cluster']['cluster_config_path']}  --instance-types-data #{node['cluster']['instance_types_data_path']}"\
             " --compute-node-bootstrap-timeout #{node['cluster']['compute_node_bootstrap_timeout']} #{no_gpu}"\
             " --realmemory-to-ec2memory-ratio #{node['cluster']['realmemory_to_ec2memory_ratio']}"\
-            " --slurmdbd-user #{node['cluster']['slurm']['dbduser']}"
+            " --slurmdbd-user #{node['cluster']['slurm']['user']}"
   end
 
   # Generate pcluster fleet config

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -69,7 +69,8 @@ unless virtualized?
             " --input-file #{node['cluster']['cluster_config_path']}  --instance-types-data #{node['cluster']['instance_types_data_path']}"\
             " --compute-node-bootstrap-timeout #{node['cluster']['compute_node_bootstrap_timeout']} #{no_gpu}"\
             " --realmemory-to-ec2memory-ratio #{node['cluster']['realmemory_to_ec2memory_ratio']}"\
-            " --slurmdbd-user #{node['cluster']['slurm']['user']}"
+            " --slurmdbd-user #{node['cluster']['slurm']['user']}"\
+            " --cluster-name #{node['cluster']['stack_name']}"
   end
 
   # Generate pcluster fleet config

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_slurm_accounting.rb
@@ -17,16 +17,16 @@
 
 template "#{node['cluster']['slurm']['install_dir']}/etc/slurmdbd.conf" do
   source 'slurm/slurmdbd.conf.erb'
-  owner "#{node['cluster']['slurm']['dbduser']}"
-  group "#{node['cluster']['slurm']['dbdgroup']}"
+  owner "#{node['cluster']['slurm']['user']}"
+  group "#{node['cluster']['slurm']['group']}"
   mode '0600'
   # Do not overwrite possible user customization if the database credentials are updated
   not_if { ::File.exist?("#{node['cluster']['slurm']['install_dir']}/etc/slurmdbd.conf") }
 end
 
 file "#{node['cluster']['slurm']['install_dir']}/etc/slurm_parallelcluster_slurmdbd.conf" do
-  owner "#{node['cluster']['slurm']['dbduser']}"
-  group "#{node['cluster']['slurm']['dbdgroup']}"
+  owner "#{node['cluster']['slurm']['user']}"
+  group "#{node['cluster']['slurm']['group']}"
   mode '0600'
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -50,21 +50,23 @@ user node['cluster']['slurm']['user'] do
   shell '/bin/bash'
 end
 
-# Setup slurmdbd group
-group node['cluster']['slurm']['dbdgroup'] do
-  comment 'slurm group'
-  gid node['cluster']['slurm']['dbdgroup_id']
-  system true
-end
+unless node['cluster']['slurm']['dbduser'].eql?(node['cluster']['slurm']['user'])
+  # Setup slurmdbd group
+  group node['cluster']['slurm']['dbdgroup'] do
+    comment 'slurm group'
+    gid node['cluster']['slurm']['dbdgroup_id']
+    system true
+  end
 
-# Setup slurmdbd user
-user node['cluster']['slurm']['dbduser'] do
-  comment 'slurmdbd user'
-  uid node['cluster']['slurm']['dbduser_id']
-  gid node['cluster']['slurm']['dbdgroup_id']
-  manage_home false
-  system true
-  shell '/bin/bash'
+  # Setup slurmdbd user
+  user node['cluster']['slurm']['dbduser'] do
+    comment 'slurmdbd user'
+    uid node['cluster']['slurm']['dbduser_id']
+    gid node['cluster']['slurm']['dbdgroup_id']
+    manage_home false
+    system true
+    shell '/bin/bash'
+  end
 end
 
 include_recipe 'aws-parallelcluster-slurm::install_jwt'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -50,25 +50,6 @@ user node['cluster']['slurm']['user'] do
   shell '/bin/bash'
 end
 
-unless node['cluster']['slurm']['dbduser'].eql?(node['cluster']['slurm']['user'])
-  # Setup slurmdbd group
-  group node['cluster']['slurm']['dbdgroup'] do
-    comment 'slurm group'
-    gid node['cluster']['slurm']['dbdgroup_id']
-    system true
-  end
-
-  # Setup slurmdbd user
-  user node['cluster']['slurm']['dbduser'] do
-    comment 'slurmdbd user'
-    uid node['cluster']['slurm']['dbduser_id']
-    gid node['cluster']['slurm']['dbdgroup_id']
-    manage_home false
-    system true
-    shell '/bin/bash'
-  end
-end
-
 include_recipe 'aws-parallelcluster-slurm::install_jwt'
 
 slurm_tarball = "#{node['cluster']['sources_dir']}/slurm-#{node['cluster']['slurm']['version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -155,7 +155,8 @@ execute "generate_pcluster_slurm_configs" do
           " --compute-node-bootstrap-timeout #{node['cluster']['compute_node_bootstrap_timeout']}" \
           " #{nvidia_installed? ? '' : '--no-gpu'}"\
           " --realmemory-to-ec2memory-ratio #{node['cluster']['realmemory_to_ec2memory_ratio']}"\
-          " --slurmdbd-user #{node['cluster']['slurm']['user']}"
+          " --slurmdbd-user #{node['cluster']['slurm']['user']}"\
+          " --cluster-name #{node['cluster']['stack_name']}"
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? }
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -155,7 +155,7 @@ execute "generate_pcluster_slurm_configs" do
           " --compute-node-bootstrap-timeout #{node['cluster']['compute_node_bootstrap_timeout']}" \
           " #{nvidia_installed? ? '' : '--no-gpu'}"\
           " --realmemory-to-ec2memory-ratio #{node['cluster']['realmemory_to_ec2memory_ratio']}"\
-          " --slurmdbd-user #{node['cluster']['slurm']['dbduser']}"
+          " --slurmdbd-user #{node['cluster']['slurm']['user']}"
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? }
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurmdbd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurmdbd.conf.erb
@@ -1,7 +1,7 @@
 AuthType=auth/munge
 LogFile=/var/log/slurmdbd.log
 DbdPort=6819
-SlurmUser=<%= node['cluster']['slurm']['dbduser'] %>
+SlurmUser=<%= node['cluster']['slurm']['user'] %>
 StorageType=accounting_storage/mysql
 
 # WARNING!!! The slurm_parallelcluster_slurmdbd.conf file included below can be updated by the pcluster process.

--- a/cookbooks/aws-parallelcluster-test/recipes/test_users.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_users.rb
@@ -57,25 +57,6 @@ if node['cluster']['scheduler'] == 'slurm'
 end
 
 ###################
-# Slurmdbd user
-###################
-if node['cluster']['scheduler'] == 'slurm'
-  unless node['cluster']['slurm']['dbduser'].eql?(node['cluster']['slurm']['user'])
-    check_user_definition(
-      node['cluster']['slurm']['dbduser'],
-      node['cluster']['slurm']['dbduser_id'],
-      node['cluster']['slurm']['dbdgroup_id'],
-      'slurmdbd user'
-    )
-
-    check_group_definition(
-      node['cluster']['slurm']['dbdgroup'],
-      node['cluster']['slurm']['dbdgroup_id']
-    )
-  end
-end
-
-###################
 # Munge user
 ###################
 if node['cluster']['scheduler'] == 'slurm'

--- a/cookbooks/aws-parallelcluster-test/recipes/validate_mysql.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/validate_mysql.rb
@@ -18,7 +18,9 @@
 #
 # Check the repository source of a package
 #
-Chef::Log.info("Checking for MySql implementation on #{node['platform']}:#{node['kernel']['machine']}")
-node['cluster']['mysql']['repository']['packages'].each do |pkg|
-  validate_package_source(pkg, node['cluster']['mysql']['repository']['expected']['source'])
+unless arm_instance? && platform?('ubuntu')
+  Chef::Log.info("Checking for MySql implementation on #{node['platform']}:#{node['kernel']['machine']}")
+  node['cluster']['mysql']['repository']['packages'].each do |pkg|
+    validate_package_source(pkg, node['cluster']['mysql']['repository']['expected']['source'])
+  end
 end

--- a/test/unit/slurm/test_slurm_config_generator.py
+++ b/test/unit/slurm/test_slurm_config_generator.py
@@ -29,7 +29,7 @@ def test_generate_slurm_config_files_nogpu(mocker, test_datadir, tmpdir, no_gpu)
         no_gpu=no_gpu,
         compute_node_bootstrap_timeout=1600,
         realmemory_to_ec2memory_ratio=0.95,
-        slurmdbd_user="slurmdbd",
+        slurmdbd_user="slurm",
     )
 
     for queue in ["efa", "gpu", "multiple_spot"]:
@@ -72,7 +72,7 @@ def test_generate_slurm_config_files_memory_scheduling(
         no_gpu=False,
         compute_node_bootstrap_timeout=1600,
         realmemory_to_ec2memory_ratio=realmemory_to_ec2memory_ratio,
-        slurmdbd_user="slurmdbd",
+        slurmdbd_user="slurm",
     )
 
     for queue in ["efa", "gpu", "multiple_spot"]:
@@ -116,7 +116,7 @@ def test_generate_slurm_config_files_slurm_accounting(mocker, test_datadir, tmpd
         no_gpu=False,
         compute_node_bootstrap_timeout=1600,
         realmemory_to_ec2memory_ratio=0.95,
-        slurmdbd_user="slurmdbd",
+        slurmdbd_user="slurm",
     )
 
     for file_type in ["", "_slurmdbd"]:
@@ -146,7 +146,7 @@ def test_generating_slurm_config_flexible_instance_types(mocker, test_datadir, t
         no_gpu=False,
         compute_node_bootstrap_timeout=1600,
         realmemory_to_ec2memory_ratio=0.95,
-        slurmdbd_user="slurmdbd",
+        slurmdbd_user="slurm",
     )
 
     for queue in ["queue1", "queue2", "queue3", "queue4", "queue5", "queue6", "queue7"]:

--- a/test/unit/slurm/test_slurm_config_generator.py
+++ b/test/unit/slurm/test_slurm_config_generator.py
@@ -18,6 +18,7 @@ def test_generate_slurm_config_files_nogpu(mocker, test_datadir, tmpdir, no_gpu)
     mocker.patch(
         "slurm.pcluster_slurm_config_generator._get_head_node_private_ip", return_value="ip.1.0.0.0", autospec=True
     )
+    mocker.patch("slurm.pcluster_slurm_config_generator._get_cluster_name", return_value="test-cluster", autospec=True)
     template_directory = os.path.dirname(slurm.__file__) + "/templates"
     generate_slurm_config_files(
         tmpdir,
@@ -60,6 +61,7 @@ def test_generate_slurm_config_files_memory_scheduling(
     mocker.patch(
         "slurm.pcluster_slurm_config_generator._get_head_node_private_ip", return_value="ip.1.0.0.0", autospec=True
     )
+    mocker.patch("slurm.pcluster_slurm_config_generator._get_cluster_name", return_value="test-cluster", autospec=True)
     template_directory = os.path.dirname(slurm.__file__) + "/templates"
     generate_slurm_config_files(
         tmpdir,
@@ -103,6 +105,7 @@ def test_generate_slurm_config_files_slurm_accounting(mocker, test_datadir, tmpd
     mocker.patch(
         "slurm.pcluster_slurm_config_generator._get_head_node_private_ip", return_value="ip.1.0.0.0", autospec=True
     )
+    mocker.patch("slurm.pcluster_slurm_config_generator._get_cluster_name", return_value="test-cluster", autospec=True)
     template_directory = os.path.dirname(slurm.__file__) + "/templates"
     generate_slurm_config_files(
         tmpdir,
@@ -128,6 +131,7 @@ def test_generating_slurm_config_flexible_instance_types(mocker, test_datadir, t
     mocker.patch(
         "slurm.pcluster_slurm_config_generator._get_head_node_private_ip", return_value="ip.1.0.0.0", autospec=True
     )
+    mocker.patch("slurm.pcluster_slurm_config_generator._get_cluster_name", return_value="test-cluster", autospec=True)
 
     input_file = os.path.join(test_datadir, "sample_input.yaml")
     instance_types_data = os.path.join(test_datadir, "sample_instance_types_data.json")

--- a/test/unit/slurm/test_slurm_config_generator.py
+++ b/test/unit/slurm/test_slurm_config_generator.py
@@ -18,7 +18,6 @@ def test_generate_slurm_config_files_nogpu(mocker, test_datadir, tmpdir, no_gpu)
     mocker.patch(
         "slurm.pcluster_slurm_config_generator._get_head_node_private_ip", return_value="ip.1.0.0.0", autospec=True
     )
-    mocker.patch("slurm.pcluster_slurm_config_generator._get_cluster_name", return_value="test-cluster", autospec=True)
     template_directory = os.path.dirname(slurm.__file__) + "/templates"
     generate_slurm_config_files(
         tmpdir,
@@ -30,6 +29,7 @@ def test_generate_slurm_config_files_nogpu(mocker, test_datadir, tmpdir, no_gpu)
         compute_node_bootstrap_timeout=1600,
         realmemory_to_ec2memory_ratio=0.95,
         slurmdbd_user="slurm",
+        cluster_name="test-cluster",
     )
 
     for queue in ["efa", "gpu", "multiple_spot"]:
@@ -61,7 +61,6 @@ def test_generate_slurm_config_files_memory_scheduling(
     mocker.patch(
         "slurm.pcluster_slurm_config_generator._get_head_node_private_ip", return_value="ip.1.0.0.0", autospec=True
     )
-    mocker.patch("slurm.pcluster_slurm_config_generator._get_cluster_name", return_value="test-cluster", autospec=True)
     template_directory = os.path.dirname(slurm.__file__) + "/templates"
     generate_slurm_config_files(
         tmpdir,
@@ -73,6 +72,7 @@ def test_generate_slurm_config_files_memory_scheduling(
         compute_node_bootstrap_timeout=1600,
         realmemory_to_ec2memory_ratio=realmemory_to_ec2memory_ratio,
         slurmdbd_user="slurm",
+        cluster_name="test-cluster",
     )
 
     for queue in ["efa", "gpu", "multiple_spot"]:
@@ -105,7 +105,6 @@ def test_generate_slurm_config_files_slurm_accounting(mocker, test_datadir, tmpd
     mocker.patch(
         "slurm.pcluster_slurm_config_generator._get_head_node_private_ip", return_value="ip.1.0.0.0", autospec=True
     )
-    mocker.patch("slurm.pcluster_slurm_config_generator._get_cluster_name", return_value="test-cluster", autospec=True)
     template_directory = os.path.dirname(slurm.__file__) + "/templates"
     generate_slurm_config_files(
         tmpdir,
@@ -117,6 +116,7 @@ def test_generate_slurm_config_files_slurm_accounting(mocker, test_datadir, tmpd
         compute_node_bootstrap_timeout=1600,
         realmemory_to_ec2memory_ratio=0.95,
         slurmdbd_user="slurm",
+        cluster_name="test-cluster",
     )
 
     for file_type in ["", "_slurmdbd"]:
@@ -131,7 +131,6 @@ def test_generating_slurm_config_flexible_instance_types(mocker, test_datadir, t
     mocker.patch(
         "slurm.pcluster_slurm_config_generator._get_head_node_private_ip", return_value="ip.1.0.0.0", autospec=True
     )
-    mocker.patch("slurm.pcluster_slurm_config_generator._get_cluster_name", return_value="test-cluster", autospec=True)
 
     input_file = os.path.join(test_datadir, "sample_input.yaml")
     instance_types_data = os.path.join(test_datadir, "sample_instance_types_data.json")
@@ -147,6 +146,7 @@ def test_generating_slurm_config_flexible_instance_types(mocker, test_datadir, t
         compute_node_bootstrap_timeout=1600,
         realmemory_to_ec2memory_ratio=0.95,
         slurmdbd_user="slurm",
+        cluster_name="test-cluster",
     )
 
     for queue in ["queue1", "queue2", "queue3", "queue4", "queue5", "queue6", "queue7"]:

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_memory_scheduling/sample_input.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_memory_scheduling/sample_input.yaml
@@ -77,6 +77,3 @@ Scheduling:
         ScaledownIdletime: 10
         EnableMemoryBasedScheduling: false
         Database: null
-Tags:
-  - Key: parallelcluster:cluster-name
-    Value: test-cluster-no-mem-sched

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_memory_scheduling/sample_input_mem_sched.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_memory_scheduling/sample_input_mem_sched.yaml
@@ -79,6 +79,3 @@ Scheduling:
         ScaledownIdletime: 10
         EnableMemoryBasedScheduling: true
         Database: null
-Tags:
-  - Key: parallelcluster:cluster-name
-    Value: test-cluster-mem-sched

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_nogpu/sample_input.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_nogpu/sample_input.yaml
@@ -76,6 +76,3 @@ Scheduling:
     SlurmSettings:
         ScaledownIdletime: 10
         Database: null
-Tags:
-  - Key: parallelcluster:cluster-name
-    Value: test-cluster-no-gpu

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_slurm_accounting.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_slurm_accounting.conf
@@ -9,7 +9,7 @@ SelectTypeParameters=CR_CPU
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost=ip-1-0-0-0
 AccountingStoragePort=6819
-AccountingStorageUser=slurmdbd
+AccountingStorageUser=slurm
 JobAcctGatherType=jobacct_gather/cgroup
 
 include <DIR>/pcluster/slurm_parallelcluster_efa_partition.conf

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_slurmdbd_slurm_accounting.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_slurmdbd_slurm_accounting.conf
@@ -4,6 +4,6 @@
 DbdHost=ip-1-0-0-0
 StorageHost=test.databaseserver.com
 StoragePort=3306
-StorageLoc=test_cluster_no_slurm_accounting
+StorageLoc=test_cluster
 StorageUser=test_admin
 StoragePass=dummy

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/sample_input.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/sample_input.yaml
@@ -22,7 +22,3 @@ Scheduling:
     SlurmSettings:
         ScaledownIdletime: 10
         Database: null
-Tags:
-    - Key: parallelcluster:cluster-name
-      Value: test-cluster-no-slurm-accounting
-

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/sample_input_slurm_accounting.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/sample_input_slurm_accounting.yaml
@@ -25,6 +25,3 @@ Scheduling:
             Uri: test.databaseserver.com
             UserName: test_admin
             PasswordSecretArn: arn:aws:secretsmanager:us-east-1:111111111111:secret:Secret-xxxxxxxx-xxxxx
-Tags:
-  - Key: parallelcluster:cluster-name
-    Value: test-cluster-no-slurm-accounting

--- a/test/unit/slurm/test_slurm_config_generator/test_generating_slurm_config_flexible_instance_types/sample_input.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generating_slurm_config_flexible_instance_types/sample_input.yaml
@@ -325,6 +325,3 @@ Scheduling:
     QueueUpdateStrategy: COMPUTE_FLEET_STOP
     ScaledownIdletime: 10
     Database: null
-Tags:
-  - Key: parallelcluster:cluster-name
-    Value: test-cluster-flexible-instance-types


### PR DESCRIPTION
### Description of changes
* Change default user for slurmdbd daemon to same user slurmctld runs with.
* Pass cluster name to pcluster_slurm_config_generator.py as parameter to the python script.

### Tests
* Ran unit tests for the introduced changes.
* Manually created cluster with Slurm accounting enabled.

### References
* #1530 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.