### PR TITLE
Remove mysql and mariadb libraries from base packages on all OSs

### DIFF
--- a/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
@@ -5,7 +5,7 @@ return unless platform?('amazon') && node['platform_version'] == "2"
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                          libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
                                          httpd boost-devel system-lsb mlocate lvm2 atlas-devel glibc-static iproute
-                                         libffi-devel dkms mysql-devel libedit-devel postgresql-devel postgresql-server
+                                         libffi-devel dkms libedit-devel postgresql-devel postgresql-server
                                          sendmail cmake byacc libglvnd-devel mdadm libgcrypt-devel libevent-devel
                                          libxml2-devel perl-devel tar gzip bison flex gcc gcc-c++ patch
                                          rpm-build rpm-sign system-rpm-config cscope ctags diffstat doxygen elfutils

--- a/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
@@ -5,7 +5,7 @@ return unless platform?('centos') && node['platform_version'].to_i == 7
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                          libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
                                          httpd boost-devel redhat-lsb mlocate lvm2 R atlas-devel
-                                         blas-devel libffi-devel dkms mariadb-devel libedit-devel
+                                         blas-devel libffi-devel dkms libedit-devel
                                          libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                          mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
                                          iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock

--- a/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
@@ -6,7 +6,7 @@ return unless platform?('redhat') && node['platform_version'].to_i == 8
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                              libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
                                              httpd boost-devel redhat-lsb mlocate lvm2 R atlas-devel
-                                             blas-devel libffi-devel dkms mariadb-devel libedit-devel
+                                             blas-devel libffi-devel dkms libedit-devel
                                              libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                              mdadm python2 python2-pip libgcrypt-devel libevent-devel glibc-static bind-utils
                                              iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
@@ -7,7 +7,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev
                                          apache2 libboost-dev libdb-dev libncurses5-dev libpam0g-dev libxt-dev
                                          libmotif-dev libxmu-dev libxft-dev man-db lvm2 python
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
-                                         libgcrypt20-dev libmysqlclient-dev libevent-dev iproute2 python3 python3-pip
+                                         libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
                                          coreutils moreutils sssd sssd-tools sssd-ldap curl python-pip python-parted)
 

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
@@ -7,7 +7,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev
                                          apache2 libboost-dev libdb-dev libncurses5-dev libpam0g-dev libxt-dev
                                          libmotif-dev libxmu-dev libxft-dev man-db lvm2 python
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
-                                         libgcrypt20-dev libmysqlclient-dev libevent-dev iproute2 python3 python3-pip
+                                         libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
                                          coreutils moreutils sssd sssd-tools sssd-ldap curl python3-parted)
 


### PR DESCRIPTION
### Description of changes
* Remove mysql and mariadb libraries from base packages on all OSs.

### Tests
* To be tested directly in pipeline.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.