### PR TITLE
Revert "[Dependencies] Downgrade Slurm to version 21.08.8"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Reduce timeout from 50 to a maximum of 5min in case of DynamoDB connection issues at compute node bootstrap.
 - Change the logic to number the routing tables when an instance have multiple NICs.
 - Upgrade Python from 3.7.13 to 3.9.13.
+- Upgrade Slurm to version 22.05.3.
 
 3.2.0
 ------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -127,9 +127,9 @@ default['cluster']['parallelcluster-awsbatch-cli-version'] = '1.0.0'
 # URLs to software packages used during install recipes
 # Slurm software
 default['cluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
-default['cluster']['slurm']['version'] = '21-08-8-2'
+default['cluster']['slurm']['version'] = '22-05-3-1'
 default['cluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['cluster']['slurm']['version']}.tar.gz"
-default['cluster']['slurm']['sha1'] = 'f7687c11f024fbbe5399b93906d1179adc5c3fb6'
+default['cluster']['slurm']['sha1'] = 'f7340a7def5ba359327dd8ff41272b76e28d8bdf'
 default['cluster']['slurm']['user'] = 'slurm'
 default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1
 default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']


### PR DESCRIPTION
### Description of changes
We want to revert the downgrade of Slurm because we found out that this is not the root cause of the observed regressions.
This reverts commit 5e38e857e5262d70eea8a597fd2caa08208d62c7.

### Tests
Will be tested on the official pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.