### PR TITLE
[bandit] Validate args before subprocess calls

### DIFF
--- a/cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd/clusterstatusmgtd.py
+++ b/cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd/clusterstatusmgtd.py
@@ -394,6 +394,7 @@ class ClusterStatusManager:
             "--override-runlist aws-parallelcluster::update_computefleet_status"
         )
         try:
+            # The command being passed has been built from string literals and local variables and can be trusted.
             _run_command(cmd, self._config.update_event_timeout_minutes)
         except Exception as e:
             log.error("Update event handler failed. Check log file %s", cinc_log_file)

--- a/cookbooks/aws-parallelcluster-install/files/default/ec2_udev_rules/ec2_dev_2_volid.py
+++ b/cookbooks/aws-parallelcluster-install/files/default/ec2_udev_rules/ec2_dev_2_volid.py
@@ -1,5 +1,6 @@
 import configparser
 import os
+import re
 import sys
 import syslog
 import time
@@ -24,11 +25,28 @@ def get_imdsv2_token():
     return headers
 
 
+def validate_device_name(device_name):
+    """
+    Validate an argument used to build a subprocess command against a regex pattern.
+
+    The validation is done after forcing the encoding to be the standard Python Unicode / UTF-8
+    :param device_name: an argument string to validate
+    :raise: Exception if the argument fails to match the patter
+    :return: True if the argument matches the pattern
+    """
+    device_name = (str(device_name).encode("utf-8", "ignore")).decode()
+    match = re.match(r"^(\w)+$", device_name)
+    if not match:
+        raise ValueError("Device name provided argument has an invalid pattern.")
+    return True
+
+
 def main():
     syslog.syslog("Starting ec2_dev_2_volid.py script")
     # Get dev
     try:
         dev = str(sys.argv[1])
+        validate_device_name(dev)
         syslog.syslog(f"Input block device is {dev}")
     except IndexError:
         syslog.syslog(syslog.LOG_ERR, "Provide block device i.e. xvdf")

--- a/test/unit/ec2_udev_rules/test_ec2_dev_2_volid.py
+++ b/test/unit/ec2_udev_rules/test_ec2_dev_2_volid.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import pytest
+from assertpy import assert_that
+from ec2_dev_2_volid import validate_device_name
+
+
+@pytest.mark.parametrize(
+    ("device_name", "raises"),
+    [
+        ("nvme0n1", False),
+        ("xvda", False),
+        ("nvme0n1p128", False),
+        ("nvme0n1&&", True),
+        ("xvda;", True),
+        ("nvme0n1|", True),
+        ("xvdb??", True),
+    ],
+)
+def test_validate_device_name(device_name, raises):
+    if raises:
+        assert_that(validate_device_name).raises(ValueError).when_called_with(device_name).contains("invalid pattern")
+    else:
+        assert_that(validate_device_name(device_name)).is_true()

--- a/test/unit/ec2_udev_rules/test_manage_volume.py
+++ b/test/unit/ec2_udev_rules/test_manage_volume.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import pytest
+from assertpy import assert_that
+from manageVolume import validate_device_name
+
+
+@pytest.mark.parametrize(
+    ("device_name", "raises"),
+    [
+        ("/dev/nvme0n1", False),
+        ("/dev/nvme0n1p1", False),
+        ("/dev/nvme0n1p128", False),
+        ("/dev/nvme0n1&&", True),
+        ("/dev/nvme0n1;", True),
+        ("/dev/nvme0n1|", True),
+        ("/dev/nvme0n1??", True),
+    ],
+)
+def test_validate_device_name(device_name, raises):
+    if raises:
+        assert_that(validate_device_name).raises(ValueError).when_called_with(device_name).contains("invalid pattern")
+    else:
+        assert_that(validate_device_name(device_name)).is_true()

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 # Default testenv. Used to run tests on all python versions.
 [testenv]
 deps = -rtest/unit/requirements.txt
-setenv = PYTHONPATH = {toxinidir}/files/default:cookbooks/aws-parallelcluster-config/files/default:cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm:cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd:cookbooks/aws-parallelcluster-config/files/default/compute_fleet_status
+setenv = PYTHONPATH = {toxinidir}/files/default:cookbooks/aws-parallelcluster-config/files/default:cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm:cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd:cookbooks/aws-parallelcluster-config/files/default/compute_fleet_status:cookbooks/aws-parallelcluster-install/files/default/ec2_udev_rules
 commands =
     py.test -l -v --basetemp={envtmpdir} --html=report.html --cov=files/default test/unit
 


### PR DESCRIPTION
### Description of changes
*  Validate device name arguments against a regex pattern before using it in subprocess call
   * N/B: The `manageVolume` and `ec2_dev_2_volid ` scripts are created in different directories (`/usr/local/sbin` and `/sbin` respectively) hence the use of their own independent validations (until we find a way to share functions, constants, modules between Python file in the cookbook)
* Add comments on why security exclusions remain valid (e.g. some subprocess calls are safe since they do not use any external arguments)


### Tests
* Unit tests
* Running existing Integrations tests

### References
* [[3.x] Reducing risks associated to Bandit findings #489](https://github.com/aws/aws-parallelcluster-node/pull/489)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.