### PR TITLE
Fix for_all_oses function

### DIFF
--- a/cookbooks/aws-parallelcluster-common/spec/spec_helper.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/spec_helper.rb
@@ -15,7 +15,7 @@ module ChefSpec
   end
 end
 
-def for_all_oses(&block)
+def for_all_oses
   [
     %w(amazon 2),
     # The only Centos7 version supported by ChefSpec
@@ -25,9 +25,7 @@ def for_all_oses(&block)
     %w(ubuntu 20.04),
     %w(redhat 8),
   ].each do |platform, version|
-    context "on #{platform}#{version}" do
-      block.call(platform, version)
-    end
+    yield(platform, version)
   end
 end
 

--- a/cookbooks/aws-parallelcluster-install/spec/unit/recipes/ami_cleanup_spec.rb
+++ b/cookbooks/aws-parallelcluster-install/spec/unit/recipes/ami_cleanup_spec.rb
@@ -2,21 +2,23 @@ require 'spec_helper'
 
 describe 'aws-parallelcluster-install::ami_cleanup' do
   for_all_oses do |platform, version|
-    let(:chef_run) do
-      ChefSpec::Runner.new(platform: platform, version: version)
-    end
+    context "on #{platform}#{version}" do
+      let(:chef_run) do
+        ChefSpec::Runner.new(platform: platform, version: version)
+      end
 
-    before do
-      chef_run.converge(described_recipe)
-    end
+      before do
+        chef_run.converge(described_recipe)
+      end
 
-    it 'Creates ami_cleanup.sh under /usr/local/sbin' do
-      is_expected.to create_cookbook_file("ami_cleanup.sh")
-        .with(source: 'base/ami_cleanup.sh')
-        .with(path: '/usr/local/sbin/ami_cleanup.sh')
-        .with(owner: 'root')
-        .with(group: 'root')
-        .with(mode: '0755')
+      it 'Creates ami_cleanup.sh under /usr/local/sbin' do
+        is_expected.to create_cookbook_file("ami_cleanup.sh")
+          .with(source: 'base/ami_cleanup.sh')
+          .with(path: '/usr/local/sbin/ami_cleanup.sh')
+          .with(owner: 'root')
+          .with(group: 'root')
+          .with(mode: '0755')
+      end
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-install/spec/unit/recipes/awscli_spec.rb
+++ b/cookbooks/aws-parallelcluster-install/spec/unit/recipes/awscli_spec.rb
@@ -6,33 +6,35 @@ describe 'aws-parallelcluster-install::awscli' do
   end
 
   for_all_oses do |platform, version|
-    let(:chef_run) do
-      ChefSpec::Runner.new(platform: platform, version: version)
-    end
-
-    context 'when aws cli exists' do
-      before do
-        mock_file_exists("/usr/local/bin/aws", true)
-        chef_run.converge(described_recipe)
+    context "on #{platform}#{version}" do
+      let(:chef_run) do
+        ChefSpec::Runner.new(platform: platform, version: version)
       end
 
-      it "should not install it" do
-        is_expected.not_to run_bash("install awscli")
-      end
-    end
+      context 'when aws cli exists' do
+        before do
+          mock_file_exists("/usr/local/bin/aws", true)
+          chef_run.converge(described_recipe)
+        end
 
-    context 'when aws cli does not exist' do
-      before do
-        mock_file_exists("/usr/local/bin/aws", false)
-        chef_run.converge(described_recipe)
-      end
-
-      it "should install unzip" do
-        is_expected.to install_package("unzip")
+        it "should not install it" do
+          is_expected.not_to run_bash("install awscli")
+        end
       end
 
-      it "should install awscli" do
-        is_expected.to run_bash("install awscli")
+      context 'when aws cli does not exist' do
+        before do
+          mock_file_exists("/usr/local/bin/aws", false)
+          chef_run.converge(described_recipe)
+        end
+
+        it "should install unzip" do
+          is_expected.to install_package("unzip")
+        end
+
+        it "should install awscli" do
+          is_expected.to run_bash("install awscli")
+        end
       end
     end
   end


### PR DESCRIPTION
### Description of changes
`for_all_oses` function doesn't work correctly when it contains `context`: the block is executed 5 times for the same OS.
Moving `context` from the function to the block solves the issue.

### Tests
* ChefSpec tests run on `aws-parallelcluster-install` cookbook.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.