### PR TITLE
Add ARM PL value for RedHat OS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,6 +90,7 @@ default['cluster']['armpl']['gcc']['url'] = [
 default['cluster']['armpl']['platform'] = value_for_platform(
   'centos' => { '~>7' => 'RHEL-7' },
   'amazon' => { '2' => 'RHEL-8' },
+  'redhat' => { 'default' => 'RHEL-8' },
   'ubuntu' => {
     '18.04' => 'Ubuntu-18.04',
     '20.04' => 'Ubuntu-20.04',


### PR DESCRIPTION
### Description of changes
* This change permits the build-image to go ahead when executing the arm_pl recipe. Previously it was failing with:
```
Stdout: [2023-02-16T13:40:07+00:00] WARN: remote_file[/opt/parallelcluster/sources/arm-performance-libraries_21.0.0__gcc-9.3.tar] cannot be downloaded from https://eu-west-1-aws-parallelcluster.s3.eu-west-1.amazonaws.com/archives/armpl//arm-performance-libraries_21.0.0__gcc-9.3.tar: 403 "Forbidden"
```

### Tests
* Manually tested creation of an AMI with the following config:
```
Build:
  InstanceType: c6g.xlarge # arm instance
  ParentImage: ami-01a073710a948b303 #rhel8 image-arm
  UpdateOsPackages:
    Enabled: true

DevSettings:
  Cookbook:
    ChefCookbook: https://github.com/enrico-usai/aws-parallelcluster-cookbook/tarball/refs/heads/wip/redhat8-2
  NodePackage: https://github.com/aws/aws-parallelcluster-node/tarball/refs/heads/develop
  AwsBatchCliPackage: https://github.com/aws/aws-parallelcluster/tarball/refs/heads/develop
```

### References
* #1769 
