### PR TITLE
3.x Publish JSON event logs to CloudWatch

### DIFF
--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_agent_config.json
@@ -4,7 +4,7 @@
     "default": "%Y-%m-%d %H:%M:%S,%f",
     "bracket_default": "[%Y-%m-%d %H:%M:%S]",
     "slurm": "%Y-%m-%dT%H:%M:%S.%f",
-    "metric": ""
+    "json": ""
   },
   "log_configs": [
     {
@@ -165,7 +165,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "metric",
+      "timestamp_format_key": "json",
       "file_path": "/var/log/parallelcluster/clustermgtd.events",
       "log_stream_name": "clustermgtd_events",
       "schedulers": [
@@ -183,9 +183,9 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "metric",
+      "timestamp_format_key": "json",
       "file_path": "/var/log/parallelcluster/slurm_resume.events",
-      "log_stream_name": "resume_events",
+      "log_stream_name": "slurm_resume_events",
       "schedulers": [
         "slurm"
       ],

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_agent_config.json
@@ -3,7 +3,8 @@
     "month_first": "%b %-d %H:%M:%S",
     "default": "%Y-%m-%d %H:%M:%S,%f",
     "bracket_default": "[%Y-%m-%d %H:%M:%S]",
-    "slurm": "%Y-%m-%dT%H:%M:%S.%f"
+    "slurm": "%Y-%m-%dT%H:%M:%S.%f",
+    "metric": ""
   },
   "log_configs": [
     {
@@ -149,6 +150,42 @@
       "timestamp_format_key": "default",
       "file_path": "/var/log/parallelcluster/clustermgtd",
       "log_stream_name": "clustermgtd",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "redhat",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "HeadNode"
+      ],
+      "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "metric",
+      "file_path": "/var/log/parallelcluster/clustermgtd.events",
+      "log_stream_name": "clustermgtd_events",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "amazon",
+        "centos",
+        "redhat",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "HeadNode"
+      ],
+      "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "metric",
+      "file_path": "/var/log/parallelcluster/slurm_resume.events",
+      "log_stream_name": "resume_events",
       "schedulers": [
         "slurm"
       ],

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/write_cloudwatch_agent_json.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/write_cloudwatch_agent_json.py
@@ -177,10 +177,7 @@ def add_timestamps(configs, timestamps_dict):
 def filter_output_fields(configs):
     """Remove fields that are not required by CloudWatch agent config file."""
     desired_keys = ["log_stream_name", "file_path", "timestamp_format", "log_group_name"]
-    return [
-        {desired_key: config[desired_key] for desired_key in desired_keys if desired_key in config}
-        for config in configs
-    ]
+    return [{desired_key: config[desired_key] for desired_key in (desired_keys & config.keys())} for config in configs]
 
 
 def create_metrics_collected(selected_configs):

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/write_cloudwatch_agent_json.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/write_cloudwatch_agent_json.py
@@ -177,7 +177,10 @@ def add_timestamps(configs, timestamps_dict):
 def filter_output_fields(configs):
     """Remove fields that are not required by CloudWatch agent config file."""
     desired_keys = ["log_stream_name", "file_path", "timestamp_format", "log_group_name"]
-    return [{desired_key: config[desired_key] for desired_key in (desired_keys & config.keys())} for config in configs]
+    return [
+        {desired_key: config[desired_key] for desired_key in desired_keys if desired_key in config}
+        for config in configs
+    ]
 
 
 def create_metrics_collected(selected_configs):

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/write_cloudwatch_agent_json.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/write_cloudwatch_agent_json.py
@@ -168,14 +168,19 @@ def add_scheduler_plugin_log(config_data, cluster_config_path):
 def add_timestamps(configs, timestamps_dict):
     """For each config, set its timestamp_format field based on its timestamp_format_key field."""
     for config in configs:
-        config["timestamp_format"] = timestamps_dict[config["timestamp_format_key"]]
+        timestamp_format = timestamps_dict[config["timestamp_format_key"]]
+        if timestamp_format:
+            config["timestamp_format"] = timestamp_format
     return configs
 
 
 def filter_output_fields(configs):
     """Remove fields that are not required by CloudWatch agent config file."""
     desired_keys = ["log_stream_name", "file_path", "timestamp_format", "log_group_name"]
-    return [{desired_key: config[desired_key] for desired_key in desired_keys} for config in configs]
+    return [
+        {desired_key: config[desired_key] for desired_key in desired_keys if desired_key in config}
+        for config in configs
+    ]
 
 
 def create_metrics_collected(selected_configs):

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -115,6 +115,12 @@ file "/var/log/parallelcluster/slurm_fleet_status_manager.log" do
   mode '0640'
 end
 
+file "/var/log/parallelcluster/clustermgtd.events" do
+  owner node['cluster']['cluster_admin_user']
+  group node['cluster']['cluster_admin_group']
+  mode '0600'
+end
+
 file "/var/log/parallelcluster/compute_console_output.log" do
   owner node['cluster']['cluster_admin_user']
   group node['cluster']['cluster_admin_group']
@@ -136,6 +142,12 @@ template "#{node['cluster']['scripts_dir']}/slurm/slurm_resume" do
 end
 
 file "/var/log/parallelcluster/slurm_resume.log" do
+  owner node['cluster']['cluster_admin_user']
+  group node['cluster']['cluster_admin_group']
+  mode '0644'
+end
+
+file "/var/log/parallelcluster/slurm_resume.events" do
   owner node['cluster']['cluster_admin_user']
   group node['cluster']['cluster_admin_group']
   mode '0644'

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -14,3 +14,4 @@ insufficient_capacity_timeout = 600
 compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] || true %>
 compute_console_logging_max_sample_size = <%= node['cluster']['slurm_plugin_console_logging']['sample_size'] %>
 compute_console_wait_time = 300
+instance_id = <%= node['ec2']['instance_id'] %>

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
@@ -9,3 +9,4 @@ use_private_hostname = <%= node['cluster']['use_private_hostname'] %>
 head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
 head_node_hostname = <%= node['ec2']['local_hostname'] %>
 clustermgtd_heartbeat_file_path = <%= node['cluster']['slurm']['install_dir'] %>/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat
+instance_id = <%= node['ec2']['instance_id'] %>


### PR DESCRIPTION
### Description of changes
* This change adds configuration to CloudWatch Agent to publish structured JSON event logs to CloudWatch log streams.
* This change also changes write_cloudwatch_agent_json.py so that it supports log streams without timestamps. This is required because CloudWatch won't parse a log event as JSON if it included anything before the JSON structure.

### Tests
* Manually deployed to personal account
* Verified log events were published to CloudWatch

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.