### PR TITLE
3.x Add configuration to clustermgtd.conf for collecting compute console output.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -640,6 +640,8 @@ default['cluster']['enable_nss_slurm'] = node['cluster']['directory_service']['e
 default['cluster']['realmemory_to_ec2memory_ratio'] = 0.95
 default['cluster']['slurm_node_reg_mem_percent'] = 75
 default['cluster']['slurmdbd_response_retries'] = 30
+default['cluster']['slurm_console_logging']['default']['enabled'] = 'True'
+default['cluster']['slurm_console_logging']['default']['sample_size'] = 1
 
 # Official ami build
 default['cluster']['is_official_ami_build'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -640,8 +640,8 @@ default['cluster']['enable_nss_slurm'] = node['cluster']['directory_service']['e
 default['cluster']['realmemory_to_ec2memory_ratio'] = 0.95
 default['cluster']['slurm_node_reg_mem_percent'] = 75
 default['cluster']['slurmdbd_response_retries'] = 30
-default['cluster']['slurm_console_logging']['default']['enabled'] = 'True'
-default['cluster']['slurm_console_logging']['default']['sample_size'] = 1
+default['cluster']['slurm_console_logging']['enabled'] = 'true'
+default['cluster']['slurm_console_logging']['sample_size'] = 1
 
 # Official ami build
 default['cluster']['is_official_ami_build'] = false

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
@@ -158,6 +158,23 @@
     },
     {
       "timestamp_format_key": "default",
+      "file_path": "/var/log/parallelcluster/compute_console_output.log",
+      "log_stream_name": "compute_console_output",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "HeadNode"
+      ],
+      "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "default",
       "file_path": "/var/log/parallelcluster/computemgtd",
       "log_stream_name": "computemgtd",
       "schedulers": [

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -173,17 +173,10 @@ replace_or_add "update node replacement timeout" do
   replace_only true
 end
 
-replace_or_add "update compute console logging enabled" do
+replace_or_add "Update compute console logging" do
   path "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
   pattern "node_replacement_timeout*"
-  line "compute_console_logging_enabled = #{node['cluster']['config'].dig(:Monitoring, :ComputeConsoleLoggingEnabled) || 'True'}"
-  replace_only true
-end
-
-replace_or_add "update compute console logging sample size" do
-  path "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
-  pattern "node_replacement_timeout*"
-  line "compute_console_logging_max_sample_size = #{node['cluster']['config'].dig(:Monitoring, :ComputeConsoleLoggingMaxSampleSize) || 100}"
+  line "compute_console_logging_enabled = #{node['cluster']['config'].dig(:Monitoring, :Logs, :CloudWatch, :Enabled) || node['cluster']['slurm_console_logging']['default']['enabled']}"
   replace_only true
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -173,6 +173,20 @@ replace_or_add "update node replacement timeout" do
   replace_only true
 end
 
+replace_or_add "update compute console logging enabled" do
+  path "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
+  pattern "node_replacement_timeout*"
+  line "compute_console_logging_enabled = #{node['cluster']['config'].dig(:Monitoring, :ComputeConsoleLoggingEnabled) || 'True'}"
+  replace_only true
+end
+
+replace_or_add "update compute console logging sample size" do
+  path "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
+  pattern "node_replacement_timeout*"
+  line "compute_console_logging_max_sample_size = #{node['cluster']['config'].dig(:Monitoring, :ComputeConsoleLoggingMaxSampleSize) || 100}"
+  replace_only true
+end
+
 ruby_block "Update Slurm Accounting" do
   block do
     if node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil?

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -176,7 +176,7 @@ end
 replace_or_add "Update compute console logging" do
   path "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
   pattern "compute_console_logging_enabled*"
-  line "compute_console_logging_enabled = #{node['cluster']['config'].dig(:Monitoring, :Logs, :CloudWatch, :Enabled) || node['cluster']['slurm_console_logging']['default']['enabled']}"
+  line "compute_console_logging_enabled = #{node['cluster']['config'].dig(:Monitoring, :Logs, :CloudWatch, :Enabled) || node['cluster']['slurm_console_logging']['enabled']}"
   replace_only true
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -175,7 +175,7 @@ end
 
 replace_or_add "Update compute console logging" do
   path "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
-  pattern "node_replacement_timeout*"
+  pattern "compute_console_logging_enabled*"
   line "compute_console_logging_enabled = #{node['cluster']['config'].dig(:Monitoring, :Logs, :CloudWatch, :Enabled) || node['cluster']['slurm_console_logging']['default']['enabled']}"
   replace_only true
 end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -11,5 +11,5 @@ head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
 head_node_hostname = <%= node['ec2']['local_hostname'] %>
 node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout'] %>
 insufficient_capacity_timeout = 600
-compute_console_logging_enabled = <%= node['cluster']['config'].dig(:Monitoring, :Logs, :CloudWatch, :Enabled) || node['cluster']['slurm_console_logging']['default']['enabled'] %>
-compute_console_logging_max_sample_size = <%=  node['cluster']['slurm_console_logging']['default']['sample_size'] %>
+compute_console_logging_enabled = <%= node['cluster']['config'].dig(:Monitoring, :Logs, :CloudWatch, :Enabled) || node['cluster']['slurm_console_logging']['enabled'] %>
+compute_console_logging_max_sample_size = <%=  node['cluster']['slurm_console_logging']['sample_size'] %>

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -11,5 +11,5 @@ head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
 head_node_hostname = <%= node['ec2']['local_hostname'] %>
 node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout'] %>
 insufficient_capacity_timeout = 600
-compute_console_logging_enabled = <%= node['cluster']['config'].dig(:Monitoring, :Logs, :CloudWatch, :Enabled) || node['cluster']['slurm_console_logging']['enabled'] %>
+compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] == 'true' && node['cluster']['slurm_console_logging']['enabled'] %>
 compute_console_logging_max_sample_size = <%=  node['cluster']['slurm_console_logging']['sample_size'] %>

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -11,3 +11,5 @@ head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
 head_node_hostname = <%= node['ec2']['local_hostname'] %>
 node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout'] %>
 insufficient_capacity_timeout = 600
+compute_console_logging_enabled = <%= node['cluster']['config'].dig(:Monitoring, :ComputeConsoleLoggingEnabled) || 'True' %>
+compute_console_logging_max_sample_size = <%= node['cluster']['config'].dig(:Monitoring, :ComputeConsoleLoggingMaxSampleSize) || 100 %>

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -11,5 +11,5 @@ head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
 head_node_hostname = <%= node['ec2']['local_hostname'] %>
 node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout'] %>
 insufficient_capacity_timeout = 600
-compute_console_logging_enabled = <%= node['cluster']['config'].dig(:Monitoring, :ComputeConsoleLoggingEnabled) || 'True' %>
-compute_console_logging_max_sample_size = <%= node['cluster']['config'].dig(:Monitoring, :ComputeConsoleLoggingMaxSampleSize) || 100 %>
+compute_console_logging_enabled = <%= node['cluster']['config'].dig(:Monitoring, :Logs, :CloudWatch, :Enabled) || node['cluster']['slurm_console_logging']['default']['enabled'] %>
+compute_console_logging_max_sample_size = <%=  node['cluster']['slurm_console_logging']['default']['sample_size'] %>

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -13,3 +13,4 @@ node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout']
 insufficient_capacity_timeout = 600
 compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] == 'true' && node['cluster']['slurm_console_logging']['enabled'] %>
 compute_console_logging_max_sample_size = <%=  node['cluster']['slurm_console_logging']['sample_size'] %>
+compute_console_wait_time = 300


### PR DESCRIPTION
### Description of changes
* Generate configuration for compute console output logging in clustermgtd.conf on cluster creation
* Update configuration for compute console output logging in clustermgtd.conf on cluster update
* Configure CloudWatch Agent to publish compute console output logs from head node.
### Testing
* Manually tested happy path (Monitoring enabled) cluster creation.
* Manually tested CloudWatch Agent configuration by making sure new log file was correctly exported to CloudWatch.
* No testing on update yet. 
* No testing on Monitoring disabled.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.