### PR TITLE
3.x Fix console output configuration error

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -640,8 +640,7 @@ default['cluster']['enable_nss_slurm'] = node['cluster']['directory_service']['e
 default['cluster']['realmemory_to_ec2memory_ratio'] = 0.95
 default['cluster']['slurm_node_reg_mem_percent'] = 75
 default['cluster']['slurmdbd_response_retries'] = 30
-default['cluster']['slurm_console_logging']['enabled'] = 'true'
-default['cluster']['slurm_console_logging']['sample_size'] = 1
+default['cluster']['slurm_plugin_console_logging']['sample_size'] = 1
 
 # Official ami build
 default['cluster']['is_official_ami_build'] = false

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -175,9 +175,8 @@ end
 
 replace_or_add "Update compute console logging" do
   path "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
-  pattern "compute_console_logging_enabled*"
-  line "compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] == 'true' && node['cluster']['slurm_console_logging']['enabled'] %>"
-  replace_only true
+  pattern "compute_console_logging_enabled.*"
+  line "compute_console_logging_enabled = #{node['cluster']['cw_logging_enabled']}"
 end
 
 ruby_block "Update Slurm Accounting" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -176,7 +176,7 @@ end
 replace_or_add "Update compute console logging" do
   path "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
   pattern "compute_console_logging_enabled*"
-  line "compute_console_logging_enabled = #{node['cluster']['config'].dig(:Monitoring, :Logs, :CloudWatch, :Enabled) || node['cluster']['slurm_console_logging']['enabled']}"
+  line "compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] == 'true' && node['cluster']['slurm_console_logging']['enabled'] %>"
   replace_only true
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -173,12 +173,6 @@ replace_or_add "update node replacement timeout" do
   replace_only true
 end
 
-replace_or_add "Update compute console logging" do
-  path "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
-  pattern "compute_console_logging_enabled.*"
-  line "compute_console_logging_enabled = #{node['cluster']['cw_logging_enabled']}"
-end
-
 ruby_block "Update Slurm Accounting" do
   block do
     if node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil?

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -11,6 +11,6 @@ head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
 head_node_hostname = <%= node['ec2']['local_hostname'] %>
 node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout'] %>
 insufficient_capacity_timeout = 600
-compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] == 'true' && node['cluster']['slurm_console_logging']['enabled'] %>
-compute_console_logging_max_sample_size = <%=  node['cluster']['slurm_console_logging']['sample_size'] %>
+compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] %>
+compute_console_logging_max_sample_size = <%=  node['cluster']['slurm_plugin_console_logging']['sample_size'] %>
 compute_console_wait_time = 300


### PR DESCRIPTION
### Description of changes
* Removed support for updating compute console logging property in clustermgtd config.
  * Value was based off of whether or not CloudWatch  was enabled which is not an updatable setting.

### Tests
* Ran test_update.py::test_update_slurm: test.
  * Update recipe successful (test failed due to  InvalidNetworkInterface.InUse)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.