### PR TITLE
Add log rotation support for ParallelCluster managed logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **ENHANCEMENTS**
 - Enforce the DCV Authenticator Server to use at least `TLS-1.2` protocol when creating the SSL Socket.
+- Add log rotation support for ParallelCluster managed logs.
 
 **CHANGES**
 - ...

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,9 @@
 default['cluster']['log_base_dir'] = '/var/log/parallelcluster'
 default['cluster']['bootstrap_error_path'] = "#{node['cluster']['log_base_dir']}/bootstrap_error_msg"
 
+# ParallelCluster log rotation file dir
+default['cluster']['pcluster_log_rotation_path'] = "/etc/logrotate.d/parallelcluster_log_rotation"
+
 # AWS domain
 default['cluster']['aws_domain'] = aws_domain
 

--- a/cookbooks/aws-parallelcluster-config/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/init.rb
@@ -37,6 +37,9 @@ fetch_config 'Fetch and load cluster configs' unless node['cluster']['scheduler'
 # Install cloudwatch, write configuration and start it.
 include_recipe "aws-parallelcluster-config::cloudwatch_agent"
 
+# ParallelCluster log rotation configuration
+include_recipe "aws-parallelcluster-config::log_rotation"
+
 # Configure additional Networking Interfaces (if present)
 include_recipe "aws-parallelcluster-config::network_interfaces" unless virtualized?
 

--- a/cookbooks/aws-parallelcluster-config/recipes/log_rotation.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/log_rotation.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster
+# Recipe:: log_rotation
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generate the parallelcluster log rotation under /etc/logrotate.d
+template node['cluster']['pcluster_log_rotation_path'] do
+  source 'log_rotation/parallelcluster_log_rotation.erb'
+  mode '0644'
+  only_if { node['cluster']['log_rotation_enabled'] == 'true' }
+end

--- a/cookbooks/aws-parallelcluster-config/templates/default/base/parallelcluster_supervisord.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/base/parallelcluster_supervisord.conf.erb
@@ -16,6 +16,7 @@ user = <%= node['cluster']['cluster_admin_user'] %>
 environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"
 redirect_stderr = true
 stdout_logfile = /var/log/parallelcluster/clustermgtd
+stdout_logfile_maxbytes = 0
 <% end -%>
 <% unless node['cluster']['scheduler'] == 'awsbatch' -%>
 [program:clusterstatusmgtd]
@@ -24,6 +25,7 @@ user = <%= node['cluster']['cluster_admin_user'] %>
 environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"
 redirect_stderr = true
 stdout_logfile = /var/log/parallelcluster/clusterstatusmgtd
+stdout_logfile_maxbytes = 0
 <% end -%>
 <% if node['cluster']['dcv_enabled'] == "head_node" && node['conditions']['dcv_supported'] -%>
 [program:pcluster_dcv_authenticator]
@@ -44,6 +46,7 @@ user = <%= node['cluster']['cluster_admin_user'] %>
 environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"
 redirect_stderr = true
 stdout_logfile = /var/log/parallelcluster/computemgtd
+stdout_logfile_maxbytes = 0
 <% end -%>
 
 <% end -%>

--- a/cookbooks/aws-parallelcluster-config/templates/default/log_rotation/parallelcluster_log_rotation.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/log_rotation/parallelcluster_log_rotation.erb
@@ -1,0 +1,188 @@
+<%# Logrotate file for logs managed by ParallelCluster %>
+<%# cloud-init log %>
+/var/log/cloud-init.log {
+  missingok
+  notifempty
+  nodateext
+  size 10M
+  rotate 1
+  copytruncate
+}
+<%# logs configured with supervisord %>
+/var/log/supervisord.log {
+  missingok
+  notifempty
+  nodateext
+  size 10M
+  rotate 1
+  su root root
+  postrotate
+    pkill --signal=SIGUSR2 supervisord
+    echo 0
+  endscript
+  create 0644 root root
+}
+<% case node['cluster']['node_type'] -%>
+<% when 'HeadNode' -%>
+<%# chef-client log %>
+/var/log/chef-client.log {
+  rotate 1
+  size 10M
+  missingok
+  notifempty
+  copytruncate
+}
+<% if node['cluster']['dcv_enabled'] == "head_node" && node['conditions']['dcv_supported'] -%>
+<%# dcv log %>
+/var/log/dcv/server.log
+/var/log/dcv/sessionlauncher.log
+/var/log/dcv/agent.*.log
+/var/log/dcv/dcv-xsession.*.log
+/var/log/dcv/Xdcv.*.log
+{
+  missingok
+  notifempty
+  size 10M
+  copytruncate
+  rotate 5
+  su dcv dcv
+}
+<% end -%>
+<% if node['cluster']["directory_service"]["generate_ssh_keys_for_users"] == 'true' -%>
+<%# pam_ssh_key_generator log %>
+/var/log/parallelcluster/pam_ssh_key_generator.log {
+  rotate 1
+  size 10M
+  missingok
+  notifempty
+  su root root
+}
+<% end -%>
+<% if node['cluster']['scheduler'] == 'slurm' -%>
+/var/log/parallelcluster/clustermgtd {
+  missingok
+  notifempty
+  nodateext
+  size 50M
+  rotate 1
+  su root root
+  postrotate
+    pkill --signal=SIGUSR2 supervisord
+    echo 0
+  endscript
+  create 0644 root root
+}
+/var/log/parallelcluster/clusterstatusmgtd {
+  missingok
+  notifempty
+  nodateext
+  size 10M
+  rotate 1
+  su root root
+  postrotate
+    pkill --signal=SIGUSR2 supervisord
+    echo 0
+  endscript
+  create 0640 root root
+}
+<%# slurm_fleet_status_manager log %>
+/var/log/parallelcluster/slurm_fleet_status_manager.log {
+  rotate 1
+  size 10M
+  missingok
+  notifempty
+  su pcluster-admin pcluster-admin
+  copytruncate
+}
+<%# slurm_resume log %>
+/var/log/parallelcluster/slurm_resume.log {
+  rotate 1
+  size 50M
+  missingok
+  notifempty
+  postrotate
+    pkill --signal=SIGUSR2 slurmctld
+    echo 0
+  endscript
+  su pcluster-admin pcluster-admin
+}
+<%# slurm_suspend log %>
+/var/log/parallelcluster/slurm_suspend.log {
+  rotate 1
+  size 10M
+  missingok
+  notifempty
+  postrotate
+    pkill --signal=SIGUSR2 slurmctld
+    echo 0
+  endscript
+  su pcluster-admin pcluster-admin
+}
+<%# slurmctld log %>
+/var/log/slurmctld.log {
+  rotate 1
+  size 50M
+  missingok
+  notifempty
+  postrotate
+    pkill -x --signal SIGUSR2 slurmctld
+    exit 0
+  endscript
+}
+<%# slurmdbd log %>
+/var/log/slurmdbd.log {
+  rotate 1
+  size 10M
+  missingok
+  notifempty
+  postrotate
+    pkill -x --signal SIGUSR2 slurmdbd
+    exit 0
+  endscript
+}
+<%# compute_console_output log %>
+/var/log/parallelcluster/compute_console_output.log {
+  rotate 1
+  size 10M
+  missingok
+  notifempty
+  copytruncate
+  su pcluster-admin pcluster-admin
+}
+<% end -%>
+<% when 'ComputeFleet' -%>
+/var/log/cloud-init-output.log {
+  missingok
+  notifempty
+  nodateext
+  size 10M
+  rotate 1
+  copytruncate
+}
+<% if node['cluster']['scheduler'] == 'slurm' -%>
+/var/log/parallelcluster/computemgtd {
+  missingok
+  notifempty
+  nodateext
+  size 10M
+  rotate 1
+  su root root
+  postrotate
+    pkill --signal=SIGUSR2 supervisord
+    echo 0
+  endscript
+  create 0644 root root
+}
+<%# slurmd log %>
+/var/log/slurmd.log {
+  rotate 1
+  size 10M
+  missingok
+  notifempty
+  postrotate
+    pkill --signal=SIGUSR2 slurmd
+    echo 0
+  endscript
+}
+<% end -%>
+<% end -%>

--- a/system_tests/dna.json
+++ b/system_tests/dna.json
@@ -31,6 +31,7 @@
     "dcv_port": "NONE",
     "enable_intel_hpc_platform": "false",
     "cw_logging_enabled": "true",
+    "log_rotation_enabled": "true",
     "cluster_s3_bucket": "parallelcluster-0000000000000000-v1-do-not-delete",
     "cluster_config_s3_key": "parallelcluster/3.0.1/clusters/pc3cluster-0000000000000000/configs/cluster-config-with-implied-values.yaml",
     "cluster_config_version": "90000000000000000000000000000000",


### PR DESCRIPTION
### Description of changes
* By default, logs configured with `supervisord` rotates when it reach 50MB and 10 backups. Disable default log rotation in supervisord in order to configure log rotation for all ParallelCluster logs through `logrotate`
* Configure log rotation for logs managed by ParallelCluster
* Log rotation configuration:
  * Cloud-init logs (cloud-init.log, cloud-init-output.log): no documentation on signals can be used for open/close log file, use copytruncate
  * supervisord, computemgtd, clustermgtd, and clusterstatusmgtd logs: logs managed by supervisord, tested log rotation using the pkill --signal=SIGUSR2 command to signal supervisord to open and close log files during rotation
  * slurm resume, suspend, slurmdbd, and slurmctld logs: it is documented log files can be open/close by running postrotate script to with signal SIGUSR2 to signal slurmctld.
  * Chef client logs:  no documentation on signals can be used for open/close log file, use copytruncate
  * slurm_fleet_manager.log: use copytuncate
  * for slurmd logs is documented we can use SIGUSR2 to reopen log files
  * for dcv logs it was suggested to use copytruncate
  * manually test with pam_exec log, it can write to new log files even if log rotation happens when writing logs. But to be on the safe side, I will still add copytruncate setting
  * for pcluster_dcv_connect.log we already have rotation set up for 5 MB

### Tests
* Manually test each log rotation
* TODO: integration tests

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.