### PR TITLE
[surface head node bootstrap errors] store error messages from custom scripts

### DIFF
--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -21,6 +21,7 @@ function error_exit () {
   script=`basename $0`
   echo "parallelcluster: ${script} - $1"
   logger -t parallelcluster "${script} - $1"
+  echo "${script} - $1" > /var/log/parallelcluster/bootstrap_error_msg
   exit 1
 }
 
@@ -31,12 +32,12 @@ function download_run (){
   tmpfile=$(mktemp)
   trap "/bin/rm -f $tmpfile" RETURN
   if [ "${scheme}" == "s3" ]; then
-    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/aws --region ${cfn_region} s3 cp ${url} - > $tmpfile || return 1
+    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/aws --region ${cfn_region} s3 cp ${url} - > $tmpfile || error_exit "Failed to run ${ACTION}, failed to download ${url} using aws s3, return code: $?"
   else
-    wget -qO- ${url} > $tmpfile || return 1
+    wget -qO- ${url} > $tmpfile || error_exit "Failed to run ${ACTION}, failed to download ${url} using wget, return code: $?"
   fi
-  chmod +x $tmpfile || return 1
-  $tmpfile "$@" || error_exit "Failed to run ${ACTION}, ${file} failed with non 0 return code: $?"
+  chmod +x $tmpfile || error_exit "Failed to run ${ACTION}, failed to run chmod +x ${tmpfile}, return code: $?"
+  $tmpfile "$@" || error_exit "Failed to run ${ACTION}, failed to execute file ${file}, return code: $?"
 }
 
 function get_stack_status () {

--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -21,7 +21,7 @@ function error_exit () {
   script=`basename $0`
   echo "parallelcluster: ${script} - $1"
   logger -t parallelcluster "${script} - $1"
-  echo "${script} - $1" > /var/log/parallelcluster/bootstrap_error_msg
+  echo "$1. If --rollback-on-failure was set to false, check /var/log/cfn-init.log and /var/log/cloud-init-output.log for more details." > /var/log/parallelcluster/bootstrap_error_msg
   exit 1
 }
 
@@ -37,7 +37,7 @@ function download_run (){
     wget -qO- ${url} > $tmpfile || error_exit "Failed to run ${ACTION}, failed to download ${url} using wget, return code: $?"
   fi
   chmod +x $tmpfile || error_exit "Failed to run ${ACTION}, failed to run chmod +x ${tmpfile}, return code: $?"
-  $tmpfile "$@" || error_exit "Failed to run ${ACTION}, failed to execute file ${file}, return code: $?"
+  $tmpfile "$@" || error_exit "Failed to run ${ACTION}, ${file} failed with non 0 return code: $?"
 }
 
 function get_stack_status () {

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -543,7 +543,7 @@ def raise_and_write_chef_error(raise_message, chef_error = nil)
   unless chef_error
     chef_error = raise_message
   end
-  Mixlib::ShellOut.new("echo '#{chef_error}' > /var/log/parallelcluster/headnode_bootstrap_error_msg").run_command
+  Mixlib::ShellOut.new("echo '#{chef_error}' > /var/log/parallelcluster/bootstrap_error_msg").run_command
   raise raise_message
 end
 


### PR DESCRIPTION
### Description of changes
During the bootstrap of the head node, if any of custom scripts (OnNodeStart or OnNodeConfigured) fails, a generic error message will be sent to CloudFormation stack without providing specific reasons of the failure. Here we write error messages into a dedicated file, which will be extracted and sent to CloudFormation stack.

Also updated the error file name from headnode_bootstrap_error_msg to bootstrap_error_msg, since this file will be used in both the head node and compute nodes.

### Tests
Manually tested by creating clusters and checking the error messages in the CloudFormation stack:  
* testing error in post-install script (OnNodeConfigured)  => expected error message in CloudFormation:
  - *'Failed to run postinstall, s3:/<xxx/.../xxx>.sh failed with non 0 return code: 1. If —rollback-on-failure was set to false, check /var/log/cfn-init.log and /var/log/cloud-init-output.log for more details.'*
* testing error in pre-install script (OnNodeStart)  => expected error message in CloudFormation:
  - *'Failed to run preinstall, s3://<xxx/.../xxx>.sh failed with non 0 return code: 1. If —rollback-on-failure was set to false, check /var/log/cfn-init.log and /var/log/cloud-init-output.log for more details.'*
* testing no access to s3  => expected error message in CloudFormation:
  - *'Failed to run postinstall, failed to download s3://<xxx/.../xxx>.sh using aws s3, return code: 1. If —rollback-on-failure was set to false, check /var/log/cfn-init.log and /var/log/cloud-init-output.log for more details.'*
* testing wrong http url of the custom script  => expected error message in CloudFormation:
  - *'Failed to run postinstall, failed to download https://github.com/<xxx/.../xxx>.sh using wget, return code: 8. If —rollback-on-failure was set to false, check /var/log/cfn-init.log and /var/log/cloud-init-output.log for more details.'*



### References
* [This PR](https://github.com/aws/aws-parallelcluster/pull/4540) shows how the error messages file is used.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.