### PR TITLE
[Multi User] Add support for AD password as SSM Parameter.

### DIFF
--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/update_directory_service_password.sh.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/update_directory_service_password.sh.erb
@@ -1,8 +1,8 @@
 #!/bin/bash
 # This script updates the password used by SSSD to read from Active Directory, according to the secret stored in
-# AWS Secrets Manager.
+# AWS Secrets Manager or AWS SSM.
 # In particular, it updates the password in /etc/sssd/sssd.conf (ldap_default_authtok) with the one stored
-# in AWS Secrets Manager, if they do not match. The resulting file is then copied to its counterpart shared with compute nodes
+# in AWS Secrets Manager or AWS SSM, if they do not match. The resulting file is then copied to its counterpart shared with compute nodes
 # to make them able to re-sync their local configuration.
 # The script does not require any argument.
 #
@@ -20,20 +20,34 @@ REGION="<%= @region %>"
 
 PYTHON_CODE_READ_CONFIG="import configparser;file='${SSSD_CONFIG_FILE}';config=configparser.ConfigParser();config.read(file)"
 
-echo "Reading password from ${SSSD_CONFIG_FILE}"
+echo "[INFO] Reading password from ${SSSD_CONFIG_FILE}"
 password_from_sssd_config=$(python3 -c "${PYTHON_CODE_READ_CONFIG}; print(config['${SSSD_SECTION}']['${SSSD_PROPERTY}'])")
 
-echo "Reading password from AWS Secrets Manager: ${SECRET_ARN}"
-password_from_secrets_manager=$(aws secretsmanager get-secret-value --secret-id ${SECRET_ARN} --region ${REGION} --query 'SecretString' --output text)
+echo "[INFO] Reading password from AWS: ${SECRET_ARN}"
+service=$(echo "${SECRET_ARN}" | cut -d ':' -f 3)
+resource=$(echo "${SECRET_ARN}" | cut -d ':' -f 6-)
+if [ "$service" == "secretsmanager" ]; then
+  secret_name=$(echo "$resource" | cut -d ':' -f 2)
+  echo "[INFO] Reading password as a secret from AWS Secrets Manager: ${secret_name}"
+  password_from_secret_store=$(aws secretsmanager get-secret-value --secret-id "${secret_name}" --region "${REGION}" --query "SecretString" --output text)
+elif [ "$service" == "ssm" ]; then
+  parameter_name=$(echo "$resource" | cut -d '/' -f 2)
+  echo "[INFO] Reading password as a parameter from AWS SSM: ${SECRET_ARN}"
+  password_from_secret_store=$(aws ssm get-parameter --name "${parameter_name}" --region "${REGION}" --with-decryption --query "Parameter.Value" --output text)
+else
+  echo "[ERROR] The secret ${SECRET_ARN} is not supported"
+  exit 1
+fi
 
-[ "${password_from_sssd_config}" == "${password_from_secrets_manager}" ] && echo "Password match, skipping update" && exit 0
+[ "${password_from_sssd_config}" == "${password_from_secret_store}" ] && echo "[WARN] Password match, skipping update" && exit 0
 
-echo "Writing AWS Secrets Manager password to ${SSSD_CONFIG_FILE}"
-python3 -c "${PYTHON_CODE_READ_CONFIG}; config['${SSSD_SECTION}']['${SSSD_PROPERTY}']='${password_from_secrets_manager}'; config.write(open(file,'w'))"
-echo "Password updated in ${SSSD_CONFIG_FILE}"
-cp ${SSSD_CONFIG_FILE} ${SSSD_SHARED_CONFIG_FILE}
-echo "${SSSD_CONFIG_FILE} copied to ${SSSD_SHARED_CONFIG_FILE}"
+echo "[INFO] Writing AWS Secrets Manager password to ${SSSD_CONFIG_FILE}"
+python3 -c "${PYTHON_CODE_READ_CONFIG}; config['${SSSD_SECTION}']['${SSSD_PROPERTY}']='${password_from_secret_store}'; config.write(open(file,'w'))"
+echo "[INFO] Password updated in ${SSSD_CONFIG_FILE}"
 
-echo "Restarting services"
+cp "${SSSD_CONFIG_FILE}" "${SSSD_SHARED_CONFIG_FILE}"
+echo "[INFO] ${SSSD_CONFIG_FILE} copied to ${SSSD_SHARED_CONFIG_FILE}"
+
+echo "[INFO] Restarting service: sssd"
 service sssd restart
-echo "Services restarted"
+echo "[INFO] Service sssd restarted"

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -600,3 +600,21 @@ def format_directory(dir)
   format_dir = "/#{format_dir}" unless format_dir.start_with?('/')
   format_dir
 end
+
+# Parse an ARN.
+# ARN format: arn:PARTITION:SERVICE:REGION:ACCOUNT_ID:RESOURCE.
+# ARN examples:
+#   1. arn:aws:secretsmanager:eu-west-1:12345678910:secret:PasswordName
+#   2. arn:aws:ssm:eu-west-1:12345678910:parameter/PasswordName
+def parse_arn(arn_string)
+  parts = arn_string.nil? ? [] : arn_string.split(':', 6)
+  raise TypeError if parts.size < 6
+
+  {
+    partition: parts[1],
+    service: parts[2],
+    region: parts[3],
+    account_id: parts[4],
+    resource: parts[5],
+  }
+end


### PR DESCRIPTION
### Description of changes
Add support for AD password as SSM Parameter.
With this extension we will be able to provide the multi-user feature in those regions where Secrets Manager is not supported, but SSM is.

#### Customer Experience
With this change the customer will be able to specify the AD password in [DirectoryService/PasswordSecretArn](https://docs.aws.amazon.com/parallelcluster/latest/ug/DirectoryService-v3.html#yaml-DirectoryService-PasswordSecretArn) both as a secret in Secrets Manager (current behaviour) and a parameter in SSM.

### Tests
* Cluster creation + AD user login with AD password specified as a secret in Secrets Manager.
* Cluster creation + AD user login with AD password specified as a parameter in SSM.
* AD Password sync with `update_directory_service_password.sh` using Secrets Manager.
* AD Password sync with `update_directory_service_password.sh` using SSM.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>