### PR TITLE
Fix kitchen test for Slurm commands sudoers configuration

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/test_users.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_users.rb
@@ -103,7 +103,7 @@ if node['cluster']['scheduler'] == 'slurm'
   check_sudoers_permissions(
     sudoers_file,
     cluster_admin_user, "root", "SLURM_COMMANDS",
-    "#{node['cluster']['slurm']['install_dir']}/bin/scontrol"
+    "#{node['cluster']['slurm']['install_dir']}/bin/scontrol, #{node['cluster']['slurm']['install_dir']}/bin/sinfo"
   )
 
   check_sudoers_permissions(


### PR DESCRIPTION
### Description of changes
* Fix kitchen test for Slurm commands sudoers configuration
* Makes kitchen test compatible with changes introduced in to https://github.com/aws/aws-parallelcluster-cookbook/pull/1826

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.