### PR TITLE
Remove mysql and mariadb devel packages from system tests dockerfiles

### DIFF
--- a/system_tests/Dockerfile.centos7
+++ b/system_tests/Dockerfile.centos7
@@ -24,7 +24,7 @@ RUN yum install -y vim ksh tcsh zsh libssl-dev net-tools \
                sudo pam-devel openmotif-dev libXmu-devel \
                hwloc-devel libdb-devel tcl-devel httpd   \
                boost-devel redhat-lsb mlocate R atlas-devel \
-               blas-devel mariadb-devel libedit-devel    \
+               blas-devel libedit-devel                  \
                libical-devel postgresql-devel            \
                postgresql-server sendmail libxml2-devel  \
                libglvnd-devel yum-plugin-versionlock     \

--- a/system_tests/Dockerfile.ubuntu
+++ b/system_tests/Dockerfile.ubuntu
@@ -13,7 +13,7 @@ RUN apt-get -y install vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-to
                libapr1-dev libconfuse-dev apache2 libboost-dev libdb-dev tcsh       \
                libncurses5-dev libpam0g-dev libxt-dev libmotif-dev libxmu-dev       \
                libxft-dev libhwloc-dev man-db lvm2 python r-base libblas-dev        \
-               libffi-dev libxml2-dev mdadm libgcrypt20-dev libmysqlclient-dev      \
+               libffi-dev libxml2-dev mdadm libgcrypt20-dev                         \
                libevent-dev iproute2 python3 python3-pip libatlas-base-dev          \
                libglvnd-dev linux-headers-aws iptables libcurl4-openssl-dev         \
                python3-parted


### PR DESCRIPTION
### Description of changes
* Remove mysql and mariadb devel packages from system tests dockerfiles.
  * These packages were removed from the base packages in the cookbook recipes, so we must remove them from the dockerfiles for the system tests github actions.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1680

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.