### PR TITLE
Upgrade EFA to 1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Add support for specifying multiple subnets for each queue to increase the EC2 capacity pool available for use.
 
 **CHANGES**
-- Upgrade EFA installer to `1.19.0`
-  - Efa-driver: `efa-1.16.0-1`
+- Upgrade EFA installer to `1.20.0`
+  - Efa-driver: `efa-2.1`
   - Efa-config: `efa-config-1.11-1`
   - Efa-profile: `efa-profile-1.5-1`
-  - Libfabric-aws: `libfabric-aws-1.16.0-1`
-  - Rdma-core: `rdma-core-41.0-2`
+  - Libfabric-aws: `libfabric-aws-1.16.1`
+  - Rdma-core: `rdma-core-43.0-2`
   - Open MPI: `openmpi40-aws-4.1.4-3`
 - Mount EFS file systems using `amazon-efs-utils`. EFS files systems can be mounted using in-transit encryption and IAM identity. 
 - Install `stunnel` 5.67 on CentOS7 and Ubuntu to support EFS in-transit encryption.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -295,7 +295,7 @@ else
 end
 
 # EFA
-default['cluster']['efa']['installer_version'] = '1.19.0'
+default['cluster']['efa']['installer_version'] = '1.20.0'
 default['cluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cluster']['efa']['installer_version']}.tar.gz"
 default['cluster']['efa']['unsupported_aarch64_oses'] = %w(centos7)
 


### PR DESCRIPTION
### Description of changes
- Upgrade EFA installer to `1.20.0`
  - Efa-driver: `efa-2.1`
  - Efa-config: `efa-config-1.11-1`
  - Efa-profile: `efa-profile-1.5-1`
  - Libfabric-aws: `libfabric-aws-1.16.1`
  - Rdma-core: `rdma-core-43.0-2`
  - Open MPI: `openmpi40-aws-4.1.4-3` Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-verify.html

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.