### PR TITLE
[2.11] Backport Install efibootmgr before updating Ubuntu OS packages

### DIFF
--- a/recipes/update_packages.rb
+++ b/recipes/update_packages.rb
@@ -21,6 +21,10 @@ when 'rhel', 'amazon'
     command "yum -y update && package-cleanup -y --oldkernels --count=1"
   end
 when 'debian'
+  execute 'install-efibootmanager' do # temporary workaround to solve https://bugs.launchpad.net/ubuntu/+source/grub2-signed/+bug/1936857
+    command "apt-get -y install efibootmgr"
+    only_if { arm_instance? }
+  end
   apt_update
   execute 'apt-upgrade' do
     command "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" --with-new-pkgs upgrade && apt-get autoremove -y"


### PR DESCRIPTION
### Description of changes
Backport https://github.com/aws/aws-parallelcluster/commit/964cd5c58708fd004b847cd90222dc27240655bf
This step is needed to unblock the ubuntu18 arm  build that is failing during the update of the `grub-efi-arm64` with the error:
```
Setting up grub-efi-arm64 (2.04-1ubuntu47.4) ...
Installing for arm64-efi platform.
grub-install: error: efibootmgr: not found.
```
This is a known issue: https://bugs.launchpad.net/ubuntu/+source/grub2-signed/+bug/1936857

The discarded alternative is to exclude some packages from the update:
```
sudo apt-mark hold grub-efi-arm64 grub-efi-arm64-bin grub-efi-arm64-signed
```

### Tests
* Test build ubuntu18 arm AMI with the patch, the step is executed -- OK
* Test build ubuntu18 arm AMI without the patch, build failed
* Test build ubuntu18 x86_64, the step is skipped: `execute[install-efibootmanager] action run (skipped due to only_if)` --OK

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.