### PR TITLE
Add resource install_packages compatible with RedHat8

### DIFF
--- a/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
@@ -4,7 +4,7 @@ return unless platform?('amazon') && node['platform_version'] == "2"
 
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                          libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
-                                         httpd boost-devel system-lsb mlocate atlas-devel glibc-static iproute
+                                         httpd boost-devel system-lsb mlocate lvm2 atlas-devel glibc-static iproute
                                          libffi-devel dkms mysql-devel libedit-devel postgresql-devel postgresql-server
                                          sendmail cmake byacc libglvnd-devel mdadm libgcrypt-devel libevent-devel
                                          libxml2-devel perl-devel tar gzip bison flex gcc gcc-c++ patch
@@ -18,6 +18,6 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
 default['cluster']['extra_packages'] = ['R3.4']
 
 default['cluster']['kernel_devel_pkg']['name'] = "kernel-devel"
-default['cluster']['kernel_devel_pkg']['version'] = node['kernel']['release'].chomp('.x86_64').chomp('.aarch64')
+default['cluster']['kernel_devel_pkg']['version'] = node['kernel']['release']
 
 default['cluster']['chrony']['conf'] = "/etc/chrony.conf"

--- a/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
@@ -5,7 +5,7 @@ return unless platform?('centos') && node['platform_version'].to_i == 7
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                          libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
                                          httpd boost-devel redhat-lsb mlocate lvm2 R atlas-devel
-                                         blas-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
+                                         blas-devel libffi-devel dkms mariadb-devel libedit-devel
                                          libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                          mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
                                          iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
@@ -18,7 +18,6 @@ if node['kernel']['machine'] == 'aarch64'
 end
 
 default['cluster']['kernel_devel_pkg']['name'] = "kernel-devel"
-# TODO: Evaluate to move the chomps where the attribute is used.
-default['cluster']['kernel_devel_pkg']['version'] = node['kernel']['release'].chomp('.x86_64').chomp('.aarch64')
+default['cluster']['kernel_devel_pkg']['version'] = node['kernel']['release']
 
 default['cluster']['chrony']['conf'] = "/etc/chrony.conf"

--- a/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
@@ -2,14 +2,11 @@
 
 return unless platform?('redhat') && node['platform_version'].to_i == 8
 
-default['cluster']['kernel_devel_pkg']['name'] = "kernel-devel"
-default['cluster']['kernel_devel_pkg']['version'] = node['kernel']['release'].chomp('.x86_64').chomp('.aarch64')
-
 # Removed libssh2-devel from base_packages since is not shipped by RedHat 8 and in conflict with package libssh-0.9.6-3.el8.x86_64
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                              libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
                                              httpd boost-devel redhat-lsb mlocate lvm2 R atlas-devel
-                                             blas-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
+                                             blas-devel libffi-devel dkms mariadb-devel libedit-devel
                                              libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                              mdadm python2 python2-pip libgcrypt-devel libevent-devel glibc-static bind-utils
                                              iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
@@ -19,6 +16,6 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
 default['cluster']['extra_repos'] = 'codeready-builder-for-rhel-8-rhui-rpms'
 
 default['cluster']['kernel_devel_pkg']['name'] = "kernel-devel"
-default['cluster']['kernel_devel_pkg']['version'] = node['kernel']['release'].chomp('.x86_64').chomp('.aarch64')
+default['cluster']['kernel_devel_pkg']['version'] = node['kernel']['release']
 
 default['cluster']['chrony']['conf'] = "/etc/chrony.conf"

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
@@ -4,8 +4,8 @@ return unless platform?('ubuntu') && node['platform_version'] == "18.04"
 
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-tools libhwloc-dev dkms
                                          tcl-dev automake autoconf libtool librrd-dev libapr1-dev libconfuse-dev
-                                         apache2 libboost-dev libdb-dev tcsh libncurses5-dev libpam0g-dev libxt-dev
-                                         libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 python
+                                         apache2 libboost-dev libdb-dev libncurses5-dev libpam0g-dev libxt-dev
+                                         libmotif-dev libxmu-dev libxft-dev man-db lvm2 python
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
                                          libgcrypt20-dev libmysqlclient-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
@@ -4,8 +4,8 @@ return unless platform?('ubuntu') && node['platform_version'] == "20.04"
 
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-tools libhwloc-dev dkms
                                          tcl-dev automake autoconf libtool librrd-dev libapr1-dev libconfuse-dev
-                                         apache2 libboost-dev libdb-dev tcsh libncurses5-dev libpam0g-dev libxt-dev
-                                         libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 python
+                                         apache2 libboost-dev libdb-dev libncurses5-dev libpam0g-dev libxt-dev
+                                         libmotif-dev libxmu-dev libxft-dev man-db lvm2 python
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
                                          libgcrypt20-dev libmysqlclient-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -22,39 +22,12 @@ include_recipe "aws-parallelcluster-install::disable_services" unless virtualize
 
 package_repos 'setup the repositories'
 
-# In the case of AL2, there are more packages to install via extras
-if platform_family?('amazon')
-  node['cluster']['extra_packages']&.each do |topic|
-    alinux_extras_topic topic
-  end
-end
-
 include_recipe "aws-parallelcluster-install::directories"
 
 build_essential
 include_recipe "aws-parallelcluster-install::python"
 
-# Install lots of packages
-
-package node['cluster']['base_packages'] do
-  retries 10
-  retry_delay 5
-  flush_cache({ before: true }) if platform_family?('rhel', 'amazon')
-end
-
-unless virtualized?
-  package "install kernel packages" do
-    case node['platform_family']
-    when 'rhel', 'amazon'
-      package_name node['cluster']['kernel_devel_pkg']['name']
-      version node['cluster']['kernel_devel_pkg']['version']
-    when 'debian'
-      package_name node['cluster']['kernel_headers_pkg']
-    end
-    retries 3
-    retry_delay 5
-  end
-end
+install_packages 'Install OS and extra packages'
 
 bash "install awscli" do
   cwd Chef::Config[:file_cache_path]

--- a/cookbooks/aws-parallelcluster-install/resources/install_packages/install_packages_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/install_packages/install_packages_amazon2.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :install_packages, platform: 'amazon', platform_version: '2'
+unified_mode true
+default_action :setup
+
+use 'partial/_install_packages_rhel_amazon.rb'
+
+action :setup do
+  action_install_base_packages
+  action_install_kernel_source unless virtualized?
+
+  # In the case of AL2, there are more packages to install via extras
+  node['cluster']['extra_packages']&.each do |topic|
+    alinux_extras_topic topic
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/install_packages/install_packages_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/install_packages/install_packages_centos7.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :install_packages, platform: 'centos' do |node|
+  node['platform_version'].to_i == 7
+end
+unified_mode true
+default_action :setup
+
+use 'partial/_install_packages_rhel_amazon.rb'
+
+action :setup do
+  action_install_base_packages
+  action_install_kernel_source unless virtualized?
+end

--- a/cookbooks/aws-parallelcluster-install/resources/install_packages/install_packages_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/install_packages/install_packages_redhat8.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :install_packages, platform: 'redhat' do |node|
+  node['platform_version'].to_i == 8
+end
+unified_mode true
+default_action :setup
+
+use 'partial/_install_packages_rhel_amazon.rb'
+
+action :setup do
+  action_install_base_packages unless virtualized?
+  action_install_kernel_source unless virtualized?
+end

--- a/cookbooks/aws-parallelcluster-install/resources/install_packages/install_packages_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/install_packages/install_packages_ubuntu18.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :install_packages, platform: 'ubuntu', platform_version: '18.04'
+unified_mode true
+default_action :setup
+
+use 'partial/_install_packages_debian.rb'
+
+action :setup do
+  action_install_base_packages
+  action_install_kernel_source unless virtualized?
+end

--- a/cookbooks/aws-parallelcluster-install/resources/install_packages/install_packages_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/install_packages/install_packages_ubuntu20.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :install_packages, platform: 'ubuntu', platform_version: '20.04'
+unified_mode true
+default_action :setup
+
+use 'partial/_install_packages_debian.rb'
+
+action :setup do
+  action_install_base_packages
+  action_install_kernel_source unless virtualized?
+end

--- a/cookbooks/aws-parallelcluster-install/resources/install_packages/partial/_install_packages_debian.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/install_packages/partial/_install_packages_debian.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+action :install_base_packages do
+  package node['cluster']['base_packages'] do
+    retries 10
+    retry_delay 5
+  end
+end
+
+action :install_kernel_source do
+  package "install kernel packages" do
+    package_name node['cluster']['kernel_headers_pkg']
+    retries 3
+    retry_delay 5
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/install_packages/partial/_install_packages_rhel_amazon.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/install_packages/partial/_install_packages_rhel_amazon.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+action :install_base_packages do
+  package node['cluster']['base_packages'] do
+    retries 10
+    retry_delay 5
+    flush_cache({ before: true })
+  end
+end
+
+action :install_kernel_source do
+  package "install kernel packages" do
+    package_name node['cluster']['kernel_devel_pkg']['name']
+    version node['cluster']['kernel_devel_pkg']['version'].chomp('.x86_64').chomp('.aarch64')
+    retries 3
+    retry_delay 5
+  end
+end

--- a/test/common/libraries/os_properties.rb
+++ b/test/common/libraries/os_properties.rb
@@ -18,4 +18,8 @@ class OsProperties < Inspec.resource(1)
   def redhat_ubi?
     docker? && inspec.os.name == 'redhat'
   end
+
+  def alinux2?
+    inspec.os.name == 'amazon' && inspec.os.release.to_i == 2
+  end
 end

--- a/test/resources/controls/aws_parallelcluster_install/install_packages_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/install_packages_spec.rb
@@ -1,0 +1,46 @@
+# Use the name matching the resource type
+control 'install_packages' do
+  title 'Test installation of packages'
+
+  only_if { !os_properties.redhat_ubi? }
+
+  describe package('lvm2') do
+    it { should be_installed }
+  end
+
+  if os.redhat? # redhat includes amazon
+
+    describe package('glibc-static') do
+      it { should be_installed }
+    end
+
+    describe package('kernel-devel') do
+      it { should be_installed }
+    end unless os_properties.docker?
+
+    # Check amazon linux2 extra
+    if os_properties.alinux2?
+      describe package('R-core') do
+        it { should be_installed }
+      end
+    end
+
+  elsif os.debian?
+
+    describe package('libssl-dev') do
+      it { should be_installed }
+    end
+
+    describe bash('dpkg -l | grep linux-headers') do
+      its('exit_status') { should eq 0 }
+    end unless os_properties.docker?
+
+  else
+    describe "unsupported OS" do
+      # this produces a skipped control (ignore-like)
+      # adding a new OS to kitchen platform list and running the tests,
+      # it would surface the fact this recipe does not support this OS.
+      pending "support for #{os.name}-#{os.release} needs to be implemented"
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
* Created new resource to install packages bases on the OS
* The resource is responsible fro:
  * Install the OS base packages
  * Install the kernel sources
  * Install extra OS packages
  * In case of RedHat 8 the package `libssh2-devel` has not been added to the list of base_packages since it was conflicting with the installed packages, and it seems not to be relevant for slurm version 22.05.

Minor change:
* Removed duplicate packages in packages list.
* Moved `.chomp('.x86_64').chomp('.aarch64')`.

### Tests
* Local Docker testing
* Remote ec2 testing

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.