### PR TITLE
Cherry pick of changes from redhat8 branch

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -148,10 +148,6 @@ default['cluster']['scheduler_plugin']['virtualenv_path'] = [
   node['cluster']['scheduler_plugin']['virtualenv'],
 ].join('/')
 
-# PMIx software
-default['cluster']['pmix']['version'] = '3.2.3'
-default['cluster']['pmix']['url'] = "https://github.com/openpmix/openpmix/releases/download/v#{node['cluster']['pmix']['version']}/pmix-#{node['cluster']['pmix']['version']}.tar.gz"
-default['cluster']['pmix']['sha256'] = '1325a1355d0794196bb47665053fdbc588f9183aa5385f3581b668427316306e'
 # Munge
 default['cluster']['munge']['munge_version'] = '0.5.14'
 default['cluster']['munge']['munge_url'] = "https://github.com/dun/munge/archive/munge-#{node['cluster']['munge']['munge_version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-awsbatch/metadata.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Manages AWS Batch in AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-common/libraries/networking.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/networking.rb
@@ -1,0 +1,19 @@
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+# Return the VPC CIDR list from node info
+def get_vpc_cidr_list
+  mac = node['ec2']['mac']
+  vpc_cidr_list = node['ec2']['network_interfaces_macs'][mac]['vpc_ipv4_cidr_blocks']
+  vpc_cidr_list.split(/\n+/)
+end

--- a/cookbooks/aws-parallelcluster-common/metadata.rb
+++ b/cookbooks/aws-parallelcluster-common/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Common AWS ParallelCluster resources and attributes'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-config/metadata.rb
+++ b/cookbooks/aws-parallelcluster-config/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Configures AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -44,21 +44,7 @@ else
   raise "node_type must be HeadNode or ComputeFleet"
 end
 
-# Ensure cluster user can sudo on SSH
-template '/etc/sudoers.d/99-parallelcluster-user-tty' do
-  source 'base/99-parallelcluster-user-tty.erb'
-  owner 'root'
-  group 'root'
-  mode '0600'
-end
-
-# Install parallelcluster specific supervisord config
-template '/etc/parallelcluster/parallelcluster_supervisord.conf' do
-  source 'base/parallelcluster_supervisord.conf.erb'
-  owner 'root'
-  group 'root'
-  mode '0644'
-end
+include_recipe "aws-parallelcluster-config::sudo"
 
 # Mount EFS, FSx
 include_recipe "aws-parallelcluster-config::fs_mount"

--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -22,25 +22,7 @@ sticky_bits "setup sticky bits"
 
 include_recipe 'aws-parallelcluster-config::nfs' unless virtualized?
 
-# Mount the ephemeral drive unless there is a mountpoint collision with shared drives
-shared_dir_array = node['cluster']['ebs_shared_dirs'].split(',') + \
-                   node['cluster']['efs_shared_dirs'].split(',') + \
-                   node['cluster']['fsx_shared_dirs'].split(',') + \
-                   [ node['cluster']['raid_shared_dir'] ]
-unless shared_dir_array.include? node['cluster']['ephemeral_dir']
-  service "setup-ephemeral" do
-    supports restart: false
-    action :enable
-  end
-
-  # Execution timeout 3600 seconds
-  unless virtualized?
-    execute "Setup of ephemeral drives" do
-      user "root"
-      command "/usr/local/sbin/setup-ephemeral-drives.sh"
-    end
-  end
-end
+include_recipe 'aws-parallelcluster-config::ephemeral_drives'
 
 include_recipe 'aws-parallelcluster-config::networking'
 

--- a/cookbooks/aws-parallelcluster-config/recipes/ephemeral_drives.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/ephemeral_drives.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-config
+# Recipe:: ephemeral_drives
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mount the ephemeral drive unless there is a mountpoint collision with shared drives
+shared_dir_array = node['cluster']['ebs_shared_dirs'].split(',') + \
+                   node['cluster']['efs_shared_dirs'].split(',') + \
+                   node['cluster']['fsx_shared_dirs'].split(',') + \
+                   [ node['cluster']['raid_shared_dir'] ]
+
+unless shared_dir_array.include? node['cluster']['ephemeral_dir']
+  service "setup-ephemeral" do
+    supports restart: false
+    action :enable
+  end
+
+  # Execution timeout 3600 seconds
+  unless virtualized?
+    execute "Setup of ephemeral drives" do
+      user "root"
+      command "/usr/local/sbin/setup-ephemeral-drives.sh"
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-config/recipes/ephemeral_drives.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/ephemeral_drives.rb
@@ -25,13 +25,11 @@ unless shared_dir_array.include? node['cluster']['ephemeral_dir']
   service "setup-ephemeral" do
     supports restart: false
     action :enable
-  end
+  end unless virtualized?
 
   # Execution timeout 3600 seconds
-  unless virtualized?
-    execute "Setup of ephemeral drives" do
-      user "root"
-      command "/usr/local/sbin/setup-ephemeral-drives.sh"
-    end
-  end
+  execute "Setup of ephemeral drives" do
+    user "root"
+    command "/usr/local/sbin/setup-ephemeral-drives.sh"
+  end unless virtualized?
 end

--- a/cookbooks/aws-parallelcluster-config/recipes/fs_update.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/fs_update.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-config
+# Recipe:: fs_update
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generate the shared storages mapping file
+template node['cluster']['shared_storages_mapping_path'] do
+  source 'shared_storages/shared_storages_data.erb'
+  mode '0644'
+end

--- a/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
@@ -16,10 +16,7 @@
 # limitations under the License.
 
 # generate the shared storages mapping file
-template node['cluster']['shared_storages_mapping_path'] do
-  source 'shared_storages/shared_storages_data.erb'
-  mode '0644'
-end
+include_recipe 'aws-parallelcluster-config::fs_update'
 
 manage_ebs "add ebs" do
   shared_dir_array node['cluster']['ebs_shared_dirs'].split(',')

--- a/cookbooks/aws-parallelcluster-config/recipes/nfs.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/nfs.rb
@@ -29,4 +29,4 @@ end
 service node['nfs']['service']['server'] do
   action %i(restart enable)
   supports restart: true
-end
+end unless virtualized?

--- a/cookbooks/aws-parallelcluster-config/recipes/sudo.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/sudo.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster
+# Recipe:: sudo
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ensure cluster user can sudo on SSH
+template '/etc/sudoers.d/99-parallelcluster-user-tty' do
+  source 'base/99-parallelcluster-user-tty.erb'
+  owner 'root'
+  group 'root'
+  mode '0600'
+end
+
+# Install parallelcluster specific supervisord config
+template '/etc/parallelcluster/parallelcluster_supervisord.conf' do
+  source 'base/parallelcluster_supervisord.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end

--- a/cookbooks/aws-parallelcluster-config/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/update.rb
@@ -22,10 +22,7 @@ unless node['cluster']['scheduler'] == 'awsbatch'
 end
 
 # generate the update shared storages mapping file
-template node['cluster']['shared_storages_mapping_path'] do
-  source 'shared_storages/shared_storages_data.erb'
-  mode '0644'
-end
+include_recipe 'aws-parallelcluster-config::fs_update'
 
 include_recipe 'aws-parallelcluster-config::directory_service'
 include_recipe 'aws-parallelcluster-slurm::update' if node['cluster']['scheduler'] == 'slurm'

--- a/cookbooks/aws-parallelcluster-install/metadata.rb
+++ b/cookbooks/aws-parallelcluster-install/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Installs AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/metadata.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Manages Custom Scheduler in AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-slurm/metadata.rb
+++ b/cookbooks/aws-parallelcluster-slurm/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Manages Slurm in AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/cookbooks/aws-parallelcluster-test/metadata.rb
+++ b/cookbooks/aws-parallelcluster-test/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Tests AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -2,7 +2,8 @@
 driver:
   name: dokken
   pull_platform_image: false # Use the local images, prevent pull of docker images from Docker Hub,
-  chef_version: 17.2.29 # Chef version aligned with the one used to build the images
+  chef_version: 17 # Chef version aligned with the one used to build the images
+  chef_image: cincproject/cinc
   env:
     # Since the kernel version of the docker images is not in the expected pattern,
     # KERNEL_RELEASE is set in the environment to override the system value.
@@ -10,6 +11,8 @@ driver:
 
 provisioner:
   name: dokken
+  product_name: cinc
+  chef_binary: /opt/cinc/bin/cinc-client
   attributes:
     virtualized: true
 

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -319,3 +319,14 @@ suites:
         fsx_shared_dirs: ''
         raid_shared_dir: ''
         ephemeral_dir: test1
+  - name: sudo_configured
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::sudo]
+    verifier:
+      controls:
+        - sudo_configured
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - recipe:aws-parallelcluster-install::sudo

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -283,6 +283,20 @@ suites:
         - recipe:aws-parallelcluster-install::directories
         - resource:package_repos
         - resource:install_packages
+  - name: ssh_target_checker
+    run_list:
+      - recipe[aws-parallelcluster-config::openssh]
+    verifier:
+      controls:
+        - ssh_target_checker_script_created
+    attributes:
+      ec2:
+        mac: mac1
+        network_interfaces_macs:
+          mac1:
+            vpc_ipv4_cidr_blocks: |
+              cidr1
+              cidr2
   - name: ephemeral_drives
     #driver:
     #  instance_type: m5d.xlarge  # instance type with ephemeral drives

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -220,3 +220,16 @@ suites:
     verifier:
       controls:
         - networking_configured
+  - name: pmix_installed
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-slurm::install_pmix]
+    verifier:
+      controls:
+        - pmix_installed
+        - pmix_library_shared
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - resource:package_repos
+        - resource:install_packages

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -220,6 +220,50 @@ suites:
 #        - recipe:aws-parallelcluster-install::directories
 #        - recipe:aws-parallelcluster-install::python
 #        - recipe:aws-parallelcluster-install::cloudwatch_agent
+  - name: fs_update
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::fs_update]
+    verifier:
+      controls:
+        - fs_data_file_created_correctly
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - recipe:aws-parallelcluster::test_dummy
+      cluster:
+        ebs_shared_dirs: ebs1,ebs2
+        volume: volume1,volume2
+        raid_shared_dir: raid1
+        raid_type: 1
+        raid_vol_ids: volume1,volume2
+        efs_shared_dirs: efs1,efs2
+        efs_fs_ids: efs-id1,efs-id2
+        efs_encryption_in_transits: true,false
+        efs_iam_authorizations: iam1,iam2
+        fsx_shared_dirs: fsx1,fsx2
+        fsx_fs_ids: fsx-id1,fsx-id2
+        fsx_fs_types: type1,type2
+        fsx_dns_names: dns1,dns2
+        fsx_mount_names: mount1,mount2
+        fsx_volume_junction_paths: value1,value2
+  - name: fs_update_default_values
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::fs_update]
+    verifier:
+      controls:
+        - fs_data_file_with_default_values
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - recipe:aws-parallelcluster::test_dummy
+      cluster:
+        ebs_shared_dirs: '/shared'
+        volume: ''
+        efs_shared_dirs: ''
+        fsx_shared_dirs: ''
+        raid_shared_dir: ''
   - name: networking_configured
     run_list:
       - recipe[aws-parallelcluster-config::networking]

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -264,6 +264,20 @@ suites:
         efs_shared_dirs: ''
         fsx_shared_dirs: ''
         raid_shared_dir: ''
+  - name: nfs_threads
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::nfs]
+    verifier:
+      controls:
+        - nfs_thread_configured
+        - nfs_service_restarted
+    attributes:
+      cluster:
+        nfs:
+          threads: 10
+      dependencies:
+        - resource:nfs
   - name: networking_configured
     run_list:
       - recipe[aws-parallelcluster-config::networking]

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -18,6 +18,9 @@ verifier:
 # You can find an example in the add_depdendencies.rb file.
 
 suites:
+
+# Install recipes
+
   - name: sudo
     run_list:
       - recipe[aws-parallelcluster-install::sudo]
@@ -202,6 +205,9 @@ suites:
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-install::directories
+
+# Config recipes
+
 #  - name: cloudwatch_agent_configured
 #    run_list:
 #      - recipe[aws-parallelcluster::add_dependencies]
@@ -233,3 +239,39 @@ suites:
         - recipe:aws-parallelcluster-install::directories
         - resource:package_repos
         - resource:install_packages
+  - name: ephemeral_drives
+    #driver:
+    #  instance_type: m5d.xlarge  # instance type with ephemeral drives
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::ephemeral_drives]
+    verifier:
+      controls:
+        - ephemeral_drives_service
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::ephemeral_drives
+      cluster:
+        ebs_shared_dirs: test1,test2
+        efs_shared_dirs: ''
+        fsx_shared_dirs: ''
+        raid_shared_dir: ''
+        ephemeral_dir: test3
+  - name: ephemeral_drives_skipped
+    #driver:
+    #  instance_type: m5d.xlarge  # instance type with ephemeral drives
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::ephemeral_drives]
+    verifier:
+      controls:
+        - ephemeral_drives_with_name_clashing_not_mounted
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::ephemeral_drives
+      cluster:
+        ebs_shared_dirs: test1,test2
+        efs_shared_dirs: ''
+        fsx_shared_dirs: ''
+        raid_shared_dir: ''
+        ephemeral_dir: test1

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -482,13 +482,6 @@ def get_system_users
   cmd.stdout.split(/\n+/)
 end
 
-# Return the VPC CIDR list from node info
-def get_vpc_cidr_list
-  mac = node['ec2']['mac']
-  vpc_cidr_list = node['ec2']['network_interfaces_macs'][mac]['vpc_ipv4_cidr_blocks']
-  vpc_cidr_list.split(/\n+/)
-end
-
 def run_command(command)
   Mixlib::ShellOut.new(command).run_command.stdout.strip
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache-2.0'
 description 'Installs/Configures AWS ParallelCluster'
 issues_url 'https://github.com/aws/aws-parallelcluster-cookbook/issues'
 source_url 'https://github.com/aws/aws-parallelcluster-cookbook'
-chef_version '17.2.29'
+chef_version '~> 17'
 version '3.6.0'
 
 supports 'amazon', '>= 2.0'

--- a/test/recipes/controls/aws_parallelcluster_config/ephemeral_drives_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/ephemeral_drives_spec.rb
@@ -12,24 +12,26 @@
 control 'ephemeral_drives_service' do
   title 'Check ephemeral drives service is running'
 
+  only_if { !os_properties.virtualized? }
+
   describe service('setup-ephemeral') do
     it { should be_installed }
     it { should be_enabled }
   end
 
-  # TODO add test to see drivers are mounted
+  # TODO: add test to see drivers are mounted
 end
 
 control 'ephemeral_drives_with_name_clashing_not_mounted' do
   title 'Check ephemeral drives are not mounted when there is name clashing with reserved names'
+
+  only_if { !os_properties.virtualized? }
 
   describe service('setup-ephemeral') do
     it { should be_installed }
     it { should_not be_enabled }
     it { should_not be_running }
   end
-
-  only_if { !os_properties.virtualized? }
 
   describe bash('systemctl show setup-ephemeral.service -p ActiveState | grep "=inactive"') do
     its(:exit_status) { should eq 0 }

--- a/test/recipes/controls/aws_parallelcluster_config/ephemeral_drives_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/ephemeral_drives_spec.rb
@@ -1,0 +1,41 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'ephemeral_drives_service' do
+  title 'Check ephemeral drives service is running'
+
+  describe service('setup-ephemeral') do
+    it { should be_installed }
+    it { should be_enabled }
+  end
+
+  # TODO add test to see drivers are mounted
+end
+
+control 'ephemeral_drives_with_name_clashing_not_mounted' do
+  title 'Check ephemeral drives are not mounted when there is name clashing with reserved names'
+
+  describe service('setup-ephemeral') do
+    it { should be_installed }
+    it { should_not be_enabled }
+    it { should_not be_running }
+  end
+
+  only_if { !os_properties.virtualized? }
+
+  describe bash('systemctl show setup-ephemeral.service -p ActiveState | grep "=inactive"') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe bash('systemctl show setup-ephemeral.service -p UnitFileState | grep "=disabled"') do
+    its(:exit_status) { should eq 0 }
+  end
+end

--- a/test/recipes/controls/aws_parallelcluster_config/fs_update_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/fs_update_spec.rb
@@ -1,0 +1,59 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'fs_data_file_created_correctly' do
+  title 'Check that shared storage info are added correctly to the data file'
+
+  describe file("/etc/parallelcluster/shared_storages_data.yaml") do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should match /^ebs:/ }
+    its('content') { should match /- volume_id: volume1/ }
+    its('content') { should match /mount_dir: ebs1/ }
+    its('content') { should match /^raid:/ }
+    its('content') { should match /- raid_shared_dir: raid1/ }
+    its('content') { should match /raid_type: 1/ }
+    its('content') { should match /raid_vol_array: volume1,volume2/ }
+    its('content') { should match /^efs:/ }
+    its('content') { should match /- efs_fs_id: efs-id2/ }
+    its('content') { should match /mount_dir: efs2/ }
+    its('content') { should match /efs_encryption_in_transit: false/ }
+    its('content') { should match /efs_iam_authorization: iam2/ }
+    its('content') { should match /^fsx:/ }
+    its('content') { should match /- fsx_fs_id: fsx-id2/ }
+    its('content') { should match /mount_dir: fsx2/ }
+    its('content') { should match /fsx_fs_type: type2/ }
+    its('content') { should match /fsx_dns_name: dns2/ }
+    its('content') { should match /fsx_mount_name: mount2/ }
+    its('content') { should match /fsx_volume_junction_path: value2/ }
+  end
+end
+
+control 'fs_data_file_with_default_values' do
+  title 'Check that shared storage info are not added to the data file'
+
+  describe file("/etc/parallelcluster/shared_storages_data.yaml") do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should match /^ebs:/ }
+    its('content') { should_not match %r{mount_dir: /shared} }
+    its('content') { should match /^raid:/ }
+    its('content') { should_not match /raid_type:/ }
+    its('content') { should match /^efs:/ }
+    its('content') { should_not match /- efs_fs_id:/ }
+    its('content') { should match /^fsx:/ }
+    its('content') { should_not match /- fsx_fs_id:/ }
+  end
+end

--- a/test/recipes/controls/aws_parallelcluster_config/nfs_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/nfs_spec.rb
@@ -1,0 +1,48 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'nfs_thread_configured' do
+  title 'Check that shared storage info are added correctly to the data file'
+
+  nfs_config_file = if os_properties.centos? || os_properties.alinux2?
+                      '/etc/sysconfig/nfs'
+                    elsif os.debian?
+                      '/etc/default/nfs-kernel-server'
+                    else
+                      '/etc/nfs.conf'
+                    end
+
+  describe file(nfs_config_file) do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should match /^RPCNFSDCOUNT="10"/ }
+  end
+end
+
+control 'nfs_service_restarted' do
+  title 'Check nfs service is restarted'
+
+  only_if { !os_properties.virtualized? }
+
+  nfs_server = if os.debian?
+                 'nfs-kernel-server.service'
+               else
+                 'nfs-server.service'
+               end
+
+  describe service(nfs_server) do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+end

--- a/test/recipes/controls/aws_parallelcluster_config/openssh_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/openssh_spec.rb
@@ -1,0 +1,22 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'ssh_target_checker_script_created' do
+  title 'Check that ssh_target_checker.sh is created correctly'
+
+  describe file('/usr/bin/ssh_target_checker.sh') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should match /VPC_CIDR_LIST=\(cidr1 cidr2\)/ }
+  end
+end

--- a/test/recipes/controls/aws_parallelcluster_config/sudo_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/sudo_spec.rb
@@ -1,0 +1,30 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'sudo_configured' do
+  title 'Check that sudo has been configured'
+
+  describe file('/etc/sudoers.d/99-parallelcluster-user-tty') do
+    it { should exist }
+    its('mode') { should cmp '0600' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should_not be_empty }
+  end
+
+  describe file('/etc/parallelcluster/parallelcluster_supervisord.conf') do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') { should_not be_empty }
+  end
+end

--- a/test/recipes/controls/aws_parallelcluster_slurm/install_pmix_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/install_pmix_spec.rb
@@ -1,0 +1,36 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'pmix_installed' do
+  title 'Checks PMIx has been installed'
+
+  describe file("/opt/pmix") do
+    it { should exist }
+    it { should be_directory }
+    its('mode') { should cmp '0755' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end unless os_properties.redhat_ubi?
+end
+
+control 'pmix_library_shared' do
+  title 'Checks PMIx shared library is part of the runtime search path'
+
+  describe file("/etc/ld.so.conf.d/pmix.conf") do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('content') do
+      should match('/opt/pmix/lib')
+    end
+  end unless os_properties.redhat_ubi?
+end


### PR DESCRIPTION
### Description of changes
* [Add tests for install_pmix recipe](https://github.com/aws/aws-parallelcluster-cookbook/commit/e216bfb80042113be9057cd5da0b41e254862f4f)
* [Move ephemeral_drives config logic into a new recipe](https://github.com/aws/aws-parallelcluster-cookbook/commit/787f9283a3f990b5801b4d7e341460ee8c487695) 
* [Use CINC in place of Chef for docker tests](https://github.com/aws/aws-parallelcluster-cookbook/commit/fece83be9745969fdab7117f42b21fdeb9eb81c0) 
* [Define new fs_update recipe and add tests for it](https://github.com/aws/aws-parallelcluster-cookbook/commit/5a2391687991f8955efce33937e9d0f78b882421) 
* [Add sudo configuration test](https://github.com/aws/aws-parallelcluster-cookbook/commit/3273fdb3413b910893ab57c3334af42f4de9e81f)
* [Test ssh_target_checker.sh script creation](https://github.com/aws/aws-parallelcluster-cookbook/commit/b3fa6ddf5af042f4d174ea98f0f2e89159cd21dc) 
* [Test set of number of nfs threads](https://github.com/aws/aws-parallelcluster-cookbook/commit/7c25731226a93e7863094c1374461dcaaa39ee90)

### Tests
* Tested running 107 integration tests (most of the features) and kitchen tests for a subset instance types