### PR TITLE
[release-3.4] Increase retries and delay for gcc download

### DIFF
--- a/cookbooks/aws-parallelcluster-install/recipes/arm_pl.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/arm_pl.rb
@@ -91,8 +91,8 @@ bash 'make install' do
       make -j $CORES
       make install
   GCC
-  retries 3
-  retry_delay 5
+  retries 5
+  retry_delay 10
   creates '/opt/arm/armpl/gcc'
 end
 


### PR DESCRIPTION
Increase retries and delay for gcc download, from 3 to 5 retries

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.