### PR TITLE
[Isolated Regions] Add support for isolated regions: us-iso-* and us-isob-*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **ENHANCEMENTS**
+- Add support for US isolated regions: us-iso-* and us-isob-*.
 - Fail cluster creation if cluster status changes to PROTECTED while provisioning static nodes.
 
 **CHANGES**

--- a/cookbooks/aws-parallelcluster-config/recipes/aws_cli.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/aws_cli.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-config
+# Recipe:: aws_cli
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Users to configure the AWS CLI for.
+# We configure the AWS CLI for all the users that are created by ParallelCluster and must interact with AWS.
+users = node['cluster']['head_node_imds_allowed_users']
+
+# AWS CLI configurations to set.
+# Note: only the configurations with a not nil value will be set.
+region = node['cluster']['region']
+configurations = {
+  'ca_bundle' =>  region.start_with?('us-iso') ? "/etc/pki/#{region}/certs/ca-bundle.pem" : nil,
+}
+
+def set_aws_cli_configuration(config_name, expected_value, user)
+  execute "Setting AWS CLI configuration for user #{user}: #{config_name} set to '#{expected_value}'" do
+    user user
+    login true
+    command "aws configure set #{config_name} #{expected_value}"
+  end
+end
+
+# AWS CLI is explicitly configured only in US iso regions.
+if region.start_with?('us-iso')
+  users.each do |user|
+    configurations.each do |config_name, config_value|
+      next if config_value.nil?
+      set_aws_cli_configuration(config_name, config_value, user)
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-config/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/init.rb
@@ -21,6 +21,11 @@ validate_os_type
 # Validate init system
 raise "Init package #{node['init_package']} not supported." unless systemd?
 
+# Execute initialization steps required by isolated regions.
+# These steps are supposed to be executed as part of the install phase, but they cannot be executed there because
+# we can execute install phase steps in Classic only.
+include_recipe 'aws-parallelcluster-config::init_isolated' if node['cluster']['region'].start_with?('us-iso')
+
 include_recipe "aws-parallelcluster-config::cfnconfig_mixed"
 
 template "/opt/parallelcluster/scripts/fetch_and_run" do

--- a/cookbooks/aws-parallelcluster-config/recipes/init_isolated.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/init_isolated.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-config
+# Recipe:: aws_cli
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This recipe is expected to be executed only in isolated regions.
+region = node['cluster']['region']
+return unless region.start_with?('us-iso')
+
+# Install CA bundle for US ISO
+ca_bundle = "/etc/pki/#{region}/certs/ca-bundle.pem"
+remote_file ca_bundle do
+  source "#{node['cluster']['artifacts_s3_url']}/certificates/ca-bundle.pem"
+  mode '0644'
+  retries 3
+  retry_delay 5
+  not_if { ::File.exist?(ca_bundle) }
+end
+
+# Configure AWS CLI for US ISO region
+include_recipe "aws-parallelcluster-config::aws_cli"

--- a/cookbooks/aws-parallelcluster-config/resources/manage_fsx.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_fsx.rb
@@ -54,6 +54,7 @@ action :mount do
                else
                  # DNS names of newly created Lustre file systems are hardcoded here.
                  # Note the Hardcoding format is only valid for lustre file systems created after Mar-1 2021
+                 # Region Building Note: DNS names have the default AWS domain (amazonaws.com) also in China and GovCloud.
                  "#{fsx_fs_id}.fsx.#{node['cluster']['region']}.amazonaws.com"
                end
     case fsx_fs_type
@@ -163,6 +164,7 @@ action :unmount do
                else
                  # DNS names of newly created Lustre file systems are hardcoded here.
                  # Note the Hardcoding format is only valid for lustre file systems created after Mar-1 2021
+                 # Region Building Note: DNS names have the default AWS domain (amazonaws.com) also in China and GovCloud.
                  "#{fsx_fs_id}.fsx.#{node['cluster']['region']}.amazonaws.com"
                end
     fsx_shared_dir = "/#{fsx_shared_dir}" unless fsx_shared_dir.start_with?('/')

--- a/cookbooks/aws-parallelcluster-config/templates/default/base/parallelcluster_supervisord.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/base/parallelcluster_supervisord.conf.erb
@@ -4,7 +4,7 @@
 <%# HeadNode -%>
 <% when 'HeadNode' -%>
 [program:cfn-hup]
-command = bash -c "[ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh; <%= node['cluster']['cfn_bootstrap_virtualenv_path'] %>/bin/cfn-hup"
+command = bash -c "[ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh; <%= node['cluster']['cfn_bootstrap_virtualenv_path'] %>/bin/cfn-hup --verbose"
 # The following are needed because cfn-hup starts as a daemon
 exitcodes = 0
 autorestart = unexpected

--- a/cookbooks/aws-parallelcluster-install/recipes/cfn_bootstrap.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/cfn_bootstrap.rb
@@ -37,9 +37,11 @@ bash "Install CloudFormation helpers from #{node['cluster']['cfn_bootstrap']['pa
   code <<-CFNTOOLS
       set -e
       region="#{node['cluster']['region']}"
-      bucket="s3.amazonaws.com"
-      [[ ${region} =~ ^cn- ]] && bucket="s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
-      curl --retry 3 -L -o #{node['cluster']['cfn_bootstrap']['package']} https://${bucket}/cloudformation-examples/#{node['cluster']['cfn_bootstrap']['package']}
+      aws_domain="#{aws_domain}"
+      s3_endpoint="s3.amazonaws.com"
+      bucket="cloudformation-examples"
+      [[ ${aws_domain} != "amazonaws.com" ]] && s3_endpoint="s3.$region.$aws_domain" && bucket="$region-aws-parallelcluster/cloudformation-examples"
+      curl --retry 3 -L -o #{node['cluster']['cfn_bootstrap']['package']} https://${s3_endpoint}/${bucket}/#{node['cluster']['cfn_bootstrap']['package']}
       #{node['cluster']['cfn_bootstrap_virtualenv_path']}/bin/pip install #{node['cluster']['cfn_bootstrap']['package']}
   CFNTOOLS
   creates "#{node['cluster']['cfn_bootstrap_virtualenv_path']}/bin/cfn-hup"

--- a/cookbooks/aws-parallelcluster-install/recipes/users.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/users.rb
@@ -28,7 +28,7 @@ user node['cluster']['cluster_admin_user'] do
   system true
   shell '/bin/bash'
   home "/home/#{node['cluster']['cluster_admin_user']}"
-  manage_home false
+  manage_home node['cluster']['node_type'] == 'HeadNode'
 end
 
 # Calling user_ulimit will override every existing limit

--- a/cookbooks/aws-parallelcluster-install/templates/default/base/pcluster.sh.erb
+++ b/cookbooks/aws-parallelcluster-install/templates/default/base/pcluster.sh.erb
@@ -3,6 +3,6 @@
 #   Setup ParallelCluster environment variables
 #
 
-PATH=$PATH:<%= node['cluster']['cfn_bootstrap_virtualenv_path'] %>/bin
+PATH=<%= node['cluster']['cfn_bootstrap_virtualenv_path'] %>/bin:$PATH
 
 export PATH

--- a/cookbooks/aws-parallelcluster-test/recipes/test_aws_cli.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_aws_cli.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-test
+# Recipe:: test_aws_cli
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+region = node["cluster"]["region"]
+
+# Users to verify the AWS CLI configuration for.
+# We verify all the users that are created by ParallelCluster and must interact with AWS.
+users = [
+  "root",
+  node["cluster"]["cluster_user"],
+  node["cluster"]["cluster_admin_user"],
+  node["cluster"]["slurm"]["user"],
+]
+users.append(node["cluster"]["scheduler_plugin"]["user"]) if node["cluster"]["scheduler"] == "plugin"
+
+# AWS CLI configurations to verify.
+# Note: a configuration with an empty value is equivalent to a not set configuration.
+configurations = {
+  "ca_bundle" =>  region.start_with?("us-iso") ? "/etc/pki/#{region}/certs/ca-bundle.pem" : "",
+}
+
+def check_aws_cli_configuration(config_name, expected_value, user)
+  bash "Check AWS CLI configuration for user #{user}: #{config_name} should be '#{expected_value}'" do
+    cwd Chef::Config[:file_cache_path]
+    user user
+    login true
+    code <<-TEST
+      actual_value=$(aws configure get #{config_name})
+      if [ "$actual_value" != "#{expected_value}" ]; then
+        >&2 echo "ERROR The AWS CLI configuration is not as expected for user #{user}: #{config_name} should be '#{expected_value}', but it is '$actual_value'."
+        exit 1
+      fi
+    TEST
+  end
+end
+
+users.each do |user|
+  configurations.each do |config_name, config_value|
+    check_aws_cli_configuration(config_name, config_value, user)
+  end
+end

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -23,6 +23,7 @@ include_recipe 'aws-parallelcluster-test::test_sudoers'
 include_recipe 'aws-parallelcluster-test::test_openssh'
 include_recipe 'aws-parallelcluster-test::test_nvidia'
 include_recipe 'aws-parallelcluster-test::test_dcv'
+include_recipe 'aws-parallelcluster-test::test_aws_cli'
 
 ###################
 # AWS Cli

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -310,9 +310,11 @@ def platform_supports_dcv?
 end
 
 def aws_domain
-  # Set the aws domain name
+  # Get the aws domain name
   aws_domain = "amazonaws.com"
-  aws_domain = "#{aws_domain}.cn" if node['cluster']['region'].start_with?("cn-")
+  aws_domain = "amazonaws.com.cn" if node['cluster']['region'].start_with?("cn-")
+  aws_domain = "c2s.ic.gov" if node['cluster']['region'].start_with?("us-iso-")
+  aws_domain = "sc2s.sgov.gov" if node['cluster']['region'].start_with?("us-isob-")
   aws_domain
 end
 

--- a/system_tests/install_cinc.sh
+++ b/system_tests/install_cinc.sh
@@ -31,12 +31,19 @@ elif [ `echo "${OS}" | grep -E '^ubuntu'` ]; then
   PLATFORM='DEBIAN'
 fi
 
-BUCKET="s3.amazonaws.com"
-[[ ${AWS_Region} =~ ^cn- ]] && BUCKET="s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
+AWS_DOMAIN="amazonaws.com"
+[[ ${AWS_Region} =~ ^cn- ]] && AWS_DOMAIN="amazonaws.com.cn"
+[[ ${AWS_Region} =~ ^us-iso- ]] && AWS_DOMAIN="c2s.ic.gov"
+[[ ${AWS_Region} =~ ^us-isob- ]] && AWS_DOMAIN="sc2s.sgov.gov"
+
+S3_ENDPOINT="s3.${AWS_Region}.${AWS_DOMAIN}"
+
+BUCKET="cloudformation-examples"
+[[ ${AWS_DOMAIN} != "amazonaws.com" ]] BUCKET="${AWS_Region}-aws-parallelcluster/cloudformation-examples"
 if [[ ${OS} =~ ^(ubuntu2004)$ ]]; then
-  CfnBootstrapUrl="https://${BUCKET}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
+  CfnBootstrapUrl="https://${S3_ENDPOINT}/${BUCKET}/aws-cfn-bootstrap-py3-latest.tar.gz"
 else
-  CfnBootstrapUrl="https://${BUCKET}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz"
+  CfnBootstrapUrl="https://${S3_ENDPOINT}/${BUCKET}/aws-cfn-bootstrap-latest.tar.gz"
 fi
 
 ARCH=$(uname -m)

--- a/util/cinc-install.sh
+++ b/util/cinc-install.sh
@@ -617,9 +617,12 @@ instance_metadata_file=$tmp_dir/instance_metadata
 get_region instance_metadata_file
 
 # Download domain detection
-if [ "${region}" != "${region#cn-*}" ]
-then
+if [[ ${region} == cn-* ]]; then
   download_domain="amazonaws.com.cn"
+elif [[ ${region} == us-iso-* ]]; then
+  download_domain="c2s.ic.gov"
+elif [[ ${region} == us-isob-* ]]; then
+  download_domain="sc2s.sgov.gov"
 else
   download_domain="amazonaws.com"
 fi


### PR DESCRIPTION
### Description of changes
Add support for US isolated regions: us-iso-* and us-isob-*.

In particular, we added:
1. support for the AWS domain in these regions;
2. configuration of the AWS CLI so that it uses the CA bundle dedicated to these regions,
stored at '/etc/pki/#{region}/certs/ca-bundle.pem'. Such configuration is applied at config time
to all the system users that are supposed to interact with AWS:
root, ec2-user (or equivalent), pcluster-admin, pcluster-scheduler-plugin and dcv.

### Tests
* New unit tests
* Custom build with validation enabled
* Cluster creation with custom built AMI
* Full regression tests will be done by the authoritative pipeline

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
