### PR TITLE
Fix Slurm Accounting password update script

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -596,6 +596,7 @@ default['cluster']['skip_install_recipes'] = 'yes'
 default['cluster']['enable_nss_slurm'] = node['cluster']['directory_service']['enabled']
 default['cluster']['realmemory_to_ec2memory_ratio'] = 0.95
 default['cluster']['slurm_node_reg_mem_percent'] = 75
+default['cluster']['slurmdbd_response_retries'] = 30
 
 # AWS domain
 default['cluster']['aws_domain'] = aws_domain

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_slurm_accounting.rb
@@ -58,9 +58,7 @@ end
 # query the database before proceeding.
 execute "wait for slurm database" do
   command "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn"
-  # Very large value to simulate infinite loop (we will hit some other timeout
-  # before this).
-  retries 100000
+  retries node['cluster']['slurmdbd_response_retries']
   retry_delay 10
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_slurm_database_password.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_slurm_database_password.sh.erb
@@ -29,7 +29,8 @@ password_from_secrets_manager=$(aws secretsmanager get-secret-value --secret-id 
 [ "${password_from_dbd_config}" == "${password_from_secrets_manager}" ] && echo "Password match, skipping update" && exit 0
 
 echo "Writing AWS Secrets Manager password to ${SLURMDBD_CONFIG_FILE}"
-sed -i "s/^${SLURMDBD_PROPERTY}=.*$/${SLURMDBD_PROPERTY}=${password_from_secrets_manager}/g" ${SLURMDBD_CONFIG_FILE}
+sed -i "/${SLURMDBD_PROPERTY}/d" ${SLURMDBD_CONFIG_FILE}
+echo "${SLURMDBD_PROPERTY}=${password_from_secrets_manager}" >> ${SLURMDBD_CONFIG_FILE}
 echo "Password updated in ${SLURMDBD_CONFIG_FILE}"
 
 if systemctl --quiet is-active slurmdbd.service; then


### PR DESCRIPTION
### Description of changes
* Change commands to update StoragePass to avoid possible issues with badly escaped characters.
* Change default number of retries when waiting for the slurm database to be ready. Also, expose it via the Chef attributes.

### Tests
* Created cluster manually.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.