### PR TITLE
Enable additional Slurm logging for the Power Saving plugin

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -69,6 +69,7 @@ SlurmctldDebug=info
 SlurmctldLogFile=/var/log/slurmctld.log
 SlurmdDebug=info
 SlurmdLogFile=/var/log/slurmd.log
+DebugFlags=Power
 JobCompType=jobcomp/none
 #
 # WARNING!!! The slurm_parallelcluster.conf file included below can be updated by the pcluster process.

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -65,7 +65,7 @@ GresTypes=gpu
 SelectType=select/cons_tres
 #
 # LOGGING
-SlurmctldDebug=info
+SlurmctldDebug=verbose
 SlurmctldLogFile=/var/log/slurmctld.log
 SlurmdDebug=info
 SlurmdLogFile=/var/log/slurmd.log


### PR DESCRIPTION
### Description of changes
* Enable additional Slurm logging for the power saving plugin

### Tests
* Tested impact of enabling the additional logging on the Slurm log files. The additional logging was considered acceptable.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.