### PR TITLE
Split package_repos resource and extend docker testing

### DIFF
--- a/cookbooks/aws-parallelcluster-install/recipes/gc_thresh_values.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/gc_thresh_values.rb
@@ -22,7 +22,7 @@ def configure_gc_thresh_values
     sysctl "net.ipv4.neigh.default.gc_thresh#{i}" do
       value node['cluster']['sysctl']['ipv4']["gc_thresh#{i}"]
       action :apply
-    end unless virtualized?
+    end
   end
 end
 

--- a/cookbooks/aws-parallelcluster-install/recipes/openssh.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/openssh.rb
@@ -17,4 +17,4 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 # Manage SSH via Chef resource
-include_recipe "openssh" unless virtualized?
+include_recipe "openssh"

--- a/cookbooks/aws-parallelcluster-install/resources/package_repos/package_repos.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/package_repos/package_repos.rb
@@ -15,9 +15,10 @@
 provides :package_repos
 unified_mode true
 
+default_action :setup
+
 action :setup do
-  case node['platform_family']
-  when 'rhel', 'amazon'
+  if platform_family?('rhel', 'amazon')
     include_recipe 'yum'
     if platform_family?('amazon')
       alinux_extras_topic 'epel'
@@ -33,8 +34,13 @@ action :setup do
         command "yum-config-manager --setopt=\*.skip_if_unavailable=1 --save"
       end
     end
+  end
 
-  when 'debian'
+  action_update
+end
+
+action :update do
+  if platform_family?('debian')
     apt_update
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/package_repos/package_repos_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/package_repos/package_repos_redhat8.rb
@@ -30,3 +30,7 @@ action :setup do
     command "yum-config-manager --enable #{node['cluster']['extra_repos']}"
   end unless virtualized?
 end
+
+action :update do
+  # Do nothing
+end

--- a/cookbooks/aws-parallelcluster-test/recipes/docker_mock.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/docker_mock.rb
@@ -17,6 +17,8 @@ case $action in
     ;;
     start)
     ;;
+    restart)
+    ;;
 esac
 }
 end
@@ -35,6 +37,7 @@ end
   /etc/init.d/nfs-client.target
   /etc/init.d/nfs-config.service
   /etc/init.d/nfs-kernel-server.service
+  /sbin/service
   /usr/local/bin/udevadm
   /usr/local/sbin/sysctl
   /usr/local/sbin/modprobe).each do |mock|
@@ -44,8 +47,5 @@ end
   end
 end
 
-directory '/sbin/service' do
-  mode '0777'
-end
 directory '/etc/cron.daily'
 directory '/etc/cron.weekly'

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -145,7 +145,7 @@ suites:
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-test::docker_mock
-        - resource:package_repos
+        - resource:package_repos:update
   - name: gc_thresh_values
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -137,16 +137,25 @@ suites:
         - disable_selinux
   - name: openssh
     run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-install::openssh]
     verifier:
       controls:
         - openssh_installed
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-test::docker_mock
+        - resource:package_repos
   - name: gc_thresh_values
     run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-install::gc_thresh_values]
     verifier:
       controls:
         - gc_thresh_values_configured
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-test::docker_mock
   - name: cfnconfig_mixed
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]

--- a/kitchen.resources.yml
+++ b/kitchen.resources.yml
@@ -36,7 +36,6 @@ suites:
 
 <% [
   'package_repos',
-  'nfs',
   ].each do |resource| %>
   - name: <%= resource %>
     run_list:
@@ -51,8 +50,6 @@ suites:
 <%end %>
   - name: c_states
     run_list:
-      # This is a test recipe executing the default action of the resource you pass as `resource` attribute,
-      # with default properties
       - recipe[aws-parallelcluster-install::test_resource]
     verifier:
       controls:
@@ -82,3 +79,13 @@ suites:
         - recipe:aws-parallelcluster::test_dummy
         - recipe:aws-parallelcluster-install::directories
       resource: mysql_client
+  - name: nfs
+    run_list:
+      - recipe[aws-parallelcluster-install::test_resource]
+    verifier:
+      controls:
+        - nfs_installed_with_right_version
+    attributes:
+      resource: nfs
+      dependencies:
+        - recipe:aws-parallelcluster-test::docker_mock

--- a/kitchen.resources.yml
+++ b/kitchen.resources.yml
@@ -11,43 +11,19 @@ verifier:
     # resource tests will use controls from this directory
     - path: test/resources
 
-
-suites:
-# This is the result of the ERB block below
-#  - name: package_repos
-#    run_list:
-#      - recipe[aws-parallelcluster::test_resource]
-#    verifier:
-#      controls:
-#        - package_repos
-#    attributes:
-#      cluster:
-#        base_os: alinux2
-#      resource: package_repos
-
-# If you need to test a resource with an action or properties different from the default ones,
-# add custom tests here and adjust `aws-parallelcluster-test::test_resource`
-# to allow `action` and/or `properties` parameters.
-
 # If you need to test a resource with recipe/resources dependencies,
 # add recipe[aws-parallelcluster::add_dependencies] as first item in the run_list
 # then define a dependencies attribute, listing them with recipe: or resource: prefix.
 # You can find an example in the add_depdendencies.rb file.
-
-<% [
-  'package_repos',
-  ].each do |resource| %>
-  - name: <%= resource %>
+suites:
+  - name: package_repos
     run_list:
-      # This is a test recipe executing the default action of the resource you pass as `resource` attribute,
-      # with default properties
-      - recipe[aws-parallelcluster::test_resource]
+      - recipe[aws-parallelcluster-install::test_resource]
     verifier:
       controls:
-        - <%= resource %>
+        - package_repos
     attributes:
-      resource: <%= resource %>
-<%end %>
+      resource: package_repos
   - name: c_states
     run_list:
       - recipe[aws-parallelcluster-install::test_resource]

--- a/kitchen.validate.yml
+++ b/kitchen.validate.yml
@@ -48,7 +48,7 @@ suites:
         - debian_udevd_reload_configuration
         - package_repos
         - install_packages
-        - nfs
+        - nfs_installed_with_right_version
         - cron_disabled_selected_daily_and_weekly_jobs
         - openssh_installed
         - ami_cleanup_file_created

--- a/recipes/add_dependencies.rb
+++ b/recipes/add_dependencies.rb
@@ -17,6 +17,7 @@
 #    dependencies:
 #      - recipe:aws-parallelcluster::test_dummy
 #      - recipe:aws-parallelcluster-install::directories
+#      - resource:ec2_udev_rules
 #      - resource:package_repos:update
 
 if defined?(node['dependencies'])

--- a/test/recipes/controls/aws_parallelcluster_install/openssh_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/openssh_spec.rb
@@ -12,8 +12,6 @@
 control 'openssh_installed' do
   title 'Check that openssh packages are installed and ssh/sshd config file exist'
 
-  only_if { !os_properties.virtualized? }
-
   files = %w(/etc/ssh/ssh_config)
   files.each do |file|
     describe file(file) do
@@ -25,10 +23,15 @@ control 'openssh_installed' do
   end
 
   files = %w(/etc/ssh/sshd_config /etc/ssh/ca_keys /etc/ssh/revoked_keys)
+  file_permission = if os.debian?
+                      '0644'
+                    else
+                      '0600'
+                    end
   files.each do |file|
     describe file(file) do
       it { should exist }
-      its('mode') { should cmp '0600' }
+      its('mode') { should cmp file_permission }
       its('owner') { should eq 'root' }
       its('group') { should eq 'root' }
     end

--- a/test/resources/controls/aws_parallelcluster_install/nfs_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/nfs_spec.rb
@@ -1,4 +1,4 @@
-control 'nfs' do
+control 'nfs_installed_with_right_version' do
   title 'Check NFS process is running and installed version'
 
   only_if { !os_properties.virtualized? }


### PR DESCRIPTION
### Description of changes
* Thanks to `cookbooks/aws-parallelcluster-test/recipes/docker_mock.rb` the actions are mocked so we can remove the virtualized check.
* gc_thresh_values and openssh are now tested on docker too.
* Permit to specify the action name when adding a resource as dep
* Split repos setup and update actions in the package_repos resource. Call the update actions for openssh test, requiring only apt_update call for Ubuntu 20.