### PR TITLE
[Isolated Regions] Setting AWS CLI system-wide environment variables within the 'patch-iso-instance' script: AWS_DEFAULT_REGION and AWS_CA_BUNDLE.

### DIFF
--- a/cookbooks/aws-parallelcluster-install/templates/default/base/patch-iso-instance.sh.erb
+++ b/cookbooks/aws-parallelcluster-install/templates/default/base/patch-iso-instance.sh.erb
@@ -58,4 +58,12 @@ done
 
 echo "[INFO] Complete: CA bundle configuration for AWS CLI in US isolated region"
 
+echo "[INFO] Starting: Setting system-wide environment variables for AWS CLI in US isolated region"
+
+echo "export AWS_DEFAULT_REGION=${REGION}" >> /etc/profile.d/aws-cli-default-config.sh
+
+echo "Defaults env_keep += \"AWS_DEFAULT_REGION AWS_CA_BUNDLE\"" > /etc/sudoers.d/pcluster-aws-cli-envkeep
+
+echo "[INFO] Complete: Setting system-wide environment variables for AWS CLI in US isolated region"
+
 echo "[INFO] Complete: instance configuration for US isolated region"


### PR DESCRIPTION
### Description of changes
Setting AWS CLI system-wide environment variables within the `patch-iso-instance` script: 
1. `AWS_DEFAULT_REGION`
2. `AWS_CA_BUNDLE`

This change allows us to provide better customer experience in isolated regions:
1. Customers will not need to specify the --region options in CLI commands for global services, e.g. STS, Route53, STS.
2. Default region and CA bundle will be environment variables preserved during switch-user commands. Note that this is something we may want in our product regardless isolated regions, but in this release we want to limit the impact of our changes to ISO regions only.

Notes to provide some context:
1. `/etc/profile.d/aws-cli-default-config.sh`: this is a file created as part of the US ISO instance setup.
2. Why setting only AWS_DEFAULT_REGION and not AWS_CA_BUNDLE in `/etc/profile.d/aws-cli-default-config.sh`? Because AWS_CA_BUNDLE is set as part of the US ISO instance setup.

### Tests
* Tested in us-isob-east-1: cluster creation + job submission to dynamic nodes with AWS CLI commands to S3 without specifying the region  in 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>