### PR TITLE
Create custom resource os_properties to expose common os properties used in tests

### DIFF
--- a/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
@@ -1,10 +1,10 @@
 #
 # Check if we are running in a virtualized environment
 #
-def virtualized?
+def docker?
   node['virtualization']['system'] == 'docker'
 end
 
 def redhat_ubi?
-  virtualized? && platform?('redhat')
+  docker? && platform?('redhat')
 end

--- a/test/common/inspec.yml
+++ b/test/common/inspec.yml
@@ -1,0 +1,5 @@
+---
+name: common parts
+title: Common testing parts
+maintainer: aws-parallelcluster
+license: Apache-2.0

--- a/test/common/libraries/os_properties.rb
+++ b/test/common/libraries/os_properties.rb
@@ -1,0 +1,21 @@
+#
+# Check if we are running in a virtualized environment
+#
+class OsProperties < Inspec.resource(1)
+  name 'os_properties'
+
+  desc '
+    Properties of an OS
+  '
+  example '
+    os_properties.redhat_ubi?
+  '
+
+  def docker?
+    inspec.virtualization.system == 'docker'
+  end
+
+  def redhat_ubi?
+    docker? && inspec.os.name == 'redhat'
+  end
+end

--- a/test/recipes/controls/aws_parallelcluster_install/python_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/python_spec.rb
@@ -16,8 +16,7 @@ pyenv_dir = "#{base_dir}/pyenv"
 
 control 'awsbatch_virtualenv_created' do
   title "awsbatch virtualenv should be created on #{python_version}"
-
-  return if virtualization.system == 'docker' && os.name == 'redhat'
+  only_if { !os_properties.redhat_ubi? }
 
   describe directory("#{pyenv_dir}/versions/#{python_version}/envs/awsbatch_virtualenv") do
     it { should exist }
@@ -29,8 +28,7 @@ end
 
 control 'cookbook_virtualenv_created' do
   title "cookbook virtualenv should be created on #{python_version}"
-
-  return if virtualization.system == 'docker' && os.name == 'redhat'
+  only_if { !os_properties.redhat_ubi? }
 
   describe directory("#{pyenv_dir}/versions/#{python_version}/envs/cookbook_virtualenv") do
     it { should exist }
@@ -42,8 +40,7 @@ end
 
 control 'node_virtualenv_created' do
   title "node virtualenv should be created on #{python_version}"
-
-  return if virtualization.system == 'docker' && os.name == 'redhat'
+  only_if { !os_properties.redhat_ubi? }
 
   describe directory("#{pyenv_dir}/versions/#{python_version}/envs/cookbook_virtualenv") do
     it { should exist }
@@ -55,8 +52,7 @@ end
 
 control 'cfnbootstrap_virtualenv_created' do
   title "cfnbootstrap virtualenv should be created on #{cfn_python_version}"
-
-  return if virtualization.system == 'docker' && os.name == 'redhat'
+  only_if { !os_properties.redhat_ubi? }
 
   describe directory("#{pyenv_dir}/versions/#{cfn_python_version}/envs/cfn_bootstrap_virtualenv") do
     it { should exist }

--- a/test/recipes/inspec.yml
+++ b/test/recipes/inspec.yml
@@ -3,3 +3,7 @@ name: recipes unit tests
 title: Recipes unit test
 maintainer: aws-parallelcluster
 license: Apache-2.0
+
+depends:
+  - name: common
+    path: test/common

--- a/test/resources/inspec.yml
+++ b/test/resources/inspec.yml
@@ -3,3 +3,7 @@ name: resources unit tests
 title: Resources unit test
 maintainer: aws-parallelcluster
 license: Apache-2.0
+
+depends:
+  - name: common
+    path: test/common


### PR DESCRIPTION
### Description of changes
We need common checks in our tests: do they run on docker? Do they run on UBI?
This PR creates `os_properties` custom resource which can be used to perform these checks.

### Tests
* Existing tests run on docker and EC2

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.