### PR TITLE
Remove environment-modules and lvm2 packages from base_packages list

### DIFF
--- a/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
@@ -12,7 +12,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                          gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl
                                          jq wget python-pip NetworkManager-config-routing-rules libibverbs-utils
                                          librdmacm-utils python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                         coreutils moreutils sssd sssd-tools sssd-ldap environment-modules)
+                                         coreutils moreutils sssd sssd-tools sssd-ldap)
 
 # Install R via amazon linux extras
 default['cluster']['extra_packages'] = ['R3.4']

--- a/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
@@ -4,7 +4,7 @@ return unless platform?('amazon') && node['platform_version'] == "2"
 
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                          libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
-                                         httpd boost-devel system-lsb mlocate lvm2 atlas-devel glibc-static iproute
+                                         httpd boost-devel system-lsb mlocate atlas-devel glibc-static iproute
                                          libffi-devel dkms libedit-devel postgresql-devel postgresql-server
                                          sendmail cmake byacc libglvnd-devel mdadm libgcrypt-devel libevent-devel
                                          libxml2-devel perl-devel tar gzip bison flex gcc gcc-c++ patch

--- a/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
@@ -4,7 +4,7 @@ return unless platform?('centos') && node['platform_version'].to_i == 7
 
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                          libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
-                                         httpd boost-devel redhat-lsb mlocate lvm2 R atlas-devel
+                                         httpd boost-devel redhat-lsb mlocate R atlas-devel
                                          blas-devel libffi-devel dkms libedit-devel
                                          libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                          mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils

--- a/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
@@ -9,7 +9,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                          libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                          mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
                                          iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                         coreutils moreutils sssd sssd-tools sssd-ldap curl environment-modules)
+                                         coreutils moreutils sssd sssd-tools sssd-ldap curl)
 
 # TODO: check if it is still relevant. Evaluate if it is worth to remove the package.
 if node['kernel']['machine'] == 'aarch64'

--- a/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
@@ -10,7 +10,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                              libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                              mdadm python2 python2-pip libgcrypt-devel libevent-devel glibc-static bind-utils
                                              iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                             coreutils moreutils sssd sssd-tools sssd-ldap curl environment-modules gcc gcc-c++)
+                                             coreutils moreutils sssd sssd-tools sssd-ldap curl gcc gcc-c++)
 
 # Needed by hwloc-devel blas-devel libedit-devel and glibc-static packages
 default['cluster']['extra_repos'] = 'codeready-builder-for-rhel-8-rhui-rpms'

--- a/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
@@ -5,7 +5,7 @@ return unless platform?('redhat') && node['platform_version'].to_i == 8
 # Removed libssh2-devel from base_packages since is not shipped by RedHat 8 and in conflict with package libssh-0.9.6-3.el8.x86_64
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                              libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
-                                             httpd boost-devel redhat-lsb mlocate lvm2 R atlas-devel
+                                             httpd boost-devel redhat-lsb mlocate R atlas-devel
                                              blas-devel libffi-devel dkms libedit-devel
                                              libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                              mdadm python2 python2-pip libgcrypt-devel libevent-devel glibc-static bind-utils

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
@@ -5,7 +5,7 @@ return unless platform?('ubuntu') && node['platform_version'] == "18.04"
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-tools libhwloc-dev dkms
                                          tcl-dev automake autoconf libtool librrd-dev libapr1-dev libconfuse-dev
                                          apache2 libboost-dev libdb-dev libncurses5-dev libpam0g-dev libxt-dev
-                                         libmotif-dev libxmu-dev libxft-dev man-db lvm2 python
+                                         libmotif-dev libxmu-dev libxft-dev man-db python
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
                                          libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
@@ -10,7 +10,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev
                                          libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
                                          coreutils moreutils sssd sssd-tools sssd-ldap curl
-                                         python-pip python-parted environment-modules)
+                                         python-pip python-parted)
 
 default['cluster']['kernel_headers_pkg'] = "linux-headers-#{node['kernel']['release']}"
 

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
@@ -9,7 +9,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
                                          libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
-                                         coreutils moreutils sssd sssd-tools sssd-ldap curl python3-parted environment-modules)
+                                         coreutils moreutils sssd sssd-tools sssd-ldap curl python3-parted)
 
 default['cluster']['kernel_headers_pkg'] = "linux-headers-#{node['kernel']['release']}"
 

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
@@ -5,7 +5,7 @@ return unless platform?('ubuntu') && node['platform_version'] == "20.04"
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-tools libhwloc-dev dkms
                                          tcl-dev automake autoconf libtool librrd-dev libapr1-dev libconfuse-dev
                                          apache2 libboost-dev libdb-dev libncurses5-dev libpam0g-dev libxt-dev
-                                         libmotif-dev libxmu-dev libxft-dev man-db lvm2 python
+                                         libmotif-dev libxmu-dev libxft-dev man-db python
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
                                          libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -51,6 +51,7 @@ suites:
       - recipe[aws-parallelcluster-install::ephemeral_drives]
     verifier:
       controls:
+        - ephemeral_drives_logical_volumes_manager_installed
         - ephemeral_drives_script_created
         - ephemeral_service_set_up
   - name: python_setup

--- a/kitchen.validate.yml
+++ b/kitchen.validate.yml
@@ -34,6 +34,7 @@ suites:
         - ulimit_configured
         - pcluster_directories_exist
         - pcluster_log_dir_is_configured
+        - ephemeral_drives_logical_volumes_manager_installed
         - ephemeral_drives_script_created
         - ephemeral_service_set_up
         - awsbatch_virtualenv_created

--- a/system_tests/Dockerfile.centos7
+++ b/system_tests/Dockerfile.centos7
@@ -19,7 +19,7 @@ RUN yum install -y kernel-modules
 RUN yum install -y vim ksh tcsh zsh libssl-dev net-tools \
                dkms tcl-dev automake autoconf libtool    \
                libconfuse-dev apache2 libboost-dev csh   \
-               man-db lvm2 mdadm iproute2 python3        \
+               man-db mdadm iproute2 python3        \
                python3-pip linux-headers-aws iptables    \
                sudo pam-devel openmotif-dev libXmu-devel \
                hwloc-devel libdb-devel tcl-devel httpd   \

--- a/system_tests/Dockerfile.ubuntu
+++ b/system_tests/Dockerfile.ubuntu
@@ -12,7 +12,7 @@ RUN apt-get -y install vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-to
                libhwloc-dev dkms tcl-dev automake autoconf libtool librrd-dev       \
                libapr1-dev libconfuse-dev apache2 libboost-dev libdb-dev tcsh       \
                libncurses5-dev libpam0g-dev libxt-dev libmotif-dev libxmu-dev       \
-               libxft-dev libhwloc-dev man-db lvm2 python r-base libblas-dev        \
+               libxft-dev libhwloc-dev man-db python r-base libblas-dev        \
                libffi-dev libxml2-dev mdadm libgcrypt20-dev                         \
                libevent-dev iproute2 python3 python3-pip libatlas-base-dev          \
                libglvnd-dev linux-headers-aws iptables libcurl4-openssl-dev         \

--- a/test/recipes/controls/aws_parallelcluster_install/ephemeral_drives_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/ephemeral_drives_spec.rb
@@ -9,6 +9,14 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+control 'ephemeral_drives_logical_volumes_manager_installed' do
+  title 'Check ephemeral drives management utility is installed'
+
+  describe package('lvm2') do
+    it { should be_installed }
+  end
+end
+
 control 'ephemeral_drives_script_created' do
   title 'Ephemeral drives script is copied to the target dir'
 

--- a/test/resources/controls/aws_parallelcluster_install/install_packages_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/install_packages_spec.rb
@@ -4,7 +4,8 @@ control 'install_packages' do
 
   only_if { !os_properties.redhat_ubi? }
 
-  describe package('lvm2') do
+  # verify package with a common name is installed
+  describe package('coreutils') do
     it { should be_installed }
   end
 


### PR DESCRIPTION
* `environment-modules` package is only required by EFA and installed as EFA requirement, in the `efa.rb` resource (as you can see it is not present in the system test dockerfiles because EFA recipe is skipped).
* `lvm2` (Logical Volume Manager 2) is only required by ephemeral_drives recipe execution and explicitly installed in the `aws-parallelcluster-install/ephemeral_drives.rb`- 