### PR TITLE
2.x: Use source_ami in place of source_ami_filter for CentOS7

### DIFF
--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -33,16 +33,7 @@
       "name" : "centos7",
       "type" : "amazon-ebs",
       "region" : "{{user `region`}}",
-      "source_ami_filter": {
-        "filters": {
-          "virtualization-type": "hvm",
-          "name": "CentOS 7.* *",
-          "root-device-type": "ebs",
-          "architecture": "{{user `ami_arch`}}"
-        },
-        "owners": ["125523088429"],
-        "most_recent": true
-      },
+      "source_ami": "{{user `custom_ami_id`}}",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",


### PR DESCRIPTION
### Description of changes
This is required because CentOS 7 AMI for x86_64 arch has been deprecated and packer does not permit to retrieve it.

In this way the custom_ami_id is retrieved upstream (by using --include-deprecated flag) and passed as input as CUSTOM_AMI_ID environment variable.

This change doesn't impact CentOS 7 arm because in that case we're using the custom-centos7 builder.

