### PR TITLE
Fix mount EFS File Systems with amazon-efs-utils

### DIFF
--- a/cookbooks/aws-parallelcluster-config/resources/manage_efs.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_efs.rb
@@ -36,9 +36,10 @@ action :mount do
     # See reference of mount options: https://docs.aws.amazon.com/efs/latest/ug/automount-with-efs-mount-helper.html
     mount_options = "_netdev,noresvport"
     if efs_encryption_in_transit == "true"
-      mount_options.concat(",tls")
-    elsif efs_iam_authorization == "true"
-      mount_options.concat(",iam")
+      mount_options += ",tls"
+      if efs_iam_authorization == "true"
+        mount_options += ",iam"
+      end
     end
 
     # Create the EFS shared directory


### PR DESCRIPTION
This commit fix bugs from https://github.com/aws/aws-parallelcluster-cookbook/pull/1588

1. string in chef is frozen. So the `concat` method is not working. We have to use `+=`.
2. `iam` requires `tls` to be true. The old logic was buggy

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.