### PR TITLE
Rename nfs-threads into nfs-configured

### DIFF
--- a/.github/workflows/dokken-unit-tests.yml
+++ b/.github/workflows/dokken-unit-tests.yml
@@ -96,7 +96,7 @@ jobs:
           - license-readme
           - fs-update
           - fs-update-default-values
-          - nfs-threads
+          - nfs-configured
           - networking-configured
           - pmix-installed
           - ssh-target-checker


### PR DESCRIPTION
### Description of changes
Rename `nfs-threads` into `nfs-configured`.

### Tests
`nfs-configured` run on EC2.

----
Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.