### PR TITLE
[DFSM] Move backing up shared storage data to fetch_config recipe

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/update.rb
@@ -21,12 +21,6 @@ unless node['cluster']['scheduler'] == 'awsbatch'
   end
 end
 
-ruby_block "backup storages mappings" do # backup shared storages mapping file to used for update and rollback
-  block do
-    ::FileUtils.cp_r(node['cluster']['shared_storages_mapping_path'], node['cluster']['previous_shared_storages_mapping_path'], remove_destination: true)
-  end
-end
-
 # generate the update shared storages mapping file
 template node['cluster']['shared_storages_mapping_path'] do
   source 'shared_storages/shared_storages_data.erb'

--- a/cookbooks/aws-parallelcluster-config/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/fetch_config.rb
@@ -18,6 +18,8 @@ action :run do
       fetch_cluster_config(node['cluster']['cluster_config_path'])
       fetch_change_set
       fetch_instance_type_data unless ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path'])
+      Chef::Log.info("Backing up old shared storages data from (#{node['cluster']['shared_storages_mapping_path']}) to (#{node['cluster']['previous_shared_storages_mapping_path']})")
+      ::FileUtils.cp_r(node['cluster']['shared_storages_mapping_path'], node['cluster']['previous_shared_storages_mapping_path'], remove_destination: true)
     else
       fetch_cluster_config(node['cluster']['cluster_config_path']) unless ::File.exist?(node['cluster']['cluster_config_path'])
       fetch_instance_type_data unless ::File.exist?(node['cluster']['instance_types_data_path'])

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -629,7 +629,7 @@ def is_slurm_database_updated?
   config["Scheduling"]["SlurmSettings"]["Database"] != previous_config["Scheduling"]["SlurmSettings"]["Database"]
 end
 
-# load cluster configuration file into node object
+# load shared storages data into node object
 def load_shared_storages_mapping
   ruby_block "load shared storages mapping during cluster update" do
     block do


### PR DESCRIPTION
Move backing up shared storage data to fetch_config recipe so it is executed when performing update. Add log message when backing up the recipe
Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.