### PR TITLE
Fix RedHat8 environment-modules config path and add test

### DIFF
--- a/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
@@ -6,6 +6,7 @@ return unless platform?('redhat') && node['platform_version'].to_i == 8
 default['cluster']['modulefile_dir'] = "/usr/share/Modules/modulefiles"
 # MODULESHOME
 default['cluster']['moduleshome'] = "/usr/share/Modules"
-default['cluster']['modulepath_config_file'] = "#{node['cluster']['moduleshome']}/init/.modulespath"
+default['cluster']['modulesconfig'] = "/etc/environment-modules"
+default['cluster']['modulepath_config_file'] = "#{node['cluster']['modulesconfig']}/modulespath"
 
 default['cluster']['chrony']['service'] = "chronyd"

--- a/cookbooks/aws-parallelcluster-install/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/install.rb
@@ -27,7 +27,7 @@ include_recipe 'aws-parallelcluster-install::base'
 
 # == PLATFORM - FEATURES
 include_recipe "aws-parallelcluster-install::nvidia" unless redhat8? # NVIDIA and CUDA
-include_recipe "aws-parallelcluster-install::intel_mpi" unless virtualized? || redhat8?
+include_recipe "aws-parallelcluster-install::intel_mpi"
 include_recipe "aws-parallelcluster-install::cloudwatch_agent"
 include_recipe "aws-parallelcluster-install::arm_pl" unless redhat8? # ARM Performance Library
 include_recipe "aws-parallelcluster-install::intel_hpc" # Intel HPC libraries

--- a/cookbooks/aws-parallelcluster-install/recipes/intel_mpi.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/intel_mpi.rb
@@ -23,6 +23,12 @@ intelmpi_installer = "l_mpi_oneapi_p_#{node['cluster']['intelmpi']['full_version
 intelmpi_installer_path = "#{node['cluster']['sources_dir']}/#{intelmpi_installer}"
 intelmpi_installer_url = "https://#{node['cluster']['region']}-aws-parallelcluster.s3.#{node['cluster']['region']}.#{aws_domain}/archives/impi/#{intelmpi_installer}"
 
+# Prerequisite for module install
+package %w(environment-modules) do
+  retries 3
+  retry_delay 5
+end
+
 # fetch intelmpi installer script
 remote_file intelmpi_installer_path do
   source intelmpi_installer_url
@@ -43,7 +49,7 @@ bash "install intel mpi" do
   creates intelmpi_installation_path.to_s
 end
 
-append_if_no_line "append intel modules file dir to modules conf" do
+append_if_no_line "append intel modules file dir to modules conf #{node['cluster']['modulepath_config_file']}" do
   path node['cluster']['modulepath_config_file']
   line "#{intelmpi_installation_path}/modulefiles/"
 end

--- a/kitchen.recipes.yml
+++ b/kitchen.recipes.yml
@@ -538,3 +538,14 @@ suites:
         - network_interfaces_configuration_script_created
         - network_interfaces_configured
         - multiple_network_interfaces_can_ping_gateway
+  - name: intel_mpi
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-install::intel_mpi]
+    verifier:
+      controls:
+        - intel_mpi_configured
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - resource:package_repos:update

--- a/kitchen.validate.yml
+++ b/kitchen.validate.yml
@@ -40,7 +40,6 @@ suites:
         - write_common_udev_configuration_files
         - ec2blkdev_service_installation
         - debian_udevd_reload_configuration
-        - package_repos
         - install_packages
         - nfs_installed_with_right_version
         - cron_disabled_selected_daily_and_weekly_jobs
@@ -62,3 +61,4 @@ suites:
         - services_disabled_on_amazon_family
         - services_disabled_on_debian_family
         - stunnel_installed
+        - intel_mpi_configured

--- a/test/recipes/controls/aws_parallelcluster_install/intel_mpi_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/intel_mpi_spec.rb
@@ -1,0 +1,19 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'intel_mpi_configured' do
+  title "intel_mpi should be installed and configured in environment-modules"
+
+  describe bash("unset MODULEPATH && source /etc/profile.d/modules.sh && module load intelmpi && mpirun --help") do
+    its('exit_status') { should eq(0) }
+    its('stdout')      { should match('Version 2021.6') }
+  end
+end


### PR DESCRIPTION
### Description of changes
* Add intel_mpi InSpec test 
* Fix RedHat8 environment-modules config path since the version of environment-modules is 4.x.x while in previous os was 3.x.x

### Tests
* Tested on docker and EC2

### References
* https://modules.readthedocs.io/en/v4.1.4/diff_v3_v4.html

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.