### PR TITLE
ChefSpec: rename converge classes

### DIFF
--- a/cookbooks/aws-parallelcluster-common/spec/unit/resources/efs_spec.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/unit/resources/efs_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-class Efs
+class ConvergeEfs
   def self.install_utils(chef_run)
     chef_run.converge_dsl do
       efs 'install_utils' do
@@ -37,7 +37,7 @@ describe 'efs:install_utils' do
     context "when same version of amazon-efs-utils already installed" do
       before do
         mock_get_package_version('amazon-efs-utils', '1.2.3')
-        Efs.install_utils(chef_run)
+        ConvergeEfs.install_utils(chef_run)
       end
 
       it 'does not install amazon-efs-utils' do
@@ -48,7 +48,7 @@ describe 'efs:install_utils' do
     context "when newer version of amazon-efs-utils already installed" do
       before do
         mock_get_package_version('amazon-efs-utils', '1.3.2')
-        Efs.install_utils(chef_run)
+        ConvergeEfs.install_utils(chef_run)
       end
 
       it 'does not install amazon-efs-utils' do
@@ -59,7 +59,7 @@ describe 'efs:install_utils' do
     context "when amazon-efs-utils not installed" do
       before do
         mock_get_package_version('amazon-efs-utils', '')
-        Efs.install_utils(chef_run)
+        ConvergeEfs.install_utils(chef_run)
       end
 
       it 'installs amazon-efs-utils' do
@@ -70,7 +70,7 @@ describe 'efs:install_utils' do
     context "when older version of amazon-efs-utils installed" do
       before do
         mock_get_package_version('amazon-efs-utils', '1.1.4')
-        Efs.install_utils(chef_run)
+        ConvergeEfs.install_utils(chef_run)
       end
 
       it 'installs amazon-efs-utils' do
@@ -117,7 +117,7 @@ describe 'efs:install_utils' do
       context "utils package not yet installed" do
         before do
           mock_already_installed('amazon-efs-utils', utils_version, false)
-          Efs.install_utils(chef_run)
+          ConvergeEfs.install_utils(chef_run)
         end
 
         it 'downloads tarball' do
@@ -139,7 +139,7 @@ describe 'efs:install_utils' do
       context "utils package already installed" do
         before do
           mock_already_installed('amazon-efs-utils', utils_version, true)
-          Efs.install_utils(chef_run)
+          ConvergeEfs.install_utils(chef_run)
         end
 
         it 'does not download tarball' do
@@ -197,7 +197,7 @@ describe 'efs:install_utils' do
       context "utils package not yet installed" do
         before do
           mock_already_installed('amazon-efs-utils', utils_version, false)
-          Efs.install_utils(chef_run)
+          ConvergeEfs.install_utils(chef_run)
         end
 
         it 'installs prerequisites' do
@@ -225,7 +225,7 @@ describe 'efs:install_utils' do
       context "utils package already installed" do
         before do
           mock_already_installed('amazon-efs-utils', utils_version, true)
-          Efs.install_utils(chef_run)
+          ConvergeEfs.install_utils(chef_run)
         end
 
         it 'does not download tarball' do

--- a/cookbooks/aws-parallelcluster-common/spec/unit/resources/network_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/unit/resources/network_service_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-class NetworkService
+class ConvergeNetworkService
   def self.restart(chef_run)
     chef_run.converge_dsl do
       network_service 'restart' do
@@ -26,7 +26,7 @@ describe 'network_service:restart' do
           platform: platform, version: version,
           step_into: ['network_service']
         )
-        NetworkService.restart(runner)
+        ConvergeNetworkService.restart(runner)
       end
       cached(:node) { chef_run.node }
       cached(:network_service_name) do
@@ -56,7 +56,7 @@ describe 'network_service:reload' do
           platform: platform, version: version,
           step_into: ['network_service']
         )
-        NetworkService.reload(runner)
+        ConvergeNetworkService.reload(runner)
       end
       cached(:network_service_name) do
         {


### PR DESCRIPTION
### Description of changes
* [Use ConvergeEfa class to converge Efa resource](https://github.com/aws/aws-parallelcluster-cookbook/commit/8b60761dbc83930e8cbc5946dee685bb6f7d4f53) 
* [Use ConvergeEfs class to converge Efs resource for the sake of consis…](https://github.com/aws/aws-parallelcluster-cookbook/commit/9702b20030fbcce1c4695363242bd60806e784cf)
* [Use ConvergeNetworkService class to converge network_service resource](https://github.com/aws/aws-parallelcluster-cookbook/commit/9328229cab9c8bb76e7f25094cb4b32c1b3a68f4)

### Tests
* ChefSpec tests

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.