### PR TITLE
Fix system tests

### DIFF
--- a/system_tests/install_cinc.sh
+++ b/system_tests/install_cinc.sh
@@ -63,7 +63,20 @@ elif [[ ${PLATFORM} == DEBIAN ]]; then
   apt-get -y install build-essential curl wget jq
 fi
 
+if [[ ${PLATFORM} == RHEL ]]; then
+  CA_CERTS_FILE=/etc/ssl/certs/ca-bundle.crt
+  yum -y upgrade ca-certificates
+elif [[ ${PLATFORM} == DEBIAN ]]; then
+  CA_CERTS_FILE=/etc/ssl/certs/ca-certificates.crt
+  apt-get -y --only-upgrade install ca-certificates
+fi
+
 curl --retry 3 -L $CINC_URL | bash -s -- -v ${ChefVersion}
+
+if [[ -e ${CA_CERTS_FILE} ]]; then
+  ln -sf ${CA_CERTS_FILE} /opt/cinc/embedded/ssl/certs/cacert.pem
+fi
+
 /opt/cinc/embedded/bin/gem install --no-document berkshelf:${BerkshelfVersion}
 
 mkdir -p /etc/chef && chown -R root:root /etc/chef


### PR DESCRIPTION
Signed-off-by: Hanwen <hanwenli@amazon.com>


### Description of changes

System tests were failing because they could not validate the certificate provided by stunnel official website. This commit backport https://github.com/aws/aws-parallelcluster/pull/4318 to update the CA before executing Chef recipes

### Tests
System tests on both Ubuntu and CentOS 7 have been passed

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.