### PR TITLE
Add test for cron recipe

### DIFF
--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -85,3 +85,10 @@ suites:
     verifier:
       controls:
         - clusterstatusmgtd_files_created
+  - name: cron
+    run_list:
+      - recipe[aws-parallelcluster-test::docker_mock]
+      - recipe[aws-parallelcluster-install::cron]
+    verifier:
+      controls:
+        - cron_disabled_selected_daily_and_weekly_jobs

--- a/test/recipes/controls/aws_parallelcluster_install/cron_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/cron_spec.rb
@@ -1,0 +1,32 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'cron_disabled_selected_daily_and_weekly_jobs' do
+  title 'Test that selected required daily and weekly cron jobs are disabled'
+
+  cron_job_deny_daily = %w(mlocate man-db.cron man-db).join("\n") << "\n"
+  describe file('/etc/cron.daily/jobs.deny') do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should eq cron_job_deny_daily }
+  end
+
+  cron_job_deny_weekly = %w(man-db).join("\n") << "\n"
+  describe file('/etc/cron.weekly/jobs.deny') do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should eq cron_job_deny_weekly }
+  end
+end


### PR DESCRIPTION
### Description of changes
This patch adds a test for the `aws-parallelcluster-install::cron` recipe.

### Tests
Run the test on all supported operating systems.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.