### PR TITLE
Move security exclusion from .bandit.ini to the corresponding code line

### DIFF
--- a/.bandit.ini
+++ b/.bandit.ini
@@ -1,5 +1,1 @@
-# B105 checks for potentially hard-coded passwords/API tokens.
-# It's disabled because it seems to have a high rate of false failures.
-# B404 checks for imports of the subprocess module.
-# It's disabled because we make use of that module.
-skips: ['B105', 'B404']
+skips: []

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -10,3 +10,4 @@ known_third_party=assertpy,boto3,botocore,dcv,gnupg,jinja2,jsonschema,pytest,req
 # )
 multi_line_output=3
 include_trailing_comma=true
+profile=black

--- a/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
@@ -19,7 +19,10 @@ import random
 import re
 import ssl
 import string
-import subprocess
+
+# A nosec comment is appended to the following line in order to disable the B404 check.
+# In this file the input of the module subprocess is trusted.
+import subprocess  # nosec
 import sys
 import time
 from collections import OrderedDict, namedtuple
@@ -130,7 +133,9 @@ class DCVAuthenticator(BaseHTTPRequestHandler):
 
     USER_REGEX = r"^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$"
     SESSION_ID_REGEX = r"^([a-zA-Z0-9_-]{0,128})$"
-    TOKEN_REGEX = r"^([a-zA-Z0-9_-]{256})$"
+    # A nosec comment is appended to the following line in order to disable the B105 check.
+    # Since the TOKEN_REGEX is not a hardcoded password
+    TOKEN_REGEX = r"^([a-zA-Z0-9_-]{256})$"  # nosec
 
     MAX_NUMBER_OF_REQUEST_TOKENS = 500
     MAX_NUMBER_OF_SESSION_TOKENS = 100

--- a/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
@@ -22,7 +22,7 @@ import string
 
 # A nosec comment is appended to the following line in order to disable the B404 check.
 # In this file the input of the module subprocess is trusted.
-import subprocess  # nosec
+import subprocess  # nosec B404
 import sys
 import time
 from collections import OrderedDict, namedtuple
@@ -135,7 +135,7 @@ class DCVAuthenticator(BaseHTTPRequestHandler):
     SESSION_ID_REGEX = r"^([a-zA-Z0-9_-]{0,128})$"
     # A nosec comment is appended to the following line in order to disable the B105 check.
     # Since the TOKEN_REGEX is not a hardcoded password
-    TOKEN_REGEX = r"^([a-zA-Z0-9_-]{256})$"  # nosec
+    TOKEN_REGEX = r"^([a-zA-Z0-9_-]{256})$"  # nosec B105
 
     MAX_NUMBER_OF_REQUEST_TOKENS = 500
     MAX_NUMBER_OF_SESSION_TOKENS = 100

--- a/cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd/clusterstatusmgtd.py
+++ b/cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd/clusterstatusmgtd.py
@@ -15,7 +15,10 @@ import json
 import logging
 import os
 import shlex
-import subprocess
+
+# A nosec comment is appended to the following line in order to disable the B404 check.
+# In this file the input of the module subprocess is trusted.
+import subprocess  # nosec
 import time
 from configparser import ConfigParser
 from datetime import datetime, timezone

--- a/cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd/clusterstatusmgtd.py
+++ b/cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd/clusterstatusmgtd.py
@@ -18,7 +18,7 @@ import shlex
 
 # A nosec comment is appended to the following line in order to disable the B404 check.
 # In this file the input of the module subprocess is trusted.
-import subprocess  # nosec
+import subprocess  # nosec B404
 import time
 from configparser import ConfigParser
 from datetime import datetime, timezone

--- a/test/unit/dcv/test_dcv_authenticator.py
+++ b/test/unit/dcv/test_dcv_authenticator.py
@@ -161,7 +161,9 @@ def test_get_request_token_parameter(parameters, keys, result):
 
 def test_get_request_token(mocker):
     """Verify the first step of the authentication process, the retrieval of the Request Token."""
-    token_value = "1234abcd_-"
+    # A nosec comment is appended to the following line in order to disable the B105 check.
+    # Since the session token is not a hardcoded password
+    token_value = "1234abcd_-"  # nosec
     user = "centos"
     session_id = "mysession"
 
@@ -288,7 +290,9 @@ def test_get_session_token(mocker):
     # working
     mock_os(mocker, user, obtain_timestamp(datetime.utcnow()))
     mock_verify_session_existence(mocker, exists=True)
-    session_token = "1234"
+    # A nosec comment is appended to the following line in order to disable the B105 check.
+    # Since the session token is not a hardcoded password
+    session_token = "1234"  # nosec
     mock_generate_random_token(mocker, session_token)
     DCVAuthenticator.request_token_manager.add_token(
         request_token, DCVAuthenticator.RequestTokenInfo(user, session_id, datetime.utcnow(), access_file)

--- a/test/unit/dcv/test_dcv_authenticator.py
+++ b/test/unit/dcv/test_dcv_authenticator.py
@@ -292,7 +292,7 @@ def test_get_session_token(mocker):
     mock_verify_session_existence(mocker, exists=True)
     # A nosec comment is appended to the following line in order to disable the B105 check.
     # Since the session token is not a hardcoded password
-    session_token = "1234"  # nosec
+    session_token = "1234"  # nosec B105
     mock_generate_random_token(mocker, session_token)
     DCVAuthenticator.request_token_manager.add_token(
         request_token, DCVAuthenticator.RequestTokenInfo(user, session_id, datetime.utcnow(), access_file)


### PR DESCRIPTION
### Description of changes
* Move security exclusion from .bandit.ini to the corresponding code line. This change aims to avoid global security exclusions.
* The security exclusions added by this PR will be assessed as part of another PR.
* Added the label skip-security-exclusions-check since now the checks are more precise.
* Also added `profile=black` in isort.cfg to avoid clashing between isort and black8


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
