### PR TITLE
Allow running kitchen tests with default parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ aws-parallelcluster-cookbook-*.date
 __pycache__
 report.html
 /assets/style.css
+/.kitchen.env.sh

--- a/kitchen.ec2.sh
+++ b/kitchen.ec2.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Variables you can set in your local .kitchen.env.sh (not to be pushed)
+#
+# KITCHEN_AWS_REGION:         AWS region;
+#                             falls back to AWS_DEFAULT_REGION, then to eu-west-1
+#
+# KITCHEN_ARCHITECTURE:       [x86_64|arm64];
+#                             default x86_64
+#
+# KITCHEN_KEY_NAME:           KeyPair to use with EC2 instances
+#                             default kitchen
+#
+# KITCHEN_SUBNET_ID:          subnet-0c8a5dd6c753bec3f
+#                             if not set will use Subnet tagged with Kitchen=true
+#
+# KITCHEN_SECURITY_GROUP_ID:  sg-0ceecc41dfe5499a8
+#                             if not set will use SG tagged with Kitchen=true
+#
+# KITCHEN_SSH_KEY_PATH:       path to private key
+#                             default ~/.ssh/${key-name}-${region}.pem
+#
+# KITCHEN_PCLUSTER_VERSION:   ParallelCluster version to use
+#                             defaults to the latest one
+#
+# KITCHEN_ALINUX2_AMI:        specific AMI to use for alinux2
+#                             if not specified, will look for the latest suitable ParallelCluster AMI
+#
+# KITCHEN_REDHAT8_AMI:        specific AMI to use for redhat8
+#                             if not specified, will look for the latest suitable ParallelCluster AMI
+#
+# KITCHEN_CENTOS7_AMI:        specific AMI to use for centos7
+#                             if not specified, will look for the latest suitable ParallelCluster AMI
+#
+# KITCHEN_UBUNTU18_AMI:       specific AMI to use for ubuntu18.04
+#                             if not specified, will look for the latest suitable ParallelCluster AMI
+#
+# KITCHEN_UBUNTU20_AMI:       specific AMI to use for ubuntu20.04
+#                             if not specified, will look for the latest suitable ParallelCluster AMI
+#
+
+export KITCHEN_LOCAL_YAML="kitchen.$1.yml"; shift;
+export KITCHEN_YAML=kitchen.ec2.yml
+export KITCHEN_GLOBAL_YAML=kitchen.global.yml
+
+THIS_DIR=$(dirname "$0")
+if [ -e "${THIS_DIR}/.kitchen.env.sh" ]
+then
+  echo "*** Apply local environment"
+  source "${THIS_DIR}/.kitchen.env.sh"
+fi
+
+kitchen "$@"

--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -1,11 +1,29 @@
+<%
+  pcluster_version = ENV['KITCHEN_PCLUSTER_VERSION'] || '3.5.0'
+  pcluster_prefix = "aws-parallelcluster-#{pcluster_version}"
+  aws_region = ENV['KITCHEN_AWS_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'eu-west-1'
+  key_name = ENV['KITCHEN_KEY_NAME'] || 'kitchen'
+%>
 ---
 driver:
   name: ec2
-  aws_ssh_key_id: <%= ENV['KITCHEN_KEY_NAME'] %>
+  aws_ssh_key_id: <%= key_name %>
+  <% if ENV['KITCHEN_SECURITY_GROUP_ID'] %>
   security_group_ids: [ "<%= ENV['KITCHEN_SECURITY_GROUP_ID'] %>" ]
-  region: <%= ENV['KITCHEN_AWS_REGION'] %>
+  <% else %>
+  security_group_filter:
+    tag: 'Kitchen'
+    value: 'true'
+  <% end %>
+  region: <%= aws_region %>
   availability_zone: a
+  <% if ENV['KITCHEN_SUBNET_ID'] %>
   subnet_id: <%= ENV['KITCHEN_SUBNET_ID'] %>
+  <% else %>
+  subnet_filter:
+    tag: 'Kitchen'
+    value: 'true'
+  <% end %>
   # Disable IMDS v1
   metadata_options:
     http_tokens: 'required'
@@ -15,10 +33,12 @@ driver:
   instance_type: t2.micro
   associate_public_ip: true
   interface: public
-  transport:
-    ssh_key: <%= ENV['KITCHEN_SSH_KEY_PATH'] %>
   tags:
     Name: test-kitchen-parallelcluster
+
+transport:
+  ssh_key: <%= ENV['KITCHEN_SSH_KEY_PATH'] || "~/.ssh/#{key_name}-#{aws_region}.pem" %>
+  compression: true
 
 provisioner:
   name: chef_zero
@@ -36,36 +56,66 @@ provisioner:
 platforms:
   - name: alinux2
     driver_plugin: ec2
-    driver_config:
+    driver:
+      <% if ENV['KITCHEN_ALINUX2_AMI'] %>
       # Use the Amazon Linux 2 AMI most similar to the base AMI used to build the ParallelCluster image
       image_id: <%= ENV['KITCHEN_ALINUX2_AMI'] %>
+      <% else %>
+      image_search:
+        name: <%= pcluster_prefix %>-amzn2-hvm-*
+        architecture: <%= ENV['KITCHEN_ARCHITECTURE'] || 'x86_64' %>
+      <% end %>
     transport:
       username: ec2-user
   - name: redhat8
     driver_plugin: ec2
-    driver_config:
+    driver:
+      <% if ENV['KITCHEN_REDHAT8_AMI'] %>
       # Use the RedHat 8 AMI most similar to the base AMI used to build the ParallelCluster image
       image_id: <%= ENV['KITCHEN_REDHAT8_AMI'] %>
+      <% else %>
+      image_search:
+        name: "RHEL-8*"
+        architecture: <%= ENV['KITCHEN_ARCHITECTURE'] || 'x86_64' %>
+      <% end %>
     transport:
       username: ec2-user
   - name: centos7
     driver_plugin: ec2
-    driver_config:
+    driver:
+      <% if ENV['KITCHEN_CENTOS7_AMI'] %>
       # Use the CentOS 7 AMI most similar to the base AMI used to build the ParallelCluster image
       image_id: <%= ENV['KITCHEN_CENTOS7_AMI'] %>
+      <% else %>
+      image_search:
+        name: <%= pcluster_prefix %>-centos7-hvm-*
+        architecture: <%= ENV['KITCHEN_ARCHITECTURE'] || 'x86_64' %>
+      <% end %>
     transport:
       username: centos
   - name: ubuntu1804
     driver_plugin: ec2
-    driver_config:
+    driver:
+      <% if ENV['KITCHEN_UBUNTU18_AMI'] %>
       # Use the Ubuntu 18 AMI most similar to the base AMI used to build the ParallelCluster image
       image_id: <%= ENV['KITCHEN_UBUNTU18_AMI'] %>
+      <% else %>
+      image_search:
+        name: <%= pcluster_prefix %>-ubuntu-1804-lts-hvm-*
+        architecture: <%= ENV['KITCHEN_ARCHITECTURE'] || 'x86_64' %>
+      <% end %>
     transport:
       username: ubuntu
   - name: ubuntu2004
     driver_plugin: ec2
-    driver_config:
+    driver:
+      <% if ENV['KITCHEN_UBUNTU20_AMI'] %>
       # Use the Ubuntu 20 AMI most similar to the base AMI used to build the ParallelCluster image
       image_id: <%= ENV['KITCHEN_UBUNTU20_AMI'] %>
+      <% else %>
+      image_search:
+        name: <%= pcluster_prefix %>-ubuntu-2004-lts-hvm-*
+        architecture: <%= ENV['KITCHEN_ARCHITECTURE'] || 'x86_64' %>
+      <% end %>
     transport:
       username: ubuntu

--- a/util/bump-version.sh
+++ b/util/bump-version.sh
@@ -26,6 +26,8 @@ sed -i "s/default\['cluster'\]\['parallelcluster-cookbook-version'\] = '$CURRENT
 sed -i "s/default\['cluster'\]\['parallelcluster-node-version'\] = '${CURRENT_PCLUSTER_VERSION}'/default['cluster']['parallelcluster-node-version'] = '${NEW_PCLUSTER_VERSION}'/g" attributes/default.rb
 sed -i "s/version '${CURRENT_PCLUSTER_VERSION_SHORT}'/version '${NEW_PCLUSTER_VERSION_SHORT}'/g" metadata.rb
 
+sed -i "s/ENV\['KITCHEN_PCLUSTER_VERSION'\] || '${CURRENT_PCLUSTER_VERSION}'/ENV\['KITCHEN_PCLUSTER_VERSION'\] || '${NEW_PCLUSTER_VERSION}'/g" kitchen.ec2.yml
+
 # Update dependencies version in main cookbook metadata
 COOKBOOKS=("aws-parallelcluster-common" "aws-parallelcluster-awsbatch" "aws-parallelcluster-config" "aws-parallelcluster-install" "aws-parallelcluster-scheduler-plugin" "aws-parallelcluster-slurm" "aws-parallelcluster-test")
 for COOKBOOK in ${COOKBOOKS[*]}


### PR DESCRIPTION
### Description of changes
Allow running kitchen tests with default parameters.
* Defaults applied to `kitchen.ec2.yml`
* `kitchen.ec2.sh` allows to run kitchen tests on EC2 as follows:
  * `./kitchen.ec2.sh <context> <kitchen options>`
  * for instance:
    * `./kitchen.ec2.sh recipes list`
    * `./kitchen.ec2.sh recipes test ephemeral-drives-setup --parallel --concurrency 5 -l debug`

### Tests
* Used this code to test `ephemeral-drives-setup` on EC2 with and without environment variables set

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.