### PR TITLE
3.x Fail cluster create on protected mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **ENHANCEMENTS**
-- Fail cluster creation early if static nodes fail to launch after a number of retries
-  - Provide a failure reason in CloudFormation indicating that the cluster failed to create due to static fleet failure.
+- Fail cluster creation if cluster status changes to PROTECTED while provisioning static nodes.
 
 **CHANGES**
 - Upgrade Slurm to version 22.05.8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 3.5.0
 ------
 
+**ENHANCEMENTS**
+- Fail cluster creation early if static nodes fail to launch after a number of retries
+  - Provide a failure reason in CloudFormation indicating that the cluster failed to create due to static fleet failure.
+
 **CHANGES**
 - Upgrade Slurm to version 22.05.8.
 - Upgrade EFA installer to `1.21.0`
@@ -36,7 +40,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Libfabric-aws: `libfabric-aws-1.16.1`
   - Rdma-core: `rdma-core-43.0-2`
   - Open MPI: `openmpi40-aws-4.1.4-3`
-- Mount EFS file systems using `amazon-efs-utils`. EFS files systems can be mounted using in-transit encryption and IAM authorized user. 
+- Mount EFS file systems using `amazon-efs-utils`. EFS files systems can be mounted using in-transit encryption and IAM authorized user.
 - Install `stunnel` 5.67 on CentOS7 and Ubuntu to support EFS in-transit encryption.
 - Add possibility to execute a custom script in the head node during the update of the cluster.
 - Upgrade Slurm to version 22.05.7.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -492,6 +492,9 @@ default['cluster']['realmemory_to_ec2memory_ratio'] = 0.95
 default['cluster']['slurm_node_reg_mem_percent'] = 75
 default['cluster']['slurmdbd_response_retries'] = 30
 default['cluster']['slurm_plugin_console_logging']['sample_size'] = 1
+default['cluster']['failure_count_map_path'] = '/var/log/parallelcluster/cluster_failure_map.json'
+default['cluster']['failure_count_cap'] = 3
+default['cluster']['min_failure_count_time'] = 300
 
 # Official ami build
 default['cluster']['is_official_ami_build'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -492,9 +492,6 @@ default['cluster']['realmemory_to_ec2memory_ratio'] = 0.95
 default['cluster']['slurm_node_reg_mem_percent'] = 75
 default['cluster']['slurmdbd_response_retries'] = 30
 default['cluster']['slurm_plugin_console_logging']['sample_size'] = 1
-default['cluster']['launch_failure_map_path'] = '/var/log/parallelcluster/launch_failure_map.json'
-default['cluster']['launch_failure_limit'] = 3
-default['cluster']['launch_failure_wait_time'] = 300
 
 # Official ami build
 default['cluster']['is_official_ami_build'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -492,9 +492,9 @@ default['cluster']['realmemory_to_ec2memory_ratio'] = 0.95
 default['cluster']['slurm_node_reg_mem_percent'] = 75
 default['cluster']['slurmdbd_response_retries'] = 30
 default['cluster']['slurm_plugin_console_logging']['sample_size'] = 1
-default['cluster']['failure_count_map_path'] = '/var/log/parallelcluster/cluster_failure_map.json'
-default['cluster']['failure_count_cap'] = 3
-default['cluster']['min_failure_count_time'] = 300
+default['cluster']['launch_failure_map_path'] = '/var/log/parallelcluster/launch_failure_map.json'
+default['cluster']['launch_failure_limit'] = 3
+default['cluster']['launch_failure_wait_time'] = 300
 
 # Official ami build
 default['cluster']['is_official_ami_build'] = false

--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize_head_node.rb
@@ -25,6 +25,45 @@ ruby_block "wait for static fleet capacity" do
   block do
     require 'chef/mixin/shell_out'
     require 'shellwords'
+    require 'json'
+
+    start_time = Time.now
+
+    failure_count_cap = node['cluster']['failure_count_cap']
+    failure_count_wait_time = node['cluster']['min_failure_count_time']
+
+    check_for_failures = lambda do
+      time_elapsed = Time.now - start_time
+
+      Chef::Log.info("Not checking failure map yet. Time elapsed: #{time_elapsed}") if time_elapsed < failure_count_wait_time
+      return if time_elapsed < failure_count_wait_time
+
+      begin
+        failure_map = JSON.load_file(node['cluster']['failure_count_map_path'])
+      rescue
+        Chef::Log.warn("Unable to load failure map")
+        return
+      end
+
+      Chef::Log.info("failure_map is empty") if failure_map.empty?
+      return if failure_map.empty?
+
+      # Example contents of failure_map:
+      #   {"queue-a": {"compute-a-1": 1, "compute-a-2": 2}, "queue-b": {"compute-b-1": 1}}
+      max_failure_count = failure_map.map { |queue, compute_resources|
+        compute_resources.map { |compute, count|
+          {
+            :queue => queue,
+            :compute => compute,
+            :count => count
+          }
+        }
+      }.flatten(1).max_by { |item| item[:count] }
+
+      Chef::Log.info("Maximum Failure: #{max_failure_count}")
+
+      raise "Failed too many times waiting for static compute fleet to start. Queue: #{max_failure_count[:queue]}, Resource: #{max_failure_count[:compute]}, Failure Count: #{max_failure_count[:count]}" if failure_count_cap and max_failure_count[:count] >= failure_count_cap
+    end
 
     # Example output for sinfo
     # $ /opt/slurm/bin/sinfo -N -h -o '%N %t'
@@ -37,6 +76,8 @@ ruby_block "wait for static fleet capacity" do
       "set -o pipefail && #{node['cluster']['slurm']['install_dir']}/bin/sinfo -N -h -o '%N %t' | { grep -E '^[a-z0-9\\-]+\\-st\\-[a-z0-9\\-]+\\-[0-9]+ .*' || true; } | { grep -v -E '(idle|alloc|mix)$' || true; }"
     )
     until shell_out!("/bin/bash -c #{is_fleet_ready_command}").stdout.strip.empty?
+      check_for_failures.()
+
       Chef::Log.info("Waiting for static fleet capacity provisioning")
       sleep(15)
     end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize_head_node.rb
@@ -32,14 +32,14 @@ ruby_block "wait for static fleet capacity" do
         cluster_state_json = shell_out!("/bin/bash -c #{fleet_status_command}").stdout.strip
         cluster_state = JSON.load(cluster_state_json)
       rescue
-        Chef::Log.warn("Unable to read cluster state")
+        Chef::Log.warn("Unable to get compute fleet status")
         return
       end
 
-      Chef::Log.info("Cluster state is empty") if cluster_state.empty?
+      Chef::Log.info("Compute fleet status is empty") if cluster_state.empty?
       return if cluster_state.empty?
 
-      raise "Cluster state has been set to PROTECTED during static node provisioning" if cluster_state["status"] == "PROTECTED"
+      raise "Cluster has been set to PROTECTED mode due to failures detected in static node provisioning" if cluster_state["status"] == "PROTECTED"
     end
 
     fleet_status_command = Shellwords.escape(

--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize_head_node.rb
@@ -43,7 +43,7 @@ ruby_block "wait for static fleet capacity" do
     end
 
     fleet_status_command = Shellwords.escape(
-      "get-compute-fleet-status.sh"
+      "/usr/local/bin/get-compute-fleet-status.sh"
     )
     # Example output for sinfo
     # $ /opt/slurm/bin/sinfo -N -h -o '%N %t'

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -14,4 +14,4 @@ insufficient_capacity_timeout = 600
 compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] || true %>
 compute_console_logging_max_sample_size = <%= node['cluster']['slurm_plugin_console_logging']['sample_size'] %>
 compute_console_wait_time = 300
-failure_count_map_path = <%= node['cluster']['failure_count_map_path'] %>
+launch_failure_map_path = <%= node['cluster']['launch_failure_map_path'] %>

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -12,5 +12,6 @@ head_node_hostname = <%= node['ec2']['local_hostname'] %>
 node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout'] %>
 insufficient_capacity_timeout = 600
 compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] || true %>
-compute_console_logging_max_sample_size = <%=  node['cluster']['slurm_plugin_console_logging']['sample_size'] %>
+compute_console_logging_max_sample_size = <%= node['cluster']['slurm_plugin_console_logging']['sample_size'] %>
 compute_console_wait_time = 300
+failure_count_map_path = <%= node['cluster']['failure_count_map_path'] %>

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -14,4 +14,3 @@ insufficient_capacity_timeout = 600
 compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] || true %>
 compute_console_logging_max_sample_size = <%= node['cluster']['slurm_plugin_console_logging']['sample_size'] %>
 compute_console_wait_time = 300
-launch_failure_map_path = <%= node['cluster']['launch_failure_map_path'] %>


### PR DESCRIPTION
### Description of changes
* This change alters the head node finalize loop for the Slurm scheduler so that if the compute fleet enters PROTECTED mode, the loop will throw an exception rather than infinitely loop.

### Tests
* Manually tested by creating a cluster with compute nodes in an isolated subnet so that AWS network calls failed.
* Manually tested by creating a cluster with a custom preinstall script that exits with an error code on the compute nodes.
* Adding an integration test in another PR.

### References
* Integration Test PR

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.