### PR TITLE
Test lustre mount and unmount

### DIFF
--- a/cookbooks/aws-parallelcluster-common/resources/lustre/partial/_mount_unmount.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/lustre/partial/_mount_unmount.rb
@@ -160,7 +160,7 @@ action :unmount do
                  "#{fsx_fs_id}.fsx.#{node['cluster']['region']}.amazonaws.com"
                end
     fsx_shared_dir = "/#{fsx_shared_dir}" unless fsx_shared_dir.start_with?('/')
-    execute 'unmount fsx' do
+    execute "unmount fsx #{fsx_shared_dir}" do
       command "umount -fl #{fsx_shared_dir}"
       retries 10
       retry_delay 6
@@ -172,13 +172,13 @@ action :unmount do
     case fsx_fs_type
     when 'LUSTRE'
       mount_name = fsx_mount_name_array[index]
-      delete_lines "remove volume from /etc/fstab" do
+      delete_lines "remove volume #{dns_name}@tcp:/#{mount_name} from /etc/fstab" do
         path "/etc/fstab"
         pattern "#{dns_name}@tcp:/#{mount_name} *"
       end
 
     when 'OPENZFS', 'ONTAP'
-      delete_lines "remove volume from /etc/fstab" do
+      delete_lines "remove volume #{dns_name}:#{fsx_volume_junction_path} from /etc/fstab" do
         path "/etc/fstab"
         pattern "#{dns_name}:#{fsx_volume_junction_path} *"
       end

--- a/cookbooks/aws-parallelcluster-common/resources/lustre/partial/_mount_unmount.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/lustre/partial/_mount_unmount.rb
@@ -159,7 +159,10 @@ action :unmount do
                  # Note the Hardcoding format is only valid for lustre file systems created after Mar-1 2021
                  "#{fsx_fs_id}.fsx.#{node['cluster']['region']}.amazonaws.com"
                end
+
     fsx_shared_dir = "/#{fsx_shared_dir}" unless fsx_shared_dir.start_with?('/')
+    fsx_volume_junction_path = "/#{fsx_volume_junction_path}" unless fsx_volume_junction_path.nil? || fsx_volume_junction_path.start_with?('/')
+
     execute "unmount fsx #{fsx_shared_dir}" do
       command "umount -fl #{fsx_shared_dir}"
       retries 10

--- a/cookbooks/aws-parallelcluster-common/spec/unit/resources/lustre_mount_spec.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/unit/resources/lustre_mount_spec.rb
@@ -275,7 +275,7 @@ describe 'lustre:unmount' do
               fsx_shared_dir_array %w(shared_dir_1 shared_dir_2)
               fsx_dns_name_array ['dns_name', '']
               fsx_mount_name_array %w(mount_name_1 mount_name_2)
-              fsx_volume_junction_path_array %w(junction_path_1 junction_path_2)
+              fsx_volume_junction_path_array %w(junction_path_1 /junction_path_2)
               action :unmount
             end
           end
@@ -292,13 +292,13 @@ describe 'lustre:unmount' do
         end
 
         it 'removes volume from /etc/fstab' do
-          is_expected.to edit_delete_lines('remove volume dns_name:junction_path_1 from /etc/fstab')
+          is_expected.to edit_delete_lines('remove volume dns_name:/junction_path_1 from /etc/fstab')
             .with(path: "/etc/fstab")
-            .with(pattern: "dns_name:junction_path_1 *")
+            .with(pattern: "dns_name:/junction_path_1 *")
 
-          is_expected.to edit_delete_lines('remove volume ontap_id_2.fsx.REGION.amazonaws.com:junction_path_2 from /etc/fstab')
+          is_expected.to edit_delete_lines('remove volume ontap_id_2.fsx.REGION.amazonaws.com:/junction_path_2 from /etc/fstab')
             .with(path: "/etc/fstab")
-            .with(pattern: "ontap_id_2.fsx.REGION.amazonaws.com:junction_path_2 *")
+            .with(pattern: "ontap_id_2.fsx.REGION.amazonaws.com:/junction_path_2 *")
         end
       end
     end

--- a/cookbooks/aws-parallelcluster-common/spec/unit/resources/lustre_mount_spec.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/unit/resources/lustre_mount_spec.rb
@@ -1,0 +1,306 @@
+require 'spec_helper'
+
+class Lustre
+  def self.mount(chef_run)
+    chef_run.converge_dsl do
+      lustre 'mount' do
+        action :mount
+      end
+    end
+  end
+end
+
+describe 'lustre:mount' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      context 'for lustre' do
+        let(:chef_run) do
+          ChefSpec::Runner.new(
+            platform: platform, version: version,
+            step_into: ['lustre']
+          ) do |node|
+            node.override['cluster']['region'] = "REGION"
+          end
+        end
+
+        before do
+          stub_command("mount | grep ' /lustre_shared_dir_with_no_mount '").and_return(false)
+          stub_command("mount | grep ' /lustre_shared_dir_with_mount '").and_return(true)
+          chef_run.converge_dsl do
+            lustre 'mount' do
+              fsx_fs_id_array %w(lustre_id_1 lustre_id_2)
+              fsx_fs_type_array %w(LUSTRE LUSTRE)
+              fsx_shared_dir_array %w(lustre_shared_dir_with_no_mount lustre_shared_dir_with_mount)
+              fsx_dns_name_array ['lustre_dns_name', '']
+              fsx_mount_name_array %w(lustre_mount_name_1 lustre_mount_name_2)
+              fsx_volume_junction_path_array ['', '']
+              action :mount
+            end
+          end
+        end
+
+        it 'creates_shared_dir' do
+          is_expected.to create_directory('/lustre_shared_dir_with_no_mount')
+            .with(owner: 'root')
+            .with(group: 'root')
+            .with(mode: '1777')
+          # .with(recursive: false)
+
+          is_expected.to create_directory('/lustre_shared_dir_with_mount')
+            .with(owner: 'root')
+            .with(group: 'root')
+            .with(mode: '1777')
+          # .with(recursive: true)
+        end
+
+        it 'mounts shared dir if not already mounted' do
+          is_expected.to mount_mount('/lustre_shared_dir_with_no_mount')
+            .with(device: 'lustre_dns_name@tcp:/lustre_mount_name_1')
+            .with(fstype: 'lustre')
+            .with(dump: 0)
+            .with(pass: 0)
+            .with(options: %w(defaults _netdev flock user_xattr noatime noauto x-systemd.automount))
+            .with(retries: 10)
+            .with(retry_delay: 6)
+        end
+
+        it 'enables shared dir mount if already mounted' do
+          is_expected.to enable_mount('/lustre_shared_dir_with_mount')
+            .with(device: 'lustre_id_2.fsx.REGION.amazonaws.com@tcp:/lustre_mount_name_2')
+            .with(fstype: 'lustre')
+            .with(dump: 0)
+            .with(pass: 0)
+            .with(options: %w(defaults _netdev flock user_xattr noatime noauto x-systemd.automount))
+            .with(retries: 10)
+            .with(retry_delay: 6)
+        end
+      end
+
+      context 'for openzfs' do
+        let(:chef_run) do
+          ChefSpec::Runner.new(
+            platform: platform, version: version,
+            step_into: ['lustre']
+          ) do |node|
+            node.override['cluster']['region'] = "REGION"
+          end
+        end
+
+        before do
+          stub_command("mount | grep ' /openzfs_shared_dir_1 '").and_return(false)
+          stub_command("mount | grep ' /openzfs_shared_dir_2 '").and_return(true)
+          chef_run.converge_dsl do
+            lustre 'mount' do
+              fsx_fs_id_array %w(openzfs_id_1 openzfs_id_2)
+              fsx_fs_type_array %w(OPENZFS OPENZFS)
+              fsx_shared_dir_array %w(openzfs_shared_dir_1 /openzfs_shared_dir_2)
+              fsx_dns_name_array ['openzfs_dns_name', '']
+              fsx_mount_name_array %w(openzfs_mount_name_1 openzfs_mount_name_2)
+              fsx_volume_junction_path_array %w(junction_path_1 /junction_path_2)
+              action :mount
+            end
+          end
+        end
+
+        it 'creates_shared_dir' do
+          is_expected.to create_directory('/openzfs_shared_dir_1')
+            .with(owner: 'root')
+            .with(group: 'root')
+            .with(mode: '1777')
+          # .with(recursive: false)
+
+          is_expected.to create_directory('/openzfs_shared_dir_2')
+            .with(owner: 'root')
+            .with(group: 'root')
+            .with(mode: '1777')
+          # .with(recursive: true)
+        end
+
+        it 'mounts shared dir if not already mounted' do
+          is_expected.to mount_mount('/openzfs_shared_dir_1')
+            .with(device: 'openzfs_dns_name:/junction_path_1')
+            .with(fstype: 'nfs')
+            .with(dump: 0)
+            .with(pass: 0)
+            .with(options: %w(nfsvers=4.2))
+            .with(retries: 10)
+            .with(retry_delay: 6)
+        end
+
+        it 'enables shared dir mount if already mounted' do
+          is_expected.to enable_mount('/openzfs_shared_dir_2')
+            .with(device: 'openzfs_id_2.fsx.REGION.amazonaws.com:/junction_path_2')
+            .with(fstype: 'nfs')
+            .with(dump: 0)
+            .with(pass: 0)
+            .with(options: %w(nfsvers=4.2))
+            .with(retries: 10)
+            .with(retry_delay: 6)
+        end
+      end
+
+      context 'for ontap' do
+        let(:chef_run) do
+          ChefSpec::Runner.new(
+            platform: platform, version: version,
+            step_into: ['lustre']
+          ) do |node|
+            node.override['cluster']['region'] = "REGION"
+          end
+        end
+
+        before do
+          stub_command("mount | grep ' /ontap_shared_dir_1 '").and_return(false)
+          stub_command("mount | grep ' /ontap_shared_dir_2 '").and_return(true)
+          chef_run.converge_dsl do
+            lustre 'mount' do
+              fsx_fs_id_array %w(ontap_id_1 ontap_id_2)
+              fsx_fs_type_array %w(ONTAP ONTAP)
+              fsx_shared_dir_array %w(ontap_shared_dir_1 /ontap_shared_dir_2)
+              fsx_dns_name_array ['ontap_dns_name', '']
+              fsx_mount_name_array %w(ontap_mount_name_1 ontap_mount_name_2)
+              fsx_volume_junction_path_array %w(junction_path_1 /junction_path_2)
+              action :mount
+            end
+          end
+        end
+
+        it 'creates_shared_dir' do
+          is_expected.to create_directory('/ontap_shared_dir_1')
+            .with(owner: 'root')
+            .with(group: 'root')
+            .with(mode: '1777')
+          # .with(recursive: false)
+
+          is_expected.to create_directory('/ontap_shared_dir_2')
+            .with(owner: 'root')
+            .with(group: 'root')
+            .with(mode: '1777')
+          # .with(recursive: true)
+        end
+
+        it 'mounts shared dir if not already mounted' do
+          is_expected.to mount_mount('/ontap_shared_dir_1')
+            .with(device: 'ontap_dns_name:/junction_path_1')
+            .with(fstype: 'nfs')
+            .with(dump: 0)
+            .with(pass: 0)
+            .with(options: %w(defaults))
+            .with(retries: 10)
+            .with(retry_delay: 6)
+        end
+
+        it 'enables shared dir mount if already mounted' do
+          is_expected.to enable_mount('/ontap_shared_dir_2')
+            .with(device: 'ontap_id_2.fsx.REGION.amazonaws.com:/junction_path_2')
+            .with(fstype: 'nfs')
+            .with(dump: 0)
+            .with(pass: 0)
+            .with(options: %w(defaults))
+            .with(retries: 10)
+            .with(retry_delay: 6)
+        end
+      end
+    end
+  end
+end
+
+describe 'lustre:unmount' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      context 'for lustre' do
+        let(:chef_run) do
+          ChefSpec::Runner.new(
+            platform: platform, version: version,
+            step_into: ['lustre']
+          ) do |node|
+            node.override['cluster']['region'] = "REGION"
+          end
+        end
+
+        before do
+          stub_command("mount | grep ' /shared_dir_1 '").and_return(false)
+          stub_command("mount | grep ' /shared_dir_2 '").and_return(true)
+          chef_run.converge_dsl do
+            lustre 'unmount' do
+              fsx_fs_id_array %w(lustre_id_1 lustre_id_2)
+              fsx_fs_type_array %w(LUSTRE LUSTRE)
+              fsx_shared_dir_array %w(shared_dir_1 shared_dir_2)
+              fsx_dns_name_array ['dns_name', '']
+              fsx_mount_name_array %w(mount_name_1 mount_name_2)
+              fsx_volume_junction_path_array ['', '']
+              action :unmount
+            end
+          end
+        end
+
+        it 'unmounts fsx only if mounted' do
+          is_expected.not_to run_execute('unmount fsx /shared_dir_1')
+
+          is_expected.to run_execute('unmount fsx /shared_dir_2')
+            .with(command: "umount -fl /shared_dir_2")
+            .with(retries: 10)
+            .with(retry_delay: 6)
+            .with(timeout: 60)
+        end
+
+        it 'removes volume from /etc/fstab' do
+          is_expected.to edit_delete_lines('remove volume dns_name@tcp:/mount_name_1 from /etc/fstab')
+            .with(path: "/etc/fstab")
+            .with(pattern: "dns_name@tcp:/mount_name_1 *")
+
+          is_expected.to edit_delete_lines('remove volume lustre_id_2.fsx.REGION.amazonaws.com@tcp:/mount_name_2 from /etc/fstab')
+            .with(path: "/etc/fstab")
+            .with(pattern: "lustre_id_2.fsx.REGION.amazonaws.com@tcp:/mount_name_2 *")
+        end
+      end
+
+      context 'for OPENZFS, ONTAP' do
+        let(:chef_run) do
+          ChefSpec::Runner.new(
+            platform: platform, version: version,
+            step_into: ['lustre']
+          ) do |node|
+            node.override['cluster']['region'] = "REGION"
+          end
+        end
+
+        before do
+          stub_command("mount | grep ' /shared_dir_1 '").and_return(false)
+          stub_command("mount | grep ' /shared_dir_2 '").and_return(true)
+          chef_run.converge_dsl do
+            lustre 'unmount' do
+              fsx_fs_id_array %w(openzfs_id_1 ontap_id_2)
+              fsx_fs_type_array %w(OPENZFS ONTAP)
+              fsx_shared_dir_array %w(shared_dir_1 shared_dir_2)
+              fsx_dns_name_array ['dns_name', '']
+              fsx_mount_name_array %w(mount_name_1 mount_name_2)
+              fsx_volume_junction_path_array %w(junction_path_1 junction_path_2)
+              action :unmount
+            end
+          end
+        end
+
+        it 'unmounts fsx only if mounted' do
+          is_expected.not_to run_execute('unmount fsx /shared_dir_1')
+
+          is_expected.to run_execute('unmount fsx /shared_dir_2')
+            .with(command: "umount -fl /shared_dir_2")
+            .with(retries: 10)
+            .with(retry_delay: 6)
+            .with(timeout: 60)
+        end
+
+        it 'removes volume from /etc/fstab' do
+          is_expected.to edit_delete_lines('remove volume dns_name:junction_path_1 from /etc/fstab')
+            .with(path: "/etc/fstab")
+            .with(pattern: "dns_name:junction_path_1 *")
+
+          is_expected.to edit_delete_lines('remove volume ontap_id_2.fsx.REGION.amazonaws.com:junction_path_2 from /etc/fstab')
+            .with(path: "/etc/fstab")
+            .with(pattern: "ontap_id_2.fsx.REGION.amazonaws.com:junction_path_2 *")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
* Add ChefSpec tests to test lustre mount and unmount
* While writing tests, I noticed and fixed an inconsistency:
  * `fsx_volume_junction_path` was normalized adding `/` at the beginning, but only for `mount`, not for `unmount`

### Tests
* ChefSpec tests

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.