### PR TITLE
Allow the installation of Slurm from any commit in the Slurm GitHub project

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -102,6 +102,8 @@ default['cluster']['armpl']['url'] = [
 # Slurm software
 default['cluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
 default['cluster']['slurm']['version'] = '22-05-8-1'
+# WARNING: specify the commit hash only if a development version of Slurm must be used
+# WARNING: the whole commit hash must be used here (not a shortened version of the hash)
 default['cluster']['slurm']['commit'] = ''
 if slurm_commit_hash?
   default['cluster']['slurm']['tar_name'] = "#{node['cluster']['slurm']['commit']}"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -102,7 +102,13 @@ default['cluster']['armpl']['url'] = [
 # Slurm software
 default['cluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
 default['cluster']['slurm']['version'] = '22-05-8-1'
-default['cluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['cluster']['slurm']['version']}.tar.gz"
+default['cluster']['slurm']['commit'] = ''
+if slurm_commit_hash?
+  default['cluster']['slurm']['tar_name'] = "#{node['cluster']['slurm']['commit']}"
+else
+  default['cluster']['slurm']['tar_name'] = "slurm-#{node['cluster']['slurm']['version']}"
+end
+default['cluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/#{node['cluster']['slurm']['tar_name']}.tar.gz"
 default['cluster']['slurm']['sha256'] = '8c8f6a26a5d51e6c63773f2e02653eb724540ee8b360125c8d7732314ce737d6'
 default['cluster']['slurm']['user'] = 'slurm'
 default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -105,11 +105,11 @@ default['cluster']['slurm']['version'] = '22-05-8-1'
 # WARNING: specify the commit hash only if a development version of Slurm must be used
 # WARNING: the whole commit hash must be used here (not a shortened version of the hash)
 default['cluster']['slurm']['commit'] = ''
-if slurm_commit_hash?
-  default['cluster']['slurm']['tar_name'] = "#{node['cluster']['slurm']['commit']}"
-else
-  default['cluster']['slurm']['tar_name'] = "slurm-#{node['cluster']['slurm']['version']}"
-end
+default['cluster']['slurm']['tar_name'] = if slurm_commit_hash?
+                                            "#{node['cluster']['slurm']['commit']}"
+                                          else
+                                            "slurm-#{node['cluster']['slurm']['version']}"
+                                          end
 default['cluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/#{node['cluster']['slurm']['tar_name']}.tar.gz"
 default['cluster']['slurm']['sha256'] = '8c8f6a26a5d51e6c63773f2e02653eb724540ee8b360125c8d7732314ce737d6'
 default['cluster']['slurm']['user'] = 'slurm'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -52,7 +52,7 @@ end
 
 include_recipe 'aws-parallelcluster-slurm::install_jwt'
 
-slurm_tarball = "#{node['cluster']['sources_dir']}/slurm-#{node['cluster']['slurm']['version']}.tar.gz"
+slurm_tarball = "#{node['cluster']['sources_dir']}/#{node['cluster']['slurm']['tar_name']}.tar.gz"
 
 # Get slurm tarball
 remote_file slurm_tarball do
@@ -84,7 +84,7 @@ bash 'make install' do
     source #{node['cluster']['cookbook_virtualenv_path']}/bin/activate
 
     tar xf #{slurm_tarball}
-    cd slurm-slurm-#{node['cluster']['slurm']['version']}
+    cd slurm-#{node['cluster']['slurm']['tar_name']}
     ./configure --prefix=#{node['cluster']['slurm']['install_dir']} --with-pmix=/opt/pmix --with-jwt=/opt/libjwt --enable-slurmrestd
     CORES=$(grep processor /proc/cpuinfo | wc -l)
     make -j $CORES

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -285,7 +285,7 @@ end
 # Check if Slurm reference is provided as commit
 #
 def slurm_commit_hash?
-  node['cluster']['slurm']['commit'] != ''
+  !node['cluster']['slurm']['commit'].empty?
 end
 
 #

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -282,6 +282,13 @@ def reload_network_config
 end
 
 #
+# Check if Slurm reference is provided as commit
+#
+def slurm_commit_hash?
+  node['cluster']['slurm']['commit'] != ''
+end
+
+#
 # Check if this is an ARM instance
 #
 def arm_instance?


### PR DESCRIPTION
### Description of changes
* Allow the installation of Slurm from any commit in the Slurm GitHub project and not just official releases (mainly for development purposes).
  * if a commit hash is provided in the cookbook attributes, then that specific commit will be used to install Slurm
  * otherwise the same behavior as before will apply (install a released version of Slurm defined via the `version` attribute).

### Tests
* Successfully created one AMI from the latest official release (22.05.7-1) to check that the previous functionality was maintained;
* Successfully created one AMI from a recent development version of Slurm (https://github.com/SchedMD/slurm/commit/eac027698b55573db6a72751fa3820350b4977dc - 23.02.0-0pre1);

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.