### PR TITLE
Remove OnOndeStart and OnNodeConfigured scripts url from showing up in CFN failure reason

### DIFF
--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -23,38 +23,29 @@ function error_exit () {
   logger -t parallelcluster "${script} - $1"
   case $custom_script in
     OnNodeStart|OnNodeConfigured)
-      echo "$1 Please check /var/log/cfn-init.log in the head node, or check the cfn-init.log in CloudWatch logs. Please refer to https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html#troubleshooting-v3-get-logs for more details on ParallelCluster logs." > /var/log/parallelcluster/bootstrap_error_msg
+      if [ -z "$2" ]; then
+        echo "$1 Please check /var/log/cfn-init.log in the head node, or check the cfn-init.log in CloudWatch logs. Please refer to https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html#troubleshooting-v3-get-logs for more details on ParallelCluster logs." > /var/log/parallelcluster/bootstrap_error_msg
+      else
+        echo "$2 Please check /var/log/cfn-init.log in the head node, or check the cfn-init.log in CloudWatch logs. Please refer to https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html#troubleshooting-v3-get-logs for more details on ParallelCluster logs." > /var/log/parallelcluster/bootstrap_error_msg
+      fi
       ;;
   esac
   exit 1
-}
-
-# URLs longer than the limit will be trimmed by replacing the middle part with ellipsis
-function process_url (){
-  url=$1
-  if [ ${#url} -gt $url_len_limit ]; then
-    head_len=$(expr $url_len_limit / 2)
-    tail_len=$(expr $url_len_limit - $head_len)
-    echo "$(echo $url | head --bytes=${head_len})......$(echo $url | tail --bytes=${tail_len})"
-  else
-    echo $url
-  fi
 }
 
 function download_run (){
   url=$1
   shift
   scheme=$(echo "${url}"| cut -d: -f1)
-  url_processed="$(process_url "$url")"
   tmpfile=$(mktemp)
   trap "/bin/rm -f $tmpfile" RETURN
   if [ "${scheme}" == "s3" ]; then
-    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/aws --region ${cfn_region} s3 cp ${url} - > $tmpfile || error_exit "Failed to download ${custom_script} script ${url_processed} using aws s3, return code: $?."
+    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/aws --region ${cfn_region} s3 cp ${url} - > $tmpfile || error_exit "Failed to download ${custom_script} script ${url} using aws s3, return code: $?." "Failed to download ${custom_script} script using aws s3, return code: $?."
   else
-    wget -qO- ${url} > $tmpfile || error_exit "Failed to download ${custom_script} script ${url_processed} using wget, return code: $?."
+    wget -qO- ${url} > $tmpfile || error_exit "Failed to download ${custom_script} script ${url} using wget, return code: $?." "Failed to download ${custom_script} script using wget, return code: $?."
   fi
   chmod +x $tmpfile || error_exit "Failed to run ${custom_script} script due to a failure in making the file executable, return code: $?."
-  $tmpfile "$@" || error_exit "Failed to execute ${custom_script} script ${url_processed}, return code: $?."
+  $tmpfile "$@" || error_exit "Failed to execute ${custom_script} script ${url}, return code: $?." "Failed to execute ${custom_script} script, return code: $?."
 }
 
 function get_stack_status () {
@@ -102,9 +93,6 @@ function run_postupdate () {
 }
 
 custom_script=""
-# To prevent massive error messages that could get truncated by CloudFormation,
-# we set a length limit (100 for now) for custom scripts URLs, and URLs exceeding the limit will be trimmed
-url_len_limit=100
 check_params
 ACTION=${1#?}
 case ${ACTION} in


### PR DESCRIPTION
### Description of changes
* Remove OnOndeStart and OnNodeConfigured scripts url from showing up in CFN failure reason for security.

### Tests
* [Describe the automated and/or manual tests executed to validate the patch.](https://github.com/aws/aws-parallelcluster/pull/4830)
* Manually test with pre-install script failure
  *  CFN failure message doesn't contains the script
```
WaitCondition received failed message: 'Failed to execute OnNodeStart script, return code: 1. Please check /var/log/cfn-init.log in the head node, or check the cfn-init.log in CloudWatch logs. Please refer to https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html#troubleshooting-v3-get-logs for more details on ParallelCluster logs.' for uniqueId: i-03d2ca41dd1c76807
```
Cfn init log message contains the script
```
parallelcluster: fetch_and_run - Failed to execute OnNodeStart script s3://amibucket11223/scripts/preinstall.sh, return code: 1.
```
### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.