### PR TITLE
Refactor ChefSpec test for efa

### DIFF
--- a/cookbooks/aws-parallelcluster-common/resources/efa/efa_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/efa_redhat8.rb
@@ -28,7 +28,6 @@ action :check_efa_support do
   if node['cluster']['platform_version'].to_f < 8.4
     log "EFA is not supported in this RHEL version #{node['cluster']['platform_version']}, supported versions are >= 8.4" do
       level :warn
-      action :write
     end
     node.override['cluster']['efa_supported'] = false
   else

--- a/cookbooks/aws-parallelcluster-common/resources/efa/partial/_setup.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/partial/_setup.rb
@@ -19,7 +19,10 @@ action :setup do
   action_check_efa_support
   if node['cluster']['efa_supported']
     if efa_installed? && !::File.exist?(efa_tarball)
-      Chef::Log.warn("Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration.")
+      log 'efa installed' do
+        message 'Existing EFA version differs from the one shipped with ParallelCluster. Skipping ParallelCluster EFA installation and configuration.'
+        level :warn
+      end
       return
     end
 


### PR DESCRIPTION
### Description of changes
Refactor ChefSpec test for efa:
- Make it fail for a not supported OS.
- Use common methods to stub behavior.
- Replace Chef::Log with log resource for better testability.

### Tests
* ChefSpec tests
* Kitchen test for `efa` on EC2

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.