### PR TITLE
Add test for CloudWatch Agent configuration recipe.

### DIFF
--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files.json
@@ -17,7 +17,8 @@
       ],
       "platforms": [
         "amazon",
-        "centos"
+        "centos",
+        "redhat"
       ],
       "node_roles": [
         "ComputeFleet",
@@ -55,6 +56,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -74,6 +76,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -93,6 +96,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -112,6 +116,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -131,6 +136,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -149,6 +155,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -166,6 +173,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -183,6 +191,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -200,6 +209,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -217,6 +227,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -234,6 +245,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -251,6 +263,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -268,6 +281,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -285,6 +299,7 @@
       "platforms": [
         "amazon",
         "centos",
+        "redhat",
         "ubuntu"
       ],
       "node_roles": [
@@ -303,6 +318,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -326,6 +342,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -352,6 +369,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -378,6 +396,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -405,6 +424,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -429,6 +449,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -453,6 +474,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -477,6 +499,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -501,6 +524,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -525,6 +549,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -547,6 +572,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -565,6 +591,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],
@@ -584,6 +611,7 @@
       ],
       "platforms": [
         "centos",
+        "redhat",
         "ubuntu",
         "amazon"
       ],

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files_schema.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_log_files_schema.json
@@ -16,7 +16,7 @@
           },
           "platforms": {
             "type": "array",
-            "items": {"type": "string", "enum": ["amazon", "centos", "ubuntu"]}
+            "items": {"type": "string", "enum": ["amazon", "centos", "ubuntu", "redhat"]}
           },
           "node_roles": {
             "type": "array",

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/write_cloudwatch_agent_json.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/write_cloudwatch_agent_json.py
@@ -21,7 +21,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Create the cloudwatch agent config file")
     parser.add_argument("--config", help="Path to JSON file describing logs that should be monitored", required=True)
     parser.add_argument(
-        "--platform", help="OS family of this instance", choices=["amazon", "centos", "ubuntu"], required=True
+        "--platform", help="OS family of this instance", choices=["amazon", "centos", "ubuntu", "redhat"], required=True
     )
     parser.add_argument("--log-group", help="Name of the log group", required=True)
     parser.add_argument(
@@ -153,7 +153,7 @@ def add_scheduler_plugin_log(config_data, cluster_config_path):
                 "file_path": log_file.get("FilePath"),
                 "log_stream_name": log_file.get("LogStreamName"),
                 "schedulers": ["plugin"],
-                "platforms": ["centos", "ubuntu", "amazon"],
+                "platforms": ["centos", "ubuntu", "amazon", "redhat"],
                 "node_roles": get_node_roles(log_file.get("NodeType")),
                 "feature_conditions": [],
             }

--- a/cookbooks/aws-parallelcluster-config/recipes/cloudwatch_agent.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/cloudwatch_agent.rb
@@ -15,6 +15,9 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: find a way to make this code work on ubi8
+return if redhat_ubi?
+
 config_script_path = '/usr/local/bin/write_cloudwatch_agent_json.py'
 cookbook_file 'write_cloudwatch_agent_json.py' do
   not_if { ::File.exist?(config_script_path) }

--- a/cookbooks/aws-parallelcluster-install/recipes/cloudwatch_agent.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/cloudwatch_agent.rb
@@ -17,6 +17,10 @@
 
 # Download the cloudwatch agent's public key. Note that the domain used to get
 # the public key must NOT be regionalized.
+
+# TODO: find a way to make this code work on ubi8
+return if redhat_ubi?
+
 remote_file node['cluster']['cloudwatch']['public_key_local_path'] do
   source node['cluster']['cloudwatch']['public_key_url']
   retries 3
@@ -95,6 +99,6 @@ when 'ubuntu'
   dpkg_package package_path do
     source package_path
   end
-when 'amazon', 'centos'
+when 'amazon', 'centos', 'redhat'
   package package_path
 end

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -202,3 +202,15 @@ suites:
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-install::directories
+  - name: cloudwatch_agent_configured
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::cloudwatch_agent]
+    verifier:
+      controls:
+        - cloudwatch_agent_configured
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - recipe:aws-parallelcluster-install::python
+        - recipe:aws-parallelcluster-install::cloudwatch_agent

--- a/test/recipes/controls.aws_parallelcluster_config/cloudwatch_agent_spec.rb
+++ b/test/recipes/controls.aws_parallelcluster_config/cloudwatch_agent_spec.rb
@@ -1,0 +1,45 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'cloudwatch_agent_configured' do
+  title 'Check that cloudwatch agent is correctly configured'
+
+  only_if { !os_properties.redhat_ubi? }
+
+  describe file('/usr/local/bin/write_cloudwatch_agent_json.py') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should_not be_empty }
+  end
+
+  files = %w(/usr/local/etc/cloudwatch_log_files.json /usr/local/etc/cloudwatch_log_files_schema.json /usr/local/bin/cloudwatch_log_configs_util.py)
+  files.each do |file|
+    describe file(file) do
+      it { should exist }
+      its('mode') { should cmp '0644' }
+      its('owner') { should eq 'root' }
+      its('group') { should eq 'root' }
+    end
+  end
+
+  desc 'Cloudwatch Agent config should have been created'
+  describe file('/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json') do
+    it { should exist }
+    its('content') { should_not be_empty }
+  end
+
+  desc 'CloudWatch Agent should be running'
+  describe bash('/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | grep status | grep running') do
+    its('exit_status') { should eq(0) }
+  end
+end


### PR DESCRIPTION
### Description of changes
Add test for CloudWatch Agent configuration recipe.

### Tests
Tested on Docker and EC2.

*Note that on RHEL8 Docker we skip installation/configuration of CW Agent as well as the config test, because we have a limitation that we cannot install PyDev, which is also the reason `aws-parallelcluster-install::python` and its test skips execution on RHEL8 Docker.*

**The code has been run in an EC2 instance with RHEL8, and the test validates that the CW Agent is running.**

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.