### PR TITLE
3.4: Remove mysql and mariadb libraries from base packages and permit downgrades

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -460,7 +460,7 @@ when 'rhel', 'amazon'
     default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                              libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
                                              httpd boost-devel redhat-lsb mlocate lvm2 R atlas-devel
-                                             blas-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
+                                             blas-devel libffi-devel openssl-devel dkms libedit-devel
                                              libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                              mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
                                              iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
@@ -476,7 +476,7 @@ when 'rhel', 'amazon'
     default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                              libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
                                              httpd boost-devel system-lsb mlocate atlas-devel glibc-static iproute
-                                             libffi-devel dkms mysql-devel libedit-devel postgresql-devel postgresql-server
+                                             libffi-devel dkms libedit-devel postgresql-devel postgresql-server
                                              sendmail cmake byacc libglvnd-devel mdadm libgcrypt-devel libevent-devel
                                              libxml2-devel perl-devel tar gzip bison flex gcc gcc-c++ patch
                                              rpm-build rpm-sign system-rpm-config cscope ctags diffstat doxygen elfutils
@@ -499,7 +499,7 @@ when 'debian'
                                            apache2 libboost-dev libdb-dev tcsh libncurses5-dev libpam0g-dev libxt-dev
                                            libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 python
                                            r-base libblas-dev libffi-dev libxml2-dev mdadm
-                                           libgcrypt20-dev libmysqlclient-dev libevent-dev iproute2 python3 python3-pip
+                                           libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                            libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
                                            coreutils moreutils sssd sssd-tools sssd-ldap curl)
 

--- a/cookbooks/aws-parallelcluster-install/recipes/install_mysql_client.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/install_mysql_client.rb
@@ -24,7 +24,7 @@ else
 
   package_installer = value_for_platform(
     'default' => "yum install -y",
-    'ubuntu' => { 'default' => "apt install -y" }
+    'ubuntu' => { 'default' => "apt install -y --allow-downgrades" }
   )
 
   mysql_archive_url = node['cluster']['mysql']['package']['archive']

--- a/system_tests/Dockerfile.centos7
+++ b/system_tests/Dockerfile.centos7
@@ -24,7 +24,7 @@ RUN yum install -y vim ksh tcsh zsh libssl-dev net-tools \
                sudo pam-devel openmotif-dev libXmu-devel \
                hwloc-devel libdb-devel tcl-devel httpd   \
                boost-devel redhat-lsb mlocate R atlas-devel \
-               blas-devel mariadb-devel libedit-devel    \
+               blas-devel libedit-devel    \
                libical-devel postgresql-devel            \
                postgresql-server sendmail libxml2-devel  \
                libglvnd-devel yum-plugin-versionlock     \

--- a/system_tests/Dockerfile.ubuntu
+++ b/system_tests/Dockerfile.ubuntu
@@ -13,7 +13,7 @@ RUN apt-get -y install vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-to
                libapr1-dev libconfuse-dev apache2 libboost-dev libdb-dev tcsh       \
                libncurses5-dev libpam0g-dev libxt-dev libmotif-dev libxmu-dev       \
                libxft-dev libhwloc-dev man-db lvm2 python r-base libblas-dev        \
-               libffi-dev libxml2-dev mdadm libgcrypt20-dev libmysqlclient-dev      \
+               libffi-dev libxml2-dev mdadm libgcrypt20-dev      \
                libevent-dev iproute2 python3 python3-pip libatlas-base-dev          \
                libglvnd-dev linux-headers-aws iptables libcurl4-openssl-dev         \
                python3-parted


### PR DESCRIPTION
### Description of changes
mysql and mariadb packages are installed by the install_mysql_client.rb recipe. 
We don't need them in the base packages list.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1680
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1684

