### PR TITLE
Test ssh_target_checker.sh script creation

### DIFF
--- a/cookbooks/aws-parallelcluster-common/libraries/networking.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/networking.rb
@@ -1,0 +1,19 @@
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+# Return the VPC CIDR list from node info
+def get_vpc_cidr_list
+  mac = node['ec2']['mac']
+  vpc_cidr_list = node['ec2']['network_interfaces_macs'][mac]['vpc_ipv4_cidr_blocks']
+  vpc_cidr_list.split(/\n+/)
+end

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -283,6 +283,20 @@ suites:
         - recipe:aws-parallelcluster-install::directories
         - resource:package_repos
         - resource:install_packages
+  - name: ssh_target_checker
+    run_list:
+      - recipe[aws-parallelcluster-config::openssh]
+    verifier:
+      controls:
+        - ssh_target_checker_script_created
+    attributes:
+      ec2:
+        mac: mac1
+        network_interfaces_macs:
+          mac1:
+            vpc_ipv4_cidr_blocks: |
+              cidr1
+              cidr2
   - name: ephemeral_drives
     #driver:
     #  instance_type: m5d.xlarge  # instance type with ephemeral drives

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -482,13 +482,6 @@ def get_system_users
   cmd.stdout.split(/\n+/)
 end
 
-# Return the VPC CIDR list from node info
-def get_vpc_cidr_list
-  mac = node['ec2']['mac']
-  vpc_cidr_list = node['ec2']['network_interfaces_macs'][mac]['vpc_ipv4_cidr_blocks']
-  vpc_cidr_list.split(/\n+/)
-end
-
 def run_command(command)
   Mixlib::ShellOut.new(command).run_command.stdout.strip
 end

--- a/test/recipes/controls/aws_parallelcluster_config/openssh_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/openssh_spec.rb
@@ -1,0 +1,22 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'ssh_target_checker_script_created' do
+  title 'Check that ssh_target_checker.sh is created correctly'
+
+  describe file('/usr/bin/ssh_target_checker.sh') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should match /VPC_CIDR_LIST=\(cidr1 cidr2\)/ }
+  end
+end


### PR DESCRIPTION
The script is created starting from an erb template, evaluated at config time by the openssh recipe.

In the script there is a VPC_CIDR_LIST variable that contains the list of vpc cidrs coming from node attributes.

