### PR TITLE
[Isolated Regions] Add support for US isolated regions: us-iso-* and us-isob-*.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **ENHANCEMENTS**
+- Add support for US isolated regions: us-iso-* and us-isob-*.
 - Fail cluster creation if cluster status changes to PROTECTED while provisioning static nodes.
 
 **CHANGES**

--- a/cookbooks/aws-parallelcluster-config/files/default/sudoers/99-parallelcluster-env-keep
+++ b/cookbooks/aws-parallelcluster-config/files/default/sudoers/99-parallelcluster-env-keep
@@ -1,0 +1,1 @@
+Defaults env_keep += "AWS_CA_BUNDLE"

--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -83,11 +83,16 @@ template '/etc/sudoers.d/99-parallelcluster-user-tty' do
 end
 
 # Install parallelcluster specific supervisord config
+region = node['cluster']['region']
 template '/etc/parallelcluster/parallelcluster_supervisord.conf' do
   source 'base/parallelcluster_supervisord.conf.erb'
   owner 'root'
   group 'root'
   mode '0644'
+  variables(
+    region: region,
+    aws_ca_bundle: region.start_with?('us-iso') ? "/etc/pki/#{region}/certs/ca-bundle.pem" : ''
+  )
 end
 
 # Mount EFS, FSx

--- a/cookbooks/aws-parallelcluster-config/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/init.rb
@@ -47,6 +47,14 @@ template "/opt/parallelcluster/scripts/fetch_and_run" do
   mode "0755"
 end
 
+cookbook_file '/etc/sudoers.d/99-parallelcluster-env-keep' do
+  source 'sudoers/99-parallelcluster-env-keep'
+  owner 'root'
+  group 'root'
+  mode '0600'
+  only_if { node['cluster']['region'].start_with?('us-iso') }
+end
+
 include_recipe "aws-parallelcluster-config::mount_shared" if node['cluster']['node_type'] == "ComputeFleet"
 
 fetch_config 'Fetch and load cluster configs' unless node['cluster']['scheduler'] == 'awsbatch'

--- a/cookbooks/aws-parallelcluster-config/resources/manage_fsx.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_fsx.rb
@@ -54,6 +54,7 @@ action :mount do
                else
                  # DNS names of newly created Lustre file systems are hardcoded here.
                  # Note the Hardcoding format is only valid for lustre file systems created after Mar-1 2021
+                 # Region Building Note: DNS names have the default AWS domain (amazonaws.com) also in China and GovCloud.
                  "#{fsx_fs_id}.fsx.#{node['cluster']['region']}.amazonaws.com"
                end
     case fsx_fs_type
@@ -163,6 +164,7 @@ action :unmount do
                else
                  # DNS names of newly created Lustre file systems are hardcoded here.
                  # Note the Hardcoding format is only valid for lustre file systems created after Mar-1 2021
+                 # Region Building Note: DNS names have the default AWS domain (amazonaws.com) also in China and GovCloud.
                  "#{fsx_fs_id}.fsx.#{node['cluster']['region']}.amazonaws.com"
                end
     fsx_shared_dir = "/#{fsx_shared_dir}" unless fsx_shared_dir.start_with?('/')

--- a/cookbooks/aws-parallelcluster-config/templates/default/base/parallelcluster_supervisord.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/base/parallelcluster_supervisord.conf.erb
@@ -4,16 +4,19 @@
 <%# HeadNode -%>
 <% when 'HeadNode' -%>
 [program:cfn-hup]
-command = bash -c "[ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh; <%= node['cluster']['cfn_bootstrap_virtualenv_path'] %>/bin/cfn-hup"
+command = bash -c "[ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh; <%= node['cluster']['cfn_bootstrap_virtualenv_path'] %>/bin/cfn-hup --verbose"
 # The following are needed because cfn-hup starts as a daemon
 exitcodes = 0
 autorestart = unexpected
 startsecs = 0
+<% if @region.start_with?('us-iso') -%>
+environment = AWS_CA_BUNDLE="<%= @aws_ca_bundle %>"
+<% end -%>
 <% if node['cluster']['scheduler'] == 'slurm' -%>
 [program:clustermgtd]
 command = <%= node['cluster']['node_virtualenv_path'] %>/bin/clustermgtd
 user = <%= node['cluster']['cluster_admin_user'] %>
-environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"
+environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"<% if @region.start_with?('us-iso') -%>,AWS_CA_BUNDLE="<%= @aws_ca_bundle %>"<% end -%>
 redirect_stderr = true
 stdout_logfile = /var/log/parallelcluster/clustermgtd
 <% end -%>
@@ -21,7 +24,7 @@ stdout_logfile = /var/log/parallelcluster/clustermgtd
 [program:clusterstatusmgtd]
 command = <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/python /opt/parallelcluster/scripts/clusterstatusmgtd.py
 user = <%= node['cluster']['cluster_admin_user'] %>
-environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"
+environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"<% if @region.start_with?('us-iso') -%>,AWS_CA_BUNDLE="<%= @aws_ca_bundle %>"<% end -%>
 redirect_stderr = true
 stdout_logfile = /var/log/parallelcluster/clusterstatusmgtd
 <% end -%>
@@ -32,7 +35,7 @@ command = <%= node['cluster']['dcv']['authenticator']['virtualenv_path'] %>/bin/
       --certificate <%= node['cluster']['dcv']['authenticator']['certificate'] %>
       --key <%= node['cluster']['dcv']['authenticator']['private_key'] %>
 user = <%= node['cluster']['dcv']['authenticator']['user'] %>
-environment = HOME="<%= node['cluster']['dcv']['authenticator']['user_home'] %>",USER="<%= node['cluster']['dcv']['authenticator']['user'] %>"
+environment = HOME="<%= node['cluster']['dcv']['authenticator']['user_home'] %>",USER="<%= node['cluster']['dcv']['authenticator']['user'] %>"<% if @region.start_with?('us-iso') -%>,AWS_CA_BUNDLE="<%= @aws_ca_bundle %>"<% end -%>
 <% end -%>
 
 <%# ComputeFleet -%>
@@ -41,7 +44,7 @@ environment = HOME="<%= node['cluster']['dcv']['authenticator']['user_home'] %>"
 [program:computemgtd]
 command = <%= node['cluster']['node_virtualenv_path'] %>/bin/computemgtd
 user = <%= node['cluster']['cluster_admin_user'] %>
-environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"
+environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"<% if @region.start_with?('us-iso') -%>,AWS_CA_BUNDLE="<%= @aws_ca_bundle %>"<% end -%>
 redirect_stderr = true
 stdout_logfile = /var/log/parallelcluster/computemgtd
 <% end -%>

--- a/cookbooks/aws-parallelcluster-install/files/default/base/patch-iso-instance.sh
+++ b/cookbooks/aws-parallelcluster-install/files/default/base/patch-iso-instance.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -ex
+
+# This script is used to configure instance so that it works as expected in US isolated regions.
+# The script supports the configuration for Amazon Linux 2 only.
+# Furthermore, the script fails if the provided region is not a US isolated region.
+#
+# Usage:   ./patch-iso-instance.sh REGION_NAME
+# Example: ./patch-iso-instance.sh us-isob-east-1
+
+REGION="${1}"
+
+[[ -z ${REGION} ]] && echo "[ERROR] Missing required argument: REGION" && exit 1
+[[ ${REGION} != us-iso* ]] && echo "[ERROR] The specified region '${REGION}' is not a US isolated region" && exit 1
+
+source /etc/os-release
+OS="${ID}${VERSION_ID}"
+[[ "${OS}" != "amzn2" ]] && echo "[ERROR] Unsupported OS '${OS}'. Configuration supported only on Amazon Linux 2." && exit 1
+
+echo "[INFO] Starting: instance configuration for US isolated region"
+
+REPOSITORY_DEFINITION_FILE="/etc/yum.repos.d/tmp-amzn2-iso.repo"
+
+cat > ${REPOSITORY_DEFINITION_FILE} <<REPO_DEFINITION
+[amzn2-iso]
+name=Amazon Linux 2 isolated region repository
+mirrorlist=http://amazonlinux.\$awsregion.\$awsdomain/\$releasever/core-\$awsregion/latest/\$basearch/mirror.list
+priority=9
+gpgcheck=0
+enabled=1
+metadata_expire=300
+mirrorlist_expire=300
+report_instanceid=yes
+REPO_DEFINITION
+
+yum --disablerepo="*" --enablerepo="amzn2-iso" install -y "*-${REGION}"
+rm -f ${REPOSITORY_DEFINITION_FILE}
+yum --disablerepo="*" --enablerepo="amzn2-*" --security -y update
+
+echo "[INFO] Complete: instance configuration for US isolated region"

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -26,6 +26,7 @@ include_recipe "aws-parallelcluster-install::directories"
 
 install_packages 'Install OS and extra packages'
 
+include_recipe "aws-parallelcluster-install::base_isolated"
 include_recipe "aws-parallelcluster-install::python"
 include_recipe "aws-parallelcluster-install::cfn_bootstrap"
 include_recipe 'aws-parallelcluster-install::node'

--- a/cookbooks/aws-parallelcluster-install/recipes/base_isolated.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base_isolated.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster
+# Recipe:: base_isolated
+#
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+cookbook_file "#{node['cluster']['scripts_dir']}/patch-iso-instance.sh" do
+  source 'base/patch-iso-instance.sh'
+  owner 'root'
+  group 'root'
+  mode '0754'
+end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -303,9 +303,11 @@ def platform_supports_dcv?
 end
 
 def aws_domain
-  # Set the aws domain name
+  # Get the aws domain name
   aws_domain = "amazonaws.com"
-  aws_domain = "#{aws_domain}.cn" if node['cluster']['region'].start_with?("cn-")
+  aws_domain = "amazonaws.com.cn" if node['cluster']['region'].start_with?("cn-")
+  aws_domain = "c2s.ic.gov" if node['cluster']['region'].start_with?("us-iso-")
+  aws_domain = "sc2s.sgov.gov" if node['cluster']['region'].start_with?("us-isob-")
   aws_domain
 end
 

--- a/system_tests/install_cinc.sh
+++ b/system_tests/install_cinc.sh
@@ -31,12 +31,19 @@ elif [ `echo "${OS}" | grep -E '^ubuntu'` ]; then
   PLATFORM='DEBIAN'
 fi
 
-BUCKET="s3.amazonaws.com"
-[[ ${AWS_Region} =~ ^cn- ]] && BUCKET="s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
+AWS_DOMAIN="amazonaws.com"
+[[ ${AWS_Region} =~ ^cn- ]] && AWS_DOMAIN="amazonaws.com.cn"
+[[ ${AWS_Region} =~ ^us-iso- ]] && AWS_DOMAIN="c2s.ic.gov"
+[[ ${AWS_Region} =~ ^us-isob- ]] && AWS_DOMAIN="sc2s.sgov.gov"
+
+S3_ENDPOINT="s3.${AWS_Region}.${AWS_DOMAIN}"
+
+BUCKET="cloudformation-examples"
+[[ ${AWS_DOMAIN} != "amazonaws.com" ]] && BUCKET="${AWS_Region}-aws-parallelcluster/cloudformation-examples"
 if [[ ${OS} =~ ^(ubuntu2004)$ ]]; then
-  CfnBootstrapUrl="https://${BUCKET}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
+  CfnBootstrapUrl="https://${S3_ENDPOINT}/${BUCKET}/aws-cfn-bootstrap-py3-latest.tar.gz"
 else
-  CfnBootstrapUrl="https://${BUCKET}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz"
+  CfnBootstrapUrl="https://${S3_ENDPOINT}/${BUCKET}/aws-cfn-bootstrap-latest.tar.gz"
 fi
 
 ARCH=$(uname -m)

--- a/util/cinc-install.sh
+++ b/util/cinc-install.sh
@@ -617,9 +617,12 @@ instance_metadata_file=$tmp_dir/instance_metadata
 get_region instance_metadata_file
 
 # Download domain detection
-if [ "${region}" != "${region#cn-*}" ]
-then
+if [[ ${region} == cn-* ]]; then
   download_domain="amazonaws.com.cn"
+elif [[ ${region} == us-iso-* ]]; then
+  download_domain="c2s.ic.gov"
+elif [[ ${region} == us-isob-* ]]; then
+  download_domain="sc2s.sgov.gov"
 else
   download_domain="amazonaws.com"
 fi


### PR DESCRIPTION
### Changes
Add support for US isolated regions: **us-iso-*** and **us-isob-***.

In particular:

1. Added support for the AWS domain in these regions.
1. Added script `/opt/parallelcluster/scripts/patch-iso-instance.sh` that is expected to be used at run-time by both head and compute nodes to configure the instance in these regions.
1. Added environment variable `AWS_CA_BUNDLE` to the environment loaded by supervisord in all the daemons when running in US isolated regions.
1. Added `/etc/sudoers.d/99-parallelcluster-env-keep` to preserve the environment variable `AWS_CA_BUNDLE` when switching user in non interactive sessions. This is done at config time only when running in US isolated regions.
1. Added `--verbose` option to the execution of cfn-hup with supervisord to make it easier to troubleshoot cfn-hup issues.
1. Added support for these regions to the scripts used to install Cinc.
1. Added a comment to `manage_fsx` recipe to explain why the file system domain must not be adapted to support these regions.

### Tests
Manual tests **(US ISO TESTS ARE STILL ONGOING)**:
1. AMI build (executed in Commercial)
2. Cluster creation (executed both in Commercial and US Isolated)
3. Cluster update with dynamic file system mounting (executed both in Commercial and US Isolated)
4. Cluster update with compute nodes min-count change (executed both in Commercial and US Isolated)
5. Submission of job that requires compute fleet autoscaling (executed both in Commercial and US Isolated)

A full regression tests will be done on the authoritative pipeline once the change will be merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>