### PR TITLE
Add test for ephemeral drives setup

### DIFF
--- a/cookbooks/aws-parallelcluster-install/recipes/ephemeral_drives.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/ephemeral_drives.rb
@@ -16,6 +16,12 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+package "install Logical Volume Manager 2 utilities" do
+  package_name "lvm2"
+  retries 3
+  retry_delay 5
+end
+
 cookbook_file 'setup-ephemeral-drives.sh' do
   source 'base/setup-ephemeral-drives.sh'
   path '/usr/local/sbin/setup-ephemeral-drives.sh'

--- a/cookbooks/aws-parallelcluster-test/recipes/cfnconfig_mock.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/cfnconfig_mock.rb
@@ -1,0 +1,7 @@
+return if virtualized?
+
+directory '/etc/parallelcluster/'
+
+file '/etc/parallelcluster/cfnconfig' do
+  content "cfn_ephemeral_dir=/scratch"
+end

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -328,27 +328,29 @@ suites:
             vpc_ipv4_cidr_blocks: |
               cidr1
               cidr2
-  - name: ephemeral_drives
-    #driver:
-    #  instance_type: m5d.xlarge  # instance type with ephemeral drives
+  - name: ephemeral_drives_mounted
+    driver:
+      instance_type: m5d.xlarge  # instance type with ephemeral drives
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-config::ephemeral_drives]
     verifier:
       controls:
-        - ephemeral_drives_service
+        - ephemeral_drives_service_running
+        - ephemeral_drives_configured
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-install::ephemeral_drives
+        - recipe:aws-parallelcluster-test::cfnconfig_mock
       cluster:
         ebs_shared_dirs: test1,test2
         efs_shared_dirs: ''
         fsx_shared_dirs: ''
         raid_shared_dir: ''
-        ephemeral_dir: test3
+        ephemeral_dir: /scratch
   - name: ephemeral_drives_skipped
-    #driver:
-    #  instance_type: m5d.xlarge  # instance type with ephemeral drives
+    driver:
+      instance_type: m5d.xlarge  # instance type with ephemeral drives
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-config::ephemeral_drives]

--- a/test/recipes/controls/aws_parallelcluster_config/ephemeral_drives_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/ephemeral_drives_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'ephemeral_drives_service' do
+control 'ephemeral_drives_service_running' do
   title 'Check ephemeral drives service is running'
 
   only_if { !os_properties.virtualized? }
@@ -18,8 +18,19 @@ control 'ephemeral_drives_service' do
     it { should be_installed }
     it { should be_enabled }
   end
+end
 
-  # TODO: add test to see drivers are mounted
+control 'ephemeral_drives_configured' do
+  title 'Ephemeral drives script is executed and we are able to write on them'
+
+  only_if { !os_properties.virtualized? }
+
+  # This value is set by cfnconfig_mock.rb
+  describe directory('/scratch') do
+    it { should exist }
+    it { should be_writable }
+    it { should be_mounted }
+  end
 end
 
 control 'ephemeral_drives_with_name_clashing_not_mounted' do


### PR DESCRIPTION
### Description of changes
The setup-ephemeral-drives.sh script requires the cfn_ephemeral_dir variable in the cfnconfig file, I added the cfnconfig_mock.rb to create the required file.

Ephemeral drives test verifies the /scratch directory (from cfnconfig) is correctly mounted in an instance type m5d.xlarge with 1 instance store.

lvm2 is already installed as part of the install_packages but it is required to have the ephemeral_drives.rb recipe self contained. The name of the package is the same in all the OSes.

### Tests
* Tested on EC2 on all the OSes.
* instance_type variable is skipped when testing on docker.