### PR TITLE
Add infrastructure to apply patches to a Slurm tarball

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/install_slurm/slurm_patches/README.md
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/install_slurm/slurm_patches/README.md
@@ -1,0 +1,10 @@
+# Slurm patches configuration
+
+This folder is for patch files for the Slurm source code. Patches must be produced by git
+(e.g. via `git diff` or by downloading the diff from a commit in GitHub).
+
+Patch files must be prepended with a zero-padded number in order to allow the cookbook to
+apply the patches in a defined order. For example:
+- 01_hashabc.diff
+- 02_hashdef.diff
+- 03_hash123.diff

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -58,6 +58,14 @@ ruby_block "Validate Slurm Tarball Checksum" do
   end
 end
 
+# Copy Slurm patches
+remote_directory "#{node['cluster']['sources_dir']}/slurm_patches" do
+  source 'install_slurm/slurm_patches'
+  mode '0755'
+  action :create
+  recursive true
+end
+
 # Install Slurm
 bash 'make install' do
   user 'root'
@@ -71,11 +79,25 @@ bash 'make install' do
 
     tar xf #{slurm_tarball}
     cd slurm-#{node['cluster']['slurm']['tar_name']}
+
+    # Apply possible Slurm patches
+    shopt -s nullglob  # with this an empty slurm_patches directory does not trigger the loop
+    for patch in #{node['cluster']['sources_dir']}/slurm_patches/*.diff; do
+      echo "Applying patch ${patch}..."
+      patch --ignore-whitespace -p1 < ${patch}
+      echo "...DONE."
+    done
+    shopt -u nullglob
+
+    # Configure Slurm
     ./configure --prefix=#{node['cluster']['slurm']['install_dir']} --with-pmix=/opt/pmix --with-jwt=/opt/libjwt --enable-slurmrestd
+
+    # Build Slurm
     CORES=$(grep processor /proc/cpuinfo | wc -l)
     make -j $CORES
     make install
     make install-contrib
+
     deactivate
   SLURM
   # TODO: Fix, so it works for upgrade


### PR DESCRIPTION
### Description of changes
* Add infrastructure to allow to apply patches to a Slurm tarball

### Tests
* The new code was already released in 3.4.1 (in that case it included also an actual patch, while here we have an empty `slurm_patches` folder).

### References
* Original Pull Request where we patched Slurm for v3.4.1: https://github.com/aws/aws-parallelcluster-cookbook/pull/1638/commits)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.