### PR TITLE
Skip unsupported install recipes when building RHEL8 images

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return if redhat8?
+
 # Add awsbatch virtualenv to default path
 template "/etc/profile.d/pcluster_awsbatchcli.sh" do
   source "awsbatch/pcluster_awsbatchcli.sh.erb"

--- a/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
@@ -5,6 +5,10 @@ def virtualized?
   node.include?('virtualized') and node['virtualized']
 end
 
+def redhat8?
+  platform?('redhat') && node['platform_version'].to_i == 8
+end
+
 def redhat_ubi?
   virtualized? && platform?('redhat')
 end

--- a/cookbooks/aws-parallelcluster-install/recipes/dcv.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/dcv.rb
@@ -15,6 +15,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+return if redhat8?
 return if File.exist?("/etc/dcv/dcv.conf")
 
 # Utility function to install a list of packages

--- a/cookbooks/aws-parallelcluster-install/recipes/efs.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/efs.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return if redhat8?
+
 package_name = "amazon-efs-utils"
 efs_utils_tarball = node['cluster']['efs_utils']['tarball_path']
 stunnel_tarball = node['cluster']['stunnel']['tarball_path']

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/install.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return if redhat8?
+
 # setup the user accounts
 include_recipe "aws-parallelcluster-scheduler-plugin::install_user"
 


### PR DESCRIPTION
### Description of changes
* AWS Batch and Scheduler Plugin won't be supported at all. 
* DCV and EFS will be supported soon.

### Tests
* Manually tested executing a `pcluster build-image`
