### PR TITLE
Apply performance tuning when mounting FSx for Lustre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Add log rotation support for ParallelCluster managed logs.
 
 **CHANGES**
-- ...
+- Upgrade Lustre client version to 2.12 on Amazon Linux 2. Lustre client 2.12 has been installed on Ubuntu 20.04, 18.04 and CentOS >= 7.7.  Upgrade Lustre client version to 2.10.8 on CentOS 7.6
 
 3.5.0
 ------

--- a/cookbooks/aws-parallelcluster-common/resources/lustre/lustre_alinux2.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/lustre/lustre_alinux2.rb
@@ -21,5 +21,5 @@ use 'partial/_mount_unmount'
 default_action :setup
 
 action :setup do
-  alinux_extras_topic 'lustre2.10'
+  alinux_extras_topic 'lustre'
 end

--- a/cookbooks/aws-parallelcluster-common/resources/lustre/lustre_centos7.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/lustre/lustre_centos7.rb
@@ -22,17 +22,17 @@ use 'partial/_install_lustre_centos_redhat'
 use 'partial/_mount_unmount'
 
 lustre_version_hash = {
-  '7.6' => "2.10.6",
+  '7.6' => "2.10.8",
   '7.5' => "2.10.5",
 }
 
 client_url_hash = {
-  '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/lustre-client-2.10.6-1.el7.x86_64.rpm",
+  '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.8/el7/client/RPMS/x86_64/lustre-client-2.10.8-1.el7.x86_64.rpm",
   '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/lustre-client-2.10.5-1.el7.x86_64.rpm",
 }
 
 kmod_url_hash = {
-  '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/kmod-lustre-client-2.10.6-1.el7.x86_64.rpm",
+  '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.8/el7/client/RPMS/x86_64/kmod-lustre-client-2.10.8-1.el7.x86_64.rpm",
   '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/kmod-lustre-client-2.10.5-1.el7.x86_64.rpm",
 }
 

--- a/test/resources/controls/aws_parallelcluster_install/lustre_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/lustre_spec.rb
@@ -1,6 +1,6 @@
 control 'lustre_client_installed' do
   title "Verify that lustre client is installed"
-
+  minimal_lustre_client_version = '2.12'
   if (os_properties.centos? && inspec.os.release.to_f >= 7.5) || os_properties.redhat?
     describe package('kmod-lustre-client') do
       it { should be_installed }
@@ -11,6 +11,14 @@ control 'lustre_client_installed' do
     end
 
     if (os_properties.centos? && inspec.os.release.to_f >= 7.7) || os_properties.redhat?
+      describe package('kmod-lustre-client') do
+        its('version') { should cmp >= minimal_lustre_client_version }
+      end
+
+      describe package('lustre-client') do
+        its('version') { should cmp >= minimal_lustre_client_version }
+      end
+
       describe yum.repo('aws-fsx') do
         it { should exist }
         it { should be_enabled }
@@ -27,20 +35,23 @@ control 'lustre_client_installed' do
 
     describe package('lustre-client-modules-aws') do
       it { should be_installed }
+      its('version') { should cmp >= minimal_lustre_client_version }
     end
 
     kernel_release = os_properties.ubuntu2004? ? '5.15.0-1028-aws' : '5.4.0-1092-aws'
     describe package("lustre-client-modules-#{kernel_release}") do
       it { should be_installed }
+      its('version') { should cmp >= minimal_lustre_client_version }
     end
   end
 
   if os_properties.alinux2?
     describe package('lustre-client') do
       it { should be_installed }
+      its('version') { should cmp >= minimal_lustre_client_version }
     end
 
-    describe yum.repo('amzn2extra-lustre2.10') do
+    describe yum.repo('amzn2extra-lustre') do
       it { should exist }
       it { should be_enabled }
     end


### PR DESCRIPTION
We have to create a custom mount helper to better accommodate parameters persistence across instance reboot and head node instance type update. lctl set_param commands have to be executed after the file systems are mounted and do not persist over instance reboot. The FSx document advises to use a boot cron job to set the parameter after reboot. However, a boot cron job is not compatible with our use case because FSx Lustre file systems are mounted upon first access instead of instance reboot (see code (https://github.com/aws/aws-parallelcluster-cookbook/blob/develop/cookbooks/aws-parallelcluster-config/resources/manage_fsx.rb#L60)). Therefore, we have to create a custom mount helper (see mount man page (https://linux.die.net/man/8/mount)):

Q: Are these operations affect the client FSx configuration or the server configuration? A: Client only.

Q: How it will work if a customer mounts FSx manually? A: If they use lustre as the mount type, the performance tuning will not be applied.

Q: How do customers know they will have to use the mount helper? A: They will have to read ParallelCluster official doc.

Signed-off-by: Hanwen <hanwenli@amazon.com>


### Tests
* TBD

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.