### PR TITLE
Add test and validate recipe chrony for RedHat 8

### DIFF
--- a/cookbooks/aws-parallelcluster-install/recipes/chrony.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/chrony.rb
@@ -23,7 +23,7 @@ end
 package %w(chrony) do
   retries 3
   retry_delay 5
-end
+end unless redhat_ubi?
 
 append_if_no_line "add configuration to chrony.conf" do
   path node['cluster']['chrony']['conf']

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -92,3 +92,10 @@ suites:
     verifier:
       controls:
         - cron_disabled_selected_daily_and_weekly_jobs
+  - name: chrony
+    run_list:
+      - recipe[aws-parallelcluster::test_dummy]
+      - recipe[aws-parallelcluster-install::chrony]
+    verifier:
+      controls:
+        - chrony_installed_and_configured

--- a/test/recipes/controls/aws_parallelcluster_install/chrony_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/chrony_spec.rb
@@ -1,0 +1,44 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'chrony_installed_and_configured' do
+  title 'Test chrony installation and configuration'
+
+  describe package('chrony') do
+    it { should be_installed }
+  end unless os_properties.redhat_ubi?
+
+  describe package('ntp') do
+    it { should_not be_installed }
+  end
+
+  describe package('ntpdate') do
+    it { should_not be_installed }
+  end
+
+  if os.redhat?
+    chrony_file = '/etc/chrony.conf'
+  elsif os.debian?
+    chrony_file = '/etc/chrony/chrony.conf'
+  else
+    describe "unsupported OS" do
+      # this produces a skipped control (ignore-like)
+      # adding a new OS to kitchen platform list and running the tests,
+      # it would surface the fact this recipe does not support this OS.
+      pending "support for #{os.name}-#{os.release} needs to be implemented"
+    end
+  end
+
+  describe file(chrony_file) do
+    it { should exist }
+    its('content') { should match(/server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4/) }
+  end
+end


### PR DESCRIPTION
### Description of changes
* Add test and validate recipe chrony for RedHat 8

### Tests
* Tested on EC2 and docker


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.