### PR TITLE
Install MySQL packages from OS repos for Ubuntu x86_64

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -210,6 +210,8 @@ default['cluster']['mysql']['repository']['definition']['md5'] = value_for_platf
 )
 
 # MySQL Packages
+# We install MySQL packages for RedHat derivatives from packages hosted on S3, while for Ubuntu we install them
+# from the OS repositories.
 default['cluster']['mysql']['package']['root'] = "#{node['cluster']['artifacts_s3_url']}/mysql"
 default['cluster']['mysql']['package']['version'] = "8.0.31-1"
 default['cluster']['mysql']['package']['source-version'] = "8.0.31"
@@ -219,11 +221,7 @@ default['cluster']['mysql']['package']['platform'] = if arm_instance?
                                                        )
                                                      else
                                                        value_for_platform(
-                                                         'default' => "el/7/x86_64",
-                                                         'ubuntu' => {
-                                                           '20.04' => "ubuntu/20.04/x86_64",
-                                                           '18.04' => "ubuntu/18.04/x86_64",
-                                                         }
+                                                         'default' => "el/7/x86_64"
                                                        )
                                                      end
 default['cluster']['mysql']['package']['file-name'] = "mysql-community-client-#{node['cluster']['mysql']['package']['version']}.tar.gz"
@@ -231,31 +229,17 @@ default['cluster']['mysql']['package']['archive'] = "#{node['cluster']['mysql'][
 default['cluster']['mysql']['package']['source'] = "#{node['cluster']['artifacts_s3_url']}/source/mysql-#{node['cluster']['mysql']['package']['source-version']}.tar.gz"
 
 # MySQL Validation
-if arm_instance?
-  default['cluster']['mysql']['repository']['packages'] = value_for_platform(
-    'default' => %w(mysql-community-devel mysql-community-libs mysql-community-common mysql-community-client-plugins mysql-community-libs-compat),
-    'ubuntu' => {
-      'default' => %w(libmysqlclient-dev libmysqlclient21),
-      '18.04' =>  %w(libmysqlclient-dev libmysqlclient20),
-    }
-  )
-  default['cluster']['mysql']['repository']['expected']['version'] = value_for_platform(
-    'default' => "8.0.31"
-    # Ubuntu 18.04/20.04 ARM: MySQL packages are installed from OS repo and we do not assert on a specific version.
-  )
-else
-  default['cluster']['mysql']['repository']['packages'] = value_for_platform(
-    'default' => %w(mysql-community-devel mysql-community-libs mysql-community-common mysql-community-client-plugins mysql-community-libs-compat),
-    'ubuntu' => { 'default' => %w(libmysqlclient-dev libmysqlclient21 mysql-common mysql-community-client-plugins) }
-  )
-  default['cluster']['mysql']['repository']['expected']['version'] = value_for_platform(
-    'default' => "8.0.31",
-    'ubuntu' => {
-      '20.04' => "8.0.31-1ubuntu20.04",
-      '18.04' => "8.0.31-1ubuntu18.04",
-    }
-  )
-end
+default['cluster']['mysql']['repository']['packages'] = value_for_platform(
+  'default' => %w(mysql-community-devel mysql-community-libs mysql-community-common mysql-community-client-plugins mysql-community-libs-compat),
+  'ubuntu' => {
+    'default' => %w(libmysqlclient-dev libmysqlclient21),
+    '18.04' =>  %w(libmysqlclient-dev libmysqlclient20),
+  }
+)
+default['cluster']['mysql']['repository']['expected']['version'] = value_for_platform(
+  'default' => "8.0.31"
+  # Ubuntu 18.04/20.04: MySQL packages are installed from OS repo and we do not assert on a specific version.
+)
 
 # EFA
 default['cluster']['efa']['installer_version'] = '1.20.0'

--- a/cookbooks/aws-parallelcluster-install/recipes/install_mysql_client.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/install_mysql_client.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-if platform?('ubuntu') && arm_instance?
+if platform?('ubuntu')
   package node['cluster']['mysql']['repository']['packages'] do
     retries 3
     retry_delay 5

--- a/cookbooks/aws-parallelcluster-test/recipes/validate_mysql.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/validate_mysql.rb
@@ -18,7 +18,7 @@
 #
 # Check the repository source of a package
 #
-unless platform?('ubuntu') && arm_instance?
+unless platform?('ubuntu')
   Chef::Log.info("Checking for MySql implementation on #{node['platform']}:#{node['kernel']['machine']}")
   node['cluster']['mysql']['repository']['packages'].each do |pkg|
     validate_package_version(pkg, node['cluster']['mysql']['repository']['expected']['version'])


### PR DESCRIPTION
### Description of changes
* Remove the previous infrastructure to install MySQL packages for Ubuntu 18.04 and 20.04 x86_64 from S3.
Now Ubuntu x86_64 is treated like Ubuntu arm.
* Relates to https://github.com/aws/aws-parallelcluster/issues/4835

### Tests
* Manually built AMIs with the patched cookbook.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.