### PR TITLE
Move sticky_bits logic into a new resource

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -18,12 +18,7 @@
 include_recipe "aws-parallelcluster-common::setup_envars"
 include_recipe 'aws-parallelcluster-config::openssh'
 
-# Restore old behavior with sticky bits in Ubuntu 20 to allow root writing to files created by other users
-if platform?('ubuntu') && node['platform_version'].to_i == 20
-  sysctl 'fs.protected_regular' do
-    value 0
-  end
-end
+sticky_bits "setup sticky bits"
 
 include_recipe 'aws-parallelcluster-config::nfs' unless virtualized?
 

--- a/cookbooks/aws-parallelcluster-config/recipes/test_resource.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/test_resource.rb
@@ -1,0 +1,10 @@
+# This is a helper recipe executing the default action of the resource
+# which type was set as `resource` attribute during the test execution.
+# This is equivalent to:
+# resource_type 'test'
+# or
+# resource_type 'test' do
+#   action :default_action
+# end
+
+declare_resource(node['resource'].to_sym, 'test')

--- a/cookbooks/aws-parallelcluster-config/resources/sticky_bits/sticky_bits.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/sticky_bits/sticky_bits.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :sticky_bits
+unified_mode true
+
+action :setup do
+  # Do nothing
+end

--- a/cookbooks/aws-parallelcluster-config/resources/sticky_bits/sticky_bits_ubuntu2004.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/sticky_bits/sticky_bits_ubuntu2004.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :sticky_bits, platform: 'ubuntu', platform_version: '20.04'
+unified_mode true
+
+action :setup do
+  # Restore old behavior with sticky bits in Ubuntu 20 to allow root writing to files created by other users
+  sysctl 'fs.protected_regular' do
+    value 0
+  end
+end

--- a/kitchen.resources.yml
+++ b/kitchen.resources.yml
@@ -65,3 +65,11 @@ suites:
       resource: nfs
       dependencies:
         - recipe:aws-parallelcluster-test::docker_mock
+  - name: sticky_bits
+    run_list:
+      - recipe[aws-parallelcluster-config::test_resource]
+    verifier:
+      controls:
+        - sticky_bits_configured
+    attributes:
+      resource: sticky_bits

--- a/test/common/libraries/os_properties.rb
+++ b/test/common/libraries/os_properties.rb
@@ -31,6 +31,10 @@ class OsProperties < Inspec.resource(1)
     inspec.os.name == 'amazon' && inspec.os.release.to_i == 2
   end
 
+  def ubuntu2004?
+    inspec.os.name == 'ubuntu' && inspec.os.release == '20.04'
+  end
+
   def debian_family?
     inspec.os.family == 'debian'
   end

--- a/test/resources/controls/aws_parallelcluster_config/sticky_bits_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_config/sticky_bits_spec.rb
@@ -1,0 +1,10 @@
+control 'sticky_bits_configured' do
+  title 'Check sticky bits configuration'
+
+  if os_properties.ubuntu2004? && !os_properties.virtualized?
+    # This test passes on Mac but doesn't work as GitHub action.
+    describe kernel_parameter('fs.protected_regular') do
+      its('value') { should eq 0 }
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
* It does nothing on all OSes except Ubuntu 20.04.

### Tests
* Tested on EC2 for both Ubuntu20 and RedHat8
