### PR TITLE
Upgrade Intel MPI to version 2021.6.0 and EFA to 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **CHANGES**
 - Upgrade Intel MPI Library to 2021.6.0.602.
+- Upgrade EFA installer to `1.18.0`
+  - Efa-driver: `efa-1.16.0-1`
+  - Efa-config: `efa-config-1.11-1`
+  - Efa-profile: `efa-profile-1.5-1`
+  - Libfabric-aws: `libfabric-aws-1.16.0~amzn4.0-1`
+  - Rdma-core: `rdma-core-41.0-2`
+  - Open MPI: `openmpi40-aws-4.1.4-2`
 
 2.11.7
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+2.11.8
+-----
+
+**CHANGES**
+- Upgrade Intel MPI Library to 2021.6.0.602.
+
 2.11.7
 -----
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -145,7 +145,7 @@ default['cfncluster']['nvidia']['fabricmanager']['repository_uri'] = value_for_p
 )
 
 # EFA
-default['cfncluster']['efa']['installer_version'] = '1.14.1'
+default['cfncluster']['efa']['installer_version'] = '1.18.0'
 default['cfncluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cfncluster']['efa']['installer_version']}.tar.gz"
 default['cfncluster']['efa']['unsupported_aarch64_oses'] = %w[centos7]
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,10 +63,10 @@ default['cfncluster']['intelpython2']['version'] = '2019.4-088'
 default['cfncluster']['intelpython3']['version'] = '2020.2-902'
 
 # Intel MPI
-default['cfncluster']['intelmpi']['version'] = '2021.4.0'
-default['cfncluster']['intelmpi']['full_version'] = "#{node['cfncluster']['intelmpi']['version']}.441"
+default['cfncluster']['intelmpi']['version'] = '2021.6.0'
+default['cfncluster']['intelmpi']['full_version'] = "#{node['cfncluster']['intelmpi']['version']}.602"
 default['cfncluster']['intelmpi']['modulefile'] = "/opt/intel/mpi/#{node['cfncluster']['intelmpi']['version']}/modulefiles/mpi"
-default['cfncluster']['intelmpi']['kitchen_test_string'] = 'Version 2021.4'
+default['cfncluster']['intelmpi']['kitchen_test_string'] = 'Version 2021.6'
 default['cfncluster']['intelmpi']['qt_version'] = '5.15.2'
 
 # Arm Performance Library

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -310,13 +310,6 @@ else
       grep "EFA installer version: #{node['cfncluster']['efa']['installer_version']}" /opt/amazon/efa_installed_packages
     EFA
   end
-  # GDR (GPUDirect RDMA)
-  if node['conditions']['efa_supported']
-    execute 'check efa gdr installed' do
-      command "modinfo efa | grep 'gdr:\ *Y'"
-      user node['cfncluster']['cfn_cluster_user']
-    end
-  end
 end
 
 ###################


### PR DESCRIPTION
### Description of changes
* Backport https://github.com/aws/aws-parallelcluster-cookbook/pull/1503
* Backport https://github.com/aws/aws-parallelcluster-cookbook/pull/1543
* Backport https://github.com/aws/aws-parallelcluster-cookbook/pull/1466

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.