### PR TITLE
[3.x] Add support for EFS in-transit encryption and iam authorization when updating clusters

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/update_shared_storages.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/update_shared_storages.rb
@@ -29,9 +29,9 @@ ruby_block "get storage to mount and unmount" do
     # get raid to mount
     node.default['cluster']['mount_raid_shared_dir'], node.default['cluster']['mount_raid_type'], node.default['cluster']['mount_raid_vol_array'] = get_raid(MOUNT_ACTION)
     # get efs to unmount
-    node.default['cluster']['unmount_efs_shared_dir_array'], node.default['cluster']['unmount_efs_fs_id_array'] = get_efs(UNMOUNT_ACTION)
+    node.default['cluster']['unmount_efs_shared_dir_array'], node.default['cluster']['unmount_efs_fs_id_array'], = get_efs(UNMOUNT_ACTION)
     # get efs to mount
-    node.default['cluster']['mount_efs_shared_dir_array'], node.default['cluster']['mount_efs_fs_id_array'] = get_efs(MOUNT_ACTION)
+    node.default['cluster']['mount_efs_shared_dir_array'], node.default['cluster']['mount_efs_fs_id_array'], node.default['cluster']['mount_efs_encryption_in_transit_array'], node.default['cluster']['mount_efs_iam_authorization_array'] = get_efs(MOUNT_ACTION)
     # get fsx to unmount
     node.default['cluster']['unmount_fsx_fs_id_array'], node.default['cluster']['unmount_fsx_fs_type_array'], node.default['cluster']['unmount_fsx_shared_dir_array'], node.default['cluster']['unmount_fsx_dns_name_array'], node.default['cluster']['unmount_fsx_mount_name_array'], node.default['cluster']['unmount_fsx_volume_junction_path_array'] = get_fsx(UNMOUNT_ACTION)
     # get fsx to mount
@@ -70,14 +70,18 @@ ruby_block "get storage to mount and unmount" do
     end
     shared_dir_array = []
     efs_fs_id_array = []
+    efs_encryption_in_transit_array = []
+    efs_iam_authorization_array = []
     unless in_shared_storages_mapping["efs"].nil?
       in_shared_storages_mapping["efs"].each do |storage|
         next unless not_in_shared_storages_mapping["efs"].nil? || !not_in_shared_storages_mapping["efs"].include?(storage)
         shared_dir_array.push(storage["mount_dir"])
         efs_fs_id_array.push(storage["efs_fs_id"])
+        efs_encryption_in_transit_array.push(storage["efs_encryption_in_transit"])
+        efs_iam_authorization_array.push(storage["efs_iam_authorization"])
       end
     end
-    [shared_dir_array, efs_fs_id_array]
+    [shared_dir_array, efs_fs_id_array, efs_encryption_in_transit_array, efs_iam_authorization_array]
   end
 
   def get_fsx(action)
@@ -178,6 +182,8 @@ end
 manage_efs "mount efs" do
   shared_dir_array(lazy { node['cluster']['mount_efs_shared_dir_array'] })
   efs_fs_id_array(lazy { node['cluster']['mount_efs_fs_id_array'] })
+  efs_encryption_in_transit_array(lazy { node['cluster']['mount_efs_encryption_in_transit_array'] })
+  efs_iam_authorization_array(lazy { node['cluster']['mount_efs_iam_authorization_array'] })
   not_if { node['cluster']['mount_efs_shared_dir_array'].empty? }
 end
 

--- a/cookbooks/aws-parallelcluster-config/resources/manage_efs.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_efs.rb
@@ -14,8 +14,8 @@ unified_mode true
 
 property :shared_dir_array, Array, required: true
 property :efs_fs_id_array, Array, required: true
-property :efs_encryption_in_transit_array, Array, required: true
-property :efs_iam_authorization_array, Array, required: true
+property :efs_encryption_in_transit_array, Array, required: false
+property :efs_iam_authorization_array, Array, required: false
 
 default_action :mount
 

--- a/cookbooks/aws-parallelcluster-config/templates/default/shared_storages/shared_storages_data.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/shared_storages/shared_storages_data.erb
@@ -17,10 +17,14 @@ raid:
 <%# EFS %>
 <% efs_fs_ids_array = node['cluster']['efs_fs_ids'].split(',') -%>
 <% efs_shared_dir_array = node['cluster']['efs_shared_dirs'].split(',') -%>
+<% efs_encryption_in_transit_array = node['cluster']['efs_encryption_in_transits'].split(',') -%>
+<% efs_iam_authorization_array = node['cluster']['efs_iam_authorizations'].split(',') -%>
 efs:
 <% efs_fs_ids_array.each_with_index do |efs_fs_id, index| -%>
   - efs_fs_id: <%= efs_fs_id %>
     mount_dir: <%= efs_shared_dir_array[index] %>
+    efs_encryption_in_transit: <%= efs_encryption_in_transit_array[index] %>
+    efs_iam_authorization: <%= efs_iam_authorization_array[index] %>
 <% end -%>
 <%# FSX %>
 <% fsx_fs_id_array = node['cluster']['fsx_fs_ids'].split(',') -%>


### PR DESCRIPTION
This PR improves the original support for EFS in-transit encryption and iam authorization when creating clusters https://github.com/aws/aws-parallelcluster-cookbook/pull/1588

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
The following integration tests have been passed
```
test-suites:
  update:
    test_update.py::test_dynamic_file_systems_update:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - alinux2
        regions:
        - eu-west-2
        schedulers:
        - slurm
  storage:
    test_efs.py::test_multiple_efs:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - alinux2
        regions:
        - us-west-1
        schedulers:
        - slurm
```

### References
After https://github.com/aws/aws-parallelcluster-cookbook/pull/1588, test_dynamic_file_systems_update started to fail. This PR fixes the failure

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.