### PR TITLE
[develop] Throw specific Exception instead of generic one

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,7 +11,10 @@ ignore =
     # W503: line break before binary operator => Conflicts with black style.
     W503,
     # D413: Missing blank line after last section
-    D413
+    D413,
+    # B028: Consider replacing f"'{foo}'" with f"{foo!r}".
+    # Currently being disabled by flake8-bugbear. See https://github.com/PyCQA/flake8-bugbear/pull/333
+    B028
 exclude =
     .tox,
     .git,
@@ -28,4 +31,4 @@ max-complexity = 10
 max-line-length = 120
 import-order-style = google
 application-import-names = flake8
-format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
+format = %(cyan)s%(path)s%(reset)s:%(bold)s%(yellow)s%(row)d%(reset)s:%(bold)s%(green)s%(col)d%(reset)s: %(bold)s%(red)s%(code)s%(reset)s %(text)s

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
@@ -25,6 +25,12 @@ class CriticalError(Exception):
     pass
 
 
+class ConfigurationFieldNotFoundError(Exception):
+    """Field not found in configuration."""
+
+    pass
+
+
 def generate_fleet_config_file(output_file, input_file):
     """
     Generate configuration file used by Fleet Manager in node daemon package.
@@ -87,7 +93,7 @@ def generate_fleet_config_file(output_file, input_file):
                     }
 
                 else:
-                    raise Exception(
+                    raise ConfigurationFieldNotFoundError(
                         "Instances or InstanceType field not found "
                         f"in queue: {queue}, compute resource: {compute_resource} configuration"
                     )


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Throw specific Exception instead of generic one

This to solve check flake8 B017

Also disable B028 flake8-bugbear lint check recently implemented.
The check is going to be disabled by the flake8-bugbear developers. See Rename B028 to B907, making it optional/opinionated. PyCQA/flake8-bugbear#333

Fix color formatting on flake8 style offenses.

### Tests
unit tested

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.