### PR TITLE
Change default NFS thread number to have better performances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - xdcv: `2022.1.433-1`
   - gl: `2022.1.973-1`
   - web_viewer: `2022.1.13300-1`
+- Configure NFS threads to be `min(256, max(8, num_cores * 4))` to ensure better stability and performance.
 
 **CHANGES**
 - Upgrade NVIDIA driver to version 470.141.03.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -484,6 +484,8 @@ end
 
 # Default NFS mount options
 default['cluster']['nfs']['hard_mount_options'] = 'hard,_netdev,noatime'
+# For performance, set NFS threads to min(256, max(8, num_cores * 4))
+default['cluster']['nfs']['threads'] = [[node['cpu']['cores'].to_i * 4, 8].max, 256].min
 
 # Lustre defaults (for CentOS >=7.7 and Ubuntu)
 default['cluster']['lustre']['public_key'] = value_for_platform(

--- a/cookbooks/aws-parallelcluster-config/recipes/nfs.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/nfs.rb
@@ -4,7 +4,7 @@
 # Cookbook:: aws-parallelcluster
 # Recipe:: nfs
 #
-# Copyright:: 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -15,12 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# For performance, set NFS threads to max(num_cores, 8)
-# This change will not be effective on Ubuntu1604 unless instance is restarted
-# Changing thread in /etc/default/nfs-kernel-server and restarting NFS server will not change nfsd settings for Ubuntu1604
-# See: https://ubuntuforums.org/showthread.php?t=2345636
-# NFS threads enhancement is omitted for Ubuntu1604
-node.force_override['nfs']['threads'] = [node['cpu']['cores'].to_i, 8].max
+node.force_override['nfs']['threads'] = node['cluster']['nfs']['threads']
 
 # Overwriting templates for node['nfs']['config']['server_template'] used by NFS cookbook for these OSs
 # When running, NFS cookbook will use nfs.conf.erb templates provided in this cookbook to generate server_template


### PR DESCRIPTION
### Description of changes
I tested to launch a job with 1000 nodes on a c5.12xlarge (24 NFS threads) and
I noticed the `nfsd: too many open connections, consider increasing the number of threads` message.

We should use at the very least one daemon per processor, but four to eight per processor is considered a better rule of thumb. We're capping the value to 256 to avoid having too many threads.

With this patch I'm also exposing the `node['cluster']['nfs']['threads']` parameter in the `default.rb`
file to permit to overwrite it from `DevSettings` if needed.

### Tests
* Executed build of AMIs with modified recipes
* Executed the `test_scaling.py::test_multiple_jobs_submission` integ tests for both x86 and ARM architecture.

### References
* According to https://nfs.sourceforge.net/nfs-howto/ar01s05.html in the early days of NFS, Sun decided on 8 as a rule of thumb, and everyone else copied. We should use at the very least one daemon per processor, but 4 to 8 per processor may be a better rule of thumb.
* According to Suse support, boosting the number of threads (even dramatically) is not likely to cause any negative side effects. Therefore, it is safe to be generous with this setting. https://www.suse.com/support/kb/doc/?id=000017927


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.