### PR TITLE
[SSL] Enforce use of TLS 1.2 for the DCV authentication server socket 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 3.6.0
 ------
 
+**ENHANCEMENTS**
+- Enforce the DCV Authenticator Server to use at least `TLS-1.2` protocol when creating the SSL Socket.
+
+**CHANGES**
+- ...
+
 3.5.0
 ------
 

--- a/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
@@ -407,18 +407,17 @@ def _run_server(port, certificate=None, key=None):
     :param certificate: the certificate to use if HTTPSs
     :param key: the private key to use if HTTPSs
     """
-    server_address = ("localhost", port)
+    server_hostname = "localhost"
+    server_address = (server_hostname, port)
     httpd = ThreadedHTTPServer(server_address, DCVAuthenticator)
 
+    ssl_context = ssl.SSLContext()
+    ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+    ssl_context.server_hostname = server_hostname
+
     if certificate:
-        if key:
-            httpd.socket = ssl.wrap_socket(  # nosec nosemgrep pylint: disable=W4902
-                httpd.socket, certfile=certificate, keyfile=key, server_side=True
-            )
-        else:
-            httpd.socket = ssl.wrap_socket(  # nosec nosemgrep pylint: disable=W4902
-                httpd.socket, certfile=certificate, server_side=True
-            )
+        ssl_context.load_cert_chain(certfile=certificate, keyfile=key)
+        httpd.socket = ssl_context.wrap_socket(httpd.socket, server_side=True)
     print(
         f"Starting DCV external authenticator {'HTTPS' if certificate else 'HTTP'} server on port {port}, use "
         f"<Ctrl-C> to stop "


### PR DESCRIPTION
### Description of changes
* [ssl.wrap_socket](https://docs.python.org/3/library/ssl.html#ssl.wrap_socket) has been deprecated since version 3.7
* The `ssl.wrap_socket` function might default to an insecure version of SSL/TLS (e.g. SSL 2.0 or SSL 3.0) when no specific protocol version is specified. This may leave the connection vulnerable to attack
* The recommended method is
    * To use [SSLContext.wrap_socket](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.wrap_socket)
    * Enforce usage of at least TLS 1.2

### Tests
* Manually connected to a DCV session
* Executed DCV integration tests successfully

### References
* [SSLContext.load_cert_chain](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain)
* [SSLContext.wrap_socket](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.wrap_socket)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.