### PR TITLE
Remove python 3.6 check and fix ruby check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - name: Install dependencies
@@ -47,15 +47,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         name:
-          - Python 3.6 Tests
           - Python 3.7 Tests
           - Python 3.8 Tests
           - Python 3.9 Tests
           - Code Checks
         include:
-          - name: Python 3.6 Tests
-            python: 3.6
-            toxenv: py36
           - name: Python 3.7 Tests
             python: 3.7
             toxenv: py37

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 toxworkdir=.tox
 skipsdist=True
 envlist =
-    py{36,37,38,39}
+    py{37,38,39}
     code-linters
 
 # Default testenv. Used to run tests on all python versions.


### PR DESCRIPTION
### Description of changes
* Remove python 3.6 check and fix ruby check as we remove support of it from pcluster 3.2.0
* Fix ruby check, reference: Reference: https://github.com/ruby/setup-ruby

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.