### PR TITLE
Test set of number of nfs threads

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/nfs.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/nfs.rb
@@ -29,4 +29,4 @@ end
 service node['nfs']['service']['server'] do
   action %i(restart enable)
   supports restart: true
-end
+end unless virtualized?

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -264,6 +264,20 @@ suites:
         efs_shared_dirs: ''
         fsx_shared_dirs: ''
         raid_shared_dir: ''
+  - name: nfs_threads
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::nfs]
+    verifier:
+      controls:
+        - nfs_thread_configured
+        - nfs_service_restarted
+    attributes:
+      cluster:
+        nfs:
+          threads: 10
+      dependencies:
+        - resource:nfs
   - name: networking_configured
     run_list:
       - recipe[aws-parallelcluster-config::networking]

--- a/test/recipes/controls/aws_parallelcluster_config/nfs_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/nfs_spec.rb
@@ -1,0 +1,48 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'nfs_thread_configured' do
+  title 'Check that shared storage info are added correctly to the data file'
+
+  nfs_config_file = if os_properties.centos? || os_properties.alinux2?
+                      '/etc/sysconfig/nfs'
+                    elsif os.debian?
+                      '/etc/default/nfs-kernel-server'
+                    else
+                      '/etc/nfs.conf'
+                    end
+
+  describe file(nfs_config_file) do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should match /^RPCNFSDCOUNT="10"/ }
+  end
+end
+
+control 'nfs_service_restarted' do
+  title 'Check nfs service is restarted'
+
+  only_if { !os_properties.virtualized? }
+
+  nfs_server = if os.debian?
+                 'nfs-kernel-server.service'
+               else
+                 'nfs-server.service'
+               end
+
+  describe service(nfs_server) do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+end


### PR DESCRIPTION
### Description of changes

The nfs.rb recipe is executed at config time to override the `/etc/nfs.conf` template by setting `node['cluster']['nfs']['threads']` as `RPCNFSDCOUNT` value

### Tests
* tested on EC2 for rhel8 and ubuntu20
