### PR TITLE
[develop] Avoid enabling NFS at boot on build image 

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/nfs.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/nfs.rb
@@ -25,7 +25,8 @@ edit_resource(:template, node['nfs']['config']['server_template']) do
 end
 
 # Explicitly restart NFS server for thread setting to take effect
+# and enable it to start at boot
 service node['nfs']['service']['server'] do
-  action :restart
+  action %i(restart enable)
   supports restart: true
 end

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -128,6 +128,11 @@ if platform?('ubuntu') && node['platform_version'].to_f >= 16.04
 end
 include_recipe "nfs::server4"
 
+# Disable NFS server service start at boot
+service node['nfs']['service']['server'] do
+  action :disable
+end
+
 # Put setup-ephemeral-drives.sh onto the host
 cookbook_file 'setup-ephemeral-drives.sh' do
   source 'base/setup-ephemeral-drives.sh'


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
NFS service at boot is not enabled at the end of the build image process so to avoid possible race conditions during cluster node bootstrap due to the sequence of start/reconfigure/restart

### Tests
tested manually executing the recipe in a PCluster instance:

* after execution of installation recipe
```
$ systemctl list-unit-files | grep enabled | grep nfs
nfs-client.target                             enabled
```
* after execution of  configuration recipe
```
$ systemctl list-unit-files | grep enabled | grep nfs
nfs-server.service                            enabled
nfs.service                                   enabled
nfs-client.target                             enabled
```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.