### PR TITLE
Fix linter error: inconsistent-return-statements

### DIFF
--- a/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
@@ -59,6 +59,8 @@ def retry(func, func_args, attempts=1, wait=0):
 
             logger.info("%s, retrying in %s seconds..", e, wait)
             time.sleep(wait)
+    # We should never reach this line, but the linters say otherwise.
+    return None
 
 
 def generate_random_token(token_length):


### PR DESCRIPTION
### Description of changes
* Linter we reporting an inconsistent return statements error.
* This change should fix the error by returning None if the while loop exits (which it should never do other than by exception).

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.