### PR TITLE
Add redhat8 to kitchen dokken GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
           - centos7
           - ubuntu18
           - ubuntu20
+          - redhat8
         suite: [ 'base' ]
       fail-fast: false
     steps:

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -32,4 +32,4 @@ platforms:
       image: dokken/ubuntu-20.04
   - name: redhat8
     driver:
-      image: cookbook-registry.access.redhat.com/ubi8-8.0
+      image: registry.access.redhat.com/ubi8/ubi

--- a/test/Dockerfile.rhel8
+++ b/test/Dockerfile.rhel8
@@ -1,4 +1,0 @@
-# Base image for RHEL8 tests.
-FROM registry.access.redhat.com/ubi8:8.0
-# Container must have an always active process to stay alive.
-ENTRYPOINT /bin/bash -c trap exit 0 SIGTERM; while :; do sleep 1; done


### PR DESCRIPTION
### Description of changes
* Change redhat8 image to use for docker tests and enable redhat8 kitchen dokken tests.
* By using the Red Hat Universal Base Image 8 ubi8/ubi we don't need to build locally a redhat8 image.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.