### PR TITLE
Upgrade Lustre client version for alinux 2 and CentOS 7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Add log rotation support for ParallelCluster managed logs.
 
 **CHANGES**
-- ...
+- Upgrade Lustre client version to 2.12 on Amazon Linux 2. Lustre client 2.12 has been installed on Ubuntu 20.04, 18.04 and CentOS >= 7.7.  Upgrade Lustre client version to 2.10.8 on CentOS 7.6.
 
 3.5.0
 ------

--- a/cookbooks/aws-parallelcluster-common/resources/lustre/lustre_alinux2.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/lustre/lustre_alinux2.rb
@@ -21,5 +21,5 @@ use 'partial/_mount_unmount'
 default_action :setup
 
 action :setup do
-  alinux_extras_topic 'lustre2.10'
+  alinux_extras_topic 'lustre'
 end

--- a/cookbooks/aws-parallelcluster-common/resources/lustre/lustre_centos7.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/lustre/lustre_centos7.rb
@@ -22,17 +22,17 @@ use 'partial/_install_lustre_centos_redhat'
 use 'partial/_mount_unmount'
 
 lustre_version_hash = {
-  '7.6' => "2.10.6",
+  '7.6' => "2.10.8",
   '7.5' => "2.10.5",
 }
 
 client_url_hash = {
-  '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/lustre-client-2.10.6-1.el7.x86_64.rpm",
+  '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.8/el7/client/RPMS/x86_64/lustre-client-2.10.8-1.el7.x86_64.rpm",
   '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/lustre-client-2.10.5-1.el7.x86_64.rpm",
 }
 
 kmod_url_hash = {
-  '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/RPMS/x86_64/kmod-lustre-client-2.10.6-1.el7.x86_64.rpm",
+  '7.6' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.8/el7/client/RPMS/x86_64/kmod-lustre-client-2.10.8-1.el7.x86_64.rpm",
   '7.5' => "https://downloads.whamcloud.com/public/lustre/lustre-2.10.5/el7.5.1804/client/RPMS/x86_64/kmod-lustre-client-2.10.5-1.el7.x86_64.rpm",
 }
 

--- a/test/resources/controls/aws_parallelcluster_install/lustre_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/lustre_spec.rb
@@ -1,6 +1,6 @@
 control 'lustre_client_installed' do
   title "Verify that lustre client is installed"
-
+  minimal_lustre_client_version = '2.12'
   if (os_properties.centos? && inspec.os.release.to_f >= 7.5) || os_properties.redhat?
     describe package('kmod-lustre-client') do
       it { should be_installed }
@@ -11,6 +11,14 @@ control 'lustre_client_installed' do
     end
 
     if (os_properties.centos? && inspec.os.release.to_f >= 7.7) || os_properties.redhat?
+      describe package('kmod-lustre-client') do
+        its('version') { should cmp >= minimal_lustre_client_version }
+      end
+
+      describe package('lustre-client') do
+        its('version') { should cmp >= minimal_lustre_client_version }
+      end
+
       describe yum.repo('aws-fsx') do
         it { should exist }
         it { should be_enabled }
@@ -27,20 +35,23 @@ control 'lustre_client_installed' do
 
     describe package('lustre-client-modules-aws') do
       it { should be_installed }
+      its('version') { should cmp >= minimal_lustre_client_version }
     end
 
     kernel_release = os_properties.ubuntu2004? ? '5.15.0-1028-aws' : '5.4.0-1092-aws'
     describe package("lustre-client-modules-#{kernel_release}") do
       it { should be_installed }
+      its('version') { should cmp >= minimal_lustre_client_version }
     end
   end
 
   if os_properties.alinux2?
     describe package('lustre-client') do
       it { should be_installed }
+      its('version') { should cmp >= minimal_lustre_client_version }
     end
 
-    describe yum.repo('amzn2extra-lustre2.10') do
+    describe yum.repo('amzn2extra-lustre') do
       it { should exist }
       it { should be_enabled }
     end


### PR DESCRIPTION
### Description of changes
Upgrade Lustre client version to 2.12 on Amazon Linux 2. Lustre client 2.12 has been installed on Ubuntu 20.04, 18.04 and CentOS >= 7.7.  Upgrade Lustre client version to 2.10.8 on CentOS 7.6

### Tests
* Checked all official ParallelCluster AMIs will have Lustre client 2.12 installed 
* Cookbook tests have been changed to test the version. The command `bash kitchen.docker.sh resources test lustre-installation` is successful

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.