### PR TITLE
remove conditioning on scheduler = awsbatch for fetch_config execution

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/config.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/config.rb
@@ -17,7 +17,7 @@
 
 include_recipe 'aws-parallelcluster-config::base'
 
-fetch_config 'Fetch and load cluster configs' unless node['cluster']['scheduler'] == 'awsbatch'
+fetch_config 'Fetch and load cluster configs'
 
 include_recipe 'aws-parallelcluster-slurm::config' if node['cluster']['scheduler'] == 'slurm'
 include_recipe 'aws-parallelcluster-scheduler-plugin::config' if node['cluster']['scheduler'] == 'plugin'

--- a/cookbooks/aws-parallelcluster-config/recipes/finalize.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/finalize.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-fetch_config 'Fetch and load cluster configs' unless node['cluster']['scheduler'] == 'awsbatch'
+fetch_config 'Fetch and load cluster configs'
 
 # Restart supervisord
 service "supervisord" do

--- a/cookbooks/aws-parallelcluster-config/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/init.rb
@@ -32,7 +32,7 @@ end
 
 include_recipe "aws-parallelcluster-config::mount_shared" if node['cluster']['node_type'] == "ComputeFleet"
 
-fetch_config 'Fetch and load cluster configs' unless node['cluster']['scheduler'] == 'awsbatch'
+fetch_config 'Fetch and load cluster configs'
 
 # Install cloudwatch, write configuration and start it.
 include_recipe "aws-parallelcluster-config::cloudwatch_agent"

--- a/cookbooks/aws-parallelcluster-config/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/update.rb
@@ -15,10 +15,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-unless node['cluster']['scheduler'] == 'awsbatch'
-  fetch_config 'Fetch and load cluster configs' do
-    update true
-  end
+fetch_config 'Fetch and load cluster configs' do
+  update true
 end
 
 # generate the update shared storages mapping file


### PR DESCRIPTION
### Description of changes
This change allows to assume that /opt/parallelcluster/shared/cluster-config.yaml is be always available on nodes, reducing the need to rely on dna.json to access configuration information.

### Tests
* `fetch_config` is lacking unit testing still

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.