### PR TITLE
Add test for ami_cleanup file creation

### DIFF
--- a/cookbooks/aws-parallelcluster-install/recipes/ami_cleanup.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/ami_cleanup.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-install
+# Recipe:: ami_cleanup
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+# Create AMI cleanup script
+cookbook_file "ami_cleanup.sh" do
+  source 'base/ami_cleanup.sh'
+  path '/usr/local/sbin/ami_cleanup.sh'
+  owner "root"
+  group "root"
+  mode "0755"
+end

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -52,14 +52,7 @@ include_recipe "aws-parallelcluster-install::gc_thresh_values"
 
 include_recipe "aws-parallelcluster-install::supervisord"
 
-# AMI cleanup script
-cookbook_file "ami_cleanup.sh" do
-  source 'base/ami_cleanup.sh'
-  path '/usr/local/sbin/ami_cleanup.sh'
-  owner "root"
-  group "root"
-  mode "0755"
-end
+include_recipe "aws-parallelcluster-install::ami_cleanup"
 
 # Configure cron and anacron
 include_recipe "aws-parallelcluster-install::cron"

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -170,3 +170,9 @@ suites:
         - recipe:aws-parallelcluster-install::users
         - recipe:aws-parallelcluster-install::directories
         - recipe:aws-parallelcluster-install::sudo
+  - name: ami_cleanup
+    run_list:
+      - recipe[aws-parallelcluster-install::ami_cleanup]
+    verifier:
+      controls:
+        - ami_cleanup_file_created

--- a/kitchen.validate.yml
+++ b/kitchen.validate.yml
@@ -49,4 +49,7 @@ suites:
         - package_repos
         - install_packages
         - nfs
+        - efa_conflicting_packages_removed
+        - efa_installed
+        - ami_cleanup_file_created
 

--- a/kitchen.validate.yml
+++ b/kitchen.validate.yml
@@ -18,14 +18,14 @@ suites:
         # This is the first stab at aws-parallelcluster-install::base testing
         # Missing tests for:
         #   - disable_services
-        #   - openssh
         #   - Disable selinux
         #   - License README
         #   - configure_gc_thresh_values
-        #   - ami_cleanup
-        #   - cron
-        #   - chrony
+        #   - chrony_installed_and_configured
         #   - c_states
+        #   - clusterstatusmgtd_files_created
+        #   - mysql_client_installed
+        #   - mysql_client_source_node_created
         # We also need to test the effect some files (service config, profile config) have on the system.
         # TODO: rethink and integrate
         - sudo_installed
@@ -49,7 +49,7 @@ suites:
         - package_repos
         - install_packages
         - nfs
-        - efa_conflicting_packages_removed
-        - efa_installed
+        - cron_disabled_selected_daily_and_weekly_jobs
+        - openssh_installed
         - ami_cleanup_file_created
 

--- a/test/recipes/controls/aws_parallelcluster_install/ami_cleanup_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/ami_cleanup_spec.rb
@@ -1,0 +1,22 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'ami_cleanup_file_created' do
+  title 'Check that ami_cleanup.sh file exists'
+
+  describe file("/usr/local/sbin/ami_cleanup.sh") do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should_not be_empty }
+  end
+end


### PR DESCRIPTION
### Tests
* Add missing controls in the validate test
* Tested on Redhat and alinux2 on EC2
``` 
  ✔  ami_cleanup_file_created: Check that ami_cleanup.sh file exists
     ✔  File /usr/local/sbin/ami_cleanup.sh is expected to exist
     ✔  File /usr/local/sbin/ami_cleanup.sh mode is expected to cmp == "0755"
     ✔  File /usr/local/sbin/ami_cleanup.sh owner is expected to eq "root"
     ✔  File /usr/local/sbin/ami_cleanup.sh group is expected to eq "root"
     ✔  File /usr/local/sbin/ami_cleanup.sh content is expected not to be empty
```