### PR TITLE
[Code Quality] Fix linter error R1710 in DCV Authenticator.

### DIFF
--- a/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/dcv/pcluster_dcv_authenticator.py
@@ -39,7 +39,7 @@ LOG_FILE_PATH = "/var/log/parallelcluster/pcluster_dcv_authenticator.log"
 logger = logging.getLogger(__name__)
 
 
-def retry(func, func_args, attempts=1, wait=0):  # pylint: disable=R1710
+def retry(func, func_args, attempts=1, wait=0):
     """
     Call function and re-execute it if it raises an Exception.
 
@@ -59,6 +59,7 @@ def retry(func, func_args, attempts=1, wait=0):  # pylint: disable=R1710
 
             logger.info("%s, retrying in %s seconds..", e, wait)
             time.sleep(wait)
+    return None
 
 
 def generate_random_token(token_length):


### PR DESCRIPTION
### Description of changes
Fix linter error R1710 in DCV Authenticator.
R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements).


### Tests
Not needed because the function either returns the function result or throws an exception.
This fix is only to address a coding best practice.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.