### PR TITLE
Add test for openssh resource execution and align name used to check fo virtualized env

### DIFF
--- a/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
@@ -1,14 +1,12 @@
 #
-# Check if we are running in a virtualized environment
+# Check if we are running in a Docker System Tests
 #
-# FIXME: added virtualized? because this helper does not return true in system-test even if the tests are run in a container
-# FIXME: changed the name from docker? to system_test_or_docker?
-def system_test_or_docker?
-  node['virtualization']['system'] == 'docker' || virtualized?
+def virtualized?
+  node.include?('virtualized') and node['virtualized']
 end
 
 def redhat_ubi?
-  system_test_or_docker? && platform?('redhat')
+  virtualized? && platform?('redhat')
 end
 
 def x86?

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -31,8 +31,7 @@ include_recipe "aws-parallelcluster-install::cfn_bootstrap"
 include_recipe 'aws-parallelcluster-install::node'
 include_recipe "aws-parallelcluster-install::awscli"
 
-# Manage SSH via Chef
-include_recipe "openssh" unless redhat_ubi?
+include_recipe "aws-parallelcluster-install::openssh"
 
 # Disable selinux
 selinux_state "SELinux Disabled" do

--- a/cookbooks/aws-parallelcluster-install/recipes/openssh.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/openssh.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster
+# Recipe:: sudoers
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+# Manage SSH via Chef resource
+include_recipe "openssh" unless virtualized?

--- a/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_amazon2.rb
@@ -17,7 +17,7 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  return if !x86? || system_test_or_docker?
+  return if !x86? || virtualized?
 
   grub_cmdline_attributes = {
     "processor.max_cstate" => { "value" => "1" },

--- a/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_centos7.rb
@@ -19,7 +19,7 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  return if !x86? || system_test_or_docker?
+  return if !x86? || virtualized?
 
   grub_cmdline_attributes = {
     "processor.max_cstate" => { "value" => "1" },

--- a/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_redhat8.rb
@@ -19,7 +19,7 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  return if !x86? || system_test_or_docker?
+  return if !x86? || virtualized?
 
   grub_cmdline_attributes = {
     "processor.max_cstate" => { "value" => "1" },

--- a/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_ubuntu18.rb
@@ -17,7 +17,7 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  return if !x86? || system_test_or_docker?
+  return if !x86? || virtualized?
 
   grub_cmdline_attributes = {
     "processor.max_cstate" => { "value" => "1" },

--- a/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/c_states/c_states_ubuntu20.rb
@@ -17,7 +17,7 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  return if !x86? || system_test_or_docker?
+  return if !x86? || virtualized?
 
   grub_cmdline_attributes = {
     "processor.max_cstate" => { "value" => "1" },

--- a/cookbooks/aws-parallelcluster-install/resources/ec2_udev_rules/partial/_common_udev_configuration.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/ec2_udev_rules/partial/_common_udev_configuration.rb
@@ -63,5 +63,5 @@ action :start_ec2blk do
   service "ec2blkdev" do
     supports restart: true
     action %i(enable start)
-  end unless system_test_or_docker?
+  end unless virtualized?
 end

--- a/cookbooks/aws-parallelcluster-install/resources/ec2_udev_rules/partial/_debian_udev_configuration.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/ec2_udev_rules/partial/_debian_udev_configuration.rb
@@ -31,6 +31,6 @@ action :set_udev_autoreload do
     user 'root'
     group 'root'
     mode '0644'
-    notifies :run, "execute[udev-daemon-reload]", :immediately unless system_test_or_docker?
+    notifies :run, "execute[udev-daemon-reload]", :immediately unless virtualized?
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/efa/efa.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/efa/efa.rb
@@ -38,7 +38,7 @@ action :remove_conflicting_packages do
 end
 
 action :setup do
-  return if docker?
+  return if virtualized?
 
   if efa_installed && !::File.exist?(efa_tarball)
     Chef::Log.warn("Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration.")

--- a/cookbooks/aws-parallelcluster-test/recipes/docker_mock.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/docker_mock.rb
@@ -1,4 +1,4 @@
-return unless docker?
+return unless virtualized?
 
 file '/bin/systemctl' do
   content %{

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -129,3 +129,10 @@ suites:
     attributes:
       dependencies:
         - recipe:aws-parallelcluster::test_dummy
+  - name: openssh
+    run_list:
+      - recipe[aws-parallelcluster-install::openssh]
+    verifier:
+      controls:
+        - openssh_installed
+

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -289,13 +289,6 @@ def arm_instance?
 end
 
 #
-# Check if we are running in a virtualized environment
-#
-def virtualized?
-  node.include?('virtualized') and node['virtualized']
-end
-
-#
 # Check if this platform supports intel's HPC platform
 #
 def platform_supports_intel_hpc_platform?

--- a/test/common/libraries/os_properties.rb
+++ b/test/common/libraries/os_properties.rb
@@ -11,12 +11,12 @@ class OsProperties < Inspec.resource(1)
     os_properties.redhat_ubi?
   '
 
-  def docker?
+  def virtualized?
     inspec.virtualization.system == 'docker'
   end
 
   def redhat_ubi?
-    docker? && inspec.os.name == 'redhat'
+    virtualized? && inspec.os.name == 'redhat'
   end
 
   def alinux2?

--- a/test/recipes/controls/aws_parallelcluster_install/openssh_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/openssh_spec.rb
@@ -1,0 +1,40 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'openssh_installed' do
+  title 'Check that openssh packages are installed and ssh/sshd config file exist'
+
+  only_if { !os_properties.virtualized? }
+
+  files = %w(/etc/ssh/ssh_config)
+  files.each do |file|
+    describe file(file) do
+      it { should exist }
+      its('mode') { should cmp '0644' }
+      its('owner') { should eq 'root' }
+      its('group') { should eq 'root' }
+    end
+  end
+
+  files = %w(/etc/ssh/sshd_config /etc/ssh/ca_keys /etc/ssh/revoked_keys)
+  files.each do |file|
+    describe file(file) do
+      it { should exist }
+      its('mode') { should cmp '0600' }
+      its('owner') { should eq 'root' }
+      its('group') { should eq 'root' }
+    end
+  end
+
+  describe package('openssh-server') do
+    it { should be_installed }
+  end
+end

--- a/test/resources/controls/aws_parallelcluster_install/c_states_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/c_states_spec.rb
@@ -1,7 +1,7 @@
 
 control 'c_states_kernel_configuration' do
   title 'Check the configuration to disable c states'
-  only_if { !os_properties.docker? && os_properties.x86? }
+  only_if { !os_properties.virtualized? && os_properties.x86? }
 
   describe file('/etc/default/grub') do
     it { should exist }

--- a/test/resources/controls/aws_parallelcluster_install/ec2_udev_rules_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/ec2_udev_rules_spec.rb
@@ -32,7 +32,7 @@ end
 control 'ec2blkdev_service_installation' do
   title "Installation of the ec2blkdev service"
 
-  only_if { !os_properties.docker? }
+  only_if { !os_properties.virtualized? }
 
   describe service('ec2blkdev') do
     it { should be_installed }

--- a/test/resources/controls/aws_parallelcluster_install/efa_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/efa_spec.rb
@@ -12,7 +12,7 @@
 control 'efa_conflicting_packages_removed' do
   title 'Check packages conflicting with EFA are not installed'
 
-  only_if { !os_properties.docker? }
+  only_if { !os_properties.virtualized? }
 
   if os.redhat?
     openmpi_packages = %w(openmpi-devel openmpi)
@@ -34,7 +34,7 @@ end
 control 'efa_installed' do
   title 'Check EFA is installed'
 
-  only_if { !os_properties.docker? }
+  only_if { !os_properties.virtualized? }
 
   describe "Verify EFA Kernel module is available\n" do
     describe command("modinfo efa") do

--- a/test/resources/controls/aws_parallelcluster_install/install_packages_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/install_packages_spec.rb
@@ -16,7 +16,7 @@ control 'install_packages' do
 
     describe package('kernel-devel') do
       it { should be_installed }
-    end unless os_properties.docker?
+    end unless os_properties.virtualized?
 
     # Check amazon linux2 extra
     if os_properties.alinux2?
@@ -33,7 +33,7 @@ control 'install_packages' do
 
     describe bash('dpkg -l | grep linux-headers') do
       its('exit_status') { should eq 0 }
-    end unless os_properties.docker?
+    end unless os_properties.virtualized?
 
   else
     describe "unsupported OS" do

--- a/test/resources/controls/aws_parallelcluster_install/nfs_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/nfs_spec.rb
@@ -1,7 +1,7 @@
 control 'nfs' do
   title 'Check NFS process is running and installed version'
 
-  only_if { !os_properties.docker? }
+  only_if { !os_properties.virtualized? }
 
   # Check nfsd process is running
   describe command('ps aux') do


### PR DESCRIPTION
### Description of changes
* Note: openssh is a resource created and managed by Chef


### Tests
* Tested on both alinux2 and redhat8 on EC2
```
  ✔  openssh_installed: Check that openssh packages are installed and ssh/sshd config file exist
     ✔  File /etc/ssh/ssh_config is expected to exist
     ✔  File /etc/ssh/ssh_config mode is expected to cmp == "0644"
     ✔  File /etc/ssh/ssh_config owner is expected to eq "root"
     ✔  File /etc/ssh/ssh_config group is expected to eq "root"
     ✔  File /etc/ssh/sshd_config is expected to exist
     ✔  File /etc/ssh/sshd_config mode is expected to cmp == "0600"
     ✔  File /etc/ssh/sshd_config owner is expected to eq "root"
     ✔  File /etc/ssh/sshd_config group is expected to eq "root"
     ✔  File /etc/ssh/ca_keys is expected to exist
     ✔  File /etc/ssh/ca_keys mode is expected to cmp == "0600"
     ✔  File /etc/ssh/ca_keys owner is expected to eq "root"
     ✔  File /etc/ssh/ca_keys group is expected to eq "root"
     ✔  File /etc/ssh/revoked_keys is expected to exist
     ✔  File /etc/ssh/revoked_keys mode is expected to cmp == "0600"
     ✔  File /etc/ssh/revoked_keys owner is expected to eq "root"
     ✔  File /etc/ssh/revoked_keys group is expected to eq "root"
     ✔  System Package openssh-server is expected to be installed
```

* Align function name used to check virtualized environment
  * Moved virtualized definition from aws-parallelcluster to aws-parallelcluster-common to simplify usage on all the cookbooks (that already have common as dep).
* Renamed system_test_or_docker and docker into virtualized?
  * The virtualized? function is defined in both common/helpers.rb and test/common/libraries/os_properties.rb
  * The first use will be used during code execution and for System Tests, the second one will be used for Inspec Tests.

### References
* https://github.com/sous-chefs/openssh
