### PR TITLE
Skip cookbooks for functionality currently unsupported in RHEL8

### DIFF
--- a/cookbooks/aws-parallelcluster-install/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/install.rb
@@ -27,9 +27,9 @@ include_recipe 'aws-parallelcluster-install::base'
 
 # == PLATFORM - FEATURES
 include_recipe "aws-parallelcluster-install::nvidia" unless redhat8? # NVIDIA and CUDA
-include_recipe "aws-parallelcluster-install::intel_mpi" unless virtualized?
+include_recipe "aws-parallelcluster-install::intel_mpi" unless virtualized? || redhat8?
 include_recipe "aws-parallelcluster-install::cloudwatch_agent"
-include_recipe "aws-parallelcluster-install::arm_pl" # ARM Performance Library
+include_recipe "aws-parallelcluster-install::arm_pl" unless redhat8? # ARM Performance Library
 include_recipe "aws-parallelcluster-install::intel_hpc" # Intel HPC libraries
 efa 'Install EFA'
 


### PR DESCRIPTION
### Description of changes
Skip cookbooks for functionality currently unsupported in RHEL8.

----

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.