### PR TITLE
Move common ChefSpec code to aws-parallelcluster-common/spec/spec_helper.rb

### DIFF
--- a/cookbooks/aws-parallelcluster-common/spec/spec_helper.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/spec_helper.rb
@@ -14,3 +14,28 @@ module ChefSpec
     end
   end
 end
+
+def for_all_oses(&block)
+  [
+    %w(amazon 2),
+    # The only Centos7 version supported by ChefSpec
+    # See the complete list here: https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md
+    %w(centos 7.8.2003),
+    %w(ubuntu 18.04),
+    %w(ubuntu 20.04),
+    %w(redhat 8),
+  ].each do |platform, version|
+    context "on #{platform}#{version}" do
+      block.call(platform, version)
+    end
+  end
+end
+
+def mock_exist_call_original
+  # This is required before mocking existence of specific files
+  allow(File).to receive(:exist?).and_call_original
+end
+
+def mock_file_exists(file, exists)
+  allow(::File).to receive(:exist?).with(file).and_return(exists)
+end

--- a/cookbooks/aws-parallelcluster-install/spec/spec_helper.rb
+++ b/cookbooks/aws-parallelcluster-install/spec/spec_helper.rb
@@ -1,42 +1,4 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-module ChefSpec
-  class Runner
-    # Allows to converge a dynamic code block
-    # For instance, it can be used to invoke actions on resources
-    def converge_dsl(*recipes, &block)
-      cookbook_name = 'any'
-      recipe_name = 'any'
-      converge(*recipes) do
-        recipe = Chef::Recipe.new(cookbook_name, recipe_name, @run_context)
-        recipe.instance_eval(&block)
-      end
-    end
-  end
-end
-
-def for_all_oses(&block)
-  [
-    %w(amazon 2),
-    # The only Centos7 version supported by ChefSpec
-    # See the complete list here: https://github.com/chefspec/fauxhai/blob/main/PLATFORMS.md
-    %w(centos 7.8.2003),
-    %w(ubuntu 18.04),
-    %w(ubuntu 20.04),
-    %w(redhat 8),
-  ].each do |platform, version|
-    context "on #{platform}#{version}" do
-      block.call(platform, version)
-    end
-  end
-end
-
-def mock_exist_call_original
-  # This is required before mocking existence of specific files
-  allow(File).to receive(:exist?).and_call_original
-end
-
-def mock_file_exists(file, exists)
-  allow(::File).to receive(:exist?).with(file).and_return(exists)
-end
+require_relative '../../../cookbooks/aws-parallelcluster-common/spec/spec_helper'


### PR DESCRIPTION
### Description of changes
Move common ChefSpec code to aws-parallelcluster-common/spec/spec_helper.rb in order to avoid code duplication

### Tests
* ChefSpec tests run both for `aws-parallelcluster-common` and `aws-parallelcluster-install` cookbooks

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.