### PR TITLE
[Release-3.1] Add workaround to fix Slurm scaling issue and backport of patch for release 3.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.1.5
+------
+
+**ENHANCEMENTS**
+- Upgrade EFA installer to `1.18.0`
+  - Efa-driver: `efa-1.16.0-1`
+  - Efa-config: `efa-config-1.11-1`
+  - Efa-profile: `efa-profile-1.5-1`
+  - Libfabric-aws: `libfabric-aws-1.16.0~amzn4.0-1`
+  - Rdma-core: `rdma-core-41.0-2`
+  - Open MPI: `openmpi40-aws-4.1.4-2`
+
 3.1.4
 ------
 
@@ -29,7 +41,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Fix the configuration parameter `DirectoryService/DomainAddr` conversion to `ldap_uri` SSSD property when it contains multiples domain addresses.
-- Fix DCV not loading user profile at session start. The user's PATH was not correctly set at DCV session connection.  
+- Fix DCV not loading user profile at session start. The user's PATH was not correctly set at DCV session connection.
 
 3.1.2
 ------
@@ -64,6 +76,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **BUG FIXES**
 - Do not configure GPUs in Slurm when NVIDIA driver is not installed.
 - Fix the way `ExtraChefAttributes` are merged into the final configuration.
+- Fix sporadic failure of build-image due to missing package
 
 3.0.3
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **ENHANCEMENTS**
+- Fix Slurm issue that prevents idle nodes termination.
 - Upgrade EFA installer to `1.18.0`
   - Efa-driver: `efa-1.16.0-1`
   - Efa-config: `efa-config-1.11-1`
@@ -14,6 +15,11 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Libfabric-aws: `libfabric-aws-1.16.0~amzn4.0-1`
   - Rdma-core: `rdma-core-41.0-2`
   - Open MPI: `openmpi40-aws-4.1.4-2`
+
+**CHANGES**
+- Upgrade Intel MPI Library to 2021.6.0.602.
+- Upgrade NVIDIA driver to version 470.141.03.
+- Upgrade NVIDIA Fabric Manager to version 470.141.03.
 
 3.1.4
 ------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -75,10 +75,10 @@ default['cluster']['intelpython2']['version'] = '2019.4-088'
 default['cluster']['intelpython3']['version'] = '2020.2-902'
 
 # Intel MPI
-default['cluster']['intelmpi']['version'] = '2021.4.0'
-default['cluster']['intelmpi']['full_version'] = "#{node['cluster']['intelmpi']['version']}.441"
+default['cluster']['intelmpi']['version'] = '2021.6.0'
+default['cluster']['intelmpi']['full_version'] = "#{node['cluster']['intelmpi']['version']}.602"
 default['cluster']['intelmpi']['modulefile'] = "/opt/intel/mpi/#{node['cluster']['intelmpi']['version']}/modulefiles/mpi"
-default['cluster']['intelmpi']['kitchen_test_string'] = 'Version 2021.4'
+default['cluster']['intelmpi']['kitchen_test_string'] = 'Version 2021.6'
 default['cluster']['intelmpi']['qt_version'] = '5.15.2'
 
 # Arm Performance Library

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@
 # Cookbook:: aws-parallelcluster
 # Attributes:: default
 #
-# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -199,7 +199,7 @@ default['cluster']['nvidia']['fabricmanager']['repository_uri'] = value_for_plat
 )
 
 # EFA
-default['cluster']['efa']['installer_version'] = '1.14.1'
+default['cluster']['efa']['installer_version'] = '1.18.0'
 default['cluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cluster']['efa']['installer_version']}.tar.gz"
 default['cluster']['efa']['unsupported_aarch64_oses'] = %w(centos7)
 


### PR DESCRIPTION
### Description of changes
* Add workaround to fix Slurm scaling issue
* Bump version and add changelog for 3.1.5
* Cherry pick of https://github.com/aws/aws-parallelcluster-cookbook/commit/3987786e3d5707122be517907395145bb8c98893
* Cherry pick of https://github.com/aws/aws-parallelcluster-cookbook/commit/41d516b3ed917b0a84714d90a197216c58e91b6d

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.