### PR TITLE
Move ephemeral_drives config into a new recipe and use CINC to test on docker

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/metadata.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Manages AWS Batch in AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-common/metadata.rb
+++ b/cookbooks/aws-parallelcluster-common/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Common AWS ParallelCluster resources and attributes'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-config/metadata.rb
+++ b/cookbooks/aws-parallelcluster-config/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Configures AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -22,25 +22,7 @@ sticky_bits "setup sticky bits"
 
 include_recipe 'aws-parallelcluster-config::nfs' unless virtualized?
 
-# Mount the ephemeral drive unless there is a mountpoint collision with shared drives
-shared_dir_array = node['cluster']['ebs_shared_dirs'].split(',') + \
-                   node['cluster']['efs_shared_dirs'].split(',') + \
-                   node['cluster']['fsx_shared_dirs'].split(',') + \
-                   [ node['cluster']['raid_shared_dir'] ]
-unless shared_dir_array.include? node['cluster']['ephemeral_dir']
-  service "setup-ephemeral" do
-    supports restart: false
-    action :enable
-  end
-
-  # Execution timeout 3600 seconds
-  unless virtualized?
-    execute "Setup of ephemeral drives" do
-      user "root"
-      command "/usr/local/sbin/setup-ephemeral-drives.sh"
-    end
-  end
-end
+include_recipe 'aws-parallelcluster-config::ephemeral_drives'
 
 include_recipe 'aws-parallelcluster-config::networking'
 

--- a/cookbooks/aws-parallelcluster-config/recipes/ephemeral_drives.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/ephemeral_drives.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-config
+# Recipe:: ephemeral_drives
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mount the ephemeral drive unless there is a mountpoint collision with shared drives
+shared_dir_array = node['cluster']['ebs_shared_dirs'].split(',') + \
+                   node['cluster']['efs_shared_dirs'].split(',') + \
+                   node['cluster']['fsx_shared_dirs'].split(',') + \
+                   [ node['cluster']['raid_shared_dir'] ]
+
+unless shared_dir_array.include? node['cluster']['ephemeral_dir']
+  service "setup-ephemeral" do
+    supports restart: false
+    action :enable
+  end
+
+  # Execution timeout 3600 seconds
+  unless virtualized?
+    execute "Setup of ephemeral drives" do
+      user "root"
+      command "/usr/local/sbin/setup-ephemeral-drives.sh"
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-config/recipes/ephemeral_drives.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/ephemeral_drives.rb
@@ -25,13 +25,11 @@ unless shared_dir_array.include? node['cluster']['ephemeral_dir']
   service "setup-ephemeral" do
     supports restart: false
     action :enable
-  end
+  end unless virtualized?
 
   # Execution timeout 3600 seconds
-  unless virtualized?
-    execute "Setup of ephemeral drives" do
-      user "root"
-      command "/usr/local/sbin/setup-ephemeral-drives.sh"
-    end
-  end
+  execute "Setup of ephemeral drives" do
+    user "root"
+    command "/usr/local/sbin/setup-ephemeral-drives.sh"
+  end unless virtualized?
 end

--- a/cookbooks/aws-parallelcluster-install/metadata.rb
+++ b/cookbooks/aws-parallelcluster-install/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Installs AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/metadata.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Manages Custom Scheduler in AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-slurm/metadata.rb
+++ b/cookbooks/aws-parallelcluster-slurm/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Manages Slurm in AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-test/metadata.rb
+++ b/cookbooks/aws-parallelcluster-test/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Tests AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -2,7 +2,8 @@
 driver:
   name: dokken
   pull_platform_image: false # Use the local images, prevent pull of docker images from Docker Hub,
-  chef_version: 17.2.29 # Chef version aligned with the one used to build the images
+  chef_version: 17 # Chef version aligned with the one used to build the images
+  chef_image: cincproject/cinc
   env:
     # Since the kernel version of the docker images is not in the expected pattern,
     # KERNEL_RELEASE is set in the environment to override the system value.
@@ -10,6 +11,8 @@ driver:
 
 provisioner:
   name: dokken
+  product_name: cinc
+  chef_binary: /opt/cinc/bin/cinc-client
   attributes:
     virtualized: true
 

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -18,6 +18,9 @@ verifier:
 # You can find an example in the add_depdendencies.rb file.
 
 suites:
+
+# Install recipes
+
   - name: sudo
     run_list:
       - recipe[aws-parallelcluster-install::sudo]
@@ -202,6 +205,9 @@ suites:
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-install::directories
+
+# Config recipes
+
 #  - name: cloudwatch_agent_configured
 #    run_list:
 #      - recipe[aws-parallelcluster::add_dependencies]
@@ -233,3 +239,39 @@ suites:
         - recipe:aws-parallelcluster-install::directories
         - resource:package_repos
         - resource:install_packages
+  - name: ephemeral_drives
+    #driver:
+    #  instance_type: m5d.xlarge  # instance type with ephemeral drives
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::ephemeral_drives]
+    verifier:
+      controls:
+        - ephemeral_drives_service
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::ephemeral_drives
+      cluster:
+        ebs_shared_dirs: test1,test2
+        efs_shared_dirs: ''
+        fsx_shared_dirs: ''
+        raid_shared_dir: ''
+        ephemeral_dir: test3
+  - name: ephemeral_drives_skipped
+    #driver:
+    #  instance_type: m5d.xlarge  # instance type with ephemeral drives
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::ephemeral_drives]
+    verifier:
+      controls:
+        - ephemeral_drives_with_name_clashing_not_mounted
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::ephemeral_drives
+      cluster:
+        ebs_shared_dirs: test1,test2
+        efs_shared_dirs: ''
+        fsx_shared_dirs: ''
+        raid_shared_dir: ''
+        ephemeral_dir: test1

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Installs/Configures AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/test/recipes/controls/aws_parallelcluster_config/ephemeral_drives_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/ephemeral_drives_spec.rb
@@ -12,24 +12,26 @@
 control 'ephemeral_drives_service' do
   title 'Check ephemeral drives service is running'
 
+  only_if { !os_properties.virtualized? }
+
   describe service('setup-ephemeral') do
     it { should be_installed }
     it { should be_enabled }
   end
 
-  # TODO add test to see drivers are mounted
+  # TODO: add test to see drivers are mounted
 end
 
 control 'ephemeral_drives_with_name_clashing_not_mounted' do
   title 'Check ephemeral drives are not mounted when there is name clashing with reserved names'
+
+  only_if { !os_properties.virtualized? }
 
   describe service('setup-ephemeral') do
     it { should be_installed }
     it { should_not be_enabled }
     it { should_not be_running }
   end
-
-  only_if { !os_properties.virtualized? }
 
   describe bash('systemctl show setup-ephemeral.service -p ActiveState | grep "=inactive"') do
     its(:exit_status) { should eq 0 }

--- a/test/recipes/controls/aws_parallelcluster_config/ephemeral_drives_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/ephemeral_drives_spec.rb
@@ -1,0 +1,41 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'ephemeral_drives_service' do
+  title 'Check ephemeral drives service is running'
+
+  describe service('setup-ephemeral') do
+    it { should be_installed }
+    it { should be_enabled }
+  end
+
+  # TODO add test to see drivers are mounted
+end
+
+control 'ephemeral_drives_with_name_clashing_not_mounted' do
+  title 'Check ephemeral drives are not mounted when there is name clashing with reserved names'
+
+  describe service('setup-ephemeral') do
+    it { should be_installed }
+    it { should_not be_enabled }
+    it { should_not be_running }
+  end
+
+  only_if { !os_properties.virtualized? }
+
+  describe bash('systemctl show setup-ephemeral.service -p ActiveState | grep "=inactive"') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe bash('systemctl show setup-ephemeral.service -p UnitFileState | grep "=disabled"') do
+    its(:exit_status) { should eq 0 }
+  end
+end


### PR DESCRIPTION
### Description of changes
* Move ephemeral_drives config logic into a new recipe
  * Added tests to verify service is enabled
  * Tested it by passing driver / instance_type: m5d.xlarge for EC2 tests.
* Use CINC in place of Chef for docker tests (from @lukeseawalker )
  * Change chef_version to support other version of CINC.
