### PR TITLE
[3.x] Add EFA error message on RH < 8.4

### DIFF
--- a/cookbooks/aws-parallelcluster-common/attributes/common.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common.rb
@@ -53,3 +53,6 @@ default['cluster']['parallelcluster-awsbatch-cli-version'] = '1.1.0'
 # EFA
 default['cluster']['efa']['installer_version'] = '1.21.0'
 default['cluster']['efa']['unsupported_aarch64_oses'] = %w(centos7)
+
+# Created this new variable to be able to mock it freely
+default['cluster']['platform_version'] = node['platform_version']

--- a/cookbooks/aws-parallelcluster-common/resources/efa/efa_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/efa_redhat8.rb
@@ -24,6 +24,18 @@ action :configure do
   # do nothing
 end
 
+action :check_efa_support do
+  if node['cluster']['platform_version'].to_f < 8.4
+    log "EFA is not supported in this RHEL version #{node['cluster']['platform_version']}, supported versions are >= 8.4" do
+      level :warn
+      action :write
+    end
+    node.override['cluster']['efa_supported'] = false
+  else
+    node.override['cluster']['efa_supported'] = true
+  end
+end
+
 action_class do
   def conflicting_packages
     %w(openmpi-devel openmpi)

--- a/cookbooks/aws-parallelcluster-common/resources/efa/partial/_setup.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/partial/_setup.rb
@@ -16,29 +16,32 @@
 efa_tarball = "#{node['cluster']['sources_dir']}/aws-efa-installer.tar.gz"
 
 action :setup do
-  if efa_installed? && !::File.exist?(efa_tarball)
-    Chef::Log.warn("Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration.")
-    return
-  end
+  action_check_efa_support
+  if node['cluster']['efa_supported']
+    if efa_installed? && !::File.exist?(efa_tarball)
+      Chef::Log.warn("Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration.")
+      return
+    end
 
-  # remove conflicting packages
-  # default openmpi installation conflicts with new install
-  # new one is installed in /opt/amazon/efa/bin/
-  package conflicting_packages do
-    action :remove
-    not_if { efa_installed? }
-  end
+    # remove conflicting packages
+    # default openmpi installation conflicts with new install
+    # new one is installed in /opt/amazon/efa/bin/
+    package conflicting_packages do
+      action :remove
+      not_if { efa_installed? }
+    end
 
-  # update repos and install prerequisite packages
-  package_repos 'update package repos' do
-    action :update
-  end
-  package %w(environment-modules) do
-    retries 3
-    retry_delay 5
-  end
+    # update repos and install prerequisite packages
+    package_repos 'update package repos' do
+      action :update
+    end
+    package %w(environment-modules) do
+      retries 3
+      retry_delay 5
+    end
 
-  action_download_and_install
+    action_download_and_install
+  end
 end
 
 action :download_and_install do
@@ -67,4 +70,8 @@ action :download_and_install do
     EFAINSTALL
     not_if { efa_installed? || virtualized? }
   end
+end
+
+action :check_efa_support do
+  node.default['cluster']['efa_supported'] = true
 end

--- a/cookbooks/aws-parallelcluster-common/spec/unit/resources/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/unit/resources/efa_spec.rb
@@ -56,6 +56,7 @@ describe 'efa:setup' do
         ) do |node|
           # override node['cluster']['efa']['installer_version'] attribute
           node.override['cluster']['efa']['installer_version'] = 'version'
+          node.override['cluster']['platform_version'] = "8.7"
         end
       end
       let(:node) { chef_run.node }
@@ -144,6 +145,25 @@ describe 'efa:setup' do
           end
         end
       end
+    end
+  end
+
+  context 'when rhel version is older than 8.4' do
+    let(:chef_run) do
+      ChefSpec::Runner.new(
+        # Create a runner for the given platform/version
+        platform: "redhat",
+        step_into: ['efa']
+      ) do |node|
+        # override node['cluster']['efa']['installer_version'] attribute
+        node.override['cluster']['platform_version'] = "8.3"
+      end
+    end
+
+    it "version" do
+      setup(chef_run)
+      is_expected.to write_log('EFA is not supported in this RHEL version 8.3, supported versions are >= 8.4').with_level(:warn)
+      is_expected.not_to update_package_repos('update package repos')
     end
   end
 end


### PR DESCRIPTION
### Description of changes
* Add EFA error message on RH < 8.4
* To be able to add the RH 8.4 if I needed to change the `setup` action name, and introduce the setup action in all the subrecipes (haven't found a better way to do that yet)

### Tests
* ChefSpec
* EC2 tests
* Docker tests

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.