### PR TITLE
Add multinic tests to kitchen.recipes.yml

### DIFF
--- a/kitchen.docker.sh
+++ b/kitchen.docker.sh
@@ -11,5 +11,6 @@
 export KITCHEN_LOCAL_YAML="kitchen.$1.yml"; shift;
 export KITCHEN_YAML=kitchen.docker.yml
 export KITCHEN_GLOBAL_YAML=kitchen.global.yml
+export KITCHEN_DRIVER=dokken
 
 kitchen "$@"

--- a/kitchen.ec2.sh
+++ b/kitchen.ec2.sh
@@ -50,6 +50,7 @@
 export KITCHEN_LOCAL_YAML="kitchen.$1.yml"; shift;
 export KITCHEN_YAML=kitchen.ec2.yml
 export KITCHEN_GLOBAL_YAML=kitchen.global.yml
+export KITCHEN_DRIVER=ec2
 
 THIS_DIR=$(dirname "$0")
 if [ -e "${THIS_DIR}/.kitchen.env.sh" ]
@@ -57,5 +58,63 @@ then
   echo "*** Apply local environment"
   source "${THIS_DIR}/.kitchen.env.sh"
 fi
+
+: "${KITCHEN_AWS_REGION:=${AWS_DEFAULT_REGION:-eu-west-1}}"
+: "${KITCHEN_KEY_NAME:=kitchen}"
+: "${KITCHEN_SSH_KEY_PATH:="~/.ssh/${KITCHEN_KEY_NAME}-${KITCHEN_AWS_REGION}.pem"}"
+: "${KITCHEN_AVAILABILITY_ZONE:=a}"
+
+# Subnet
+if [ -z "${KITCHEN_SUBNET_ID}" ]; then
+  echo "** KITCHEN_SUBNET_ID not explicitly set: looking for subnet tagged Kitchen=true"
+
+  KITCHEN_SUBNET_ID=$(aws ec2 describe-subnets --region "${KITCHEN_AWS_REGION}" \
+      --filters "Name=tag:Kitchen,Values=true" \
+                "Name=availability-zone,Values=${KITCHEN_AWS_REGION}${KITCHEN_AVAILABILITY_ZONE}" \
+      --query 'Subnets[0].SubnetId' --output text)
+
+  echo "** KITCHEN_SUBNET_ID: ${KITCHEN_SUBNET_ID}"
+
+  if [ "${KITCHEN_SUBNET_ID}" = "None" ]; then
+    echo "Subnet tagged Kitchen=true not found in AZ ${KITCHEN_AWS_REGION}${KITCHEN_AVAILABILITY_ZONE}"
+    exit 1
+  fi
+fi
+
+# VPC
+KITCHEN_VPC_ID=$(aws ec2 describe-subnets --region "${KITCHEN_AWS_REGION}" \
+    --subnet-ids "${KITCHEN_SUBNET_ID}" \
+    --query 'Subnets[0].VpcId' --output text)
+
+echo "** KITCHEN_VPC_ID: ${KITCHEN_VPC_ID}"
+
+# Security Group
+if [ -z "${KITCHEN_SECURITY_GROUP_ID}" ]; then
+  echo "** KITCHEN_SECURITY_GROUP_ID not explicitly set"
+
+  if [ -z "${KITCHEN_SECURITY_GROUP_NAME}" ]; then
+    echo "** KITCHEN_SECURITY_GROUP_NAME not explicitly set, looking for tag Kitchen=true"
+
+    KITCHEN_SECURITY_GROUP_ID=$(aws ec2 describe-security-groups --region "${KITCHEN_AWS_REGION}" \
+                --filters "Name=tag:Kitchen,Values=true" "Name=vpc-id,Values=${KITCHEN_VPC_ID}" \
+                --query 'SecurityGroups[0].GroupId' --output text)
+  else
+    echo "** Looking for SG named ${KITCHEN_SECURITY_GROUP_NAME}"
+
+    KITCHEN_SECURITY_GROUP_ID=$(aws ec2 describe-security-groups --region "${KITCHEN_AWS_REGION}" \
+                --filters "Name=vpc-id,Values=${KITCHEN_VPC_ID}" "Name=group-name,Values=${KITCHEN_SECURITY_GROUP_NAME}" \
+                --query 'SecurityGroups[0].GroupId' --output text)
+  fi
+
+  echo "** KITCHEN_SECURITY_GROUP_ID: ${KITCHEN_SECURITY_GROUP_ID}"
+
+fi
+
+export KITCHEN_AWS_REGION
+export KITCHEN_KEY_NAME
+export KITCHEN_SSH_KEY_PATH
+export KITCHEN_SUBNET_ID
+export KITCHEN_VPC_ID
+export KITCHEN_SECURITY_GROUP_ID
 
 kitchen "$@"

--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -1,13 +1,11 @@
 <%
   pcluster_version = ENV['KITCHEN_PCLUSTER_VERSION'] || '3.6.0'
   pcluster_prefix = "aws-parallelcluster-#{pcluster_version}"
-  aws_region = ENV['KITCHEN_AWS_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'eu-west-1'
-  key_name = ENV['KITCHEN_KEY_NAME'] || 'kitchen'
 %>
 ---
 driver:
   name: ec2
-  aws_ssh_key_id: <%= key_name %>
+  aws_ssh_key_id: <%= ENV['KITCHEN_KEY_NAME'] %>
   <% if ENV['KITCHEN_SECURITY_GROUP_ID'] %>
   security_group_ids: [ "<%= ENV['KITCHEN_SECURITY_GROUP_ID'] %>" ]
   <% else %>
@@ -15,29 +13,23 @@ driver:
     tag: 'Kitchen'
     value: 'true'
   <% end %>
-  region: <%= aws_region %>
-  availability_zone: a
-  <% if ENV['KITCHEN_SUBNET_ID'] %>
+  region: <%= ENV['KITCHEN_AWS_REGION'] %>
+  availability_zone: <%= ENV['KITCHEN_AVAILABILITY_ZONE'] %>
   subnet_id: <%= ENV['KITCHEN_SUBNET_ID'] %>
-  <% else %>
-  subnet_filter:
-    tag: 'Kitchen'
-    value: 'true'
-  <% end %>
   # Disable IMDS v1
   metadata_options:
     http_tokens: 'required'
     http_put_response_hop_limit: 1
     instance_metadata_tags: 'enabled'
   #iam_profile_name: chef-client
-  instance_type: <%= ENV['KITCHEN_INSTANCE_TYPE'] || "t2.micro" %>
+  instance_type: <%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
   associate_public_ip: true
   interface: public
   tags:
     Name: test-kitchen-parallelcluster
 
 transport:
-  ssh_key: <%= ENV['KITCHEN_SSH_KEY_PATH'] || "~/.ssh/#{key_name}-#{aws_region}.pem" %>
+  ssh_key: <%= ENV['KITCHEN_SSH_KEY_PATH']  %>
   compression: true
 
 provisioner:
@@ -75,7 +67,7 @@ platforms:
       image_id: <%= ENV['KITCHEN_REDHAT8_AMI'] %>
       <% else %>
       image_search:
-        name: "RHEL-8*_HVM*"
+        name: "RHEL-8.7.*_HVM*"
         architecture: <%= ENV['KITCHEN_ARCHITECTURE'] || 'x86_64' %>
       <% end %>
     transport:

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -523,3 +523,18 @@ suites:
         nfs:
           hard_mount_options: hard,_netdev,noatime
         head_node_private_ip: '127.0.0.1'
+  - name: network_interfaces
+    # Verifies multiple Network Interfaces recipes
+    # These recipes can be tested on EC2 on instance type with multiple network interfaces
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#network-cards
+    run_list:
+      - recipe[aws-parallelcluster-config::network_interfaces]
+    driver:
+      instance_type: c6in.32xlarge # available in eu-west-1, all AZs
+      # availability_zone: ...
+      # subnet_id: ...
+    verifier:
+      controls:
+        - network_interfaces_configuration_script_created
+        - network_interfaces_configured
+        - multiple_network_interfaces_can_ping_gateway

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -15,6 +15,12 @@ verifier:
     - test/recipes
     - test/resources
 
+lifecycle:
+  <% %w(post_create pre_converge pre_destroy).each do |op| %>
+  <%= op %>:
+    - local: bash ./test/recipes/hooks/run.sh <%= op %> $(dirname "$0")
+  <% end %>
+
 # If you need to test a recipe with recipe/resources dependencies,
 # add recipe[aws-parallelcluster::add_dependencies] as first item in the run_list
 # then define a dependencies attribute, listing them with recipe: or resource: prefix.

--- a/test/recipes/hooks/network_interfaces/post_create.sh
+++ b/test/recipes/hooks/network_interfaces/post_create.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "**** post_create"
+
+[[ "${KITCHEN_DRIVER}" = "ec2" ]] || return
+
+echo "** Creating ENI..."
+
+KITCHEN_ENI_ID=$(aws ec2 create-network-interface --region "${KITCHEN_AWS_REGION}" \
+    --description "Kitchen tests ENI for ${KITCHEN_SUITE_NAME} on ${KITCHEN_EC2_INSTANCE_ID}" \
+    --subnet-id "${KITCHEN_SUBNET_ID}" \
+    --groups "${KITCHEN_SECURITY_GROUP_ID}" \
+    --tag-specifications "ResourceType=network-interface,Tags=[{Key=Kitchen, Value=true}]" \
+    --query "NetworkInterface.NetworkInterfaceId" --output text)
+
+echo "** ENI created: ${KITCHEN_ENI_ID}"
+
+aws ec2 attach-network-interface --region "${KITCHEN_AWS_REGION}" \
+    --device-index 1 --instance-id "${KITCHEN_EC2_INSTANCE_ID}" \
+    --network-interface-id "${KITCHEN_ENI_ID}" \
+    --network-card-index 1

--- a/test/recipes/hooks/run.sh
+++ b/test/recipes/hooks/run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+export KITCHEN_HOOK=$1
+export KITCHEN_ROOT_DIR=$2
+
+echo "*** Run ${KITCHEN_HOOK} for suite ${KITCHEN_SUITE_NAME} on host ${KITCHEN_INSTANCE_HOSTNAME}"
+
+THIS_DIR=$(dirname "$0")
+SCRIPT="${THIS_DIR}/${KITCHEN_SUITE_NAME}/${KITCHEN_HOOK}.sh"
+
+if [ -e "${SCRIPT}" ]; then
+  if [ "${KITCHEN_DRIVER}" = "ec2" ]; then
+    echo "*** Retrieve EC2 instance id using key ${KITCHEN_SSH_KEY_PATH}"
+
+    case $KITCHEN_PLATFORM_NAME in
+      alinux*|redhat* ) export KITCHEN_EC2_USER='ec2-user';;
+      centos*         ) export KITCHEN_EC2_USER='centos';;
+      ubuntu*         ) export KITCHEN_EC2_USER='ubuntu';;
+    esac
+
+    KITCHEN_EC2_INSTANCE_ID=$(ssh -o StrictHostKeyChecking=no -i "${KITCHEN_SSH_KEY_PATH}" \
+      "${KITCHEN_EC2_USER}@${KITCHEN_INSTANCE_HOSTNAME}" '
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600") \
+      && curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/instance-id
+    ')
+
+    echo "EC2 instance id: ${KITCHEN_EC2_INSTANCE_ID}"
+
+    export KITCHEN_EC2_INSTANCE_ID
+  fi
+
+  # shellcheck disable=SC1090
+  source "${SCRIPT}"
+
+else
+  echo "*** Hook ${KITCHEN_HOOK} undefined for ${KITCHEN_SUITE_NAME}"
+fi


### PR DESCRIPTION
### Description of changes
* [Enable kitchen lifecycle hooks for recipes](https://github.com/aws/aws-parallelcluster-cookbook/commit/21e8ead3f44b9ac20082f859f47cd88ac8daabe8) 
* [Add multinic tests to kitchen.recipes.yml](https://github.com/aws/aws-parallelcluster-cookbook/commit/06ffa28d37b337a7f9b67264c9dca9c3ae8b69fe)

### Tests
* `network_interfaces` run manually on EC2

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.