### PR TITLE
Allow cluster admin user to run sinfo command as root

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/99-parallelcluster-slurm.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/99-parallelcluster-slurm.erb
@@ -1,4 +1,4 @@
-Cmnd_Alias SLURM_COMMANDS = <%= node['cluster']['slurm']['install_dir'] %>/bin/scontrol
+Cmnd_Alias SLURM_COMMANDS = <%= node['cluster']['slurm']['install_dir'] %>/bin/scontrol, <%= node['cluster']['slurm']['install_dir'] %>/bin/sinfo
 Cmnd_Alias SLURM_HOOKS_COMMANDS = <%= node['cluster']['node_virtualenv_path'] %>/bin/slurm_suspend, <%= node['cluster']['node_virtualenv_path'] %>/bin/slurm_resume, <%= node['cluster']['node_virtualenv_path'] %>/bin/slurm_fleet_status_manager
 Cmnd_Alias SHUTDOWN = /usr/sbin/shutdown
 


### PR DESCRIPTION
### Description of changes
* Allow cluster admin user to run sinfo command as root.
    * This prevents issues in the logic of clustermgtd in case `PrivateData=nodes` is configured in Slurm.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.