### PR TITLE
Move gc_threshold configuration into a new recipe and add tests

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -421,11 +421,6 @@ default['cluster']['lustre']['client_url'] = value_for_platform(
   }
 )
 
-# Default gc_thresh values for performance at scale
-default['cluster']['sysctl']['ipv4']['gc_thresh1'] = 0
-default['cluster']['sysctl']['ipv4']['gc_thresh2'] = 15_360
-default['cluster']['sysctl']['ipv4']['gc_thresh3'] = 16_384
-
 # ParallelCluster internal variables (also in /etc/parallelcluster/cfnconfig)
 default['cluster']['region'] = 'us-east-1'
 default['cluster']['stack_name'] = nil

--- a/cookbooks/aws-parallelcluster-install/attributes/default.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default.rb
@@ -1,1 +1,6 @@
 # aws-parallelcluster-install attributes
+
+# Default gc_thresh values for performance at scale
+default['cluster']['sysctl']['ipv4']['gc_thresh1'] = 0
+default['cluster']['sysctl']['ipv4']['gc_thresh2'] = 15_360
+default['cluster']['sysctl']['ipv4']['gc_thresh3'] = 16_384

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -52,8 +52,7 @@ nfs 'install NFS daemon'
 include_recipe "aws-parallelcluster-install::ephemeral_drives"
 ec2_udev_rules 'configure udev'
 
-# Configure gc_thresh values to be consistent with alinux2 default values for performance at scale
-configure_gc_thresh_values
+include_recipe "aws-parallelcluster-install::gc_thresh_values"
 
 include_recipe "aws-parallelcluster-install::supervisord"
 

--- a/cookbooks/aws-parallelcluster-install/recipes/gc_thresh_values.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/gc_thresh_values.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-install
+# Recipe:: gc_thresh_values
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configure gc_thresh values to be consistent with alinux2 default values for performance at scale
+
+def configure_gc_thresh_values
+  (1..3).each do |i|
+    sysctl "net.ipv4.neigh.default.gc_thresh#{i}" do
+      value node['cluster']['sysctl']['ipv4']["gc_thresh#{i}"]
+      action :apply
+    end unless virtualized?
+  end
+end
+
+configure_gc_thresh_values

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -135,4 +135,9 @@ suites:
     verifier:
       controls:
         - openssh_installed
-
+  - name: gc_thresh_values
+    run_list:
+      - recipe[aws-parallelcluster-install::gc_thresh_values]
+    verifier:
+      controls:
+        - gc_thresh_values_configured

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -477,16 +477,6 @@ def get_metadata_with_token(token, uri)
   metadata
 end
 
-def configure_gc_thresh_values
-  (1..3).each do |i|
-    # Configure gc_thresh values to be consistent with alinux2 default values
-    sysctl "net.ipv4.neigh.default.gc_thresh#{i}" do
-      value node['cluster']['sysctl']['ipv4']["gc_thresh#{i}"]
-      action :apply
-    end
-  end
-end
-
 def get_system_users
   cmd = Mixlib::ShellOut.new("cat /etc/passwd | cut -d: -f1")
   cmd.run_command

--- a/test/recipes/controls/aws_parallelcluster_install/gc_thresh_values_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/gc_thresh_values_spec.rb
@@ -1,0 +1,26 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'gc_thresh_values_configured' do
+  title 'Verify gc_thresh values are configured in the kernel settings'
+
+  only_if { !os_properties.virtualized? }
+
+  # We cannot access node attributes in the inspec tests
+  @thresh_numbers = [ 1, 2, 3 ]
+  @thresh_values = [ 0, 15_360, 16_384 ]
+
+  @thresh_numbers.zip(@thresh_values).each do |thresh_number, thresh_value|
+    describe kernel_parameter("net.ipv4.neigh.default.gc_thresh#{thresh_number}") do
+      its('value') { should eq thresh_value }
+    end
+  end
+end


### PR DESCRIPTION
Moved attributes and usage into aws-parallelcluster-install recipe

### Tests
Tested on both alinux2 and redhat8 on EC2
```
  ✔  gc_thresh_values_configured: Verify gc_thresh values are configured in the kernel settings
     ✔  Kernel Parameter net.ipv4.neigh.default.gc_thresh1 value is expected to eq 0
     ✔  Kernel Parameter net.ipv4.neigh.default.gc_thresh2 value is expected to eq 15360
     ✔  Kernel Parameter net.ipv4.neigh.default.gc_thresh3 value is expected to eq 16384
```

