### PR TITLE
Fix pre-commit hooks config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
     rev: v3.4.0
     hooks:
       - id: trailing-whitespace


### PR DESCRIPTION
### Description of changes
Pre-commit hooks execution hangs if github account is configured to use an ssh key and the repo in the yaml file is specified with the git protocol

### Tests
* Failed to commit a simple change locally while using git protocol in yaml file
* Switched to https protocol and successfully committed (along with commit-hooks execution) this change and prepared the PR

### References
- None

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.