### PR TITLE
Add DebugFlags=Power to slurm.conf

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -69,6 +69,7 @@ SlurmctldDebug=info
 SlurmctldLogFile=/var/log/slurmctld.log
 SlurmdDebug=info
 SlurmdLogFile=/var/log/slurmd.log
+DebugFlags=Power
 JobCompType=jobcomp/none
 #
 # WARNING!!! The slurm_parallelcluster.conf file included below can be updated by the pcluster process.


### PR DESCRIPTION
This setting enable plugin-specific logging messages, they don't pollute the logs but these messages are useful to debug scaling issues.

### Tests
* TODO

