### PR TITLE
Remove validation of MySQL packages on Ubuntu 18.04/20.04 ARM as they are installed from OS repos.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -277,11 +277,8 @@ if arm_instance?
     }
   )
   default['cluster']['mysql']['repository']['expected']['version'] = value_for_platform(
-    'default' => "8.0.31",
-    'ubuntu' => {
-      '20.04' => "8.0.30-0ubuntu0.20.04.2",
-      '18.04' => "5.7.39-0ubuntu0.18.04.2",
-    }
+    'default' => "8.0.31"
+    # Ubuntu 18.04/20.04 ARM: MySQL packages are installed from OS repo and we do not assert on a specific version.
   )
 else
   default['cluster']['mysql']['repository']['packages'] = value_for_platform(

--- a/cookbooks/aws-parallelcluster-install/recipes/install_mysql_client.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/install_mysql_client.rb
@@ -30,6 +30,8 @@ else
   mysql_archive_url = node['cluster']['mysql']['package']['archive']
   mysql_tar_file = "/tmp/#{node['cluster']['mysql']['package']['file-name']}"
 
+  log "Downloading MySQL packages archive from #{mysql_archive_url}"
+
   remote_file mysql_tar_file do
     source mysql_archive_url
     mode '0644'

--- a/cookbooks/aws-parallelcluster-test/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-test/libraries/helpers.rb
@@ -263,9 +263,9 @@ end
 def validate_package_version(package, expected_version)
   case node['platform']
   when 'amazon', 'centos'
-    test_expression = "$(yum info #{package} | grep 'Version' | awk '{print $3}')"
+    test_expression = "$(yum info installed #{package} | grep 'Version' | awk '{print $3}')"
   when 'ubuntu'
-    test_expression = "$(apt show #{package} | grep 'Version:' | awk '{print $2}')"
+    test_expression = "$(apt list --installed #{package} | awk '{print $2}')"
   else
     raise "Platform not supported: #{node['platform']}"
   end

--- a/cookbooks/aws-parallelcluster-test/recipes/validate_mysql.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/validate_mysql.rb
@@ -18,7 +18,9 @@
 #
 # Check the repository source of a package
 #
-Chef::Log.info("Checking for MySql implementation on #{node['platform']}:#{node['kernel']['machine']}")
-node['cluster']['mysql']['repository']['packages'].each do |pkg|
-  validate_package_version(pkg, node['cluster']['mysql']['repository']['expected']['version'])
+unless platform?('ubuntu') && arm_instance?
+  Chef::Log.info("Checking for MySql implementation on #{node['platform']}:#{node['kernel']['machine']}")
+  node['cluster']['mysql']['repository']['packages'].each do |pkg|
+    validate_package_version(pkg, node['cluster']['mysql']['repository']['expected']['version'])
+  end
 end


### PR DESCRIPTION
### Description of changes
1. Remove validation of MySQL packages on Ubuntu 18.04/20.04 ARM as they are installed from OS repos.
2. Fix logic to validate package versions so that it will consider only installed packages.
3. Add log line to know the URL the MYSQL package is downloaded from.

### Tests
1. Custom build on Ubuntu 18.04 ARM with validation enabled => succeeded

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>