### PR TITLE
Check status of Slurm services after starting them

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -219,3 +219,13 @@ service "slurmctld" do
   supports restart: false
   action %i(enable start)
 end
+
+# The slurmctld service does not return an error code to `systemctl start slurmctld`, so
+# we must explicitly check the status of the service to capture failures
+chef_sleep 3
+
+execute "check slurmctld status" do
+  command "systemctl is-active --quiet slurmctld.service"
+  retries 5
+  retry_delay 2
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize_compute.rb
@@ -40,6 +40,17 @@ service 'slurmd' do
   not_if { node['kitchen'] }
 end
 
+# The slurmd service does not return an error code to `systemctl start slurmd`, so
+# we must explicitly check the status of the service to capture failures
+chef_sleep 3
+
+execute "check slurmd status" do
+  command "systemctl is-active --quiet slurmd.service"
+  retries 5
+  retry_delay 2
+  not_if { node['kitchen'] }
+end
+
 execute 'resume_node' do
   # Always try to resume a static node on start up
   # Command will fail if node is already in IDLE, ignoring failure

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -191,6 +191,14 @@ end
 
 chef_sleep '5'
 
+# The slurmctld service does not return an error code to `systemctl start slurmctld`, so
+# we must explicitly check the status of the service to capture failures
+execute "check slurmctld status" do
+  command "systemctl is-active --quiet slurmctld.service"
+  retries 5
+  retry_delay 2
+end
+
 execute 'reload config for running nodes' do
   command "#{node['cluster']['slurm']['install_dir']}/bin/scontrol reconfigure"
   retries 3


### PR DESCRIPTION
### Description of changes
* Check status of Slurm services after starting them
    * This allows to surface any failure of the slurmctld or slurmd services while running the Chef cookbooks.

### Tests
* [PENDING] Manual cluster creations with bad Slurm parameters to check that the cookbooks fail at the status checks.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.