### PR TITLE
Add template to configure setup-ephemeral.service in order to wait after network-online.target for redhat8

### DIFF
--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -39,7 +39,7 @@ include_recipe "aws-parallelcluster-install::disable_selinux"
 include_recipe "aws-parallelcluster-install::license_readme"
 
 nfs 'install NFS daemon'
-include_recipe "aws-parallelcluster-install::ephemeral_drives"
+ephemeral_drives 'install'
 ec2_udev_rules 'configure udev'
 
 include_recipe "aws-parallelcluster-install::gc_thresh_values"

--- a/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/ephemeral_drives_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/ephemeral_drives_amazon2.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :ephemeral_drives, platform: 'amazon', platform_version: '2'
+
+use 'partial/_ephemeral_drives_common.rb'
+
+action_class do
+  def network_target
+    'network.target'
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/ephemeral_drives_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/ephemeral_drives_centos7.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :ephemeral_drives, platform: 'centos' do |node|
+  node['platform_version'].to_i == 7
+end
+
+use 'partial/_ephemeral_drives_common.rb'
+
+action_class do
+  def network_target
+    'network.target'
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/ephemeral_drives_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/ephemeral_drives_redhat8.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :ephemeral_drives, platform: 'redhat' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_ephemeral_drives_common.rb'
+
+action_class do
+  def network_target
+    'network-online.target'
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/ephemeral_drives_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/ephemeral_drives_ubuntu18.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :ephemeral_drives, platform: 'ubuntu', platform_version: '18.04'
+
+use 'partial/_ephemeral_drives_common.rb'
+
+action_class do
+  def network_target
+    'network.target'
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/ephemeral_drives_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/ephemeral_drives_ubuntu20.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :ephemeral_drives, platform: 'ubuntu', platform_version: '20.04'
+
+use 'partial/_ephemeral_drives_common.rb'
+
+action_class do
+  def network_target
+    'network.target'
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/partial/_ephemeral_drives_common.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/ephemeral_drivers/partial/_ephemeral_drives_common.rb
@@ -16,24 +16,30 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-package "install Logical Volume Manager 2 utilities" do
-  package_name "lvm2"
-  retries 3
-  retry_delay 5
-end
+unified_mode true
+default_action :setup
 
-cookbook_file 'setup-ephemeral-drives.sh' do
-  source 'base/setup-ephemeral-drives.sh'
-  path '/usr/local/sbin/setup-ephemeral-drives.sh'
-  owner 'root'
-  group 'root'
-  mode '0744'
-end
+action :setup do
+  package "install Logical Volume Manager 2 utilities" do
+    package_name "lvm2"
+    retries 3
+    retry_delay 5
+  end
 
-cookbook_file 'setup-ephemeral.service' do
-  source 'base/setup-ephemeral.service'
-  path '/etc/systemd/system/setup-ephemeral.service'
-  owner 'root'
-  group 'root'
-  mode '0644'
+  cookbook_file 'setup-ephemeral-drives.sh' do
+    source 'base/setup-ephemeral-drives.sh'
+    path '/usr/local/sbin/setup-ephemeral-drives.sh'
+    owner 'root'
+    group 'root'
+    mode '0744'
+  end
+
+  template 'setup-ephemeral.service' do
+    source 'base/setup-ephemeral.service.erb'
+    path '/etc/systemd/system/setup-ephemeral.service'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    variables(network_target: network_target)
+  end
 end

--- a/cookbooks/aws-parallelcluster-install/templates/default/base/setup-ephemeral.service.erb
+++ b/cookbooks/aws-parallelcluster-install/templates/default/base/setup-ephemeral.service.erb
@@ -1,6 +1,6 @@
 [Unit]
 Description=Setup ephemeral drives service
-After=network.target
+After=<%= @network_target %>
 
 [Service]
 ExecStart=/usr/local/sbin/setup-ephemeral-drives.sh

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -49,14 +49,6 @@ suites:
       controls:
         - pcluster_directories_exist
         - pcluster_log_dir_is_configured
-  - name: ephemeral_drives_setup
-    run_list:
-      - recipe[aws-parallelcluster-install::ephemeral_drives]
-    verifier:
-      controls:
-        - ephemeral_drives_logical_volumes_manager_installed
-        - ephemeral_drives_script_created
-        - ephemeral_service_set_up
   - name: python_setup
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]

--- a/kitchen.resources.yml
+++ b/kitchen.resources.yml
@@ -178,6 +178,17 @@ suites:
       resource: dns_domain
       cluster:
         dns_domain: test-domain
+  - name: ephemeral_drives
+    run_list:
+      - recipe[aws-parallelcluster-install::test_resource]
+    attributes:
+      resource: ephemeral_drives
+    verifier:
+      controls:
+        - ephemeral_drives_logical_volumes_manager_installed
+        - ephemeral_drives_script_created
+        - ephemeral_service_set_up
+        - ephemeral_service_after_network_config
   - name: nfs_configured
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]

--- a/kitchen.validate.yml
+++ b/kitchen.validate.yml
@@ -26,6 +26,10 @@ suites:
         - ephemeral_drives_logical_volumes_manager_installed
         - ephemeral_drives_script_created
         - ephemeral_service_set_up
+        - ephemeral_service_after_network_config
+        - ephemeral_drives_configured
+        - ephemeral_drives_service_running
+        - ephemeral_drives_with_name_clashing_not_mounted
         - awsbatch_virtualenv_created
         - cookbook_virtualenv_created
         - cfnbootstrap_virtualenv_created

--- a/test/resources/controls/aws_parallelcluster_install/ephemeral_drives_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/ephemeral_drives_spec.rb
@@ -52,3 +52,15 @@ control 'ephemeral_drives_with_name_clashing_not_mounted' do
     its(:exit_status) { should eq 0 }
   end
 end
+
+control 'ephemeral_service_after_network_config' do
+  title 'Check setup-ephemeral service to have the correct After statement'
+  network_target = os_properties.redhat? ? /^After=network-online.target/ : /^After=network.target$/
+  describe file('/etc/systemd/system/setup-ephemeral.service') do
+    it { should exist }
+    its('content') { should match network_target }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0644' }
+  end
+end


### PR DESCRIPTION

### Description of changes
* Add template to configure setup-ephemeral.service in order to wait after network-online.target for redhat8
  * The service was failing in starting in RedHat 8 since the target `network` did not mean that the network was working. Following the [RedHat article](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/systemd-network-targets-and-services_configuring-and-managing-networking) the target has been changed to `network-online`.
  * The recipe has been transformed in a resource because it is dependent on the OS.

### Tests
* Tested in the integration test
* Manual tested

### References
* https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/systemd-network-targets-and-services_configuring-and-managing-networking

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.