### PR TITLE
Fixes to kitchen tests

### DIFF
--- a/.github/workflows/dokken-unit-tests.yml
+++ b/.github/workflows/dokken-unit-tests.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os:
+        os: &os-list
           - alinux2
           - centos7
           - ubuntu18
           - ubuntu20
-          - redhat8
+          - rhel8
         suite:
           - setup-envars
       fail-fast: false
@@ -36,12 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os:
-          - alinux2
-          - centos7
-          - ubuntu18
-          - ubuntu20
-          - redhat8
+        os: *os-list
         suite:
           - package-repos
           - lustre-installation
@@ -66,12 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os:
-          - alinux2
-          - centos7
-          - ubuntu18
-          - ubuntu20
-          - redhat8
+        os: *os-list
         suite:
           - sudo
           - users
@@ -123,7 +113,7 @@ jobs:
           - centos7
           - ubuntu18
           - ubuntu20
-          - redhat8
+          - rhel8
         suite:
           - fs-update
           - fs-update-default-values
@@ -155,12 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os:
-          - alinux2
-          - centos7
-          - ubuntu18
-          - ubuntu20
-          - redhat8
+        os: *os-list
         suite:
           - install-packages
           - c-states
@@ -193,12 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os:
-          - alinux2
-          - centos7
-          - ubuntu18
-          - ubuntu20
-          - redhat8
+        os: *os-list
         suite:
           - sticky-bits
           - efa-configure-compute

--- a/.github/workflows/dokken-validate.yml
+++ b/.github/workflows/dokken-validate.yml
@@ -16,7 +16,7 @@ jobs:
           - centos7
           - ubuntu18
           - ubuntu20
-          - redhat8
+          - rhel8
         suite:
           - aws-parallelcluster-install
       fail-fast: false

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -217,7 +217,7 @@ end
 ###################
 # EFA - Intel MPI
 ###################
-if node['conditions']['intel_mpi_supported']
+if node['conditions']['intel_mpi_supported'] && !redhat8?
   if node['cluster']['os'] == 'ubuntu1804'
     case node['cluster']['node_type']
     when 'HeadNode'
@@ -235,7 +235,7 @@ if node['conditions']['intel_mpi_supported']
 
   # Test only on head node since on compute nodes we mount an empty /opt/intel drive in kitchen tests that
   # overrides intel binaries.
-  if node['cluster']['node_type'] == 'HeadNode'
+  if node['cluster']['node_type'] == 'HeadNode' && !redhat8?
     bash 'check intel mpi version' do
       cwd Chef::Config[:file_cache_path]
       code <<-INTELMPI

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -52,7 +52,7 @@ platforms:
       cluster:
         base_os: ubuntu2004
         kernel_release: '5.15.0-1028-aws'
-  - name: redhat8
+  - name: rhel8
     driver:
       image: registry.access.redhat.com/ubi8/ubi
       intermediate_instructions:

--- a/kitchen.ec2.sh
+++ b/kitchen.ec2.sh
@@ -69,12 +69,12 @@ then
   source "${THIS_DIR}/.kitchen.env.sh"
 fi
 
-if [ "$1" == "create" ] || [ "$1" == "converge" ] || [ "$1" == "verify" ] || [ "$1" == "destroy" ] || [ "$1" == "test" ]; then
-  : "${KITCHEN_AWS_REGION:=${AWS_DEFAULT_REGION:-eu-west-1}}"
-  : "${KITCHEN_KEY_NAME:=kitchen}"
-  : "${KITCHEN_SSH_KEY_PATH:="~/.ssh/${KITCHEN_KEY_NAME}-${KITCHEN_AWS_REGION}.pem"}"
-  : "${KITCHEN_AVAILABILITY_ZONE:=a}"
+: "${KITCHEN_AWS_REGION:=${AWS_DEFAULT_REGION:-eu-west-1}}"
+: "${KITCHEN_KEY_NAME:=kitchen}"
+: "${KITCHEN_SSH_KEY_PATH:="~/.ssh/${KITCHEN_KEY_NAME}-${KITCHEN_AWS_REGION}.pem"}"
+: "${KITCHEN_AVAILABILITY_ZONE:=a}"
 
+if [ "$1" == "create" ] || [ "$1" == "converge" ] || [ "$1" == "verify" ] || [ "$1" == "destroy" ] || [ "$1" == "test" ]; then
   # Subnet
   if [ -z "${KITCHEN_SUBNET_ID}" ]; then
     echo "** KITCHEN_SUBNET_ID not explicitly set: looking for subnet tagged Kitchen=true"
@@ -120,28 +120,27 @@ if [ "$1" == "create" ] || [ "$1" == "converge" ] || [ "$1" == "verify" ] || [ "
     echo "** KITCHEN_SECURITY_GROUP_ID: ${KITCHEN_SECURITY_GROUP_ID}"
 
   fi
-
-  export KITCHEN_AWS_REGION
-  export KITCHEN_KEY_NAME
-  export KITCHEN_SSH_KEY_PATH
-  export KITCHEN_AVAILABILITY_ZONE
-  export KITCHEN_SUBNET_ID
-  export KITCHEN_VPC_ID
-  export KITCHEN_SECURITY_GROUP_ID
-
-  echo "** KITCHEN_AWS_REGION: ${KITCHEN_AWS_REGION}"
-  echo "** KITCHEN_KEY_NAME: ${KITCHEN_KEY_NAME}"
-  echo "** KITCHEN_SSH_KEY_PATH: ${KITCHEN_SSH_KEY_PATH}"
-  echo "** KITCHEN_AVAILABILITY_ZONE: ${KITCHEN_AVAILABILITY_ZONE}"
-  echo "** KITCHEN_SUBNET_ID: ${KITCHEN_SUBNET_ID}"
-  echo "** KITCHEN_VPC_ID: ${KITCHEN_VPC_ID}"
-  echo "** KITCHEN_SECURITY_GROUP_ID: ${KITCHEN_SECURITY_GROUP_ID}"
-  echo "** KITCHEN_IAM_PROFILE: ${KITCHEN_IAM_PROFILE}"
 fi
 
-echo "export KITCHEN_LOCAL_YAML=$KITCHEN_LOCAL_YAML"
-echo "export KITCHEN_YAML=$KITCHEN_YAML"
-echo "export KITCHEN_GLOBAL_YAML=$KITCHEN_GLOBAL_YAML"
+export KITCHEN_AWS_REGION
+export KITCHEN_KEY_NAME
+export KITCHEN_SSH_KEY_PATH
+export KITCHEN_AVAILABILITY_ZONE
+export KITCHEN_SUBNET_ID
+export KITCHEN_VPC_ID
+export KITCHEN_SECURITY_GROUP_ID
+
+echo "** KITCHEN_AWS_REGION: ${KITCHEN_AWS_REGION}"
+echo "** KITCHEN_KEY_NAME: ${KITCHEN_KEY_NAME}"
+echo "** KITCHEN_SSH_KEY_PATH: ${KITCHEN_SSH_KEY_PATH}"
+echo "** KITCHEN_AVAILABILITY_ZONE: ${KITCHEN_AVAILABILITY_ZONE}"
+echo "** KITCHEN_SUBNET_ID: ${KITCHEN_SUBNET_ID}"
+echo "** KITCHEN_VPC_ID: ${KITCHEN_VPC_ID}"
+echo "** KITCHEN_SECURITY_GROUP_ID: ${KITCHEN_SECURITY_GROUP_ID}"
+echo "** KITCHEN_IAM_PROFILE: ${KITCHEN_IAM_PROFILE}"
+echo "** KITCHEN_LOCAL_YAML: $KITCHEN_LOCAL_YAML"
+echo "** KITCHEN_YAML: $KITCHEN_YAML"
+echo "** KITCHEN_GLOBAL_YAML: $KITCHEN_GLOBAL_YAML"
 echo "kitchen $*"
 
 kitchen "$@"

--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -73,7 +73,7 @@ platforms:
     attributes:
       cluster:
         cluster_user: ec2-user
-  - name: redhat8
+  - name: rhel8
     driver_plugin: ec2
     driver:
       <% if ENV['KITCHEN_REDHAT8_AMI'] %>


### PR DESCRIPTION
### Description of changes
* [Fix logging into EC2 instance](https://github.com/aws/aws-parallelcluster-cookbook/pull/1900/commits/02291ebc08a89f47d24700f7176d8d200dbac4df) 
* [Rename OS used by Kitchen tests from redhat8 to rhel8](https://github.com/aws/aws-parallelcluster-cookbook/pull/1900/commits/875a8db35685894376a008429213d2ab04016332) 
* [Temporarily exclude IntelMPI from kitchen tests](https://github.com/aws/aws-parallelcluster-cookbook/pull/1900/commits/7a502c01d7910caa2eb779b5e3f48cc56944fea0)

### Tests
* Kitchen tests run on Jenkins and locally on EC2

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.