### PR TITLE
Fix EFA resource code

### DIFF
--- a/cookbooks/aws-parallelcluster-common/libraries/networking.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/networking.rb
@@ -19,7 +19,7 @@ def get_vpc_cidr_list
 end
 
 def efa_supported?
-  !arm_instance? || !default['cluster']['efa']['unsupported_aarch64_oses'].include?(node['cluster']['base_os'])
+  !arm_instance? || !node['cluster']['efa']['unsupported_aarch64_oses'].include?(node['cluster']['base_os'])
 end
 
 def efa_installed?

--- a/cookbooks/aws-parallelcluster-common/resources/efa/partial/_setup.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/partial/_setup.rb
@@ -13,6 +13,8 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+efa_tarball = "#{node['cluster']['sources_dir']}/aws-efa-installer.tar.gz"
+
 action :setup do
   if efa_installed? && !::File.exist?(efa_tarball)
     Chef::Log.warn("Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration.")
@@ -42,10 +44,8 @@ end
 action :download_and_install do
   return if virtualized?
 
-  efa_tarball = "#{node['cluster']['sources_dir']}/aws-efa-installer.tar.gz"
-  efa_installer_url = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cluster']['efa']['installer_version']}.tar.gz"
-
   # Get EFA Installer
+  efa_installer_url = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cluster']['efa']['installer_version']}.tar.gz"
   remote_file efa_tarball do
     source efa_installer_url
     mode '0644'


### PR DESCRIPTION
### Description of changes
#### Move efa_tarball variable into a common place

The variable is used by both download_and_install and setup actions
This was not discovered by tests because the `efa_tarball`
is used by setup action only when efa is already installed in the AMI (e.g. DLAMI).

#### Fix efa_supported library function

This function was defined in the attributes/default.rb,
we moved it into a library so we need to use `node` in place of `default`.

This issue was causing the ARM build to fail, it was not discovered by unit tests because we didn't test ARM instances.

### Tests
* Manually tested on ARM instance (before and after the fix)
```
KITCHEN_ALINUX2_AMI=ami-0b4e4769b816b3425
```
```
  - name: efa
    driver:
      instance_type: c6g.xlarge  # ARM instance type
```
* Manually tested on DLAMI instance (efa already installed)
```
export KITCHEN_UBUNTU20_AMI=ami-0a532245f05a1badd
```
```
       Recipe: aws-parallelcluster-common::test_resource
         * efa[test] action setup[2023-02-14T10:32:05+00:00] WARN: Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration.
        (up to date)
...
  ×  efa_conflicting_packages_removed: Check packages conflicting with EFA are not installed
     ×  System Package libopenmpi-dev is expected not to be installed
     expected System Package libopenmpi-dev not to be installed
  ✔  efa_prereq_packages_installed: EFA prereq packages are installed
     ✔  System Package environment-modules is expected to be installed
  ×  efa_installed: Check EFA is installed (1 failed)
     ✔  Verify EFA Kernel module is available
      Command: `modinfo efa` exit_status is expected to eq 0
     ✔  Verify EFA Kernel module is available
      Command: `modinfo efa` stdout is expected to match "description: +Elastic Fabric Adapter"
     ✔  Verify version of EFA
      File /opt/amazon/efa_installed_packages is expected to exist
     ×  Verify version of EFA
      File /opt/amazon/efa_installed_packages content is expected to match /EFA installer version: 1.21.0/
     expected "# EFA installer version: 1.19.0\n# Debug packages installed: no\n# Packages installed:\nefa-config_1...librdmacm1_41.0-1_amd64 rdma-core_41.0-1_amd64 rdmacm-utils_41.0-1_amd64 efa_1.16.0-1.amzn1_amd64\n" to match /EFA installer version: 1.21.0/
```

### References
* Follow up of #1754 and #1764 
