### PR TITLE
3.x Fix failure when missing cloudwatch in dna.json

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -11,6 +11,6 @@ head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
 head_node_hostname = <%= node['ec2']['local_hostname'] %>
 node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout'] %>
 insufficient_capacity_timeout = 600
-compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] %>
+compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] || true %>
 compute_console_logging_max_sample_size = <%=  node['cluster']['slurm_plugin_console_logging']['sample_size'] %>
 compute_console_wait_time = 300


### PR DESCRIPTION
### Description of changes
* If cw_logging_enabled is missing from dna.json, clustermgtd will fail to start due to an unparsable boolean value. This change provides a default value of true to the clustermgtd.conf template if the property is missing.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.