### PR TITLE
Fix tj-actions/changed-files patch version

### DIFF
--- a/.github/workflows/dokken-validate.yml
+++ b/.github/workflows/dokken-validate.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@main
       - name: Get changed files
         id: changed-files-excluding-tests
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v35.6.0
         with:
           files_ignore: |
             !.github

--- a/.github/workflows/system-tests-centos7.yml
+++ b/.github/workflows/system-tests-centos7.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@main
       - name: Get changed files
         id: changed-files-excluding-tests
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v35.6.0
         with:
           files_ignore: |
             !.github

--- a/.github/workflows/system-tests-ubuntu.yml
+++ b/.github/workflows/system-tests-ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@main
       - name: Get changed files
         id: changed-files-excluding-tests
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v35.6.0
         with:
           files_ignore: |
             !.github


### PR DESCRIPTION
### Description of changes
Fix tj-actions/changed-files patch version.
v35 started failing for unknown reasons.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.