### PR TITLE
[RedHat-8] Populate validate with all the controls for aws_parallelcluster_install

### DIFF
--- a/.github/workflows/dokken-validate.yml
+++ b/.github/workflows/dokken-validate.yml
@@ -14,7 +14,7 @@ jobs:
           - ubuntu20
           - redhat8
         suite:
-          - platform-base
+          - aws-parallelcluster-install
       fail-fast: false
     steps:
       - name: Check out code

--- a/cookbooks/aws-parallelcluster-install/recipes/chrony.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/chrony.rb
@@ -15,6 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return if redhat_ubi?
+
 # Install Amazon Time Sync
 package %w(ntp ntpdate ntp*) do
   action :remove
@@ -23,7 +25,7 @@ end
 package %w(chrony) do
   retries 3
   retry_delay 5
-end unless redhat_ubi?
+end
 
 append_if_no_line "add configuration to chrony.conf" do
   path node['cluster']['chrony']['conf']

--- a/cookbooks/aws-parallelcluster-install/recipes/lustre.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/lustre.rb
@@ -63,6 +63,10 @@ elsif platform?('centos') && node['platform_version'].to_f >= 7.7
     retry_delay 5
   end
 
+  package_repos 'centos_skip_if_unavail' do
+    action :centos_skip_if_unavail
+  end
+
   package %w(kmod-lustre-client lustre-client) do
     retries 3
     retry_delay 5

--- a/cookbooks/aws-parallelcluster-install/resources/package_repos/package_repos.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/package_repos/package_repos.rb
@@ -29,11 +29,7 @@ action :setup do
     # the epel recipe doesn't work on aarch64, needs epel-release package
     package 'epel-release' if node['platform_version'].to_i == 7 && node['kernel']['machine'] == 'aarch64'
 
-    unless node['platform_version'].to_i < 7
-      execute 'yum-config-manager_skip_if_unavail' do
-        command "yum-config-manager --setopt=\*.skip_if_unavailable=1 --save"
-      end
-    end
+    action_centos_skip_if_unavail
   end
 
   action_update
@@ -42,5 +38,13 @@ end
 action :update do
   if platform_family?('debian')
     apt_update
+  end
+end
+
+action :centos_skip_if_unavail do
+  if platform?('centos') && node['platform_version'].to_i >= 7
+    execute 'yum-config-manager_skip_if_unavail' do
+      command "yum-config-manager --setopt=\*.skip_if_unavailable=1 --save"
+    end
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/package_repos/package_repos_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/package_repos/package_repos_redhat8.rb
@@ -29,6 +29,10 @@ action :setup do
   execute 'yum-config-manager-rhel' do
     command "yum-config-manager --enable #{node['cluster']['extra_repos']}"
   end unless virtualized?
+
+  execute 'yum-config-manager_skip_if_unavail' do
+    command "yum-config-manager --setopt=\*.skip_if_unavailable=1 --save"
+  end
 end
 
 action :update do

--- a/cookbooks/aws-parallelcluster-test/recipes/docker_mock.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/docker_mock.rb
@@ -49,3 +49,5 @@ end
 
 directory '/etc/cron.daily'
 directory '/etc/cron.weekly'
+
+directory '/etc/chef'

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -27,17 +27,37 @@ platforms:
   - name: alinux2
     driver:
       image: dokken/amazonlinux-2
+    attributes:
+      cluster:
+        base_os: alinux2
+        kernel_release: '5.10.157-139.675.amzn2.x86_64'
   - name: centos7
     driver:
       image: dokken/centos-7
+    attributes:
+      cluster:
+        base_os: centos7
+        kernel_release: '3.10.0-1160.76.1.el7.x86_64'
   - name: ubuntu1804
     driver:
       image: dokken/ubuntu-18.04
+    attributes:
+      cluster:
+        base_os: ubuntu1804
+        kernel_release: '5.4.0-1092-aws'
   - name: ubuntu2004
     driver:
       image: dokken/ubuntu-20.04
+    attributes:
+      cluster:
+        base_os: ubuntu2004
+        kernel_release: '5.15.0-1028-aws'
   - name: redhat8
     driver:
       image: registry.access.redhat.com/ubi8/ubi
       intermediate_instructions:
         - RUN chmod +t /tmp
+    attributes:
+      cluster:
+        base_os: redhat8
+        kernel_release: '4.18.0-425.3.1.el8.x86_64'

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -3,9 +3,6 @@ provisioner:
   attributes:
     cluster:
       # right now tests depend on this parameter: we will try to remove the dependency later
-      base_os: alinux
+      base_os: alinux2
       region: us-east-1
-      dcv:
-        server: {}
       parallelcluster-node-version: '3.4.1'
-      node_type: 'HeadNode'

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -3,6 +3,5 @@ provisioner:
   attributes:
     cluster:
       # right now tests depend on this parameter: we will try to remove the dependency later
-      base_os: alinux2
       region: us-east-1
       parallelcluster-node-version: '3.4.1'

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -138,7 +138,7 @@ suites:
       - recipe[aws-parallelcluster-install::disable_selinux]
     verifier:
       controls:
-        - disable_selinux
+        - selinux_disabled
   - name: openssh
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -183,6 +183,8 @@ suites:
         - recipe:aws-parallelcluster-install::users
         - recipe:aws-parallelcluster-install::directories
         - recipe:aws-parallelcluster-install::sudo
+      cluster:
+        node_type: 'HeadNode'
   - name: mount_shared
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]

--- a/kitchen.resources.yml
+++ b/kitchen.resources.yml
@@ -40,7 +40,7 @@ suites:
       - recipe[aws-parallelcluster-install::test_resource]
     verifier:
       controls:
-        - c_states_kernel_configuration
+        - c_states_kernel_configured
     attributes:
       resource: c_states
   - name: ec2_udev_rules
@@ -124,7 +124,7 @@ suites:
       - recipe[aws-parallelcluster-common::test_resource]
     verifier:
       controls:
-        - efa_system_settings_configured
+        - efa_debian_system_settings_configured
     attributes:
       resource: efa:configure
       cluster:

--- a/kitchen.validate.yml
+++ b/kitchen.validate.yml
@@ -8,24 +8,13 @@ verifier:
     - test/resources
 
 suites:
-  - name: platform_base
+  - name: aws_parallelcluster_install
     run_list:
       - recipe[aws-parallelcluster::test_dummy]
       - recipe[aws-parallelcluster-test::docker_mock]
-      - recipe[aws-parallelcluster-install::base]
+      - recipe[aws-parallelcluster-install::install]
     verifier:
       controls:
-        # This is the first stab at aws-parallelcluster-install::base testing
-        # Missing tests for:
-        #   - disable_services
-        #   - Disable selinux
-        #   - License README
-        #   - configure_gc_thresh_values
-        #   - chrony_installed_and_configured
-        #   - c_states
-        #   - clusterstatusmgtd_files_created
-        #   - mysql_client_installed
-        #   - mysql_client_source_node_created
         # We also need to test the effect some files (service config, profile config) have on the system.
         # TODO: rethink and integrate
         - sudo_installed
@@ -53,7 +42,19 @@ suites:
         - cron_disabled_selected_daily_and_weekly_jobs
         - openssh_installed
         - ami_cleanup_file_created
-        # TODO: enable following controls when testing install.rb recipe
-        # - efa_conflicting_packages_removed
-        # - efa_prereq_packages_installed
-        # - efa_installed
+        - c_states_kernel_configuration
+        - chrony_installed_and_configured
+        - clusterstatusmgtd_files_created
+        - disable_selinux
+        - efa_conflicting_packages_removed
+        - efa_installed
+        - efa_prereq_packages_installed
+        - efs_utils_installed
+        - gc_thresh_values_configured
+        - license_readme_created
+        - mysql_client_installed
+        - mysql_client_source_node_created
+        - node_attributes
+        - services_disabled_on_amazon_family
+        - services_disabled_on_debian_family
+        - stunnel_installed

--- a/kitchen.validate.yml
+++ b/kitchen.validate.yml
@@ -42,10 +42,10 @@ suites:
         - cron_disabled_selected_daily_and_weekly_jobs
         - openssh_installed
         - ami_cleanup_file_created
-        - c_states_kernel_configuration
+        - c_states_kernel_configured
         - chrony_installed_and_configured
         - clusterstatusmgtd_files_created
-        - disable_selinux
+        - selinux_disabled
         - efa_conflicting_packages_removed
         - efa_installed
         - efa_prereq_packages_installed
@@ -54,7 +54,7 @@ suites:
         - license_readme_created
         - mysql_client_installed
         - mysql_client_source_node_created
-        - node_attributes
+        - node_attributes_created
         - services_disabled_on_amazon_family
         - services_disabled_on_debian_family
         - stunnel_installed

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -190,6 +190,9 @@ def validate_os_type
   when 'centos'
     current_os = "centos#{node['platform_version'].to_i}"
     raise_os_not_match(current_os, node['cluster']['base_os']) if node['cluster']['base_os'] != current_os
+  when 'redhat'
+    current_os = "redhat#{node['platform_version'].to_i}"
+    raise_os_not_match(current_os, node['cluster']['base_os']) if node['cluster']['base_os'] != current_os
   end
 end
 

--- a/test/recipes/controls/aws_parallelcluster_install/chrony_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/chrony_spec.rb
@@ -12,9 +12,11 @@
 control 'chrony_installed_and_configured' do
   title 'Test chrony installation and configuration'
 
+  only_if { !os_properties.redhat_ubi? }
+
   describe package('chrony') do
     it { should be_installed }
-  end unless os_properties.redhat_ubi?
+  end
 
   describe package('ntp') do
     it { should_not be_installed }

--- a/test/recipes/controls/aws_parallelcluster_install/disable_selinux_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/disable_selinux_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'disable_selinux' do
+control 'selinux_disabled' do
   title 'Check if selinux is disabled'
   describe selinux do
     it { should be_disabled }

--- a/test/resources/controls/aws_parallelcluster_config/efa_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_config/efa_spec.rb
@@ -1,5 +1,5 @@
-control 'efa_system_settings_configured' do
-  title 'Check system is correctly configured for EFA'
+control 'efa_debian_system_settings_configured' do
+  title 'Check debian system is correctly configured for EFA'
 
   only_if { os.debian? && !os_properties.virtualized? }
 

--- a/test/resources/controls/aws_parallelcluster_config/efa_system_settings_configured_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_config/efa_system_settings_configured_spec.rb
@@ -1,0 +1,9 @@
+control 'efa_system_settings_configured' do
+  title 'Check system is correctly configured for EFA'
+
+  only_if { os.debian? && !os_properties.virtualized? }
+
+  describe kernel_parameter('kernel.yama.ptrace_scope') do
+    its('value') { should eq 0 }
+  end
+end

--- a/test/resources/controls/aws_parallelcluster_install/c_states_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/c_states_spec.rb
@@ -1,5 +1,5 @@
 
-control 'c_states_kernel_configuration' do
+control 'c_states_kernel_configured' do
   title 'Check the configuration to disable c states'
   only_if { !os_properties.virtualized? && os_properties.x86? }
 

--- a/test/resources/controls/aws_parallelcluster_install/efa_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/efa_spec.rb
@@ -59,13 +59,3 @@ control 'efa_installed' do
     end
   end
 end
-
-control 'efa_system_settings_configured' do
-  title 'Check system is correctly configured for EFA'
-
-  only_if { os.debian? && !os_properties.virtualized? }
-
-  describe kernel_parameter('kernel.yama.ptrace_scope') do
-    its('value') { should eq 0 }
-  end
-end

--- a/test/resources/controls/aws_parallelcluster_install/node_attributes_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/node_attributes_spec.rb
@@ -1,4 +1,4 @@
-control 'node_attributes' do
+control 'node_attributes_created' do
   title 'Test the generation of the node attributes json file'
 
   describe file('/etc/chef/node_attributes.json') do

--- a/util/search-spec-validation.sh
+++ b/util/search-spec-validation.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script requires yq. https://github.com/mikefarah/yq/#install
+# The script shows the differences between the suite of validators in kitchen.validate.yml and the inspec controls in the specified directory
+# The script searches inspec control in directories test/recipes/ and test/resources/
+# The script have to be run in the root of the repository
+# Example util/search-spec-validation.sh <suite> <inspec_folder>
+
+CONTROLS_FROM_KITCHEN_YML=$(yq '... comments="" | .suites[select(.name == "$1")].verifier.controls[]' kitchen.validate.yml | sort -u)
+CONTROLS_FROM_TEST_DIRECTORY=$(grep -Rh "control " test/*/*/$1 | awk -F\' '{print $2}' | grep . | sort -u)
+diff <(echo "$CONTROLS_FROM_KITCHEN_YML") <(echo "$CONTROLS_FROM_TEST_DIRECTORY")


### PR DESCRIPTION
### Description of changes
* [Add search-spec-validation.sh to show diff between kitchen.validate.yml](https://github.com/aws/aws-parallelcluster-cookbook/pull/1791/commits/da1cc4ccb9c55aad038b9bdccddf1a4a437168f3)
  * Utility script to print the difference between the controls in kitchen.validate.yml and in the directories of the inspec tests 
* [Mov efa_system_settings_configured control in config directory](https://github.com/aws/aws-parallelcluster-cookbook/pull/1791/commits/c8d80cce6edffc676be05baa5a17153bcc76aec2)
  * Minor move of an existing tests from install to config inspec test directory to reflect the usage
* [Add controls to kitchen.validate.yml and removed unused configuration](https://github.com/aws/aws-parallelcluster-cookbook/pull/1791/commits/1511bee4bd1fe2e05962fe6eb7f2dd62dad4b870)
  * Added the missing inspec test and moved attribute at "lower level" in order to keep the kitchen files as general as possible
* [Add validate_os_type for redhat8](https://github.com/aws/aws-parallelcluster-cookbook/pull/1791/commits/52b2487199c601276851b8abe0a717c5f2fd0a87)
  * Add a missing validator on the OS version for RedHat8
* [Fix chrony recipe and spec in case of redhat_ubi](https://github.com/aws/aws-parallelcluster-cookbook/pull/1791/commits/97960567258aacb3759639c1bb64696a5d42d236)
  * Fix a bug in the chrony recipe and spec that was not able to deal with the docker image of RedHat8
* [Move cluster attribute from global kitchen config to clusterstatusmgtd_init_slurm test](https://github.com/aws/aws-parallelcluster-cookbook/pull/1791/commits/4f2983cdf1906186f59c1be3fe5e9c49bdbdc7b2)
  * Moved attribute at "lower level" in order to keep the kitchen files as general as possible
* [Add to lustre repo skip_if_unavail](https://github.com/aws/aws-parallelcluster-cookbook/pull/1791/commits/69261417e7c09327b681911c4b218d4e1656096e)

### Tests
* Locally tested on docker

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.