### PR TITLE
Transform node_attributes to a common recipe

### DIFF
--- a/cookbooks/aws-parallelcluster-common/recipes/node_attributes.rb
+++ b/cookbooks/aws-parallelcluster-common/recipes/node_attributes.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+#
+# Cookbook:: aws-parallelcluster-install
+# Recipe:: node_attributes
+#
 # Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -12,15 +16,8 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-provides :node_attributes
-unified_mode true
-default_action :generate_json
-
-action :generate_json do
-  json_content = Chef::JSONCompat.to_json_pretty(node)
-  file "/etc/chef/node_attributes.json" do
-    content "#{json_content}"
-    owner 'root'
-    mode '0644'
-  end
+file "/etc/chef/node_attributes.json" do
+  content Chef::JSONCompat.to_json_pretty(node)
+  owner 'root'
+  mode '0644'
 end

--- a/cookbooks/aws-parallelcluster-common/spec/unit/recipes/node_attributes_spec.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/unit/recipes/node_attributes_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-common::node_attributes' do
+  context 'Sets up environment variables' do
+    cached(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'ubuntu') do |node|
+        node.override['test']['attr'] = 'attr_value'
+      end.converge(described_recipe)
+    end
+
+    it 'creates file /etc/chef/node_attributes.json with all the node attributes' do
+      is_expected.to render_file('/etc/chef/node_attributes.json')
+        .with_content(/"test": {\s*"attr": "attr_value"\s*}/)
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/install.rb
@@ -20,7 +20,7 @@ validate_os_type
 
 return if node['conditions']['ami_bootstrapped']
 
-node_attributes 'Generate export in json at /etc/chef/node_attributes.json'
+include_recipe "aws-parallelcluster-common::node_attributes"
 
 # == PLATFORM - BASE
 include_recipe 'aws-parallelcluster-install::base'


### PR DESCRIPTION
### Description of changes
`node_attributes` was mistakenly created as a resource. 
We transform it into a recipe and move to `aws-parallelcluster-common` cookbook so that it can be used everywhere.

### Tests
* ChefSpec test
* Used this recipe in Kitchen tests on EC2

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.