### PR TITLE
Add directories.rb recipe extracting from base.rb

### DIFF
--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -29,21 +29,7 @@ if platform_family?('amazon')
   end
 end
 
-# Setup directories
-directory '/etc/parallelcluster'
-directory node['cluster']['base_dir']
-directory node['cluster']['sources_dir']
-directory node['cluster']['scripts_dir']
-directory node['cluster']['license_dir']
-directory node['cluster']['configs_dir']
-directory node['cluster']['shared_dir']
-
-# Create ParallelCluster log folder
-directory '/var/log/parallelcluster/' do
-  owner 'root'
-  mode '1777'
-  recursive true
-end
+include_recipe "aws-parallelcluster-install::directories"
 
 build_essential
 include_recipe "aws-parallelcluster-install::python"

--- a/cookbooks/aws-parallelcluster-install/recipes/directories.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/directories.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook:: aws-parallelcluster
+# Recipe:: directories
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Setup directories
+directory '/etc/parallelcluster'
+directory node['cluster']['base_dir']
+directory node['cluster']['sources_dir']
+directory node['cluster']['scripts_dir']
+directory node['cluster']['license_dir']
+directory node['cluster']['configs_dir']
+directory node['cluster']['shared_dir']
+
+# Create ParallelCluster log folder
+directory '/var/log/parallelcluster/' do
+  owner 'root'
+  mode '1777'
+  recursive true
+end

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -29,3 +29,12 @@ suites:
       controls:
         - admin_user
         - ulimit
+  - name: directories
+    run_list:
+      # runs the recipe to test, along with the recipes it depends on
+      - recipe[aws-parallelcluster::test_dummy]
+      - recipe[aws-parallelcluster-install::directories]
+    verifier:
+      controls:
+        - pcluster_directories_exist
+        - pcluster_log_dir_is_configured

--- a/test/recipes/controls/aws_parallelcluster_install/directories_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/directories_spec.rb
@@ -1,0 +1,21 @@
+control 'pcluster_directories_exist' do
+  title 'Setup of ParallelCluster directories'
+
+  base_dir = "/opt/parallelcluster"
+  dirs = [ base_dir, "#{base_dir}/sources", "#{base_dir}/scripts", "#{base_dir}/licenses", "#{base_dir}/configs", "#{base_dir}/shared" ]
+  dirs.each do |path|
+    describe directory(path) do
+      it { should exist }
+    end
+  end
+end
+
+control 'pcluster_log_dir_is_configured' do
+  title 'Setup of ParallelCluster log folder'
+
+  describe directory("/var/log/parallelcluster") do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('mode') { should cmp '01777' }
+  end
+end


### PR DESCRIPTION
Signed-off-by: Edoardo Antonini <eantonin@amazon.com>


### Description of changes
* Add directories.rb recipe extracting from base.rb

### Tests
* `kitchen test directories --parallel --concurrency 5` locally
* `kitchen test directories --parallel --concurrency 5` on EC2

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.