### PR TITLE
Perform a describe stacks call only when a post install script has been provided

### DIFF
--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -49,9 +49,9 @@ function get_stack_status () {
 function run_preinstall () {
   if [ "${cfn_preinstall}" != "NONE" ]; then
     if [ "${cfn_preinstall_args}" != "NONE" ]; then
-      download_run ${cfn_preinstall} "${cfn_preinstall_args[@]}"
+      download_run "${cfn_preinstall}" "${cfn_preinstall_args[@]}"
     else
-      download_run ${cfn_preinstall}
+      download_run "${cfn_preinstall}"
     fi
   fi || error_exit "Failed to run pre install hook"
 }
@@ -59,23 +59,23 @@ function run_preinstall () {
 function run_postinstall () {
   if [ "${cfn_postinstall}" != "NONE" ]; then
     if [ "${cfn_postinstall_args}" != "NONE" ]; then
-      download_run ${cfn_postinstall} "${cfn_postinstall_args[@]}"
+      download_run "${cfn_postinstall}" "${cfn_postinstall_args[@]}"
     else
-      download_run ${cfn_postinstall}
+      download_run "${cfn_postinstall}"
     fi
   fi || error_exit "Failed to run post install hook"
 }
 
 function run_postupdate () {
   if [ "${cfn_postupdate}" != "NONE" ]; then
-    stack_status=$(get_stack_status) || error_exit "Failed to get the stack status, check the HeadNode instance profile's Iam policies"
+    stack_status=$(get_stack_status) || error_exit "Failed to get the stack status, check the HeadNode instance profile's IAM policies"
 
     if [ "${stack_status}" != "UPDATE_IN_PROGRESS" ]; then
       echo "Post update hook called with CFN stack in state ${stack_status}, doing nothing"
     elif [ "${cfn_postupdate_args}" != "NONE" ]; then
-      download_run ${cfn_postupdate} "${cfn_postupdate_args[@]}"
+      download_run "${cfn_postupdate}" "${cfn_postupdate_args[@]}"
     else
-      download_run ${cfn_postupdate}
+      download_run "${cfn_postupdate}"
     fi
   fi || error_exit "Failed to run post update hook"
 }

--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -69,16 +69,12 @@ function run_postinstall () {
 }
 
 function run_postupdate () {
-  stack_status=$(get_stack_status) || error_exit "Failed to get the stack status"
-
-  if [ "${stack_status}" != "UPDATE_IN_PROGRESS" ]; then
-    echo "Post update hook called with CFN stack in state ${stack_status}, doing nothing"
-    exit 0
-  fi
-
   if [ "${cfn_postupdate}" != "NONE" ]; then
-    file="${cfn_postupdate}"
-    if [ "${cfn_postupdate_args}" != "NONE" ]; then
+    stack_status=$(get_stack_status) || error_exit "Failed to get the stack status, check the HeadNode instance profile's Iam policies"
+
+    if [ "${stack_status}" != "UPDATE_IN_PROGRESS" ]; then
+      echo "Post update hook called with CFN stack in state ${stack_status}, doing nothing"
+    elif [ "${cfn_postupdate_args}" != "NONE" ]; then
       download_run ${cfn_postupdate} "${cfn_postupdate_args[@]}"
     else
       download_run ${cfn_postupdate}

--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -48,7 +48,6 @@ function get_stack_status () {
 
 function run_preinstall () {
   if [ "${cfn_preinstall}" != "NONE" ]; then
-    file="${cfn_preinstall}"
     if [ "${cfn_preinstall_args}" != "NONE" ]; then
       download_run ${cfn_preinstall} "${cfn_preinstall_args[@]}"
     else
@@ -59,7 +58,6 @@ function run_preinstall () {
 
 function run_postinstall () {
   if [ "${cfn_postinstall}" != "NONE" ]; then
-    file="${cfn_postinstall}"
     if [ "${cfn_postinstall_args}" != "NONE" ]; then
       download_run ${cfn_postinstall} "${cfn_postinstall_args[@]}"
     else


### PR DESCRIPTION
### Description of changes
Perform a describe stacks call only when a post install script has been provided.

### Test
Manually tested by launching an update after manually modifying the `fetch_and_run` script on the head node.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.