### PR TITLE
Increasing mounting retry_delay for EFS to 60 seconds

### DIFF
--- a/cookbooks/aws-parallelcluster-config/resources/manage_efs.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_efs.rb
@@ -42,7 +42,7 @@ action :mount do
       pass 0
       action :mount
       retries 10
-      retry_delay 6
+      retry_delay 60 # increase to 60s because it takes about 5 minutes for a  managed EFS to be ready to mount after creation complete
       not_if "mount | grep ' #{efs_shared_dir} '"
     end
 


### PR DESCRIPTION
### Description of changes
* Increase to 60s because it takes about 5 minutes for a  managed EFS to be ready to mount after creation complete

### Tests
* Manually test with updating cluster with one managed EFS, after 5 retrying, it is able to mount
```
[2022-10-14T17:03:34+00:00] INFO: Retrying execution of mount[/efs_managed_add], 9 attempts left
[2022-10-14T17:04:34+00:00] INFO: Retrying execution of mount[/efs_managed_add], 8 attempts left
[2022-10-14T17:05:34+00:00] INFO: Retrying execution of mount[/efs_managed_add], 7 attempts left
[2022-10-14T17:06:35+00:00] INFO: Retrying execution of mount[/efs_managed_add], 6 attempts left
[2022-10-14T17:07:35+00:00] INFO: Retrying execution of mount[/efs_managed_add], 5 attempts left
[2022-10-14T17:08:39+00:00] INFO: mount[/efs_managed_add] mounted

      - mount fs-01d4b8277dcec5247.efs.us-east-1.amazonaws.com:/ to /efs_managed_add
    * mount[/efs_managed_add] action enable[2022-10-14T17:08:39+00:00] INFO: Processing mount[/efs_managed_add] action enable (/etc/chef/local-mode-cache/cache/cookbooks/aws-parallelcluster-config/resources/manage_efs.rb line 49)
[2022-10-14T17:08:39+00:00] INFO: mount[/efs_managed_add] enabled

```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.