### PR TITLE
Cancel system test in progress when a new one starts for the same PR

### DIFF
--- a/.github/workflows/system-tests-centos7.yml
+++ b/.github/workflows/system-tests-centos7.yml
@@ -6,6 +6,10 @@ on:
       - develop
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   systemtest-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/system-tests-ubuntu.yml
+++ b/.github/workflows/system-tests-ubuntu.yml
@@ -6,6 +6,10 @@ on:
       - develop
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   systemtest-build:
     runs-on: ubuntu-latest

--- a/cookbooks/aws-parallelcluster-install/spec/unit/recipes/ami_cleanup_spec.rb
+++ b/cookbooks/aws-parallelcluster-install/spec/unit/recipes/ami_cleanup_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 
 describe 'aws-parallelcluster-install::ami_cleanup' do
-  # print "It #{it.class}"
-  # print "Self #{self.class}"
-
   for_all_oses do |platform, version|
     let(:chef_run) do
       ChefSpec::Runner.new(platform: platform, version: version)


### PR DESCRIPTION
### Description of changes
* [Cancel system test in progress when a new one starts for the same PR](https://github.com/aws/aws-parallelcluster-cookbook/commit/fa0e28ffe4193614b89d56591e09f02f46188722)
* [Cleanup aws-parallelcluster-install::ami_cleanup_spec.rb](https://github.com/aws/aws-parallelcluster-cookbook/pull/1814/commits/6c34b76f910ab5c24150d875d3f2a6702aaf4d15)

### Tests
* verified system tests have been cancelled after new ones were started due to a new push to the same PR

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.