### PR TITLE
[2.11] Revert "Backport update slurmctld and slurmd systemd service files"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Libfabric-aws: `libfabric-aws-1.16.0~amzn4.0-1`
   - Rdma-core: `rdma-core-41.0-2`
   - Open MPI: `openmpi40-aws-4.1.4-2`
-- Update slurmctld and slurmd systemd service files.
 
 2.11.7
 -----

--- a/files/default/slurmctld.service
+++ b/files/default/slurmctld.service
@@ -1,13 +1,12 @@
 [Unit]
 Description=Slurm controller daemon
-After=network-online.target munge.service
-Wants=network-online.target
+After=network.target munge.service
 ConditionPathExists=/opt/slurm/etc/slurm.conf
 
 [Service]
 Type=simple
 EnvironmentFile=-/etc/sysconfig/slurmctld
-ExecStart=/opt/slurm/sbin/slurmctld -D -s $SLURMCTLD_OPTIONS
+ExecStart=/opt/slurm/sbin/slurmctld -D $SLURMCTLD_OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 LimitNOFILE=562930
 LimitMEMLOCK=infinity

--- a/files/default/slurmd.service
+++ b/files/default/slurmd.service
@@ -1,13 +1,12 @@
 [Unit]
 Description=Slurm node daemon
-After=munge.service network-online.target remote-fs.target
-Wants=network-online.target
+After=munge.service network.target remote-fs.target
 ConditionPathExists=/opt/slurm/etc/slurm.conf
 
 [Service]
 Type=simple
 EnvironmentFile=-/etc/sysconfig/slurmd
-ExecStart=/opt/slurm/sbin/slurmd -D -s $SLURMD_OPTIONS
+ExecStart=/opt/slurm/sbin/slurmd -D $SLURMD_OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 LimitNOFILE=131072


### PR DESCRIPTION
### Description of changes
* This reverts commit a5cdad2a0fef415005cc7dbbc4cc81b27984acb4. Revert the commit becauses of update of the slurm files are only require when upgrade to 21.08 

See https://github.com/aws/aws-parallelcluster-cookbook/pull/1473 and https://github.com/aws/aws-parallelcluster-cookbook/commit/d264c6b9c1b751eac761bf48aaff88ca0e794cdf

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.