### PR TITLE
Restore environment-modules in the base_packages list

### DIFF
--- a/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
@@ -2,6 +2,7 @@
 
 return unless platform?('amazon') && node['platform_version'] == "2"
 
+# environment-modules required by EFA, Intel MPI and ARM PL
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                          libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
                                          httpd boost-devel system-lsb mlocate atlas-devel glibc-static iproute
@@ -12,7 +13,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                          gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl
                                          jq wget python-pip NetworkManager-config-routing-rules libibverbs-utils
                                          librdmacm-utils python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                         coreutils moreutils sssd sssd-tools sssd-ldap)
+                                         coreutils moreutils sssd sssd-tools sssd-ldap environment-modules)
 
 # Install R via amazon linux extras
 default['cluster']['extra_packages'] = ['R3.4']

--- a/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
@@ -2,6 +2,7 @@
 
 return unless platform?('centos') && node['platform_version'].to_i == 7
 
+# environment-modules required by EFA, Intel MPI and ARM PL
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                          libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
                                          httpd boost-devel redhat-lsb mlocate R atlas-devel
@@ -9,7 +10,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                          libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                          mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
                                          iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                         coreutils moreutils sssd sssd-tools sssd-ldap curl)
+                                         coreutils moreutils sssd sssd-tools sssd-ldap curl environment-modules)
 
 # TODO: check if it is still relevant. Evaluate if it is worth to remove the package.
 if node['kernel']['machine'] == 'aarch64'

--- a/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
@@ -2,6 +2,7 @@
 
 return unless platform?('redhat') && node['platform_version'].to_i == 8
 
+# environment-modules required by EFA, Intel MPI and ARM PL
 # Removed libssh2-devel from base_packages since is not shipped by RedHat 8 and in conflict with package libssh-0.9.6-3.el8.x86_64
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                              libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
@@ -10,7 +11,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                              libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                              mdadm python2 python2-pip libgcrypt-devel libevent-devel glibc-static bind-utils
                                              iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                             coreutils moreutils sssd sssd-tools sssd-ldap curl gcc gcc-c++)
+                                             coreutils moreutils sssd sssd-tools sssd-ldap curl environment-modules gcc gcc-c++)
 
 # Needed by hwloc-devel blas-devel libedit-devel and glibc-static packages
 default['cluster']['extra_repos'] = 'codeready-builder-for-rhel-8-rhui-rpms'

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
@@ -2,6 +2,7 @@
 
 return unless platform?('ubuntu') && node['platform_version'] == "18.04"
 
+# environment-modules required by EFA, Intel MPI and ARM PL
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-tools libhwloc-dev dkms
                                          tcl-dev automake autoconf libtool librrd-dev libapr1-dev libconfuse-dev
                                          apache2 libboost-dev libdb-dev libncurses5-dev libpam0g-dev libxt-dev
@@ -10,7 +11,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev
                                          libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
                                          coreutils moreutils sssd sssd-tools sssd-ldap curl
-                                         python-pip python-parted)
+                                         python-pip python-parted environment-modules)
 
 default['cluster']['kernel_headers_pkg'] = "linux-headers-#{node['kernel']['release']}"
 

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
@@ -2,6 +2,7 @@
 
 return unless platform?('ubuntu') && node['platform_version'] == "20.04"
 
+# environment-modules required by EFA, Intel MPI and ARM PL
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-tools libhwloc-dev dkms
                                          tcl-dev automake autoconf libtool librrd-dev libapr1-dev libconfuse-dev
                                          apache2 libboost-dev libdb-dev libncurses5-dev libpam0g-dev libxt-dev
@@ -9,7 +10,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
                                          libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
-                                         coreutils moreutils sssd sssd-tools sssd-ldap curl python3-parted)
+                                         coreutils moreutils sssd sssd-tools sssd-ldap curl python3-parted environment-modules)
 
 default['cluster']['kernel_headers_pkg'] = "linux-headers-#{node['kernel']['release']}"
 


### PR DESCRIPTION
This reverts commit 7d00d32ef89299f209738678d9ee1a3668039a64

This package is required by both EFA resource and Intel MPI recipe.

Without this package the build was failing with:
``` 
2023-02-17 01:27:12.078000	Stdout:     Error executing action `edit` on resource 'append_if_no_line[append intel modules file dir to modules conf]'
2023-02-17 01:27:12.078000	Stdout:     ================================================================================
2023-02-17 01:27:12.078000	Stdout:
2023-02-17 01:27:12.078000	Stdout:     Chef::Exceptions::EnclosingDirectoryDoesNotExist
2023-02-17 01:27:12.078000	Stdout:     ------------------------------------------------
2023-02-17 01:27:12.078000	Stdout:     file[/usr/share/modules/init/.modulespath] (/etc/chef/local-mode-cache/cache/cookbooks/line/resources/append_if_no_line.rb line 24) had an error: Chef::Exceptions::EnclosingDirectoryDoesNotExist: Parent directory /usr/share/modules/init does not exist.
2023-02-17 01:27:12.078000	Stdout:
```