### PR TITLE
[3.x] Fix raid in redhat8 

### DIFF
--- a/cookbooks/aws-parallelcluster-config/resources/manage_raid/manage_raid.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_raid/manage_raid.rb
@@ -1,0 +1,9 @@
+provides :manage_raid
+
+use 'partial/_raid_configuration'
+
+action_class do
+  def raid_superblock_version
+    '0.90'
+  end
+end

--- a/cookbooks/aws-parallelcluster-config/resources/manage_raid/manage_raid_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_raid/manage_raid_redhat8.rb
@@ -1,0 +1,11 @@
+provides :manage_raid, platform: 'redhat' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_raid_configuration'
+
+action_class do
+  def raid_superblock_version
+    '1.2'
+  end
+end

--- a/cookbooks/aws-parallelcluster-config/resources/manage_raid/manage_raid_ubunu2004.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_raid/manage_raid_ubunu2004.rb
@@ -1,0 +1,9 @@
+provides :manage_raid, platform: 'ubuntu', platform_version: '20.04'
+
+use 'partial/_raid_configuration'
+
+action_class do
+  def raid_superblock_version
+    '1.2'
+  end
+end

--- a/cookbooks/aws-parallelcluster-config/resources/manage_raid/partial/_raid_configuration.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_raid/partial/_raid_configuration.rb
@@ -8,8 +8,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource_name :manage_raid
-provides :manage_raid
 unified_mode true
 
 property :raid_shared_dir, String, required: true
@@ -51,15 +49,10 @@ action :mount do
   end
 
   raid_dev = "/dev/md0"
-
-  # Create RAID device with mdadm
-  raid_superblock_version = value_for_platform(
-    'ubuntu' => { '>=20.04' => '1.2' },
-    'default' => '0.90'
-  )
   mdadm "MY_RAID" do
     raid_device raid_dev
     level raid_type
+    # Raid superblock documentation https://raid.wiki.kernel.org/index.php/RAID_superblock_formats
     metadata raid_superblock_version
     devices raid_dev_path
   end

--- a/cookbooks/aws-parallelcluster-config/spec/unit/resources/manage_raid_export_unexport_spec.rb
+++ b/cookbooks/aws-parallelcluster-config/spec/unit/resources/manage_raid_export_unexport_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+def mock_get_vpc_cidr_list(cidr)
+  allow_any_instance_of(Object).to receive(:get_vpc_cidr_list).and_return(cidr)
+end
+
+describe 'manage_raid:export' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner = ChefSpec::Runner.new(
+          platform: platform, version: version,
+          step_into: ['manage_raid']
+        )
+        runner.converge_dsl do
+          manage_raid 'export' do
+            action :export
+            raid_vol_array "vol-0, vol-1"
+            raid_shared_dir "raid_shared_dir"
+          end
+        end
+      end
+
+      before do
+        mock_get_vpc_cidr_list('0.0.0.0/0
+                              192.168.200.4/30')
+      end
+      it "exports shared dir" do
+        is_expected.to create_nfs_export("/raid_shared_dir")
+          .with(network: get_vpc_cidr_list)
+          .with(writeable: true)
+          .with(options: %w(no_root_squash))
+      end
+    end
+  end
+end
+
+describe 'manage_raid:unexport' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner = ChefSpec::Runner.new(
+          platform: platform, version: version,
+          step_into: ['manage_raid']
+        )
+        runner.converge_dsl do
+          manage_raid 'unexport' do
+            action :unexport
+            raid_vol_array "vol-0, vol-1"
+            raid_shared_dir "raid_shared_dir"
+          end
+        end
+      end
+
+      it "unexports raid directory via NFS" do
+        is_expected.to edit_delete_lines("remove volume from /etc/exports")
+          .with(path: "/etc/exports")
+          .with(pattern: "/raid_shared_dir *")
+      end
+
+      it "unexports volume" do
+        is_expected.to run_execute("unexport volume").with(command: "exportfs -ra")
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-config/spec/unit/resources/manage_raid_mount_unmount_spec.rb
+++ b/cookbooks/aws-parallelcluster-config/spec/unit/resources/manage_raid_mount_unmount_spec.rb
@@ -1,0 +1,188 @@
+require 'spec_helper'
+
+class Chef::Resource::RubyBlock
+  def wait_for_block_dev(_path)
+    # do nothing
+  end
+end
+
+describe 'manage_raid:mount' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:venv_path) { 'venv' }
+      cached(:raid_superblock_version) do
+        platform == 'redhat' || "#{platform}#{version}" == 'ubuntu20.04' ? '1.2' : '0.90'
+      end
+      cached(:chef_run) do
+        runner = ChefSpec::Runner.new(
+          platform: platform, version: version,
+          step_into: ['manage_raid']
+        ) do |node|
+          node.override['cluster']['cookbook_virtualenv_path'] = venv_path
+        end
+        runner.converge_dsl do
+          manage_raid 'mount' do
+            action :mount
+            raid_vol_array "vol-0, vol-1"
+            raid_shared_dir "raid_shared_dir"
+            raid_type ' 0'
+          end
+        end
+      end
+
+      it "attaches volumes" do
+        # Attach RAID EBS volume
+        is_expected.to run_execute("attach_raid_volume_0")
+          .with(command: "#{venv_path}/bin/python /usr/local/sbin/manageVolume.py --volume-id vol-0 --attach")
+          .with(creates: "/dev/disk/by-ebs-volumeid/vol-0")
+
+        is_expected.to run_execute("attach_raid_volume_1")
+          .with(command: "#{venv_path}/bin/python /usr/local/sbin/manageVolume.py --volume-id vol-1 --attach")
+          .with(creates: "/dev/disk/by-ebs-volumeid/vol-1")
+
+        block = chef_run.find_resource('ruby_block', 'sleeping_for_raid_volume_0')
+        expect(block).to receive(:wait_for_block_dev).with('/dev/disk/by-ebs-volumeid/vol-0')
+        block.block.call
+        expect(block).to subscribe_to('execute[attach_raid_volume_0]').on(:run).immediately
+
+        block = chef_run.find_resource('ruby_block', 'sleeping_for_raid_volume_1')
+        expect(block).to receive(:wait_for_block_dev).with('/dev/disk/by-ebs-volumeid/vol-1')
+        block.block.call
+        expect(block).to subscribe_to('execute[attach_raid_volume_1]').on(:run).immediately
+      end
+
+      it "initializes raid" do
+        is_expected.to create_mdadm("MY_RAID")
+          .with(raid_device: '/dev/md0')
+          .with(level: 0)
+          .with(metadata: raid_superblock_version)
+          .with(devices: %w(/dev/disk/by-ebs-volumeid/vol-0 /dev/disk/by-ebs-volumeid/vol-1))
+
+        block = chef_run.find_resource('ruby_block', 'sleeping_for_raid_block')
+        expect(block).to receive(:wait_for_block_dev).with('/dev/md0')
+        block.block.call
+        expect(block).to subscribe_to('mdadm[MY_RAID]').on(:run).immediately
+      end
+
+      it "setups raid disk" do
+        is_expected.to nothing_execute("setup_raid_disk")
+          .with(command: "sudo mkfs.ext4 /dev/md0")
+
+        command = chef_run.execute("setup_raid_disk")
+        expect(command).to subscribe_to('ruby_block[sleeping_for_raid_block]').on(:run).immediately
+      end
+
+      it "creates Raid config" do
+        is_expected.to nothing_execute("create_raid_config")
+          .with(command: "sudo mdadm --detail --scan | sudo tee -a /etc/mdadm.conf")
+
+        command = chef_run.execute("create_raid_config")
+        expect(command).to subscribe_to('execute[setup_raid_disk]').on(:run).immediately
+      end
+
+      it "creates the shared dir" do
+        is_expected.to create_directory('/raid_shared_dir')
+          .with(owner: 'root')
+          .with(group: 'root')
+          .with(mode: '1777')
+        # recursive do not work
+        # .with(recursive: true)
+      end
+
+      it "mounts and enables the shared dir" do
+        is_expected.to mount_mount('/raid_shared_dir')
+          .with(device: "/dev/md0")
+          .with(fstype: "ext4")
+          .with(options: %w(defaults nofail _netdev))
+          .with(retries: 10)
+          .with(retry_delay: 6)
+
+        is_expected.to enable_mount('/raid_shared_dir')
+          .with(device: "/dev/md0")
+          .with(fstype: "ext4")
+          .with(options: %w(defaults nofail _netdev))
+          .with(retries: 10)
+          .with(retry_delay: 6)
+      end
+
+      it "changes permission for the shared dir" do
+        is_expected.to create_directory('/raid_shared_dir')
+          .with(owner: 'root')
+          .with(group: 'root')
+          .with(mode: '1777')
+      end
+    end
+  end
+end
+
+describe 'manage_raid:unmount' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:venv_path) { 'venv' }
+      cached(:chef_run) do
+        runner = ChefSpec::Runner.new(
+          platform: platform, version: version,
+          step_into: ['manage_raid']
+        ) do |node|
+          node.override['cluster']['cookbook_virtualenv_path'] = venv_path
+        end
+        runner.converge_dsl do
+          manage_raid 'unmount' do
+            action :unmount
+            raid_vol_array "vol-0, vol-1"
+            raid_shared_dir "raid_shared_dir"
+            raid_type ' 0'
+          end
+        end
+      end
+
+      stubs_for_provider('manage_raid') do |resource|
+        allow(resource).to receive(:get_raid_devices).with("/dev/md0").and_return("device1 device2")
+      end
+
+      it "unmounts and disables shared dir" do
+        is_expected.to unmount_mount("/raid_shared_dir")
+          .with(device: "/dev/md0")
+          .with(fstype: "ext4")
+          .with(options: %w(defaults nofail _netdev))
+          .with(retries: 10)
+          .with(retry_delay: 6)
+
+        is_expected.to disable_mount("/raid_shared_dir")
+          .with(device: "/dev/md0")
+          .with(fstype: "ext4")
+          .with(options: %w(defaults nofail _netdev))
+          .with(retries: 10)
+          .with(retry_delay: 6)
+      end
+
+      it "deletes shared dir" do
+        is_expected.to delete_directory("/raid_shared_dir").with(recursive: true)
+      end
+
+      it "stops RAID device" do
+        is_expected.to run_execute("Deactivate array, releasing all resources")
+          .with(command: "mdadm --stop /dev/md0")
+      end
+
+      it "removes the superblocks" do
+        is_expected.to run_execute("Erase the MD superblock from a device")
+          .with(command: "mdadm --zero-superblock device1 device2")
+      end
+
+      it "removes RAID from /etc/mdadm.conf" do
+        is_expected.to edit_delete_lines("Remove RAID from /etc/mdadm.conf")
+          .with(path: "/etc/mdadm.conf")
+          .with(pattern: "ARRAY /dev/md0 *")
+      end
+
+      it "detaches each volume" do
+        is_expected.to run_execute("detach_raid_volume_0")
+          .with(command: "#{venv_path}/bin/python /usr/local/sbin/manageVolume.py --volume-id vol-0 --detach")
+
+        is_expected.to run_execute("detach_raid_volume_1")
+          .with(command: "#{venv_path}/bin/python /usr/local/sbin/manageVolume.py --volume-id vol-1 --detach")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
* [Make manage_raid as a proper resource with the minimal os-split](https://github.com/aws/aws-parallelcluster-cookbook/commit/86b6c2905b2d452ad3f32c6bf95247d371bbf958)
* [Cover the resource with ChefSpec](https://github.com/aws/aws-parallelcluster-cookbook/commit/ed718186ad99e0ae2b070c60db353c71ffec075c)

### Tests
* ChefSpec
* Manually tried in a RH8 instance
* Launch the integration-test that was failing (in progress)

### References
* Same approach as https://github.com/aws/aws-parallelcluster-cookbook/pull/789

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.