### PR TITLE
Allow awsbatch-related kitchen tests to fetch from s3

### DIFF
--- a/kitchen.jenkins.yml
+++ b/kitchen.jenkins.yml
@@ -145,6 +145,9 @@ suites:
         # base_os is one of the base OSs supported by pcluster
         base_os: <%= ENV['BASE_OS'] %>
         custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
+        cluster_s3_bucket: <%= ENV['CLUSTER_CONFIG_S3_BUCKET'] %>
+        cluster_config_s3_key: <%= ENV['CLUSTER_CONFIG_S3_KEY'] %>
+        instance_types_data_s3_key: <%= ENV['INSTANCE_TYPES_DATA_S3_KEY'] %>
         # os attribute is used in pipeline code. i.e. centos7, centos7-custom
         os: <%= ENV['OS'] %>
         dcv_enabled: 'head_node'


### PR DESCRIPTION
### Description of changes
`awsbatch` kitchen tests didn't fetch cluster config from S3 and didn't require related attributes to be set.
Since we enabled fetching cluster config regardless of the scheduler type, we need to set those attributes also for awsbatch.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.