### PR TITLE
Handle filesystems rollback if case of cluster update failure

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,7 +36,7 @@ default['cluster']['launch_templates_config_path'] = "#{node['cluster']['shared_
 default['cluster']['instance_types_data_path'] = "#{node['cluster']['shared_dir']}/instance-types-data.json"
 default['cluster']['computefleet_status_path'] = "#{node['cluster']['shared_dir']}/computefleet-status.json"
 default['cluster']['shared_storages_mapping_path'] = "/etc/parallelcluster/shared_storages_data.yaml"
-default['cluster']['update_shared_storages_mapping_path'] = "/etc/parallelcluster/update_shared_storages_data.yaml"
+default['cluster']['previous_shared_storages_mapping_path'] = "/etc/parallelcluster/previous_shared_storages_data.yaml"
 
 default['cluster']['reserved_base_uid'] = 400
 

--- a/cookbooks/aws-parallelcluster-config/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/update.rb
@@ -21,8 +21,14 @@ unless node['cluster']['scheduler'] == 'awsbatch'
   end
 end
 
+ruby_block "backup storages mappings" do # backup shared storages mapping file to used for update and rollback
+  block do
+    ::FileUtils.cp_r(node['cluster']['shared_storages_mapping_path'], node['cluster']['previous_shared_storages_mapping_path'], remove_destination: true)
+  end
+end
+
 # generate the update shared storages mapping file
-template node['cluster']['update_shared_storages_mapping_path'] do
+template node['cluster']['shared_storages_mapping_path'] do
   source 'shared_storages/shared_storages_data.erb'
   mode '0644'
 end

--- a/cookbooks/aws-parallelcluster-config/recipes/update_shared_storages.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/update_shared_storages.rb
@@ -203,9 +203,3 @@ manage_fsx "mount fsx" do
   fsx_volume_junction_path_array(lazy { node['cluster']['mount_fsx_volume_junction_path_array'] })
   not_if { node['cluster']['mount_fsx_fs_id_array'].empty? }
 end
-
-ruby_block "replace shared storages mappings" do
-  block do
-    ::FileUtils.cp_r(node['cluster']['update_shared_storages_mapping_path'], node['cluster']['shared_storages_mapping_path'], remove_destination: true)
-  end
-end

--- a/cookbooks/aws-parallelcluster-config/resources/manage_efs.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_efs.rb
@@ -40,9 +40,22 @@ action :mount do
       options 'nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=30,retrans=2,noresvport,_netdev'
       dump 0
       pass 0
-      action %i(mount enable)
+      action :mount
       retries 10
       retry_delay 6
+      not_if "mount | grep ' #{efs_shared_dir} '"
+    end
+
+    mount efs_shared_dir do
+      device "#{efs_fs_id}.efs.#{node['cluster']['region']}.#{node['cluster']['aws_domain']}:/"
+      fstype 'nfs4'
+      options 'nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=30,retrans=2,noresvport,_netdev'
+      dump 0
+      pass 0
+      action :enable
+      retries 10
+      retry_delay 6
+      only_if "mount | grep ' #{efs_shared_dir} '"
     end
 
     # Make sure EFS shared directory permissions are correct
@@ -57,21 +70,22 @@ end
 action :unmount do
   efs_shared_dir_array = new_resource.shared_dir_array.dup
   efs_fs_id_array = new_resource.efs_fs_id_array.dup
-  efs_fs_id_array.zip(efs_shared_dir_array).each do |efs_fs_id, efs_shared_dir|
+  efs_fs_id_array.zip(efs_shared_dir_array).each do |efs_shared_dir|
     # Path needs to be fully qualified, for example "shared/temp" becomes "/shared/temp"
     efs_shared_dir = "/#{efs_shared_dir}" unless efs_shared_dir.start_with?('/')
     # Unmount EFS
-    mount efs_shared_dir do
-      device "#{efs_fs_id}.efs.#{node['cluster']['region']}.#{node['cluster']['aws_domain']}:/"
-      fstype 'nfs4'
-      options 'nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=30,retrans=2,noresvport,_netdev'
-      dump 0
-      pass 0
-      action %i(unmount disable)
+    execute 'unmount efs' do
+      command "umount -fl #{efs_shared_dir}"
       retries 10
       retry_delay 6
+      timeout 60
+      only_if "mount | grep ' #{efs_shared_dir} '"
     end
-
+    # remove volume from fstab
+    delete_lines "remove volume from /etc/fstab" do
+      path "/etc/fstab"
+      pattern " #{efs_shared_dir} "
+    end
     # Delete the EFS shared directory
     directory efs_shared_dir do
       owner 'root'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -635,8 +635,8 @@ def load_shared_storages_mapping
     block do
       require 'yaml'
       # regenerate the shared storages mapping file after update
-      node.default['cluster']['shared_storages_mapping'] = YAML.safe_load(File.read(node['cluster']['shared_storages_mapping_path']))
-      node.default['cluster']['update_shared_storages_mapping'] = YAML.safe_load(File.read(node['cluster']['update_shared_storages_mapping_path']))
+      node.default['cluster']['shared_storages_mapping'] = YAML.safe_load(File.read(node['cluster']['previous_shared_storages_mapping_path']))
+      node.default['cluster']['update_shared_storages_mapping'] = YAML.safe_load(File.read(node['cluster']['shared_storages_mapping_path']))
     end
   end
 end


### PR DESCRIPTION
### Description of changes
* Make shared storages resources idempotent to make it handle the external filesystem rollback.
* Backup shared storage mapping file during update in case we need to use it during rollback.
### Tests
* Manually test with Update cluster with problematic EBS, EFS and FSX

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.