### PR TITLE
Add dokken and ec2 driver to run kitchen test locally

### DIFF
--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -1,0 +1,35 @@
+---
+driver:
+  name: dokken
+  pull_platform_image: false # Use the local images, prevent pull of docker images from Docker Hub,
+  chef_version: 17.2.29 # Chef version aligned with the one used to build the images
+  env:
+    # Since the kernel version of the docker images is not in the expected pattern,
+    # KERNEL_RELEASE is set in the environment to override the system value.
+    - KERNEL_RELEASE=3.10.0-1160.42.2.el7.x86_64
+
+provisioner:
+  name: dokken
+
+transport:
+  name: dokken
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: alinux2
+    driver:
+      image: dokken/amazonlinux-2
+  - name: centos7
+    driver:
+      image: dokken/centos-7
+  - name: ubuntu1804
+    driver:
+      image: dokken/ubuntu-18.04
+  - name: ubuntu2004
+    driver:
+      image: dokken/ubuntu-20.04
+  - name: redhat8
+    driver:
+      image: cookbook-registry.access.redhat.com/ubi8-8.0

--- a/kitchen.ec2.yaml
+++ b/kitchen.ec2.yaml
@@ -1,0 +1,48 @@
+---
+driver:
+  name: ec2
+  aws_ssh_key_id: <%= ENV['KITCHEN_KEY_NAME'] %>
+  security_group_ids: [ "<%= ENV['KITCHEN_SECURITY_GROUP_ID'] %>" ]
+  region: <%= ENV['KITCHEN_AWS_REGION'] %>
+  availability_zone: a
+  subnet_id: <%= ENV['KITCHEN_SUBNET_ID'] %>
+  # Disable IMDS v1
+  metadata_options:
+    http_tokens: 'required'
+    http_put_response_hop_limit: 1
+    instance_metadata_tags: 'enabled'
+  #iam_profile_name: chef-client
+  instance_type: t2.micro
+  associate_public_ip: true
+  interface: public
+  transport:
+    ssh_key: <%= ENV['KITCHEN_SSH_KEY_PATH'] %>
+
+provisioner:
+  name: chef_zero
+  require_chef_omnibus: 17.2.29
+  chef_omnibus_url: https://raw.githubusercontent.com/aws/aws-parallelcluster-cookbook/develop/util/cinc-install.sh
+  chef_omnibus_root: /opt/cinc
+  retry_on_exit_code:
+    - 35 # 35 is the exit code signaling that the node is rebooting
+  max_retries: 1
+  wait_for_retry: 120
+  client_rb:
+    exit_status: :enabled # Opt-in to the standardized exit codes
+    client_fork: false  # Forked instances don't return the real exit code
+
+platforms:
+  - name: alinux2
+    driver_plugin: ec2
+    driver_config:
+      # Use the Amazon Linux 2 AMI most similar to the base AMI used to build the ParallelCluster image
+      image_id: <%= ENV['KITCHEN_ALINUX2_AMI'] %>
+    transport:
+      username: ec2-user
+  - name: redhat8
+    driver_plugin: ec2
+    driver_config:
+      # Use the RedHat 8 AMI most similar to the base AMI used to build the ParallelCluster  image
+      image_id: <%= ENV['KITCHEN_REDHAT8_AMI'] %>
+    transport:
+      username: ec2-user

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -23,7 +23,7 @@ suites:
       controls:
         # verifier runs controls listed above, looking for them in test/recipes and test/resources
         # beware: these are not file names but control names
-        # (see test/resources/prerequisites/controls/another.rb for an example)
+        # (see test/resources/example_control/controls/example_resource_spec.rb for an example)
         # this control tests the recipe
         - example_recipe
         # some resource tests can be reused to test the recipe including them, some might not fit

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -1,0 +1,39 @@
+# Allows to test single recipes
+#
+# Must be run as local file (override) of kitchen.docker.yml
+# export KITCHEN_YAML=kitchen.docker.yml
+# export KITCHEN_LOCAL_YAML=kitchen.recipes.yml
+# See: https://kitchen.ci/docs/reference/configuration
+---
+verifier:
+  name: inspec
+  inspec_tests:
+    # recipe tests will use controls from these directories
+    - test/recipes
+    - test/resources
+
+suites:
+  - name: base
+    run_list:
+      # runs the recipe to test, along with the recipes it depends on
+      - recipe[aws-parallelcluster::test_dummy]
+      - recipe[aws-parallelcluster::example_recipe]
+      #- recipe[aws-parallelcluster-install::base]
+    verifier:
+      controls:
+        # verifier runs controls listed above, looking for them in test/recipes and test/resources
+        # beware: these are not file names but control names
+        # (see test/resources/prerequisites/controls/another.rb for an example)
+        # this control tests the recipe
+        - example_recipe
+        # some resource tests can be reused to test the recipe including them, some might not fit
+        #
+        # consider what is the expected outcome and decide what you want to test and what are just
+        # implementation details.
+    attributes:
+      cluster:
+        # right now tests depend on this parameter: we will try to remove the dependency later
+        base_os: alinux
+        region: us-east-1
+        dcv:
+          server: {}

--- a/kitchen.resources.yml
+++ b/kitchen.resources.yml
@@ -1,0 +1,50 @@
+# Allows to test single resources.
+#
+# Must be run as local file (override) of kitchen.docker.yml
+# export KITCHEN_YAML=kitchen.docker.yml
+# export KITCHEN_LOCAL_YAML=kitchen.resources.yml
+# See: https://kitchen.ci/docs/reference/configuration
+---
+verifier:
+  name: inspec
+  inspec_tests:
+    # resource tests will use controls from this directory
+    - path: test/resources
+
+
+suites:
+# This is the result of the ERB block below
+#  - name: package_repos
+#    run_list:
+#      - recipe[aws-parallelcluster::test_resource]
+#    verifier:
+#      controls:
+#        - package_repos
+#    attributes:
+#      cluster:
+#        base_os: alinux2
+#      resource: package_repos
+
+<% ['example_resource'].each do |resource| %>
+  - name: <%= resource %>
+    run_list:
+      # This is a test recipe executing the default action of the resource you pass as `resource` attribute,
+      # with default properties
+      - recipe[aws-parallelcluster::test_resource]
+    verifier:
+      controls:
+        - <%= resource %>
+    attributes:
+      cluster:
+        # right now tests depend on this parameter: we will try to remove the dependency later
+        base_os: alinux
+        region: us-east-1
+        dcv:
+          server: {}
+      resource: <%= resource %>
+
+<%end %>
+
+# If you need to test a resource with an action or properties different from the default ones,
+# add custom tests here and adjust `aws-parallelcluster-test::test_resource`
+# to allow `action` and/or `properties` parameters.

--- a/recipes/example_recipe.rb
+++ b/recipes/example_recipe.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+#
+# Cookbook:: aws-parallelcluster
+# Recipe:: example_recipe
+#
+# This is a recipe executing the example_resource
+#
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+example_resource 'example'

--- a/recipes/test_dummy.rb
+++ b/recipes/test_dummy.rb
@@ -1,0 +1,1 @@
+# do nothing, but import aws-parallelcluster cookbook as entry point

--- a/recipes/test_resource.rb
+++ b/recipes/test_resource.rb
@@ -1,0 +1,10 @@
+# This is a helper recipe executing the default action of the resource
+# which type was set as `resource` attribute during the test execution.
+# This is equivalent to:
+# resource_type 'test'
+# or
+# resource_type 'test' do
+#   action :default_action
+# end
+
+declare_resource(node['resource'].to_sym, 'test')

--- a/resources/example_resource.rb
+++ b/resources/example_resource.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+provides :example_resource
+unified_mode true
+
+# Resource:: example resource
+
+default_action :example
+
+action :example do
+  file "/tmp/example_file" do
+    action :create_if_missing
+  end
+end

--- a/test/Dockerfile.rhel8
+++ b/test/Dockerfile.rhel8
@@ -1,0 +1,4 @@
+# Base image for RHEL8 tests.
+FROM registry.access.redhat.com/ubi8:8.0
+# Container must have an always active process to stay alive.
+ENTRYPOINT /bin/bash -c trap exit 0 SIGTERM; while :; do sleep 1; done

--- a/test/recipes/example_control/controls/example_recipe_spec.rb
+++ b/test/recipes/example_control/controls/example_recipe_spec.rb
@@ -1,0 +1,9 @@
+# Use the name matching the resource type
+control 'example_recipe' do
+  # describe the resource
+  title 'Example recipe'
+
+  describe file('/tmp/example_file') do
+    it { should exist }
+  end
+end

--- a/test/recipes/example_control/inspec.yml
+++ b/test/recipes/example_control/inspec.yml
@@ -1,0 +1,5 @@
+---
+name: recipes unit tests
+title: Recipes unit test
+maintainer: aws-parallelcluster
+license: Apache-2.0

--- a/test/resources/example_control/controls/example_resource_spec.rb
+++ b/test/resources/example_control/controls/example_resource_spec.rb
@@ -1,0 +1,9 @@
+# Use the name matching the resource type
+control 'example_resource' do
+  # describe the resource
+  title 'Example resource'
+
+  describe file('/tmp/example_file') do
+    it { should exist }
+  end
+end

--- a/test/resources/example_control/inspec.yml
+++ b/test/resources/example_control/inspec.yml
@@ -1,0 +1,5 @@
+---
+name: resources unit tests
+title: Resources unit test
+maintainer: aws-parallelcluster
+license: Apache-2.0


### PR DESCRIPTION
### Description of changes
* Added kitchen config to locally test the recipes with dokken
* Added kitchen config to locally test the recipes with ec2
* Added config to locally test a single recipe
* Added config to locally test a single resource or list of resources
* Added an example_resource

### Tests
* Manual tested 

### References
* https://github.com/aws/aws-parallelcluster-cookbook/compare/develop...awslitvit:aws-parallelcluster-cookbook:wip/redhat8-poc


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.