### PR TITLE
[surface head node bootstrap errors] create chef handler to store chef errors

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,10 @@ default['cluster']['license_dir'] = "#{node['cluster']['base_dir']}/licenses"
 default['cluster']['configs_dir'] = "#{node['cluster']['base_dir']}/configs"
 default['cluster']['shared_dir'] = "#{node['cluster']['base_dir']}/shared"
 
+# ParallelCluster log dir
+default['cluster']['log_base_dir'] = '/var/log/parallelcluster'
+default['cluster']['bootstrap_error_path'] = "#{node['cluster']['log_base_dir']}/bootstrap_error_msg"
+
 # AWS domain
 default['cluster']['aws_domain'] = aws_domain
 
@@ -160,8 +164,8 @@ default['cluster']['scheduler_plugin']['system_group_id_start'] = default['clust
 
 # Scheduler plugin event handler
 default['cluster']['scheduler_plugin']['home'] = '/home/pcluster-scheduler-plugin'
-default['cluster']['scheduler_plugin']['handler_log_out'] = '/var/log/parallelcluster/scheduler-plugin.out.log'
-default['cluster']['scheduler_plugin']['handler_log_err'] = '/var/log/parallelcluster/scheduler-plugin.err.log'
+default['cluster']['scheduler_plugin']['handler_log_out'] = "#{node['cluster']['log_base_dir']}/scheduler-plugin.out.log"
+default['cluster']['scheduler_plugin']['handler_log_err'] = "#{node['cluster']['log_base_dir']}/scheduler-plugin.err.log"
 default['cluster']['scheduler_plugin']['shared_dir'] = "#{node['cluster']['shared_dir']}/scheduler-plugin"
 default['cluster']['scheduler_plugin']['local_dir'] = "#{node['cluster']['base_dir']}/scheduler-plugin"
 default['cluster']['scheduler_plugin']['handler_dir'] = "#{node['cluster']['scheduler_plugin']['local_dir']}/.configs"

--- a/files/default/event_handler/write_chef_error_handler.rb
+++ b/files/default/event_handler/write_chef_error_handler.rb
@@ -1,11 +1,35 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster
+#
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
 
 module WriteChefError
+  # this class is used to handle chef errors and write the errors into a certain file if the file does not exist yet
   class WriteChefError < Chef::Handler
     def report
+      # the run_status object is initialized by Chef Infra Client and keep track of status of a Chef Infra Client run
+      # the "failed?" property is evaluated to be true when a Chef Infra Client run fails
+      # reference: https://docs.chef.io/handlers/#run_status-object
       if run_status.failed?
-        error_file = '/var/log/parallelcluster/bootstrap_error_msg'
+        error_file = node['cluster']['bootstrap_error_path']
         unless File.exist?(error_file)
-          message = "Failed when running chef recipes (If --rollback-on-failure was set to false, more details can be found in /var/log/chef-client.log and /var/log/cloud-init-output.log.):"
+          if node['cluster']['node_type'] == 'HeadNode'
+            more_details = "/var/log/chef-client.log and /var/log/cloud-init-output.log"
+          else
+            more_details = "/var/log/cloud-init-output.log"
+          end
+          message = "Failed when running chef recipes (If --rollback-on-failure was set to false, more details can be found in '#{more_details}'.):"
           Mixlib::ShellOut.new("echo '#{message}' '#{run_status.formatted_exception}' > '#{error_file}'").run_command
         end
       end

--- a/files/default/event_handler/write_chef_error_handler.rb
+++ b/files/default/event_handler/write_chef_error_handler.rb
@@ -3,7 +3,7 @@
 #
 # Cookbook:: aws-parallelcluster
 #
-# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at

--- a/files/default/event_handler/write_chef_error_handler.rb
+++ b/files/default/event_handler/write_chef_error_handler.rb
@@ -3,7 +3,9 @@ module WriteChefError
   class WriteChefError < Chef::Handler
     def report
       if run_status.failed?
-        Mixlib::ShellOut.new("echo 'Failed when running chef recipes: #{run_status.formatted_exception}' > /var/log/parallelcluster/headnode_bootstrap_error_msg").run_command
+        unless File.exist?('/var/log/parallelcluster/headnode_bootstrap_error_msg')
+          Mixlib::ShellOut.new("echo 'Failed when running chef recipes: #{run_status.formatted_exception}' > /var/log/parallelcluster/headnode_bootstrap_error_msg").run_command
+        end
       end
     end
   end

--- a/files/default/event_handler/write_chef_error_handler.rb
+++ b/files/default/event_handler/write_chef_error_handler.rb
@@ -3,8 +3,10 @@ module WriteChefError
   class WriteChefError < Chef::Handler
     def report
       if run_status.failed?
-        unless File.exist?('/var/log/parallelcluster/headnode_bootstrap_error_msg')
-          Mixlib::ShellOut.new("echo 'Failed when running chef recipes: #{run_status.formatted_exception}' > /var/log/parallelcluster/headnode_bootstrap_error_msg").run_command
+        error_file = '/var/log/parallelcluster/headnode_bootstrap_error_msg'
+        unless File.exist?(error_file)
+          message = "Failed when running chef recipes (If --rollback-on-failure was set to false, more details can be found in /var/log/chef-client.log and /var/log/cloud-init-output.log.):"
+          Mixlib::ShellOut.new("echo '#{message}' '#{run_status.formatted_exception}' > '#{error_file}'").run_command
         end
       end
     end

--- a/files/default/event_handler/write_chef_error_handler.rb
+++ b/files/default/event_handler/write_chef_error_handler.rb
@@ -1,0 +1,10 @@
+
+module WriteChefError
+  class WriteChefError < Chef::Handler
+    def report
+      if run_status.failed?
+        Mixlib::ShellOut.new("echo 'Failed when running chef recipes: #{run_status.formatted_exception}' > /var/log/parallelcluster/chef_error_msg").run_command
+      end
+    end
+  end
+end

--- a/files/default/event_handler/write_chef_error_handler.rb
+++ b/files/default/event_handler/write_chef_error_handler.rb
@@ -3,7 +3,7 @@ module WriteChefError
   class WriteChefError < Chef::Handler
     def report
       if run_status.failed?
-        Mixlib::ShellOut.new("echo 'Failed when running chef recipes: #{run_status.formatted_exception}' > /var/log/parallelcluster/chef_error_msg").run_command
+        Mixlib::ShellOut.new("echo 'Failed when running chef recipes: #{run_status.formatted_exception}' > /var/log/parallelcluster/headnode_bootstrap_error_msg").run_command
       end
     end
   end

--- a/files/default/event_handler/write_chef_error_handler.rb
+++ b/files/default/event_handler/write_chef_error_handler.rb
@@ -3,7 +3,7 @@ module WriteChefError
   class WriteChefError < Chef::Handler
     def report
       if run_status.failed?
-        error_file = '/var/log/parallelcluster/headnode_bootstrap_error_msg'
+        error_file = '/var/log/parallelcluster/bootstrap_error_msg'
         unless File.exist?(error_file)
           message = "Failed when running chef recipes (If --rollback-on-failure was set to false, more details can be found in /var/log/chef-client.log and /var/log/cloud-init-output.log.):"
           Mixlib::ShellOut.new("echo '#{message}' '#{run_status.formatted_exception}' > '#{error_file}'").run_command

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -15,4 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# enable chef error handler
+include_recipe "aws-parallelcluster::enable_chef_error_handler"
+
 include_recipe 'aws-parallelcluster-config::config'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -15,7 +15,5 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# enable chef error handler
 include_recipe "aws-parallelcluster::enable_chef_error_handler"
-
 include_recipe 'aws-parallelcluster-config::config'

--- a/recipes/enable_chef_error_handler.rb
+++ b/recipes/enable_chef_error_handler.rb
@@ -17,6 +17,6 @@
 
 chef_handler 'WriteChefError::WriteChefError' do
   source "/etc/chef/cookbooks/aws-parallelcluster/files/default/event_handler/write_chef_error_handler.rb"
-  supports :exception => true
+  type exception: true
   action :enable
 end

--- a/recipes/enable_chef_error_handler.rb
+++ b/recipes/enable_chef_error_handler.rb
@@ -1,0 +1,13 @@
+
+cookbook_file "#{node['cluster']['scripts_dir']}/write_chef_error_handler.rb" do
+  source 'event_handler/write_chef_error_handler.rb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
+chef_handler 'WriteChefError::WriteChefError' do
+  source "#{node['cluster']['scripts_dir']}/write_chef_error_handler.rb"
+  supports :exception => true
+  action :enable
+end

--- a/recipes/enable_chef_error_handler.rb
+++ b/recipes/enable_chef_error_handler.rb
@@ -4,7 +4,7 @@
 # Cookbook:: aws-parallelcluster
 # Recipe:: enable_chef_error_handler
 #
-# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at

--- a/recipes/enable_chef_error_handler.rb
+++ b/recipes/enable_chef_error_handler.rb
@@ -1,13 +1,22 @@
+# frozen_string_literal: true
 
-cookbook_file "#{node['cluster']['scripts_dir']}/write_chef_error_handler.rb" do
-  source 'event_handler/write_chef_error_handler.rb'
-  owner 'root'
-  group 'root'
-  mode '0755'
-end
+#
+# Cookbook:: aws-parallelcluster
+# Recipe:: enable_chef_error_handler
+#
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
 
 chef_handler 'WriteChefError::WriteChefError' do
-  source "#{node['cluster']['scripts_dir']}/write_chef_error_handler.rb"
+  source "/etc/chef/cookbooks/aws-parallelcluster/files/default/event_handler/write_chef_error_handler.rb"
   supports :exception => true
   action :enable
 end

--- a/recipes/finalize.rb
+++ b/recipes/finalize.rb
@@ -15,4 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# enable chef error handler
+include_recipe "aws-parallelcluster::enable_chef_error_handler"
+
 include_recipe "aws-parallelcluster-config::finalize"

--- a/recipes/finalize.rb
+++ b/recipes/finalize.rb
@@ -15,7 +15,5 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# enable chef error handler
 include_recipe "aws-parallelcluster::enable_chef_error_handler"
-
 include_recipe "aws-parallelcluster-config::finalize"

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -14,8 +14,6 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# enable chef error handler
-include_recipe "aws-parallelcluster::enable_chef_error_handler"
 
+include_recipe "aws-parallelcluster::enable_chef_error_handler"
 include_recipe "aws-parallelcluster-config::init"

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -14,4 +14,8 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# enable chef error handler
+include_recipe "aws-parallelcluster::enable_chef_error_handler"
+
 include_recipe "aws-parallelcluster-config::init"


### PR DESCRIPTION
### Description of changes
During the bootstrap of the head node, if any of chef recipes fails, a generic error message will be sent to CloudFormation stack without providing specific reasons of the failure. Here we create a chef handler and apply to recipes. The handler will write error messages into a dedicated file, which will be extracted and sent to CloudFormation stack.

### Tests
Manually tested.
* Test chef handler handling chef errors:
  - Introduce an error in the config recipe (for example aws-parallelcluster-config::head_node_base.rb), then create a cluster, got error message in CloudFormation stack as expected:
  - _Failed when running chef recipes (If --rollback-on-failure was set to false, more details can be found in /var/log/chef-client.log and /var/log/cloud-init-output.log.): Chef::Exceptions::FileNotFound: template[bad_file.txt] (aws-parallelcluster::exception_test line 5) had an error: Chef::Exceptions::FileNotFound: Cookbook aws-parallelcluster (3.4.0) does not contain a file at any of these locations:
  templates/host-ip-10-0-0-49.ec2.internal/shared_storages/bad_file.txt.erb
  ......_
* Test chef handler not affecting existing BYOS handler:
  - Introduce an error in BYOS plugin and create a cluster, the error message still stay the same as implemented in this PR
  - _Failed when running HeadConfigure for the configured scheduler plugin. Additional info can be found in /var/log/chef-client.log, /var/log/parallelcluster/scheduler-plugin.out.log and /var/log/parallelcluster/scheduler-plugin.err.log._

### References
* [This PR](https://github.com/aws/aws-parallelcluster/pull/4540) shows how the error messages file is used.
* [This PR](https://github.com/aws/aws-parallelcluster-cookbook/pull/1329/files) handles BYOS plugin errors.


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.