### PR TITLE
Add tests for node_attributes and install_packages

### DIFF
--- a/cookbooks/aws-parallelcluster-install/recipes/test_resources.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/test_resources.rb
@@ -7,4 +7,6 @@
 #   action :default_action
 # end
 
-declare_resource(node['resource'].to_sym, 'test')
+node['resources'].each do |resource|
+  declare_resource(resource.to_sym, 'test')
+end

--- a/cookbooks/aws-parallelcluster-install/resources/node_attributes/node_attributes.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/node_attributes/node_attributes.rb
@@ -17,6 +17,7 @@ unified_mode true
 default_action :generate_json
 
 action :generate_json do
+  return unless Chef::File.directory?('/etc/chef/')
   json_content = Chef::JSONCompat.to_json_pretty(node)
   file "/etc/chef/node_attributes.json" do
     content "#{json_content}"

--- a/kitchen.resources.yml
+++ b/kitchen.resources.yml
@@ -16,43 +16,60 @@ suites:
 # This is the result of the ERB block below
 #  - name: package_repos
 #    run_list:
-#      - recipe[aws-parallelcluster::test_resource]
+#      - recipe[aws-parallelcluster::test_resources]
 #    verifier:
 #      controls:
 #        - package_repos
 #    attributes:
 #      cluster:
 #        base_os: alinux2
-#      resource: package_repos
+#      resource:
+#        - package_repos
 
 <% [
   'package_repos',
   'nfs',
+  'node_attributes',
   ].each do |resource| %>
   - name: <%= resource %>
     run_list:
       # This is a test recipe executing the default action of the resource you pass as `resource` attribute,
       # with default properties
-      - recipe[aws-parallelcluster::test_resource]
+      - recipe[aws-parallelcluster::test_resources]
     verifier:
       controls:
         - <%= resource %>
     attributes:
-      resource: <%= resource %>
+      resources:
+        - <%= resource %>
 <%end %>
-  - name: ec2_udev_rules
+  - name: install_packages
     run_list:
       # This is a test recipe executing the default action of the resource you pass as `resource` attribute,
       # with default properties
-      - recipe[aws-parallelcluster-install::test_resource]
+      - recipe[aws-parallelcluster::test_resources]
+    verifier:
+      controls:
+        - package_repos
+        - install_packages
+    attributes:
+      resources:
+        - package_repos
+        - install_packages
+  - name: ec2_udev_rules
+    run_list:
+      # This is a test recipe executing the default action of the resource you pass as `resources` attribute array,
+      # with default properties
+      - recipe[aws-parallelcluster-install::test_resources]
     verifier:
       controls:
         - write_common_udev_configuration_files
         - ec2blkdev_service_installation
         - debian_udevd_reload_configuration
     attributes:
-      resource: ec2_udev_rules
+      resources:
+        - ec2_udev_rules
 
 # If you need to test a resource with an action or properties different from the default ones,
-# add custom tests here and adjust `aws-parallelcluster-test::test_resource`
+# add custom tests here and adjust `aws-parallelcluster::test_resources`
 # to allow `action` and/or `properties` parameters.

--- a/recipes/test_resources.rb
+++ b/recipes/test_resources.rb
@@ -7,4 +7,6 @@
 #   action :default_action
 # end
 
-declare_resource(node['resource'].to_sym, 'test')
+node['resources'].each do |resource|
+  declare_resource(resource.to_sym, 'test')
+end

--- a/test/resources/controls/aws_parallelcluster_install/node_attributes_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/node_attributes_spec.rb
@@ -1,10 +1,12 @@
 control 'node_attributes' do
   title 'Test the generation of the node attributes json file'
 
-  describe file('/etc/chef/node_attributes.json') do
-    it { should exist }
-    its('content') { should match(/^    "cluster": \{$/) }
-    # its('content_as_json') { should include('cluster') }
-    # its('content_as_json') { should include('cluster' => { 'base_dir' => '/opt/parallelcluster' }) }
+  if File.directory?('/etc/chef/')
+    describe file('/etc/chef/node_attributes.json') do
+      it { should exist }
+      its('content') { should match(/^    "cluster": \{$/) }
+      # its('content_as_json') { should include('cluster') }
+      # its('content_as_json') { should include('cluster' => { 'base_dir' => '/opt/parallelcluster' }) }
+    end
   end
 end


### PR DESCRIPTION
### Description of changes
* Added missing resources tests
* Modified the test_resource to allow multiple resources in case of dependancies:
  * For example `install_packages` depends on `package_repos`

### Tests
* Tests for `node_attributes` worked locally [kitchen node_attributes.log](https://github.com/aws/aws-parallelcluster-cookbook/files/10511156/kitchen.node_attributes.log)
* Tests for `install_packages` worked locally [kitchen install_packages.log](https://github.com/aws/aws-parallelcluster-cookbook/files/10511155/kitchen.install_packages.log)

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.