### PR TITLE
simply align 2.11 slurm files with 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **CHANGES**
 - Upgrade Slurm to version 21.08.
+- Update slurmctld and slurmd systemd service files.
 
 2.11.7
 -----

--- a/files/default/slurmctld.service
+++ b/files/default/slurmctld.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Slurm controller daemon
-After=network.target munge.service
+After=network-online.target munge.service
+Wants=network-online.target
 ConditionPathExists=/opt/slurm/etc/slurm.conf
 
 [Service]
 Type=simple
 EnvironmentFile=-/etc/sysconfig/slurmctld
-ExecStart=/opt/slurm/sbin/slurmctld -D $SLURMCTLD_OPTIONS
+ExecStart=/opt/slurm/sbin/slurmctld -D -s $SLURMCTLD_OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 LimitNOFILE=562930
 LimitMEMLOCK=infinity

--- a/files/default/slurmd.service
+++ b/files/default/slurmd.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Slurm node daemon
-After=munge.service network.target remote-fs.target
+After=munge.service network-online.target remote-fs.target
+Wants=network-online.target
 ConditionPathExists=/opt/slurm/etc/slurm.conf
 
 [Service]
 Type=simple
 EnvironmentFile=-/etc/sysconfig/slurmd
-ExecStart=/opt/slurm/sbin/slurmd -D $SLURMD_OPTIONS
+ExecStart=/opt/slurm/sbin/slurmd -D -s $SLURMD_OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 LimitNOFILE=131072


### PR DESCRIPTION
### Description of changes
align the compute and head node files between 2.11 and 3.x

### References
* Link to documentation useful to understand the changes.
Minor fix to slurm service files: https://github.com/aws/aws-parallelcluster-cookbook/commit/6fd9f377186f53a4d22eeb0df1e29585f9b2f5ce
Update slurmd.service and slurmctld.service
: https://github.com/aws/aws-parallelcluster-cookbook/commit/d264c6b9c1b751eac761bf48aaff88ca0e794cdf
Factor out slurm installation dir: https://github.com/aws/aws-parallelcluster-cookbook/commit/def877110c2bf1562be58b93e1f5550f469411b7#diff-5c42e5f029215133e088c66f03fb437d02e7605c303046b6694acce4bb70f8db

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.