### PR TITLE
Add environment-modules package because intel_mpi recipe relies on it

### DIFF
--- a/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
@@ -12,7 +12,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                          gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl
                                          jq wget python-pip NetworkManager-config-routing-rules libibverbs-utils
                                          librdmacm-utils python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                         coreutils moreutils sssd sssd-tools sssd-ldap)
+                                         coreutils moreutils sssd sssd-tools sssd-ldap environment-modules)
 
 # Install R via amazon linux extras
 default['cluster']['extra_packages'] = ['R3.4']

--- a/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
@@ -9,7 +9,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                          libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                          mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
                                          iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                         coreutils moreutils sssd sssd-tools sssd-ldap curl)
+                                         coreutils moreutils sssd sssd-tools sssd-ldap curl environment-modules)
 
 # TODO: check if it is still relevant. Evaluate if it is worth to remove the package.
 if node['kernel']['machine'] == 'aarch64'

--- a/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
@@ -10,7 +10,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                              libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                              mdadm python2 python2-pip libgcrypt-devel libevent-devel glibc-static bind-utils
                                              iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                             coreutils moreutils sssd sssd-tools sssd-ldap curl)
+                                             coreutils moreutils sssd sssd-tools sssd-ldap curl environment-modules)
 
 # Needed by hwloc-devel blas-devel libedit-devel and glibc-static packages
 default['cluster']['extra_repos'] = 'codeready-builder-for-rhel-8-rhui-rpms'

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
@@ -9,7 +9,8 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
                                          libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
-                                         coreutils moreutils sssd sssd-tools sssd-ldap curl python-pip python-parted)
+                                         coreutils moreutils sssd sssd-tools sssd-ldap curl
+                                         python-pip python-parted environment-modules)
 
 default['cluster']['kernel_headers_pkg'] = "linux-headers-#{node['kernel']['release']}"
 

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
@@ -9,7 +9,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
                                          libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
-                                         coreutils moreutils sssd sssd-tools sssd-ldap curl python3-parted)
+                                         coreutils moreutils sssd sssd-tools sssd-ldap curl python3-parted environment-modules)
 
 default['cluster']['kernel_headers_pkg'] = "linux-headers-#{node['kernel']['release']}"
 


### PR DESCRIPTION
### Description of changes
* Add environment-modules package because intel_mpi recipe relies on it

### Test
* Test with kitchen in EC2

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.