### PR TITLE
[develop] Add tests to verify pam_slurm_adopt module installation

### DIFF
--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -416,6 +416,7 @@ suites:
         - slurm_licence_configured
         - slurm_shared_libraries_compiled
         - slurm_library_shared
+        - pam_slurm_adopt_module_installed
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-install::directories

--- a/test/recipes/controls/aws_parallelcluster_slurm/install_slurm_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/install_slurm_spec.rb
@@ -132,3 +132,33 @@ control 'slurm_library_shared' do
     end
   end
 end
+
+control 'pam_slurm_adopt_module_installed' do
+  title "Check that pam_slurm_adopt has been built and installed"
+
+  lib_security_folder = '/lib/security/'
+  if os.redhat?
+    lib_security_folder = '/lib64/security/'
+  end
+
+  describe file("#{lib_security_folder}/pam_slurm_adopt.a") do
+    it { should exist }
+    its('mode') { should cmp '0644' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end
+
+  describe file("#{lib_security_folder}/pam_slurm_adopt.la") do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end
+
+  describe file("#{lib_security_folder}/pam_slurm_adopt.so") do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end
+end


### PR DESCRIPTION
### Description of changes
* Add tests to install-slurm recipe to verify that pam_slurm_adopt module has been built and installed as expected

### Tests
* Tested on some debian faimly OS on EC2 and redhat family OS on Docker

```
  ✔  pam_slurm_adopt_module_installed: Check that pam_slurm_adopt has been built and installed
     ✔  File /lib/security//pam_slurm_adopt.a is expected to exist
     ✔  File /lib/security//pam_slurm_adopt.a mode is expected to cmp == "0644"
     ✔  File /lib/security//pam_slurm_adopt.a owner is expected to eq "root"
     ✔  File /lib/security//pam_slurm_adopt.a group is expected to eq "root"
     ✔  File /lib/security//pam_slurm_adopt.la is expected to exist
     ✔  File /lib/security//pam_slurm_adopt.la mode is expected to cmp == "0755"
     ✔  File /lib/security//pam_slurm_adopt.la owner is expected to eq "root"
     ✔  File /lib/security//pam_slurm_adopt.la group is expected to eq "root"
     ✔  File /lib/security//pam_slurm_adopt.so is expected to exist
     ✔  File /lib/security//pam_slurm_adopt.so mode is expected to cmp == "0755"
     ✔  File /lib/security//pam_slurm_adopt.so owner is expected to eq "root"
     ✔  File /lib/security//pam_slurm_adopt.so group is expected to eq "root"

```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.