### PR TITLE
[bandit] Use absolute path for program called in subprocess call

### DIFF
--- a/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
@@ -360,7 +360,8 @@ class DCVAuthenticator(BaseHTTPRequestHandler):
         """
         logger.info("Verifying NICE DCV session validity..")
         # Remove the first and the last because they are the heading and empty, respectively
-        processes = subprocess.check_output(["ps", "aux"]).decode("utf-8").split("\n")[1:-1]  # nosec
+        # All commands and arguments in this subprocess call are built as literals
+        processes = subprocess.check_output(["/bin/ps", "aux"]).decode("utf-8").split("\n")[1:-1]  # nosec B603
 
         # Check the filter is empty
         if not next(


### PR DESCRIPTION
### Description of changes
* Use of `ps` command in subprocess call has a security risk if the PATH variable is manipulated ([B607: start_process_with_partial_path](https://bandit.readthedocs.io/en/latest/plugins/b607_start_process_with_partial_path.html))
* This commit uses the absolute path `/bin/ps`. `/bin/ps` can be found in all supported ParallelCluster OS platforms
* After fixing the [B607](https://bandit.readthedocs.io/en/latest/plugins/b607_start_process_with_partial_path.html) risk, a new risk came up ([B603: subprocess_without_shell_equals_true](https://bandit.readthedocs.io/en/latest/plugins/b603_subprocess_without_shell_equals_true.html)) which will be addressed in a separate PR.
* Worth noting as well that an alternative to using a subprocesss comand to get the list of DCV sessions is to use the [DCV Session Manager](https://docs.aws.amazon.com/dcv/latest/sm-admin/what-is-sm.html).
    * A setting has been added to DCV server to allow
    * The DCV session manager can perform admin tasks without running as root
    * This can be configured using the administrators setting of the `security` section.
    * Further instructions here: [](https://docs.aws.amazon.com/dcv/latest/sm-admin/servers.html)
    * The administrator can then run `dcv list-sessions -j` to get the list of sessions (and associated info e.g. the users)
    * This however involves setting up the [session manager](https://docs.aws.amazon.com/dcv/latest/sm-admin/what-is-sm.html) which is out of scope for these changes


alinux2
```
$ which ps
/usr/bin/ps

$ /usr/bin/ps --version
procps-ng version 3.3.10
$ ls -l /usr/bin/ps
-rwxr-xr-x 1 root root 100168 Aug 14  2019 /usr/bin/ps

$ /bin/ps --version
procps-ng version 3.3.10
$ ls -l /bin/ps
-rwxr-xr-x 1 root root 100168 Aug 14  2019 /bin/ps
```

ubuntu2004
```
$ which ps
/usr/bin/ps

$ /usr/bin/ps --version
ps from procps-ng 3.3.16
$ ls -lt /usr/bin/ps
-rwxr-xr-x 1 root root 137688 Sep  9  2021 /usr/bin/ps

$ /bin/ps --version
ps from procps-ng 3.3.16
$ ls -lt /bin/ps
-rwxr-xr-x 1 root root 137688 Sep  9  2021 /bin/ps
```

ubuntu1804
```
$ which ps
/bin/ps

$ /bin/ps --version
ps from procps-ng 3.3.12
$ ls -lt /bin/ps
-rwxr-xr-x 1 root root 133432 Aug  9  2019 /bin/ps

$ /usr/bin/ps --version
-bash: /usr/bin/ps: No such file or directory
```

centos7
```
$ which ps
/usr/bin/ps

$ /usr/bin/ps --version
procps-ng version 3.3.10
$ ls -lt /usr/bin/ps
-rwxr-xr-x. 1 root root 100112 Sep 30  2020 /usr/bin/ps

$ /bin/ps --version
procps-ng version 3.3.10
$ ls -lt /bin/ps
-rwxr-xr-x. 1 root root 100112 Sep 30  2020 /bin/ps
```

### Tests
* Ran existing unit tests
* Ran DCV integration tests

### References
* [B607: start_process_with_partial_path](https://bandit.readthedocs.io/en/latest/plugins/b607_start_process_with_partial_path.html)
* [B603: subprocess_without_shell_equals_true](https://bandit.readthedocs.io/en/latest/plugins/b603_subprocess_without_shell_equals_true.html)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.