### PR TITLE
Fix efs mount error

### DIFF
--- a/cookbooks/aws-parallelcluster-config/resources/manage_efs.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_efs.rb
@@ -69,8 +69,7 @@ end
 
 action :unmount do
   efs_shared_dir_array = new_resource.shared_dir_array.dup
-  efs_fs_id_array = new_resource.efs_fs_id_array.dup
-  efs_fs_id_array.zip(efs_shared_dir_array).each do |efs_shared_dir|
+  efs_shared_dir_array.each do |efs_shared_dir|
     # Path needs to be fully qualified, for example "shared/temp" becomes "/shared/temp"
     efs_shared_dir = "/#{efs_shared_dir}" unless efs_shared_dir.start_with?('/')
     # Unmount EFS


### PR DESCRIPTION
Fix EFS mounting error inttoduce by the change in https://github.com/aws/aws-parallelcluster-cookbook/pull/1556 Previously I change `efs_fs_id_array.zip(efs_shared_dir_array).each do |efs_fs_id, efs_shared_dir|` to `efs_fs_id_array.zip(efs_shared_dir_array).each do | efs_shared_dir|` to fix a linter issue, but it is not a right fix and introduce another error.

Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.