### PR TITLE
[Multi User] Fix regression impacting the retrieval of PasswordSecretArn when it is expressed as a secrets in Secrets Manager.

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
@@ -60,8 +60,7 @@ if node['cluster']['node_type'] == 'HeadNode'
   password_secret_resource = password_secret_arn[:resource]
   ldap_password =
     if password_secret_service == "secretsmanager" && password_secret_resource.start_with?("secret")
-      (secret_name = password_secret_resource.split(":")[1])
-      shell_out!("aws secretsmanager get-secret-value --secret-id #{secret_name} --region #{region} --query 'SecretString' --output text").stdout.strip
+      shell_out!("aws secretsmanager get-secret-value --secret-id #{password_secret_arn_str} --region #{region} --query 'SecretString' --output text").stdout.strip
     elsif password_secret_service == "ssm" && password_secret_resource.start_with?("parameter")
       (parameter_name = password_secret_resource.split("/")[1])
       shell_out!("aws ssm get-parameter --name #{parameter_name} --region #{region} --with-decryption --query 'Parameter.Value' --output text").stdout.strip


### PR DESCRIPTION
### Description of changes
Fix regression impacting the retrieval of `PasswordSecretArn` when it is expressed as a secrets in Secrets Manager.
In particular the fix consists in retrieving the secret using the secret ARN rather than the secret name.

Regression was introduced by https://github.com/aws/aws-parallelcluster-cookbook/pull/1824

### Tests
* Cluster creation failing without this change due to unauthorized error on the secrets retrieval.
* Cluster creation succeeding with this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>