### PR TITLE
Revert headnode error messages commits

### DIFF
--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -21,7 +21,6 @@ function error_exit () {
   script=`basename $0`
   echo "parallelcluster: ${script} - $1"
   logger -t parallelcluster "${script} - $1"
-  echo "$1. If --rollback-on-failure was set to false, check /var/log/cfn-init.log and /var/log/cloud-init-output.log for more details." > /var/log/parallelcluster/bootstrap_error_msg
   exit 1
 }
 
@@ -32,11 +31,11 @@ function download_run (){
   tmpfile=$(mktemp)
   trap "/bin/rm -f $tmpfile" RETURN
   if [ "${scheme}" == "s3" ]; then
-    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/aws --region ${cfn_region} s3 cp ${url} - > $tmpfile || error_exit "Failed to run ${ACTION}, failed to download ${url} using aws s3, return code: $?"
+    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/aws --region ${cfn_region} s3 cp ${url} - > $tmpfile || return 1
   else
-    wget -qO- ${url} > $tmpfile || error_exit "Failed to run ${ACTION}, failed to download ${url} using wget, return code: $?"
+    wget -qO- ${url} > $tmpfile || return 1
   fi
-  chmod +x $tmpfile || error_exit "Failed to run ${ACTION}, failed to run chmod +x ${tmpfile}, return code: $?"
+  chmod +x $tmpfile || return 1
   $tmpfile "$@" || error_exit "Failed to run ${ACTION}, ${file} failed with non 0 return code: $?"
 }
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -543,7 +543,7 @@ def raise_and_write_chef_error(raise_message, chef_error = nil)
   unless chef_error
     chef_error = raise_message
   end
-  Mixlib::ShellOut.new("echo '#{chef_error}' > /var/log/parallelcluster/headnode_bootstrap_error_msg").run_command
+  Mixlib::ShellOut.new("echo '#{chef_error}' > /var/log/parallelcluster/chef_error_msg").run_command
   raise raise_message
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -543,7 +543,7 @@ def raise_and_write_chef_error(raise_message, chef_error = nil)
   unless chef_error
     chef_error = raise_message
   end
-  Mixlib::ShellOut.new("echo '#{chef_error}' > /var/log/parallelcluster/bootstrap_error_msg").run_command
+  Mixlib::ShellOut.new("echo '#{chef_error}' > /var/log/parallelcluster/headnode_bootstrap_error_msg").run_command
   raise raise_message
 end
 


### PR DESCRIPTION
### Description of changes
* We'd like to revert the changes related to headnode error message handling.
  - 7bcebe3c
  - 7a6541b3

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.