### PR TITLE
Define dns_domain resource 

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
@@ -24,7 +24,7 @@ if node['cluster']['scheduler'] == 'slurm' && node['cluster']['use_private_hostn
     # Configure custom dns domain (only if defined) by appending the Route53 domain created within the cluster
     # ($CLUSTER_NAME.pcluster) and be listed as a "search" domain in the resolv.conf file.
     dns_domain 'configure dns name resolution' do
-      :configure
+      action :configure
     end
   end
 
@@ -69,7 +69,7 @@ end
 hostname "set short hostname" do
   compile_time false
   hostname(lazy { node['cluster']['assigned_short_hostname'] })
-end unless virtualized?
+end
 
 # Resource to be called to reload ohai attributes after /etc/hosts update
 ohai 'reload_hostname' do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
@@ -16,6 +16,11 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+package "hostname" do
+  retries 3
+  retry_delay 5
+end
+
 # It is possible to restore the SIT behaviour by setting the use_private_hostname = true as extra_json parameter
 if node['cluster']['scheduler'] == 'slurm' && node['cluster']['use_private_hostname'] == 'false'
   # Heterogeneous Instance Type

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
@@ -16,8 +16,6 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-return if virtualized?
-
 # It is possible to restore the SIT behaviour by setting the use_private_hostname = true as extra_json parameter
 if node['cluster']['scheduler'] == 'slurm' && node['cluster']['use_private_hostname'] == 'false'
   # Heterogeneous Instance Type
@@ -65,10 +63,13 @@ else
 end
 
 # Configure short hostname
+# setting the hostname requires root privileges, however by default docker containers are launched with limited root
+# privileges, so this command will fail.
+# Skipping this check in containers.
 hostname "set short hostname" do
   compile_time false
   hostname(lazy { node['cluster']['assigned_short_hostname'] })
-end
+end unless virtualized?
 
 # Resource to be called to reload ohai attributes after /etc/hosts update
 ohai 'reload_hostname' do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
@@ -16,6 +16,8 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+return if virtualized?
+
 # It is possible to restore the SIT behaviour by setting the use_private_hostname = true as extra_json parameter
 if node['cluster']['scheduler'] == 'slurm' && node['cluster']['use_private_hostname'] == 'false'
   # Heterogeneous Instance Type

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
@@ -23,28 +23,9 @@ if node['cluster']['scheduler'] == 'slurm' && node['cluster']['use_private_hostn
   if !node['cluster']['dns_domain'].nil? && !node['cluster']['dns_domain'].empty?
     # Configure custom dns domain (only if defined) by appending the Route53 domain created within the cluster
     # ($CLUSTER_NAME.pcluster) and be listed as a "search" domain in the resolv.conf file.
-    if platform?('ubuntu')
-
-      Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/systemd/resolved.conf")
-      # Configure resolved to automatically append Route53 search domain in resolv.conf.
-      # On Ubuntu18 resolv.conf is managed by systemd-resolved.
-      replace_or_add "append Route53 search domain in /etc/systemd/resolved.conf" do
-        path "/etc/systemd/resolved.conf"
-        pattern "Domains=*"
-        line "Domains=#{node['cluster']['dns_domain']}"
-      end
-    else
-
-      Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/dhcp/dhclient.conf")
-      # Configure dhclient to automatically append Route53 search domain in resolv.conf
-      # - on CentOS7 and Alinux2 resolv.conf is managed by NetworkManager + dhclient,
-      replace_or_add "append Route53 search domain in /etc/dhcp/dhclient.conf" do
-        path "/etc/dhcp/dhclient.conf"
-        pattern "append domain-name*"
-        line "append domain-name \" #{node['cluster']['dns_domain']}\";"
-      end
+    dns_domain 'configure dns name resolution' do
+      :configure
     end
-    restart_network_service
   end
 
   if node['cluster']['node_type'] == "ComputeFleet"

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain.rb
@@ -13,31 +13,20 @@ unified_mode true
 
 default_action :configure
 
+use 'partial/_dns_search_domain_ubuntu'
+use 'partial/_dns_search_domain_redhat'
+
 # Configure custom dns domain (only if defined) by appending the Route53 domain created within the cluster
 # ($CLUSTER_NAME.pcluster) and be listed as a "search" domain in the resolv.conf file.
 action :configure do
   return if virtualized?
 
+  # once we split this we can simplify the naming since only one partial will be imported
   if platform?('ubuntu')
-
-    Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/systemd/resolved.conf")
-    # Configure resolved to automatically append Route53 search domain in resolv.conf.
-    # On Ubuntu18 resolv.conf is managed by systemd-resolved.
-    replace_or_add "append Route53 search domain in /etc/systemd/resolved.conf" do
-      path "/etc/systemd/resolved.conf"
-      pattern "Domains=*"
-      line "Domains=#{node['cluster']['dns_domain']}"
-    end
+    action_update_search_domain_ubuntu
   else
-
-    Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/dhcp/dhclient.conf")
-    # Configure dhclient to automatically append Route53 search domain in resolv.conf
-    # - on CentOS7 and Alinux2 resolv.conf is managed by NetworkManager + dhclient,
-    replace_or_add "append Route53 search domain in /etc/dhcp/dhclient.conf" do
-      path "/etc/dhcp/dhclient.conf"
-      pattern "append domain-name*"
-      line "append domain-name \" #{node['cluster']['dns_domain']}\";"
-    end
+    action_update_search_domain_redhat
   end
+
   restart_network_service
 end

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain.rb
@@ -16,6 +16,8 @@ default_action :configure
 # Configure custom dns domain (only if defined) by appending the Route53 domain created within the cluster
 # ($CLUSTER_NAME.pcluster) and be listed as a "search" domain in the resolv.conf file.
 action :configure do
+  return if virtualized?
+
   if platform?('ubuntu')
 
     Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/systemd/resolved.conf")

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain.rb
@@ -1,0 +1,41 @@
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :dns_domain
+unified_mode true
+
+default_action :configure
+
+# Configure custom dns domain (only if defined) by appending the Route53 domain created within the cluster
+# ($CLUSTER_NAME.pcluster) and be listed as a "search" domain in the resolv.conf file.
+action :configure do
+  if platform?('ubuntu')
+
+    Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/systemd/resolved.conf")
+    # Configure resolved to automatically append Route53 search domain in resolv.conf.
+    # On Ubuntu18 resolv.conf is managed by systemd-resolved.
+    replace_or_add "append Route53 search domain in /etc/systemd/resolved.conf" do
+      path "/etc/systemd/resolved.conf"
+      pattern "Domains=*"
+      line "Domains=#{node['cluster']['dns_domain']}"
+    end
+  else
+
+    Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/dhcp/dhclient.conf")
+    # Configure dhclient to automatically append Route53 search domain in resolv.conf
+    # - on CentOS7 and Alinux2 resolv.conf is managed by NetworkManager + dhclient,
+    replace_or_add "append Route53 search domain in /etc/dhcp/dhclient.conf" do
+      path "/etc/dhcp/dhclient.conf"
+      pattern "append domain-name*"
+      line "append domain-name \" #{node['cluster']['dns_domain']}\";"
+    end
+  end
+  restart_network_service
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
@@ -18,6 +18,8 @@ default_action :configure
 # Configure custom dns domain (only if defined) by appending the Route53 domain created within the cluster
 # ($CLUSTER_NAME.pcluster) and be listed as a "search" domain in the resolv.conf file.
 action :configure do
+  return if virtualized?
+
   Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/dhcp/dhclient.conf")
   # Configure dhclient to automatically append Route53 search domain in resolv.conf
   # - on CentOS7 and Alinux2 resolv.conf is managed by NetworkManager + dhclient,

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
@@ -15,19 +15,14 @@ unified_mode true
 
 default_action :configure
 
+use 'partial/_dns_search_domain_redhat'
+
 # Configure custom dns domain (only if defined) by appending the Route53 domain created within the cluster
 # ($CLUSTER_NAME.pcluster) and be listed as a "search" domain in the resolv.conf file.
 action :configure do
   return if virtualized?
 
-  Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/dhcp/dhclient.conf")
-  # Configure dhclient to automatically append Route53 search domain in resolv.conf
-  # - on CentOS7 and Alinux2 resolv.conf is managed by NetworkManager + dhclient,
-  replace_or_add "append Route53 search domain in /etc/dhcp/dhclient.conf" do
-    path "/etc/dhcp/dhclient.conf"
-    pattern "append domain-name*"
-    line "append domain-name \" #{node['cluster']['dns_domain']}\";"
-  end
+  action_update_search_domain_redhat
 
   restart_network_service
 end

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
@@ -1,0 +1,31 @@
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :dns_domain, platform: 'redhat' do |node|
+  node['platform_version'].to_i == 8
+end
+unified_mode true
+
+default_action :configure
+
+# Configure custom dns domain (only if defined) by appending the Route53 domain created within the cluster
+# ($CLUSTER_NAME.pcluster) and be listed as a "search" domain in the resolv.conf file.
+action :configure do
+  Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/dhcp/dhclient.conf")
+  # Configure dhclient to automatically append Route53 search domain in resolv.conf
+  # - on CentOS7 and Alinux2 resolv.conf is managed by NetworkManager + dhclient,
+  replace_or_add "append Route53 search domain in /etc/dhcp/dhclient.conf" do
+    path "/etc/dhcp/dhclient.conf"
+    pattern "append domain-name*"
+    line "append domain-name \" #{node['cluster']['dns_domain']}\";"
+  end
+
+  restart_network_service
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/partial/_dns_search_domain_redhat.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/partial/_dns_search_domain_redhat.rb
@@ -1,0 +1,9 @@
+action :update_search_domain_redhat do
+  Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/dhcp/dhclient.conf")
+  # Configure dhclient to automatically append Route53 search domain in resolv.conf
+  replace_or_add "append Route53 search domain in /etc/dhcp/dhclient.conf" do
+    path "/etc/dhcp/dhclient.conf"
+    pattern "append domain-name*"
+    line "append domain-name \" #{node['cluster']['dns_domain']}\";"
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/partial/_dns_search_domain_ubuntu.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/partial/_dns_search_domain_ubuntu.rb
@@ -1,0 +1,10 @@
+action :update_search_domain_ubuntu do
+  Chef::Log.info("Appending search domain '#{node['cluster']['dns_domain']}' to /etc/systemd/resolved.conf")
+  # Configure resolved to automatically append Route53 search domain in resolv.conf.
+  # On Ubuntu18 resolv.conf is managed by systemd-resolved.
+  replace_or_add "append Route53 search domain in /etc/systemd/resolved.conf" do
+    path "/etc/systemd/resolved.conf"
+    pattern "Domains=*"
+    line "Domains=#{node['cluster']['dns_domain']}"
+  end
+end

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -437,3 +437,4 @@ suites:
       ec2:
         local_hostname: dokken
         local_ipv4: 172.17.1.15
+      ipaddress: 172.17.1.15

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -424,6 +424,8 @@ suites:
     verifier:
       controls:
         - hostname_configured
+    driver:
+      privileged: true # required to set hostname
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-install::directories

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -426,6 +426,12 @@ suites:
         - hostname_configured
     attributes:
       dependencies:
-        - resource:dns_domain
+        - recipe:aws-parallelcluster-install::directories
       cluster:
+        node_type: HeadNode
         dns_domain: test-domain
+        assigned_hostname: fqn-hostname
+        assigned_short_hostname: short-hostname
+      ec2:
+        local_hostname: dokken
+        local_ipv4: 172.17.1.15

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -417,3 +417,15 @@ suites:
         scheduler: slurm
         head_node_imds_secured: 'true'
         head_node_imds_allowed_users: ['root', 'nobody']
+  - name: init_dns
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-slurm::init_dns]
+    verifier:
+      controls:
+        - hostname_configured
+    attributes:
+      dependencies:
+        - resource:dns_domain
+      cluster:
+        dns_domain: test-domain

--- a/kitchen.resources.yml
+++ b/kitchen.resources.yml
@@ -173,3 +173,16 @@ suites:
         - recipe:aws-parallelcluster-install::directories
         - resource:package_repos
         - resource:install_packages
+  - name: dns_domain
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-slurm::test_resource]
+    verifier:
+      controls:
+        - dns_domain_configured
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+      resource: dns_domain
+      cluster:
+        dns_domain: test-domain

--- a/test/recipes/controls/aws_parallelcluster_slurm/init_dns_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/init_dns_spec.rb
@@ -17,7 +17,7 @@ control 'hostname_configured' do
     its('content') do
       should match("^ip-[0-9]*-[0-9]*-[0-9]*-[0-9]*")
     end
-  end
+  end unless os_properties.virtualized?
 
   describe file('/etc/hosts') do
     it { should exist }
@@ -25,5 +25,5 @@ control 'hostname_configured' do
       should match("^[0-9]*.[0-9]*.[0-9]*.[0-9]*")
       should match("ip-[0-9]*-[0-9]*-[0-9]*-[0-9]*")
     end
-  end
+  end unless os_properties.virtualized?
 end

--- a/test/recipes/controls/aws_parallelcluster_slurm/init_dns_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/init_dns_spec.rb
@@ -17,7 +17,7 @@ control 'hostname_configured' do
     its('content') do
       should match("short-hostname")
     end
-  end unless os_properties.virtualized?
+  end
 
   describe file('/etc/hosts') do
     it { should exist }

--- a/test/recipes/controls/aws_parallelcluster_slurm/init_dns_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/init_dns_spec.rb
@@ -12,6 +12,10 @@
 control 'hostname_configured' do
   title 'Checks hostname is properly set'
 
+  describe package('hostname') do
+    it { should be_installed }
+  end
+
   describe file('/etc/hostname') do
     it { should exist }
     its('content') do

--- a/test/recipes/controls/aws_parallelcluster_slurm/init_dns_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/init_dns_spec.rb
@@ -9,19 +9,21 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'dns_domain_configured' do
-  title "Checks that the DNS search domain is configured"
+control 'hostname_configured' do
+  title 'Checks hostname is properly set'
 
-  dns_domain_string = 'test-domain'
-  config_file = '/etc/dhcp/dhclient.conf'
-  if os_properties.debian_family?
-    config_file = '/etc/systemd/resolved.conf'
-  end
-
-  describe file(config_file) do
+  describe file('/etc/hostname') do
     it { should exist }
     its('content') do
-      should match(dns_domain_string)
+      should match("^ip-[0-9]*-[0-9]*-[0-9]*-[0-9]*")
+    end
+  end
+
+  describe file('/etc/hosts') do
+    it { should exist }
+    its('content') do
+      should match("^[0-9]*.[0-9]*.[0-9]*.[0-9]*")
+      should match("ip-[0-9]*-[0-9]*-[0-9]*-[0-9]*")
     end
   end
 end

--- a/test/recipes/controls/aws_parallelcluster_slurm/init_dns_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/init_dns_spec.rb
@@ -15,15 +15,14 @@ control 'hostname_configured' do
   describe file('/etc/hostname') do
     it { should exist }
     its('content') do
-      should match("^ip-[0-9]*-[0-9]*-[0-9]*-[0-9]*")
+      should match("short-hostname")
     end
   end unless os_properties.virtualized?
 
   describe file('/etc/hosts') do
     it { should exist }
     its('content') do
-      should match("^[0-9]*.[0-9]*.[0-9]*.[0-9]*")
-      should match("ip-[0-9]*-[0-9]*-[0-9]*-[0-9]*")
+      should match('fqn-hostname short-hostname')
     end
-  end unless os_properties.virtualized?
+  end
 end

--- a/test/resources/controls/aws_parallelcluster_slurm/dns_domain_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_slurm/dns_domain_spec.rb
@@ -23,5 +23,5 @@ control 'dns_domain_configured' do
     its('content') do
       should match(dns_domain_string)
     end
-  end
+  end unless os_properties.virtualized?
 end

--- a/test/resources/controls/aws_parallelcluster_slurm/dns_domain_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_slurm/dns_domain_spec.rb
@@ -1,0 +1,29 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+
+
+control 'dns_domain_configured' do
+  title "Checks that the DNS search domain is configured"
+
+  dns_domain_string = 'test-domain'
+  config_file = '/etc/dhcp/dhclient.conf'
+  if os_properties.debian_family?
+    config_file = '/etc/systemd/resolved.conf'
+  end
+
+  describe file(config_file) do
+    it { should exist }
+    its('content') do
+      should match(dns_domain_string)
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
* Define dns_domain resource
* Add tests for init_dns recipe
* Add hostname package as requirement of init_dns recipe (missing in RHEL8 image)

### Tests
Use privileged_true when testing init_dns recipe
This flag is required to change the hostname,
in this way we can remove the virtualized guard and test it on docker.

### References
* Replacement of: https://github.com/aws/aws-parallelcluster-cookbook/pull/1767
