### PR TITLE
Use a custom NetworkManager.conf with the correct dhcp plugin in Red Hat 8

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/redhat/dns_domain/NetworkManager.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/redhat/dns_domain/NetworkManager.conf
@@ -1,0 +1,52 @@
+# Configuration file for NetworkManager.
+#
+# See "man 5 NetworkManager.conf" for details.
+#
+# The directories /usr/lib/NetworkManager/conf.d/ and /run/NetworkManager/conf.d/
+# can contain additional .conf snippets installed by packages. These files are
+# read before NetworkManager.conf and have thus lowest priority.
+# The directory /etc/NetworkManager/conf.d/ can contain additional .conf
+# snippets. Those snippets are merged last and overwrite the settings from this main
+# file.
+#
+# The files within one conf.d/ directory are read in asciibetical order.
+#
+# You can prevent loading a file /usr/lib/NetworkManager/conf.d/NAME.conf
+# by having a file NAME.conf in either /run/NetworkManager/conf.d/ or /etc/NetworkManager/conf.d/.
+# Likewise, snippets from /run can be prevented from loading by placing
+# a file with the same name in /etc/NetworkManager/conf.d/.
+#
+# If two files define the same key, the one that is read afterwards will overwrite
+# the previous one.
+
+[main]
+plugins = ifcfg-rh,
+dhcp = dhclient
+
+[logging]
+# When debugging NetworkManager, enabling debug logging is of great help.
+#
+# Logfiles contain no passwords and little sensitive information. But please
+# check before posting the file online. You can also personally hand over the
+# logfile to a NM developer to treat it confidential. Meet us on #nm on Libera.Chat.
+#
+# You can also change the log-level at runtime via
+#   $ nmcli general logging level TRACE domains ALL
+# However, usually it's cleaner to enable debug logging
+# in the configuration and restart NetworkManager so that
+# debug logging is enabled from the start.
+#
+# You will find the logfiles in syslog, for example via
+#   $ journalctl -u NetworkManager
+#
+# Please post full logfiles for bug reports without pre-filtering or truncation.
+# Also, for debugging the entire `journalctl` output can be interesting. Don't
+# limit unnecessarily with `journalctl -u`. Exceptions are if you are worried
+# about private data. Check before posting logfiles!
+#
+# Note that debug logging of NetworkManager can be quite verbose. Some messages
+# might be rate-limited by the logging daemon (see RateLimitIntervalSec, RateLimitBurst
+# in man journald.conf). Please disable rate-limiting before collecting debug logs!
+#
+#level=TRACE
+#domains=ALL

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
@@ -22,6 +22,18 @@ use 'partial/_dns_search_domain_redhat'
 action :configure do
   return if virtualized?
 
+  # On RHEL8 dhclient is not enabled by default
+  # Put pcluster version of NetworkManager.conf in place
+  # dhcp = dhclient needs to be added under [main] section to enable dhclient
+  # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/networking_considerations-in-adopting-rhel-8#dhcp_plugin_networking
+  cookbook_file 'NetworkManager.conf' do
+    path '/etc/NetworkManager/NetworkManager.conf'
+    source 'dns_domain/NetworkManager.conf'
+    user 'root'
+    group 'root'
+    mode '0644'
+  end
+
   action_update_search_domain_redhat
 
   network_service 'Restart network service'

--- a/test/resources/controls/aws_parallelcluster_slurm/dns_domain_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_slurm/dns_domain_spec.rb
@@ -24,4 +24,11 @@ control 'dns_domain_configured' do
       should match(dns_domain_string)
     end
   end unless os_properties.virtualized?
+
+  describe file("/etc/resolv.conf") do
+    it { should exist }
+    its('content') do
+      should match(dns_domain_string)
+    end
+  end unless os_properties.virtualized?
 end


### PR DESCRIPTION
### Description of changes
* Use a custom NetworkManager.conf with the correct dhcp plugin in Red Hat 8

### Tests
* Created a test that was passing in all OS apart from RH8
* Fixed the code and now the test passed also in RH8

### References
* Solution inspired by https://github.com/aws/aws-parallelcluster-cookbook/pull/1011

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.