### PR TITLE
[3.1.x] Revert "Prevent mountpoint collision between ephemeral drive and shar…

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -27,23 +27,16 @@ end
 
 include_recipe 'aws-parallelcluster-config::nfs' unless virtualized?
 
-# Mount the ephemeral drive unless there is a mountpoint collision with shared drives
-shared_dir_array = node['cluster']['ebs_shared_dirs'].split(',') + \
-                   node['cluster']['efs_shared_dirs'].split(',') + \
-                   node['cluster']['fsx_shared_dirs'].split(',') + \
-                   [ node['cluster']['raid_shared_dir'] ]
-unless shared_dir_array.include? node['cluster']['ephemeral_dir']
-  service "setup-ephemeral" do
-    supports restart: false
-    action :enable
-  end
+service "setup-ephemeral" do
+  supports restart: false
+  action :enable
+end
 
-  # Execution timeout 3600 seconds
-  unless virtualized?
-    execute "Setup of ephemeral drives" do
-      user "root"
-      command "/usr/local/sbin/setup-ephemeral-drives.sh"
-    end
+# Execution timeout 3600 seconds
+unless virtualized?
+  execute "Setup of ephemeral drivers" do
+    user "root"
+    command "/usr/local/sbin/setup-ephemeral-drives.sh"
   end
 end
 

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -334,25 +334,9 @@ end
 ###################
 # instance store
 ###################
-
-ebs_shared_dirs_array = node['cluster']['ebs_shared_dirs'].split(',')
-
-if ebs_shared_dirs_array.include? node['cluster']['ephemeral_dir']
-  # In this case the ephemeral storage should not be mounted because the mountpoint
-  # clashes with the mountpoint coming from t
-  bash 'test instance store mountpoint collision' do
-    cwd Chef::Config[:file_cache_path]
-    user node['cluster']['cluster_user']
-    code <<-COLLISION
-      systemctl show setup-ephemeral.service -p ActiveState | grep "=inactive"
-      systemctl show setup-ephemeral.service -p UnitFileState | grep "=disabled"
-    COLLISION
-  end
-else
-  bash 'test instance store' do
-    cwd Chef::Config[:file_cache_path]
-    user node['cluster']['cluster_user']
-    code <<-EPHEMERAL
+bash 'test instance store' do
+  cwd Chef::Config[:file_cache_path]
+  code <<-EPHEMERAL
       set -xe
       EPHEMERAL_DIR="#{node['cluster']['ephemeral_dir']}"
 
@@ -405,11 +389,11 @@ else
         mkdir -p ${EPHEMERAL_DIR}/test_dir
         touch ${EPHEMERAL_DIR}/test_dir/test_file
       fi
-    EPHEMERAL
-  end
-  execute 'check setup-ephemeral service is enabled' do
-    command "systemctl is-enabled setup-ephemeral"
-  end
+  EPHEMERAL
+  user node['cluster']['cluster_user']
+end
+execute 'check setup-ephemeral service is enabled' do
+  command "systemctl is-enabled setup-ephemeral"
 end
 
 ###################


### PR DESCRIPTION
This reverts commit fe7d84790af792f0f58f549cd50f2f09ea221c0a.


### Description of changes
* Reverting is needed because using this commit will need to backport other parts of code, which we don't want to touch

### Tests
No tests needed

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.