### PR TITLE
[bandit] Use SHA256 instead of SHA1 checksum

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -103,7 +103,7 @@ default['cluster']['armpl']['url'] = [
 default['cluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'
 default['cluster']['slurm']['version'] = '22-05-7-1'
 default['cluster']['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['cluster']['slurm']['version']}.tar.gz"
-default['cluster']['slurm']['sha1'] = 'a9208e0d6af8465e417d5a60a6ea82b151b6fc34'
+default['cluster']['slurm']['sha256'] = '2ad7e8a415d54d45977ab64b4e73c891154d2f41a04505fedf6f8d3df385acb1'
 default['cluster']['slurm']['user'] = 'slurm'
 default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1
 default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']
@@ -143,7 +143,7 @@ default['cluster']['scheduler_plugin']['virtualenv_path'] = [
 # PMIx software
 default['cluster']['pmix']['version'] = '3.2.3'
 default['cluster']['pmix']['url'] = "https://github.com/openpmix/openpmix/releases/download/v#{node['cluster']['pmix']['version']}/pmix-#{node['cluster']['pmix']['version']}.tar.gz"
-default['cluster']['pmix']['sha1'] = 'ed5c525baf1330d2303afb2b6bd2fd53ab0406a0'
+default['cluster']['pmix']['sha256'] = '1325a1355d0794196bb47665053fdbc588f9183aa5385f3581b668427316306e'
 # Munge
 default['cluster']['munge']['munge_version'] = '0.5.14'
 default['cluster']['munge']['munge_url'] = "https://github.com/dun/munge/archive/munge-#{node['cluster']['munge']['munge_version']}.tar.gz"
@@ -154,7 +154,7 @@ default['cluster']['munge']['group_id'] = node['cluster']['munge']['user_id']
 # JWT
 default['cluster']['jwt']['version'] = '1.12.0'
 default['cluster']['jwt']['url'] = "https://github.com/benmcollins/libjwt/archive/refs/tags/v#{node['cluster']['jwt']['version']}.tar.gz"
-default['cluster']['jwt']['sha1'] = '1c6fec984a8e0ca1122bfc3552a49f45bdb0c4e8'
+default['cluster']['jwt']['sha256'] = 'eaf5d8b31d867c02dde767efa2cf494840885a415a3c9a62680bf870a4511bee'
 
 # NVIDIA
 default['cluster']['nvidia']['enabled'] = 'no'
@@ -191,7 +191,7 @@ default['cluster']['nvidia']['fabricmanager']['repository_uri'] = value_for_plat
 # NVIDIA GDRCopy
 default['cluster']['nvidia']['gdrcopy']['version'] = '2.3'
 default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrcopy/archive/refs/tags/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"
-default['cluster']['nvidia']['gdrcopy']['sha1'] = '8ee4f0e3c9d0454ff461742c69b0c0ee436e06e1'
+default['cluster']['nvidia']['gdrcopy']['sha256'] = 'b85d15901889aa42de6c4a9233792af40dd94543e82abe0439e544c87fd79475'
 default['cluster']['nvidia']['gdrcopy']['service'] = value_for_platform(
   'ubuntu' => { 'default' => 'gdrdrv' },
   'default' => 'gdrcopy'

--- a/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
@@ -157,7 +157,7 @@ if node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['e
   gdrcopy_version = node['cluster']['nvidia']['gdrcopy']['version']
   gdrcopy_version_extended = "#{node['cluster']['nvidia']['gdrcopy']['version']}-1"
   gdrcopy_tarball = "#{node['cluster']['sources_dir']}/gdrcopy-#{gdrcopy_version}.tar.gz"
-  gdrcopy_checksum = node['cluster']['nvidia']['gdrcopy']['sha1']
+  gdrcopy_checksum = node['cluster']['nvidia']['gdrcopy']['sha256']
   gdrcopy_build_dependencies = value_for_platform(
     'ubuntu' => {
       'default' => %w(build-essential devscripts debhelper check libsubunit-dev fakeroot pkg-config dkms),
@@ -177,7 +177,7 @@ if node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['e
   ruby_block "Validate NVIDIA GDRCopy Tarball Checksum" do
     block do
       require 'digest'
-      checksum = Digest::SHA1.file(gdrcopy_tarball).hexdigest # nosemgrep
+      checksum = Digest::SHA256.file(gdrcopy_tarball).hexdigest
       raise "Downloaded NVIDIA GDRCopy Tarball Checksum #{checksum} does not match expected checksum #{gdrcopy_checksum}" if checksum != gdrcopy_checksum
     end
   end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_jwt.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_jwt.rb
@@ -29,8 +29,8 @@ end
 ruby_block "Validate libjwt Tarball Checksum" do
   block do
     require 'digest'
-    checksum = Digest::SHA1.file(jwt_tarball).hexdigest # nosemgrep
-    raise "Downloaded Tarball Checksum #{checksum} does not match expected checksum #{node['cluster']['jwt']['sha1']}" if checksum != node['cluster']['jwt']['sha1']
+    checksum = Digest::SHA256.file(jwt_tarball).hexdigest
+    raise "Downloaded Tarball Checksum #{checksum} does not match expected checksum #{node['cluster']['jwt']['sha256']}" if checksum != node['cluster']['jwt']['sha256']
   end
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_pmix.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_pmix.rb
@@ -28,8 +28,8 @@ end
 ruby_block "Validate PMIx Tarball Checksum" do
   block do
     require 'digest'
-    checksum = Digest::SHA1.file(pmix_tarball).hexdigest # nosemgrep
-    raise "Downloaded Tarball Checksum #{checksum} does not match expected checksum #{node['cluster']['pmix']['sha1']}" if checksum != node['cluster']['pmix']['sha1']
+    checksum = Digest::SHA256.file(pmix_tarball).hexdigest
+    raise "Downloaded Tarball Checksum #{checksum} does not match expected checksum #{node['cluster']['pmix']['sha256']}" if checksum != node['cluster']['pmix']['sha256']
   end
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -67,8 +67,8 @@ end
 ruby_block "Validate Slurm Tarball Checksum" do
   block do
     require 'digest'
-    checksum = Digest::SHA1.file(slurm_tarball).hexdigest # nosemgrep
-    raise "Downloaded Tarball Checksum #{checksum} does not match expected checksum #{node['cluster']['slurm']['sha1']}" if checksum != node['cluster']['slurm']['sha1']
+    checksum = Digest::SHA256.file(slurm_tarball).hexdigest
+    raise "Downloaded Tarball Checksum #{checksum} does not match expected checksum #{node['cluster']['slurm']['sha256']}" if checksum != node['cluster']['slurm']['sha256']
   end
 end
 


### PR DESCRIPTION




### Description of changes
- slurm, pmix, jwt and gdrcopy dependencies are verified by checking a SHA1 based checksum
- SHA1 has been discovered to be insecure due to hash collisions: https://sg.run/e4qX
- This commit ensures that the above dependencies are verified using a SHA256 checksum which has less likely hash collisions

### Tests
* Run the install recipe by running `pcluster build-image`
* Confirmed the checksum block succeeds

### References
* [weak-hashes-sha1.weak-hashes-sha1](https://sg.run/e4qX)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.