### PR TITLE
Upgrade Slurm to version 22.05.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Mount EFS file systems using `amazon-efs-utils`. EFS files systems can be mounted using in-transit encryption and IAM authorized user. 
 - Install `stunnel` 5.67 on CentOS7 and Ubuntu to support EFS in-transit encryption.
 - Add possibility to execute a custom script in the head node during the update of the cluster.
+- Upgrade Slurm to version 22.05.6.
 - Upgrade Python to 3.9.16 and 3.7.16.
 
 3.3.0

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -138,9 +138,9 @@ default['cluster']['cfn_bootstrap']['package'] = "aws-cfn-bootstrap-py3-#{node['
 # URLs to software packages used during install recipes
 # Slurm software
 default['cluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
-default['cluster']['slurm']['version'] = '22-05-5-1'
+default['cluster']['slurm']['version'] = '22-05-6-1'
 default['cluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['cluster']['slurm']['version']}.tar.gz"
-default['cluster']['slurm']['sha1'] = 'afc0b304755718655f523b973401b243f98f0062'
+default['cluster']['slurm']['sha1'] = 'bd2fbc4f6fcf41bfce899eaac0d92d9f09996cd3'
 default['cluster']['slurm']['user'] = 'slurm'
 default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1
 default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -189,8 +189,6 @@ service 'slurmctld' do
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? }
 end
 
-chef_sleep '5'
-
 execute 'reload config for running nodes' do
   command "#{node['cluster']['slurm']['install_dir']}/bin/scontrol reconfigure"
   retries 3

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -189,6 +189,8 @@ service 'slurmctld' do
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? }
 end
 
+chef_sleep '5'
+
 execute 'reload config for running nodes' do
   command "#{node['cluster']['slurm']['install_dir']}/bin/scontrol reconfigure"
   retries 3


### PR DESCRIPTION
### Description of changes
* Upgrade Slurm to version 22.05.6

### Tests
* Ran manually the slurm `schedulers` integration tests

### References
* CLI: https://github.com/aws/aws-parallelcluster/pull/4671
* Cookbook: https://github.com/aws/aws-parallelcluster-cookbook/pull/1622
* Node: https://github.com/aws/aws-parallelcluster-node/pull/473

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
