### PR TITLE
RHEL8: Define new recipe to automatically import recipes and resources deps

### DIFF
--- a/cookbooks/aws-parallelcluster-install/resources/mysql_client/mysql_client.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/mysql_client/mysql_client.rb
@@ -23,10 +23,9 @@ use 'partial/_download_and_install'
 # MySQL Packages
 # We install MySQL packages from the OS repositories for ubuntu platform, while we
 # retrieve the packages from S3 for RedHat & derivatives.
-# Also on ubuntu an apt update is required to align the apt cache with the current list
-# of available package versions.
 action :setup do
   if platform?('ubuntu')
+    # An apt update is required to align the apt cache with the current list of available package versions.
     apt_update
     package node['cluster']['mysql']['repository']['packages'] do
       retries 3

--- a/cookbooks/aws-parallelcluster-install/resources/mysql_client/partial/_download_and_install.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/mysql_client/partial/_download_and_install.rb
@@ -16,7 +16,6 @@
 action :download_and_install do
   mysql_archive_url = node['cluster']['mysql']['package']['archive']
   mysql_tar_file = "/tmp/#{node['cluster']['mysql']['package']['file-name']}"
-  package_installer = 'yum install -y'
 
   log "Downloading MySQL packages archive from #{mysql_archive_url}"
 
@@ -37,7 +36,7 @@ action :download_and_install do
 
         EXTRACT_DIR=$(mktemp -d --tmpdir mysql.XXXXXXX)
         tar xf "#{mysql_tar_file}" --directory "${EXTRACT_DIR}"
-        #{package_installer} ${EXTRACT_DIR}/*
+        yum install -y ${EXTRACT_DIR}/*
     MYSQL
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/mysql_client/partial/_source_link.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/mysql_client/partial/_source_link.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 action :create_source_link do
-  # Add MySQL source file
+  # Add MySQL source file to be compliant with Licensing
   file "#{node['cluster']['sources_dir']}/mysql_source_code.txt" do
     content %(You can get MySQL source code here:
 

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -12,6 +12,11 @@ verifier:
     - test/recipes
     - test/resources
 
+# If you need to test a recipe with recipe/resources dependencies,
+# add recipe[aws-parallelcluster::add_dependencies] as first item in the run_list
+# then define a dependencies attribute, listing them with recipe: or resource: prefix.
+# You can find an example in the add_depdendencies.rb file.
+
 suites:
   - name: sudo
     run_list:
@@ -22,12 +27,15 @@ suites:
         - sudoers_file_configured
   - name: users
     run_list:
-      - recipe[aws-parallelcluster::test_dummy]
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-install::users]
     verifier:
       controls:
         - admin_user_created
         - ulimit_configured
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster::test_dummy
   - name: directories
     run_list:
       - recipe[aws-parallelcluster-install::directories]
@@ -44,26 +52,35 @@ suites:
         - ephemeral_service_set_up
   - name: python_setup
     run_list:
-      - recipe[aws-parallelcluster-install::directories]
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-install::python]
     verifier:
       controls:
         - awsbatch_virtualenv_created
         - cookbook_virtualenv_created
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
   - name: cfn_bootstrap_setup
     run_list:
-      - recipe[aws-parallelcluster-install::directories]
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-install::cfn_bootstrap]
     verifier:
       controls:
         - cfnbootstrap_virtualenv_created
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
   - name: node_setup
     run_list:
-      - recipe[aws-parallelcluster-install::directories]
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-install::node]
     verifier:
       controls:
         - node_virtualenv_created
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
   - name: supervisord_setup
     run_list:
       - recipe[aws-parallelcluster-install::supervisord]
@@ -73,30 +90,42 @@ suites:
         - supervisord_service_set_up
   - name: awscli
     run_list:
-      - recipe[aws-parallelcluster-install::directories]
-      - recipe[aws-parallelcluster-install::python]
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-install::awscli]
     verifier:
       controls:
         - awscli_installed
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - recipe:aws-parallelcluster-install::python
   - name: clusterstatusmgtd
     run_list:
-      - recipe[aws-parallelcluster-install::directories]
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-install::clusterstatusmgtd]
     verifier:
       controls:
         - clusterstatusmgtd_files_created
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
   - name: cron
     run_list:
-      - recipe[aws-parallelcluster-test::docker_mock]
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-install::cron]
     verifier:
       controls:
         - cron_disabled_selected_daily_and_weekly_jobs
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-test::docker_mock
   - name: chrony
     run_list:
-      - recipe[aws-parallelcluster::test_dummy]
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-install::chrony]
     verifier:
       controls:
         - chrony_installed_and_configured
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster::test_dummy

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -18,15 +18,16 @@ suites:
       - recipe[aws-parallelcluster-install::sudo]
     verifier:
       controls:
-        - sudo
+        - sudo_installed
+        - sudoers_file_configured
   - name: users
     run_list:
       - recipe[aws-parallelcluster::test_dummy]
       - recipe[aws-parallelcluster-install::users]
     verifier:
       controls:
-        - admin_user
-        - ulimit
+        - admin_user_created
+        - ulimit_configured
   - name: directories
     run_list:
       - recipe[aws-parallelcluster-install::directories]
@@ -77,7 +78,7 @@ suites:
       - recipe[aws-parallelcluster-install::awscli]
     verifier:
       controls:
-        - awscli_is_installed
+        - awscli_installed
   - name: clusterstatusmgtd
     run_list:
       - recipe[aws-parallelcluster-install::directories]

--- a/kitchen.resources.yml
+++ b/kitchen.resources.yml
@@ -54,15 +54,13 @@ suites:
       resource: ec2_udev_rules
   - name: mysql_client
     run_list:
-      # This is a test recipe executing the default action of the resource you pass as `resource` attribute,
-      # with default properties
       - recipe[aws-parallelcluster::test_dummy]
       - recipe[aws-parallelcluster-install::directories]
       - recipe[aws-parallelcluster-install::test_resource]
     verifier:
       controls:
         - mysql_client_installed
-        - mysql_client_source_code_configured
+        - mysql_client_source_node_created
     attributes:
       resource: mysql_client
 

--- a/kitchen.resources.yml
+++ b/kitchen.resources.yml
@@ -25,6 +25,15 @@ suites:
 #        base_os: alinux2
 #      resource: package_repos
 
+# If you need to test a resource with an action or properties different from the default ones,
+# add custom tests here and adjust `aws-parallelcluster-test::test_resource`
+# to allow `action` and/or `properties` parameters.
+
+# If you need to test a resource with recipe/resources dependencies,
+# add recipe[aws-parallelcluster::add_dependencies] as first item in the run_list
+# then define a dependencies attribute, listing them with recipe: or resource: prefix.
+# You can find an example in the add_depdendencies.rb file.
+
 <% [
   'package_repos',
   'nfs',
@@ -42,8 +51,6 @@ suites:
 <%end %>
   - name: ec2_udev_rules
     run_list:
-      # This is a test recipe executing the default action of the resource you pass as `resource` attribute,
-      # with default properties
       - recipe[aws-parallelcluster-install::test_resource]
     verifier:
       controls:
@@ -54,16 +61,14 @@ suites:
       resource: ec2_udev_rules
   - name: mysql_client
     run_list:
-      - recipe[aws-parallelcluster::test_dummy]
-      - recipe[aws-parallelcluster-install::directories]
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-install::test_resource]
     verifier:
       controls:
         - mysql_client_installed
         - mysql_client_source_node_created
     attributes:
+      dependencies:
+        - recipe:aws-parallelcluster::test_dummy
+        - recipe:aws-parallelcluster-install::directories
       resource: mysql_client
-
-# If you need to test a resource with an action or properties different from the default ones,
-# add custom tests here and adjust `aws-parallelcluster-test::test_resource`
-# to allow `action` and/or `properties` parameters.

--- a/kitchen.validate.yml
+++ b/kitchen.validate.yml
@@ -28,9 +28,10 @@ suites:
         #   - c_states
         # We also need to test the effect some files (service config, profile config) have on the system.
         # TODO: rethink and integrate
-        - sudo
-        - admin_user
-        - ulimit
+        - sudo_installed
+        - sudoers_file_configured
+        - admin_user_created
+        - ulimit_configured
         - pcluster_directories_exist
         - pcluster_log_dir_is_configured
         - ephemeral_drives_script_created
@@ -41,7 +42,7 @@ suites:
         - node_virtualenv_created
         - supervisord_config_created
         - supervisord_service_set_up
-        - awscli_is_installed
+        - awscli_installed
         - write_common_udev_configuration_files
         - ec2blkdev_service_installation
         - debian_udevd_reload_configuration

--- a/recipes/add_dependencies.rb
+++ b/recipes/add_dependencies.rb
@@ -1,0 +1,29 @@
+# This is a helper recipe to automatically add dependencies, including recipes and resources
+# This is useful if you need to test a resource with recipe/resources dependencies in the kitchen.resources/recipes.yml.
+
+# To use it add recipe[aws-parallelcluster::add_dependencies] as first item in the run_list
+# then define a dependencies attribute, listing them with recipe: or resource: prefix. Example:
+
+#- name: resource_with_deps
+#  run_list:
+#    - recipe[aws-parallelcluster::add_dependencies]
+#    - recipe[aws-parallelcluster-install::test_resource_or_recipe_to_test]
+#  verifier:
+#    controls:
+#      - resource_control_name
+#  attributes:
+#    resource: resource_name
+#    dependencies:
+#      - recipe:aws-parallelcluster::test_dummy
+#      - recipe:aws-parallelcluster-install::directories
+#      - resource:ec2_udev_rules
+
+if defined?(node['dependencies'])
+  node['dependencies'].each do |dep|
+    if dep.start_with?('recipe:')
+      include_recipe dep.gsub('recipe:', '')
+    else
+      declare_resource(dep.gsub('resource:', ''), 'test')
+    end
+  end
+end

--- a/test/recipes/controls/aws_parallelcluster_install/awscli_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/awscli_spec.rb
@@ -13,7 +13,7 @@ python_version = '3.9.16'
 base_dir = "/opt/parallelcluster"
 pyenv_dir = "#{base_dir}/pyenv"
 
-control 'awscli_is_installed' do
+control 'awscli_installed' do
   title 'awscli package should be installed in cookbook virtualenv'
 
   only_if { !os_properties.redhat_ubi? }

--- a/test/recipes/controls/aws_parallelcluster_install/sudo_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/sudo_spec.rb
@@ -9,12 +9,16 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'sudo' do
-  title 'Install sudo package and prepare sudoers file'
+control 'sudo_installed' do
+  title 'Verify sudo package is installed'
 
   describe package('sudo') do
     it { should be_installed }
   end
+end
+
+control 'sudoers_file_configured' do
+  title 'Verify sudoers file is correctly configured'
 
   describe file('/etc/sudoers.d/99-parallelcluster-secure-path') do
     it { should exist }

--- a/test/recipes/controls/aws_parallelcluster_install/users_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/users_spec.rb
@@ -1,6 +1,6 @@
 user = "pcluster-admin"
 
-control 'admin_user' do
+control 'admin_user_created' do
   title 'Configure cluster admin user'
 
   describe command("grep #{user} /etc/passwd") do
@@ -13,7 +13,7 @@ control 'admin_user' do
   end
 end
 
-control 'ulimit' do
+control 'ulimit_configured' do
   title 'Configure soft ulimit nofile'
   describe limits_conf("/etc/security/limits.d/00_all_limits.conf") do
     its('*') { should include ['-', 'nofile', "10000"] }

--- a/test/resources/controls/aws_parallelcluster_install/mysql_client_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/mysql_client_spec.rb
@@ -34,7 +34,7 @@ control 'mysql_client_installed' do
   end
 end
 
-control 'mysql_client_source_code_configured' do
+control 'mysql_client_source_node_created' do
   title 'MySql client source code is configured in target dir'
 
   describe file('/opt/parallelcluster/sources/mysql_source_code.txt') do

--- a/test/resources/controls/aws_parallelcluster_install/nfs_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/nfs_spec.rb
@@ -1,5 +1,5 @@
 control 'nfs' do
-  title 'NFS resource'
+  title 'Check NFS process is running and installed version'
 
   only_if { !os_properties.docker? }
 


### PR DESCRIPTION
### Description of changes

* This new recipe will permit to define tests requiring multiple dependencies in term of resources and recipes.
  * Intead of using the run_list attribute to define the list of recipes we are now using the dependencies attribute, on which it's possible to define a list of deps, identified by the recipe: or resource: prefix.

* Rename sudo, users, awscli controls to have a unique convention
  * The name of the control for the inspec test should describe the test we're doing and should not correspond to the name of the recipe.

### Tests
Adapted existing tests accordingly.
