### PR TITLE
Several small fixes following nitpicks in previous PRs

### DIFF
--- a/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
@@ -5,6 +5,6 @@ def virtualized?
   node['virtualization']['system'] == 'docker'
 end
 
-def ubi?
+def redhat_ubi?
   virtualized? && platform?('redhat')
 end

--- a/cookbooks/aws-parallelcluster-install/recipes/ephemeral_drives.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/ephemeral_drives.rb
@@ -19,7 +19,7 @@
 cookbook_file 'setup-ephemeral-drives.sh' do
   source 'base/setup-ephemeral-drives.sh'
   path '/usr/local/sbin/setup-ephemeral-drives.sh'
-  user 'root'
+  owner 'root'
   group 'root'
   mode '0744'
 end

--- a/cookbooks/aws-parallelcluster-install/recipes/python.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/python.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # TODO: find a way to make this code work on ubi8
-return if ubi?
+return if redhat_ubi?
 
 install_pyenv node['cluster']['python-version'] do
   prefix node['cluster']['system_pyenv_root']

--- a/kitchen.docker.sh
+++ b/kitchen.docker.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Run tests as follows:
+# ./kitchen.docker.sh <context> <kitchen options>
+# where <context> is either recipes or resources.
+#
+# For instance:
+# ./kitchen.docker.sh recipes list
+# ./kitchen.docker.sh recipes test ephemeral-drives-setup -c 5 -l debug
+
 export KITCHEN_LOCAL_YAML="kitchen.$1.yml"; shift;
 export KITCHEN_YAML=kitchen.docker.yml
 export KITCHEN_GLOBAL_YAML=kitchen.global.yml

--- a/kitchen.ec2.sh
+++ b/kitchen.ec2.sh
@@ -39,6 +39,14 @@
 #                             if not specified, will look for the latest suitable ParallelCluster AMI
 #
 
+# Run tests as follows:
+# ./kitchen.ec2.sh <context> <kitchen options>
+# where <context> is either recipes or resources.
+#
+# For instance:
+# ./kitchen.ec2.sh recipes list
+# ./kitchen.ec2.sh recipes test ephemeral-drives-setup --parallel --concurrency 5 -l debug
+
 export KITCHEN_LOCAL_YAML="kitchen.$1.yml"; shift;
 export KITCHEN_YAML=kitchen.ec2.yml
 export KITCHEN_GLOBAL_YAML=kitchen.global.yml

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -40,8 +40,8 @@ suites:
       - recipe[aws-parallelcluster-install::ephemeral_drives]
     verifier:
       controls:
-        - 'Ephemeral drives script is copied to the target dir'
-        - 'Ephemeral service is set up to run ephemeral drives script'
+        - 'ephemeral_drives_script_created'
+        - 'ephemeral_service_set_up'
 
   - name: python_setup
     run_list:

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -40,8 +40,8 @@ suites:
       - recipe[aws-parallelcluster-install::ephemeral_drives]
     verifier:
       controls:
-        - 'ephemeral_drives_script_created'
-        - 'ephemeral_service_set_up'
+        - ephemeral_drives_script_created
+        - ephemeral_service_set_up
 
   - name: python_setup
     run_list:
@@ -49,7 +49,7 @@ suites:
       - recipe[aws-parallelcluster-install::python]
     verifier:
       controls:
-        - 'awsbatch_virtualenv_installed'
-        - 'cookbook_virtualenv_installed'
-        - 'node_virtualenv_installed'
-        - 'cfnbootstrap_virtualenv_installed'
+        - awsbatch_virtualenv_created
+        - cookbook_virtualenv_created
+        - node_virtualenv_created
+        - cfnbootstrap_virtualenv_created

--- a/test/recipes/controls/aws_parallelcluster_install/ephemeral_drives_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/ephemeral_drives_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'Ephemeral drives script is copied to the target dir' do
+control 'ephemeral_drives_script_created' do
   title 'Ephemeral drives script is copied to the target dir'
 
   describe file('/usr/local/sbin/setup-ephemeral-drives.sh') do
@@ -21,7 +21,7 @@ control 'Ephemeral drives script is copied to the target dir' do
   end
 end
 
-control 'Ephemeral service is set up to run ephemeral drives script' do
+control 'ephemeral_service_set_up' do
   title 'Ephemeral service is set up to run ephemeral drives script'
 
   describe file('/etc/systemd/system/setup-ephemeral.service') do

--- a/test/recipes/controls/aws_parallelcluster_install/python_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/python_spec.rb
@@ -14,8 +14,8 @@ cfn_python_version = '3.7.16'
 base_dir = "/opt/parallelcluster"
 pyenv_dir = "#{base_dir}/pyenv"
 
-control 'awsbatch_virtualenv_installed' do
-  title "awsbatch virtualenv should be installed on #{python_version}"
+control 'awsbatch_virtualenv_created' do
+  title "awsbatch virtualenv should be created on #{python_version}"
 
   return if virtualization.system == 'docker' && os.name == 'redhat'
 
@@ -27,8 +27,8 @@ control 'awsbatch_virtualenv_installed' do
   end
 end
 
-control 'cookbook_virtualenv_installed' do
-  title "cookbook virtualenv should be installed on #{python_version}"
+control 'cookbook_virtualenv_created' do
+  title "cookbook virtualenv should be created on #{python_version}"
 
   return if virtualization.system == 'docker' && os.name == 'redhat'
 
@@ -40,8 +40,8 @@ control 'cookbook_virtualenv_installed' do
   end
 end
 
-control 'node_virtualenv_installed' do
-  title "node virtualenv should be installed on #{python_version}"
+control 'node_virtualenv_created' do
+  title "node virtualenv should be created on #{python_version}"
 
   return if virtualization.system == 'docker' && os.name == 'redhat'
 
@@ -53,8 +53,8 @@ control 'node_virtualenv_installed' do
   end
 end
 
-control 'cfnbootstrap_virtualenv_installed' do
-  title "cfnbootstrap virtualenv should be installed on #{cfn_python_version}"
+control 'cfnbootstrap_virtualenv_created' do
+  title "cfnbootstrap virtualenv should be created on #{cfn_python_version}"
 
   return if virtualization.system == 'docker' && os.name == 'redhat'
 


### PR DESCRIPTION
### Description of changes
* Comments added to `kitchen.docker.sh` and `kitchen.ec2.sh` as requested [here](https://github.com/aws/aws-parallelcluster-cookbook/pull/1667#discussion_r1084976629)
* `user` property replaced by `owner` as requested [here](https://github.com/aws/aws-parallelcluster-cookbook/pull/1665#discussion_r1084187525)
* control names with blanks replaces by snake case names following team's decision
* control names fixed for `python_setup` suite as requested [here](https://github.com/aws/aws-parallelcluster-cookbook/pull/1668#discussion_r1085350549)
* function name `ubi?` changed to `redhat_ubi?` as requested [here](https://github.com/aws/aws-parallelcluster-cookbook/pull/1668#discussion_r1085361084)

### Tests
* existing tests run on Docker in order to avoid regressions

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.