### PR TITLE
Fix network interface configuration for rhel8

### DIFF
--- a/cookbooks/aws-parallelcluster-config/files/redhat-8/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-config/files/redhat-8/network_interfaces/configure_nw_interface.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Configure a specific Network Interface according to the OS
+# The configuration involves 3 aspects:
+# - Main configuration (IP address, protocol and gateway)
+# - A specific routing table, so that all traffic coming to a network interface leaves the instance using the same
+#   interface
+# - A routing rule to make the OS use the specific routing table for this network interface
+
+# RedHat 8 official documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/configuring-policy-based-routing-to-define-alternative-routes_configuring-and-managing-networking
+
+set -e
+
+if
+  [ -z "${DEVICE_NAME}" ] ||          # name of the device
+  [ -z "${DEVICE_NUMBER}" ] ||        # number of the device
+  [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
+  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
+  [ -z "${CIDR_PREFIX_LENGTH}" ]      # the prefix length of the device IP cidr block
+then
+  echo 'One or more environment variables missing'
+  exit 1
+fi
+
+con_name="System ${DEVICE_NAME}"
+route_table="100${DEVICE_NUMBER}"
+priority="100${DEVICE_NUMBER}"
+metric="100${DEVICE_NUMBER}"
+
+# Rename connection
+original_con_name=`nmcli -t -f GENERAL.CONNECTION device show ${DEVICE_NAME} | cut -f2 -d':'`
+nmcli connection modify "${original_con_name}" con-name "${con_name}" ifname ${DEVICE_NAME}
+
+configured_ip=`nmcli -t -f IP4.ADDRESS device show ${DEVICE_NAME} | cut -f2 -d':'`
+if [ -z "${configured_ip}" ]; then
+  # Setup connection method to "manual", configure ip address and gateway, only if not already configured.
+  sudo nmcli connection modify "${con_name}" ipv4.method manual ipv4.addresses ${DEVICE_IP_ADDRESS}/${CIDR_PREFIX_LENGTH} ipv4.gateway ${GW_IP_ADDRESS}
+fi
+
+# Setup routes
+# This command uses the ipv4.routes parameter to add a static route to the routing table with ID ${route_table}.
+# This static route for 0.0.0.0/0 uses the IP of the gateway as next hop.
+nmcli connection modify "${con_name}" ipv4.routes "0.0.0.0/0 ${GW_IP_ADDRESS} ${metric} table=${route_table}"
+
+# Setup routing rules
+# The command uses the ipv4.routing-rules parameter to add a routing rule with priority ${priority} that routes
+# traffic from ${DEVICE_IP_ADDRESS} to table ${route_table}. Low values have a high priority.
+# The syntax in the ipv4.routing-rules parameter is the same as in an "ip rule add" command,
+# except that ipv4.routing-rules always requires specifying a priority.
+nmcli connection modify "${con_name}" ipv4.routing-rules "priority ${priority} from ${DEVICE_IP_ADDRESS} table ${route_table}"
+
+# Reapply previous connection modification.
+nmcli device reapply ${DEVICE_NAME}


### PR DESCRIPTION
### Description of changes
Fix network interface configuration for rhel8

### Tests
* Integration test (failed for unrelated reasons, but the communication between head and compute node worked at the beginning)

### References
* [RedHat8 official documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/configuring-policy-based-routing-to-define-alternative-routes_configuring-and-managing-networking)


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.