### PR TITLE
Log script that fails

### DIFF
--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -36,7 +36,7 @@ function download_run (){
     wget -qO- ${url} > $tmpfile || return 1
   fi
   chmod +x $tmpfile || return 1
-  $tmpfile "$@" || error_exit "Failed to run ${ACTION}, ${file} failed with non 0 return code: $?"
+  $tmpfile "$@" || error_exit "Failed to run ${ACTION}, ${url} failed with non 0 return code: $?"
 }
 
 function get_stack_status () {


### PR DESCRIPTION
### Description of changes
Previously, we set a `file` variable that we assigned the `cfn_preinstall`, `cfn_postinstall` or `cfn_postupdate` to. We can simply assign the `url` instead, since it has the same content.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.