### PR TITLE
[head node bootstrap errors] store custom script errors 

### DIFF
--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -29,19 +29,32 @@ function error_exit () {
   exit 1
 }
 
+# URLs longer than the limit will be trimmed by replacing the middle part with ellipsis
+function process_url (){
+  url=$1
+  if [ ${#url} -gt $url_len_limit ]; then
+    head_len=$(expr $url_len_limit / 2)
+    tail_len=$(expr $url_len_limit - $head_len)
+    echo "$(echo $url | head --bytes=${head_len})......$(echo $url | tail --bytes=${tail_len})"
+  else
+    echo $url
+  fi
+}
+
 function download_run (){
   url=$1
   shift
   scheme=$(echo "${url}"| cut -d: -f1)
+  url_processed="$(process_url "$url")"
   tmpfile=$(mktemp)
   trap "/bin/rm -f $tmpfile" RETURN
   if [ "${scheme}" == "s3" ]; then
-    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/aws --region ${cfn_region} s3 cp ${url} - > $tmpfile || error_exit "Failed to download ${custom_script} script ${url} using aws s3, return code: $?."
+    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/aws --region ${cfn_region} s3 cp ${url} - > $tmpfile || error_exit "Failed to download ${custom_script} script ${url_processed} using aws s3, return code: $?."
   else
-    wget -qO- ${url} > $tmpfile || error_exit "Failed to download ${custom_script} script ${url} using wget, return code: $?."
+    wget -qO- ${url} > $tmpfile || error_exit "Failed to download ${custom_script} script ${url_processed} using wget, return code: $?."
   fi
   chmod +x $tmpfile || error_exit "Failed to run ${custom_script} script due to a failure in making the file executable, return code: $?."
-  $tmpfile "$@" || error_exit "Failed to execute ${custom_script} script ${url}, return code: $?."
+  $tmpfile "$@" || error_exit "Failed to execute ${custom_script} script ${url_processed}, return code: $?."
 }
 
 function get_stack_status () {
@@ -88,10 +101,12 @@ function run_postupdate () {
   fi || error_exit "Failed to run post update hook"
 }
 
-check_params
-
-ACTION=${1#?}
 custom_script=""
+# To prevent massive error messages that could get truncated by CloudFormation,
+# we set a length limit (100 for now) for custom scripts URLs, and URLs exceeding the limit will be trimmed
+url_len_limit=100
+check_params
+ACTION=${1#?}
 case ${ACTION} in
   preinstall)
     run_preinstall

--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -21,7 +21,11 @@ function error_exit () {
   script=`basename $0`
   echo "parallelcluster: ${script} - $1"
   logger -t parallelcluster "${script} - $1"
-  echo "$1. If --rollback-on-failure was set to false, check /var/log/cfn-init.log and /var/log/cloud-init-output.log for more details." > /var/log/parallelcluster/bootstrap_error_msg
+  case $custom_script in
+    OnNodeStart|OnNodeConfigured)
+      echo "$1 Please check /var/log/cfn-init.log in the head node, or check the cfn-init.log in CloudWatch logs. Please refer to https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html#troubleshooting-v3-get-logs for more details on ParallelCluster logs." > /var/log/parallelcluster/bootstrap_error_msg
+      ;;
+  esac
   exit 1
 }
 
@@ -32,12 +36,12 @@ function download_run (){
   tmpfile=$(mktemp)
   trap "/bin/rm -f $tmpfile" RETURN
   if [ "${scheme}" == "s3" ]; then
-    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/aws --region ${cfn_region} s3 cp ${url} - > $tmpfile || error_exit "Failed to run ${ACTION}, failed to download ${url} using aws s3, return code: $?"
+    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/aws --region ${cfn_region} s3 cp ${url} - > $tmpfile || error_exit "Failed to download ${custom_script} script ${url} using aws s3, return code: $?."
   else
-    wget -qO- ${url} > $tmpfile || error_exit "Failed to run ${ACTION}, failed to download ${url} using wget, return code: $?"
+    wget -qO- ${url} > $tmpfile || error_exit "Failed to download ${custom_script} script ${url} using wget, return code: $?."
   fi
-  chmod +x $tmpfile || error_exit "Failed to run ${ACTION}, failed to run chmod +x ${tmpfile}, return code: $?"
-  $tmpfile "$@" || error_exit "Failed to run ${ACTION}, ${url} failed with non 0 return code: $?"
+  chmod +x $tmpfile || error_exit "Failed to run ${custom_script} script due to a failure in making the file executable, return code: $?."
+  $tmpfile "$@" || error_exit "Failed to execute ${custom_script} script ${url}, return code: $?."
 }
 
 function get_stack_status () {
@@ -48,26 +52,29 @@ function get_stack_status () {
 }
 
 function run_preinstall () {
+  custom_script="OnNodeStart"
   if [ "${cfn_preinstall}" != "NONE" ]; then
     if [ "${cfn_preinstall_args}" != "NONE" ]; then
       download_run "${cfn_preinstall}" "${cfn_preinstall_args[@]}"
     else
       download_run "${cfn_preinstall}"
     fi
-  fi || error_exit "Failed to run pre install hook"
+  fi || error_exit "Failed to run ${custom_script} script."
 }
 
 function run_postinstall () {
+  custom_script="OnNodeConfigured"
   if [ "${cfn_postinstall}" != "NONE" ]; then
     if [ "${cfn_postinstall_args}" != "NONE" ]; then
       download_run "${cfn_postinstall}" "${cfn_postinstall_args[@]}"
     else
       download_run "${cfn_postinstall}"
     fi
-  fi || error_exit "Failed to run post install hook"
+  fi || error_exit "Failed to run ${custom_script} script."
 }
 
 function run_postupdate () {
+  custom_script="OnNodeUpdated"
   if [ "${cfn_postupdate}" != "NONE" ]; then
     stack_status=$(get_stack_status) || error_exit "Failed to get the stack status, check the HeadNode instance profile's IAM policies"
 
@@ -84,6 +91,7 @@ function run_postupdate () {
 check_params
 
 ACTION=${1#?}
+custom_script=""
 case ${ACTION} in
   preinstall)
     run_preinstall


### PR DESCRIPTION
### Description of changes
During the bootstrap of the head node in a ParallelCluster cluster, customer-defined shell scripts such as OnNodeStart and OnNodeConfigured script, will be executed if they were provided. Currently, if any of these steps fails, the error messages refer to these scripts as "pre-install" or "post-install". In this PR, the names of the scripts will be changed to OnNodeStart and OnNodeConfigured script. Error messages will also be slightly revised.

In addition, when the error message is too long (in our experience when longer than around 1024 bytes; no official CloudFormation documentation found) it will be truncated in CloudFormation, leading to information loss. Thus, to prevent the error message from getting too long, we will handle the length of the URLs of custom scripts, and trim it when it's longer than a pre-defined limit (we set it to be 100 for now), by taking the beginning and end of the URL and connecting them using ellipsis. 

Note that in our implementation, the failure of the `check_params` function will not write specific error message into the specific `bootstrap_error_msg` file, because the params error will be different than the custom script errors this activity is handling. Thus, after this PR, if the `check_params` function fails during the cluster creation step, a general error message will show up in CloudFormation stack (controlled through the [user_data.sh](https://github.com/aws/aws-parallelcluster/blob/develop/cli/src/pcluster/resources/head_node/user_data.sh#L129)).

### Tests
Manual test using a really long example URL as custom script:
- Before code change:
>WaitCondition received failed message: 'Failed to run postinstall, failed to download https://github.com/aws/aws-parallelcluster-cookbook/blob/develop/pre_post_install_scripts/pre_post_install_scripts/throw_error.sh/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBhQSERIUExQUFRUUFxcXFhQYFBQXGBgYFhkVGBkVFxUXHCYfGBojGRQVHy8gJCcpLCwsFh4xNTAqNSYrLCkBCQoKDgwOGg8PGiokHyQpLDUqKSwsLCksKSwpKSwsLCwpKSkpLCwpLCksKSwpLCkpLCwsLCkpKSwsLCwsLDQsLP/AABEIAM0A9gMBIgACEQEDEQH/xAAcAAACAgMBAQAAAAAAAAAAAAAABQQGAgMHAQj/xABTEAACAAQCBAcLBgsFBwUAAAABAgADBBESIQUGMUEHEyJRYYGRFBYyVHF0lKGxs9IjNEKS0dMXMzVSYmRypMHj8GOTo7LiJENzosLh8RVTgoPD/8QAGQEBAAMBAQAAAAAAAAAAAAAAAAECAwQF/8QAJxEAAgIBAwMEAgMAAAAAAAAAAAECEQMSITEEE0EiUWGBkfAyceH/2gAMAwEAAhEDEQA/AOiaq6q0b0NGzUlMzNTySWMiUSSZaEkkrmbw17z6LxOl9HlfDBqf8wovNpHu0hvACjvPovE6X0eV8MHefReJ0vo8r4YbwQAo7z6LxOl9HlfDB3n0XidL6PK+GG8EAKO8+i8TpfR5Xwwd59F4nS+jyvhhsTaKnX69gzGlUiCc6+FMZsMpTuBYAlj0LnFoxcuCG0ht3n0XidL6PK+GDvPovE6X0eV8MIX0jpQ8pe5SPzeKndmLFl2QuPCpMpnwV1Pg345ZuLc4DbfbG0enlJelp/ZR5EuS3959F4nS+jyvhg7z6LxOl9HlfDDCjrFmosxCSrgMLixsdmRzEb45zQUd59F4nS+jyvhg7z...' for uniqueId: i-0489e5d9db39840b2

- After code change:
>WaitCondition received failed message: 'Failed to download OnNodeConfigured script https://github.com/aws/aws-parallelcluster-cookboo....../7t4Ig6X0+JqOOLteYreHfYrC3g9MeRJFH/throw_error.sh using wget, return code: 8. Please check /var/log/cfn-init.log in the head node, or check the cfn-init.log in CloudWatch logs. Please refer to https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html#troubleshooting-v3-get-logs for more details on ParallelCluster logs.' for uniqueId: i-080e525266bfcb753


### References
https://github.com/aws/aws-parallelcluster/pull/4566
The max amount of data cfn-signal can pass is 4096 bytes according to [this page](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html), and this PR handles this 4096 bytes size limit. Note that it is different than the size limit the current PR is handling.

https://github.com/aws/aws-parallelcluster-cookbook/pull/1595
This is a previous PR regarding the custom script error message. The current PR is a followup on it.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.