### PR TITLE
Define new fs_update recipe and add tests for it

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/fs_update.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/fs_update.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-config
+# Recipe:: fs_update
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generate the shared storages mapping file
+template node['cluster']['shared_storages_mapping_path'] do
+  source 'shared_storages/shared_storages_data.erb'
+  mode '0644'
+end

--- a/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
@@ -16,10 +16,7 @@
 # limitations under the License.
 
 # generate the shared storages mapping file
-template node['cluster']['shared_storages_mapping_path'] do
-  source 'shared_storages/shared_storages_data.erb'
-  mode '0644'
-end
+include_recipe 'aws-parallelcluster-config::fs_update'
 
 manage_ebs "add ebs" do
   shared_dir_array node['cluster']['ebs_shared_dirs'].split(',')

--- a/cookbooks/aws-parallelcluster-config/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/update.rb
@@ -22,10 +22,7 @@ unless node['cluster']['scheduler'] == 'awsbatch'
 end
 
 # generate the update shared storages mapping file
-template node['cluster']['shared_storages_mapping_path'] do
-  source 'shared_storages/shared_storages_data.erb'
-  mode '0644'
-end
+include_recipe 'aws-parallelcluster-config::fs_update'
 
 include_recipe 'aws-parallelcluster-config::directory_service'
 include_recipe 'aws-parallelcluster-slurm::update' if node['cluster']['scheduler'] == 'slurm'

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -214,6 +214,50 @@ suites:
 #        - recipe:aws-parallelcluster-install::directories
 #        - recipe:aws-parallelcluster-install::python
 #        - recipe:aws-parallelcluster-install::cloudwatch_agent
+  - name: fs_update
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::fs_update]
+    verifier:
+      controls:
+        - fs_data_file_created_correctly
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - recipe:aws-parallelcluster::test_dummy
+      cluster:
+        ebs_shared_dirs: ebs1,ebs2
+        volume: volume1,volume2
+        raid_shared_dir: raid1
+        raid_type: 1
+        raid_vol_ids: volume1,volume2
+        efs_shared_dirs: efs1,efs2
+        efs_fs_ids: efs-id1,efs-id2
+        efs_encryption_in_transits: true,false
+        efs_iam_authorizations: iam1,iam2
+        fsx_shared_dirs: fsx1,fsx2
+        fsx_fs_ids: fsx-id1,fsx-id2
+        fsx_fs_types: type1,type2
+        fsx_dns_names: dns1,dns2
+        fsx_mount_names: mount1,mount2
+        fsx_volume_junction_paths: value1,value2
+  - name: fs_update_default_values
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::fs_update]
+    verifier:
+      controls:
+        - fs_data_file_with_default_values
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - recipe:aws-parallelcluster::test_dummy
+      cluster:
+        ebs_shared_dirs: '/shared'
+        volume: ''
+        efs_shared_dirs: ''
+        fsx_shared_dirs: ''
+        raid_shared_dir: ''
   - name: networking_configured
     run_list:
       - recipe[aws-parallelcluster-config::networking]

--- a/test/recipes/controls/aws_parallelcluster_config/fs_update_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/fs_update_spec.rb
@@ -1,0 +1,59 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'fs_data_file_created_correctly' do
+  title 'Check that shared storage info are added correctly to the data file'
+
+  describe file("/etc/parallelcluster/shared_storages_data.yaml") do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should match /^ebs:/ }
+    its('content') { should match /- volume_id: volume1/ }
+    its('content') { should match /mount_dir: ebs1/ }
+    its('content') { should match /^raid:/ }
+    its('content') { should match /- raid_shared_dir: raid1/ }
+    its('content') { should match /raid_type: 1/ }
+    its('content') { should match /raid_vol_array: volume1,volume2/ }
+    its('content') { should match /^efs:/ }
+    its('content') { should match /- efs_fs_id: efs-id2/ }
+    its('content') { should match /mount_dir: efs2/ }
+    its('content') { should match /efs_encryption_in_transit: false/ }
+    its('content') { should match /efs_iam_authorization: iam2/ }
+    its('content') { should match /^fsx:/ }
+    its('content') { should match /- fsx_fs_id: fsx-id2/ }
+    its('content') { should match /mount_dir: fsx2/ }
+    its('content') { should match /fsx_fs_type: type2/ }
+    its('content') { should match /fsx_dns_name: dns2/ }
+    its('content') { should match /fsx_mount_name: mount2/ }
+    its('content') { should match /fsx_volume_junction_path: value2/ }
+  end
+end
+
+control 'fs_data_file_with_default_values' do
+  title 'Check that shared storage info are not added to the data file'
+
+  describe file("/etc/parallelcluster/shared_storages_data.yaml") do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should match /^ebs:/ }
+    its('content') { should_not match %r{mount_dir: /shared} }
+    its('content') { should match /^raid:/ }
+    its('content') { should_not match /raid_type:/ }
+    its('content') { should match /^efs:/ }
+    its('content') { should_not match /- efs_fs_id:/ }
+    its('content') { should match /^fsx:/ }
+    its('content') { should_not match /- fsx_fs_id:/ }
+  end
+end


### PR DESCRIPTION
### Description of changes

The shared_storages_data.yaml file is created starting from an erb template adding information for ebs, raid, efs and fsx storages only when defined.

Added fs_update and fs_update_default_values to test the two cases

### Tests
Tested on RH8 and Ubuntu20 on docker and EC2