### PR TITLE
Upgrade EFA installer from 1.21.0 to 1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Add support for US isolated regions: us-iso-east-1 and us-isob-east-1.
 
 **CHANGES**
+- Upgrade EFA installer to `1.22.0`
+  - Efa-driver: `efa-2.1.1g`
+  - Efa-config: `efa-config-1.13-1`
+  - Efa-profile: `efa-profile-1.5-1`
+  - Libfabric-aws: `libfabric-aws-1.17.0-1`
+  - Rdma-core: `rdma-core-43.0-1`
+  - Open MPI: `openmpi40-aws-4.1.5-1`
 - Upgrade NICE DCV to version `2022.2-14521`.
   - server: `2022.2.14521-1`
   - xdcv: `2022.2.519-1`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -242,7 +242,7 @@ default['cluster']['mysql']['repository']['expected']['version'] = value_for_pla
 )
 
 # EFA
-default['cluster']['efa']['installer_version'] = '1.21.0'
+default['cluster']['efa']['installer_version'] = '1.22.0'
 default['cluster']['efa']['installer_url'] = "https://efa-installer.amazonaws.com/aws-efa-installer-#{node['cluster']['efa']['installer_version']}.tar.gz"
 default['cluster']['efa']['unsupported_aarch64_oses'] = %w(centos7)
 


### PR DESCRIPTION
### Description of changes
- Efa-driver: `efa-2.1.1g`
- Efa-config: `efa-config-1.13-1`
- Efa-profile: `efa-profile-1.5-1`
- Libfabric-aws: `libfabric-aws-1.17.0-1`
- Rdma-core: `rdma-core-43.0-1`
- Open MPI: `openmpi40-aws-4.1.5-1`

### Tests
* Tested manual installation
``` 
[ec2-user@ip-10-0-0-33 aws-efa-installer]$ cat /opt/amazon/efa_installed_packages
# EFA installer version: 1.22.0
# Debug packages installed: no
# Packages installed:
efa-config-1.13-1.el8.noarch efa-profile-1.5-1.el8.noarch libfabric-aws-1.17.0-1.el8.x86_64 libfabric-aws-devel-1.17.0-1.el8.x86_64 openmpi40-aws-4.1.5-1.x86_64 ibacm-43.0-1.el8.x86_64 infiniband-diags-43.0-1.el8.x86_64 infiniband-diags-compat-43.0-1.el8.x86_64 libibumad-43.0-1.el8.x86_64 libibverbs-43.0-1.el8.x86_64 libibverbs-utils-43.0-1.el8.x86_64 librdmacm-43.0-1.el8.x86_64 librdmacm-utils-43.0-1.el8.x86_64 python3-pyverbs-43.0-1.el8.x86_64 rdma-core-43.0-1.el8.x86_64 rdma-core-devel-43.0-1.el8.x86_64
```
