### PR TITLE
Fix hardcoded region in MySQL validation test

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -244,7 +244,7 @@ if arm_instance?
   )
   default['cluster']['mysql']['repository']['expected']['source'] = value_for_platform(
     'default' => "mysql80-community",
-    'ubuntu' => { 'default' => "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports" }
+    'ubuntu' => { 'default' => "http://#{node['cluster']['region']}.ec2.ports.ubuntu.com/ubuntu-ports" }
   )
 else
   default['cluster']['mysql']['repository']['packages'] = value_for_platform(


### PR DESCRIPTION
### Description of changes
* Validation test was hardcoded to us-east-1 for Ubuntu Arm builds
* Fixed it so that the region is dynamic.

### Tests
* Built an image for [Ubuntu 2004, Arm ]in eu-west-1
* Ran a 2nd stage build on a Jenkins server not in us-west-1

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.