### PR TITLE
Fix update cluster to remove shared EBS volumes can potentially cause node launching failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - ...
 
+**BUG FIXES**
+- Fix update cluster to remove shared EBS volumes can potentially cause node launching failures if `MountDir` match the same pattern in `/etc/exports`. 
+
 3.5.0
 ------
 

--- a/cookbooks/aws-parallelcluster-config/resources/manage_raid.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_raid.rb
@@ -187,7 +187,7 @@ action :unexport do
   # Unexport RAID directory via nfs
   delete_lines "remove volume from /etc/exports" do
     path "/etc/exports"
-    pattern "#{raid_shared_dir} *"
+    pattern "^#{raid_shared_dir} *"
   end
 
   execute "unexport volume" do


### PR DESCRIPTION
Fix update cluster to remove shared EBS volumes can potentially cause node launching failures if `MountDir` match the same pattern in `/etc/exports`

Update changelog with the fix in  https://github.com/aws/aws-parallelcluster-cookbook/pull/1808


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.