### PR TITLE
Backport remove rubocop-gitlab-security

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,3 @@
-require: rubocop-gitlab-security
-
 Layout/LineLength:
   Max: 200
 Layout/ParameterAlignment:


### PR DESCRIPTION
### Description of changes
* Backport https://github.com/aws/aws-parallelcluster-cookbook/commit/49f8092cf71aa07972d72d47f36e312a889acf3f
* Need to backport it because there are checks fail here: https://github.com/aws/aws-parallelcluster-cookbook/pull/1566
### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.