### PR TITLE
[MultiAZ] Include Networking/SubnetIds in the `fleet-config` file for CreateFleet API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.x.x
+------
+
+**ENHANCEMENTS**
+- Add support for specifying multiple subnets for each queue to increase the EC2 capacity pool available for use.
+
 3.3.0
 ------
 

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
@@ -40,6 +40,9 @@ def generate_fleet_config_file(output_file, input_file):
                     { "InstanceType": ... }
                 ],
                 "MaxPrice": ...
+                "Networking": {
+                    "SubnetIds": [...]
+                }
             }
             "single-compute-resource": {
                 "Api": "run-instances",
@@ -73,6 +76,9 @@ def generate_fleet_config_file(output_file, input_file):
                     }
                     if capacity_type == "spot" and compute_resource_config["SpotPrice"]:
                         fleet_config[queue][compute_resource]["MaxPrice"] = compute_resource_config["SpotPrice"]
+                    fleet_config[queue][compute_resource]["Networking"] = {
+                        "SubnetIds": queue_config["Networking"]["SubnetIds"]
+                    }
 
                 elif compute_resource_config.get("InstanceType"):
                     fleet_config[queue][compute_resource] = {

--- a/test/unit/slurm/test_fleet_config_generator.py
+++ b/test/unit/slurm/test_fleet_config_generator.py
@@ -50,6 +50,7 @@ from slurm.pcluster_fleet_config_generator import generate_fleet_config_file
                             "Name": "q1",
                             "CapacityType": "ONDEMAND",
                             "ComputeResources": [{"Name": "cr1", "Instances": []}],
+                            "Networking": {"SubnetIds": ["123"]},
                         }
                     ]
                 }
@@ -67,6 +68,7 @@ from slurm.pcluster_fleet_config_generator import generate_fleet_config_file
                                 {"Name": "cr1", "Instances": [{"InstanceType": "test"}]},
                                 {"Name": "cr2", "InstanceType": "test"},
                             ],
+                            "Networking": {"SubnetIds": ["123"]},
                         }
                     ]
                 }
@@ -81,6 +83,7 @@ from slurm.pcluster_fleet_config_generator import generate_fleet_config_file
                             "Name": "q1",
                             "CapacityType": "SPOT",
                             "ComputeResources": [{"Name": "cr1", "Instances": [{"InstanceType": "test"}]}],
+                            "Networking": {"SubnetIds": ["123"]},
                         }
                     ]
                 }
@@ -97,11 +100,45 @@ from slurm.pcluster_fleet_config_generator import generate_fleet_config_file
                             "ComputeResources": [
                                 {"Name": "cr1", "Instances": [{"InstanceType": "test"}], "SpotPrice": 10}
                             ],
+                            "Networking": {"SubnetIds": ["123"]},
                         }
                     ]
                 }
             },
             None,
+        ),
+        (
+            {
+                "Scheduling": {
+                    "SlurmQueues": [
+                        {
+                            "Name": "q1",
+                            "CapacityType": "SPOT",
+                            "ComputeResources": [
+                                {"Name": "cr1", "Instances": [{"InstanceType": "test"}], "SpotPrice": 10}
+                            ],
+                        }
+                    ]
+                }
+            },
+            "Unable to find key 'Networking' in the configuration of queue: q1, compute resource: cr1",
+        ),
+        (
+            {
+                "Scheduling": {
+                    "SlurmQueues": [
+                        {
+                            "Name": "q1",
+                            "CapacityType": "SPOT",
+                            "ComputeResources": [
+                                {"Name": "cr1", "Instances": [{"InstanceType": "test"}], "SpotPrice": 10}
+                            ],
+                            "Networking": {},
+                        }
+                    ]
+                }
+            },
+            "Unable to find key 'SubnetIds' in the configuration of queue: q1, compute resource: cr1",
         ),
     ],
 )

--- a/test/unit/slurm/test_fleet_config_generator.py
+++ b/test/unit/slurm/test_fleet_config_generator.py
@@ -81,6 +81,46 @@ from slurm.pcluster_fleet_config_generator import generate_fleet_config_file
                     "SlurmQueues": [
                         {
                             "Name": "q1",
+                            "CapacityType": "ONDEMAND",
+                            "ComputeResources": [
+                                {"Name": "cr1", "Instances": [{"InstanceType": "test"}, {"InstanceType": "test-2"}]},
+                                {"Name": "cr2", "InstanceType": "test"},
+                            ],
+                            "Networking": {"SubnetIds": ["123", "456", "789"]},
+                        }
+                    ]
+                }
+            },
+            None,
+        ),
+        (
+            {
+                "Scheduling": {
+                    "SlurmQueues": [
+                        {
+                            "Name": "q1",
+                            "CapacityType": "SPOT",
+                            "ComputeResources": [
+                                {
+                                    "Name": "cr1",
+                                    "Instances": [{"InstanceType": "test"}, {"InstanceType": "test-2"}],
+                                    "SpotPrice": "10",
+                                },
+                                {"Name": "cr2", "InstanceType": "test", "SpotPrice": "10"},
+                            ],
+                            "Networking": {"SubnetIds": ["123", "456", "789"]},
+                        }
+                    ]
+                }
+            },
+            None,
+        ),
+        (
+            {
+                "Scheduling": {
+                    "SlurmQueues": [
+                        {
+                            "Name": "q1",
                             "CapacityType": "SPOT",
                             "ComputeResources": [{"Name": "cr1", "Instances": [{"InstanceType": "test"}]}],
                             "Networking": {"SubnetIds": ["123"]},

--- a/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/expected_outputs/fleet-config.json
+++ b/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/expected_outputs/fleet-config.json
@@ -22,7 +22,41 @@
                 {
                     "InstanceType": "r5n.4xlarge"
                 }
+            ],
+            "Networking": {
+                "SubnetIds": [
+                    "subnet-0230367ab0e5123a4"
+                ]
+            }
+        }
+    },
+    "multiple-subnets": {
+        "single": {
+            "Api": "run-instances",
+            "Instances": [
+                {
+                    "InstanceType": "c5n.4xlarge"
+                }
             ]
+        },
+        "fleet": {
+            "Api": "create-fleet",
+            "CapacityType": "on-demand",
+            "AllocationStrategy": "lowest-price",
+            "Instances": [
+                {
+                    "InstanceType": "c5n.4xlarge"
+                },
+                {
+                    "InstanceType": "r5.4xlarge"
+                }
+            ],
+            "Networking": {
+                "SubnetIds": [
+                    "subnet-0230367ab0e5123a4",
+                    "subnet-0b903123096649662"
+                ]
+            }
         }
     },
     "spot-mixed": {
@@ -43,7 +77,12 @@
                     "InstanceType": "c5n.18xlarge"
                 }
             ],
-            "MaxPrice": 10
+            "MaxPrice": 10,
+            "Networking": {
+                "SubnetIds": [
+                    "subnet-0230367ab0e5123a4"
+                ]
+            }
         },
         "fleet-noprice": {
             "Api": "create-fleet",
@@ -53,7 +92,12 @@
                 {
                     "InstanceType": "c5n.18xlarge"
                 }
-            ]
+            ],
+            "Networking": {
+                "SubnetIds": [
+                    "subnet-0230367ab0e5123a4"
+                ]
+            }
         }
     }
 }

--- a/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/sample_input.yaml
+++ b/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/sample_input.yaml
@@ -54,6 +54,59 @@ Scheduling:
       SecurityGroups: null
       SubnetIds:
       - subnet-0230367ab0e5123a4
+  - AllocationStrategy: lowest-price
+    CapacityType: ONDEMAND
+    ComputeResources:
+    - DisableSimultaneousMultithreading: false
+      Efa:
+        Enabled: false
+        GdrSupport: false
+      InstanceType: c5n.4xlarge
+      MaxCount: 10
+      MinCount: 0
+      Name: single
+      SchedulableMemory: null
+      SpotPrice: null
+    - DisableSimultaneousMultithreading: false
+      Efa:
+        Enabled: true
+        GdrSupport: false
+      Instances:
+        - InstanceType: c5n.4xlarge
+        - InstanceType: r5.4xlarge
+      MaxCount: 10
+      MinCount: 1
+      Name: fleet
+      SchedulableMemory: null
+      SpotPrice: null
+    ComputeSettings:
+      LocalStorage:
+        EphemeralVolume: null
+        RootVolume:
+          Encrypted: true
+          Iops: 3000
+          Size: null
+          Throughput: 125
+          VolumeType: gp3
+    CustomActions: null
+    Iam:
+      AdditionalIamPolicies: []
+      InstanceProfile: null
+      InstanceRole: null
+      S3Access: null
+    Image: null
+    Name: multiple-subnets
+    Networking:
+      AdditionalSecurityGroups: null
+      AssignPublicIp: null
+      PlacementGroup:
+        Enabled: true
+        Id: null
+      Proxy: null
+      SecurityGroups: null
+      SubnetIds:
+      - subnet-0230367ab0e5123a4
+      - subnet-0b903123096649662
   - AllocationStrategy: capacity-optimized
     CapacityType: SPOT
     ComputeResources:


### PR DESCRIPTION
### Description of changes
* The `fleet-config` file is used by the cluster node daemons to determine which launch API to use and which launch parameters should be applied
* To pass along the Subnet Ids that should be included in a CreateFleet Request, these changes add a Networking/SubnetIds section in the `fleet-config` file
* Expected format for CreateFleet API section in the `fleet-config` file is as follows
```
{
    "queue": {
        "compute-resource": {
            "Api": "create-fleet",
            "Instances": [
                {
                    "InstanceType": "..."
                },
                ...
            ]
            "Networking": {
                "SubnetIds": [...]
            }
        }
    }
}
```
### Tests
* Automated tests
    * Queue with a single subnet + Compute Resource that uses `Instances` should include a Networking/SubnetIds section in the `fleet-config` file
    * Queue with multiple subnets + Compute Resource that uses `Instances` should include a Networking/SubnetIds section in the `fleet-config` file

### References
* [Node Daemon PR](https://github.com/aws/aws-parallelcluster-node/pull/456)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.