### PR TITLE
Change docker? helper to system_test_or_docker? 

### DIFF
--- a/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
@@ -1,12 +1,14 @@
 #
 # Check if we are running in a virtualized environment
 #
-def docker?
-  node['virtualization']['system'] == 'docker'
+# FIXME: added virtualized? because this helper does not return true in system-test even if the tests are run in a container
+# FIXME: changed the name from docker? to system_test_or_docker?
+def system_test_or_docker?
+  node['virtualization']['system'] == 'docker' || virtualized?
 end
 
 def redhat_ubi?
-  docker? && platform?('redhat')
+  system_test_or_docker? && platform?('redhat')
 end
 
 def x86?

--- a/cookbooks/aws-parallelcluster-config/files/default/compute_fleet_status/compute_fleet_status.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/compute_fleet_status/compute_fleet_status.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0719
 import argparse
 import datetime
 import json

--- a/cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd/clusterstatusmgtd.py
+++ b/cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd/clusterstatusmgtd.py
@@ -10,6 +10,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=W0719
 import functools
 import json
 import logging

--- a/cookbooks/aws-parallelcluster-install/files/default/ec2_udev_rules/manageVolume.py
+++ b/cookbooks/aws-parallelcluster-install/files/default/ec2_udev_rules/manageVolume.py
@@ -1,4 +1,5 @@
 # pylint: disable=C0103
+# pylint: disable=W0719
 # This file should name manage_volume.py by convention
 import argparse
 import configparser

--- a/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_amazon2.rb
@@ -17,7 +17,7 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  return if !x86? || docker?
+  return if !x86? || system_test_or_docker?
 
   grub_cmdline_attributes = {
     "processor.max_cstate" => { "value" => "1" },

--- a/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_centos7.rb
@@ -19,7 +19,7 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  return if !x86? || docker?
+  return if !x86? || system_test_or_docker?
 
   grub_cmdline_attributes = {
     "processor.max_cstate" => { "value" => "1" },

--- a/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_redhat8.rb
@@ -19,7 +19,7 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  return if !x86? || docker?
+  return if !x86? || system_test_or_docker?
 
   grub_cmdline_attributes = {
     "processor.max_cstate" => { "value" => "1" },

--- a/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_ubuntu18.rb
@@ -17,7 +17,7 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  return if !x86? || docker?
+  return if !x86? || system_test_or_docker?
 
   grub_cmdline_attributes = {
     "processor.max_cstate" => { "value" => "1" },

--- a/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_ubuntu20.rb
@@ -17,7 +17,7 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  return if !x86? || docker?
+  return if !x86? || system_test_or_docker?
 
   grub_cmdline_attributes = {
     "processor.max_cstate" => { "value" => "1" },

--- a/cookbooks/aws-parallelcluster-install/resources/ec2_udev_rules/partial/_common_udev_configuration.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/ec2_udev_rules/partial/_common_udev_configuration.rb
@@ -63,5 +63,5 @@ action :start_ec2blk do
   service "ec2blkdev" do
     supports restart: true
     action %i(enable start)
-  end unless docker?
+  end unless system_test_or_docker?
 end

--- a/cookbooks/aws-parallelcluster-install/resources/ec2_udev_rules/partial/_debian_udev_configuration.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/ec2_udev_rules/partial/_debian_udev_configuration.rb
@@ -31,6 +31,6 @@ action :set_udev_autoreload do
     user 'root'
     group 'root'
     mode '0644'
-    notifies :run, "execute[udev-daemon-reload]", :immediately unless docker?
+    notifies :run, "execute[udev-daemon-reload]", :immediately unless system_test_or_docker?
   end
 end

--- a/test/unit/compute_fleet_status/test_compute_fleet_status.py
+++ b/test/unit/compute_fleet_status/test_compute_fleet_status.py
@@ -18,7 +18,6 @@ from compute_fleet_status import get_status_with_last_updated_time, update_statu
     [True, False],
 )
 def test_get_status_with_last_updated_time(no_error, mocker, capsys):
-
     if no_error:
         mocker.patch(
             "compute_fleet_status.get_dynamo_db_data",
@@ -49,7 +48,6 @@ def test_get_status_with_last_updated_time(no_error, mocker, capsys):
     ],
 )
 def test_update_status_with_last_updated_time(current_status, mocker):
-
     mocker.patch(
         "compute_fleet_status.get_dynamo_db_data",
         return_value={"lastStatusUpdatedTime": "2022-01-14T04:40:47.653Z", "status": current_status},

--- a/tox.ini
+++ b/tox.ini
@@ -157,7 +157,7 @@ commands =
 [testenv:semgrep]
 basepython = python3
 deps =
-    semgrep
+    semgrep>=1.8.0
 commands =
     semgrep \
         --config p/r2c-security-audit \


### PR DESCRIPTION
### Description of the change
* Change docker? helper to system_test_or_docker? because it was in conflict with chef-utils - introspection.rb

Adding `|| virtualized?` because in system-test the value of `node['virtualization']['system']` is:
```
#19 23.29       +    "virtualization": {
#19 23.29       +      "systems": {
#19 23.29       +
#19 23.29       +      }
#19 23.29       +    }
```

* minor linter fix