### PR TITLE
Avoid interacting with S3 and DDB in kitchen tests

### DIFF
--- a/cookbooks/aws-parallelcluster-common/libraries/cluster_config.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/cluster_config.rb
@@ -1,0 +1,12 @@
+# load cluster configuration file into node object
+def load_cluster_config
+  ruby_block "load cluster configuration" do
+    block do
+      require 'yaml'
+      config = YAML.safe_load(File.read(node['cluster']['cluster_config_path']))
+      Chef::Log.debug("Config read #{config}")
+      node.override['cluster']['config'].merge! config
+    end
+    only_if { node['cluster']['config'].nil? }
+  end
+end

--- a/cookbooks/aws-parallelcluster-common/libraries/kitchen.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/kitchen.rb
@@ -1,0 +1,20 @@
+# Check if recipes are executed during kitchen tests.
+def kitchen_test?
+  node['kitchen']
+end
+
+def kitchen_root_path
+  '/tmp/kitchen'
+end
+
+def kitchen_data_path
+  "#{kitchen_root_path}/data"
+end
+
+def kitchen_cluster_config_path
+  "#{kitchen_data_path}/cluster-config.yml"
+end
+
+def kitchen_instance_types_data_path
+  "#{kitchen_data_path}/instance-types-data.json"
+end

--- a/cookbooks/aws-parallelcluster-config/recipes/head_node_fleet_status.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/head_node_fleet_status.rb
@@ -44,7 +44,7 @@ template "/etc/parallelcluster/clusterstatusmgtd.conf" do
   mode '0644'
 end
 
-unless virtualized?
+unless virtualized? || kitchen_test? && !node['interact_with_ddb']
   execute 'initialize compute fleet status in DynamoDB' do
     # Initialize the status of the compute fleet in the DynamoDB table. Set it to RUNNING.
     command "#{node['cluster']['cookbook_virtualenv_path']}/bin/aws dynamodb put-item --table-name #{node['cluster']['ddb_table']}"\

--- a/cookbooks/aws-parallelcluster-config/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/fetch_config.rb
@@ -51,9 +51,16 @@ action_class do # rubocop:disable Metrics/BlockLength
   end
 
   def fetch_cluster_config(config_path)
-    # Copy cluster config file from S3 URI
-    version_id = node['cluster']['cluster_config_version'] unless node['cluster']['cluster_config_version'].nil?
-    fetch_s3_object("copy_cluster_config_from_s3", node['cluster']['cluster_config_s3_key'], config_path, version_id)
+    if kitchen_test? && !node['interact_with_s3']
+      remote_file "copy fake cluster config" do
+        path node['cluster']['cluster_config_path']
+        source "file://#{kitchen_cluster_config_path}"
+      end
+    else
+      # Copy cluster config file from S3 URI
+      version_id = node['cluster']['cluster_config_version'] unless node['cluster']['cluster_config_version'].nil?
+      fetch_s3_object("copy_cluster_config_from_s3", node['cluster']['cluster_config_s3_key'], config_path, version_id)
+    end
   end
 
   def fetch_change_set
@@ -62,7 +69,14 @@ action_class do # rubocop:disable Metrics/BlockLength
   end
 
   def fetch_instance_type_data
-    # Copy instance type infos file from S3 URI
-    fetch_s3_object("copy_instance_type_data_from_s3", node['cluster']['instance_types_data_s3_key'], node['cluster']['instance_types_data_path'])
+    if kitchen_test? && !node['interact_with_s3']
+      remote_file "copy fake instance type data" do
+        path node['cluster']['instance_types_data_path']
+        source "file://#{kitchen_instance_types_data_path}"
+      end
+    else
+      # Copy instance type infos file from S3 URI
+      fetch_s3_object("copy_instance_type_data_from_s3", node['cluster']['instance_types_data_s3_key'], node['cluster']['instance_types_data_path'])
+    end
   end
 end

--- a/cookbooks/aws-parallelcluster-config/spec/unit/resources/fetch_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-config/spec/unit/resources/fetch_config_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'fetch_config:run' do
+  context "when running from kitchen" do
+    cached(:cluster_config_path) { 'cluster_config_path' }
+    cached(:instance_types_data_path) { 'instance_types_data_path' }
+    cached(:chef_run) do
+      runner = ChefSpec::Runner.new(
+        platform: 'ubuntu', step_into: %w(fetch_config)
+      ) do |node|
+        node.override['kitchen'] = true
+        node.override['cluster']['cluster_config_path'] = cluster_config_path
+        node.override['cluster']['instance_types_data_path'] = instance_types_data_path
+      end
+      runner.converge_dsl do
+        fetch_config 'run' do
+          action :run
+        end
+      end
+    end
+
+    it "copies data from kitchen data dir" do
+      is_expected.to create_remote_file("copy fake cluster config")
+        .with(path: cluster_config_path)
+        .with(source: "file://#{kitchen_cluster_config_path}")
+
+      is_expected.to create_remote_file("copy fake instance type data")
+        .with(path: instance_types_data_path)
+        .with(source: "file://#{kitchen_instance_types_data_path}")
+    end
+  end
+end

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -1,6 +1,16 @@
-# export KITCHEN_GLOBAL_YAML=kitchen.global.yml
+verifier:
+  name: inspec
+  inspec_tests:
+    - test/recipes
+    - test/resources
+  reporter:
+    - cli
+    - junit:.kitchen/inspec/results/%{platform}_%{suite}_inspec.xml
+
 provisioner:
+  data_path: test/data
   attributes:
+    kitchen: true
     cluster:
       # right now tests depend on this parameter: we will try to remove the dependency later
       region: us-east-1

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -294,24 +294,6 @@ def run_command(command)
   Mixlib::ShellOut.new(command).run_command.stdout.strip
 end
 
-# Check if recipes are executed during kitchen tests.
-def kitchen_test?
-  node['kitchen'] == 'true'
-end
-
-# load cluster configuration file into node object
-def load_cluster_config
-  ruby_block "load cluster configuration" do
-    block do
-      require 'yaml'
-      config = YAML.safe_load(File.read(node['cluster']['cluster_config_path']))
-      Chef::Log.debug("Config read #{config}")
-      node.override['cluster']['config'].merge! config
-    end
-    only_if { node['cluster']['config'].nil? }
-  end
-end
-
 def raise_and_write_chef_error(raise_message, chef_error = nil)
   unless chef_error
     chef_error = raise_message

--- a/test/data/cluster-config.yml
+++ b/test/data/cluster-config.yml
@@ -1,0 +1,224 @@
+AdditionalPackages: null
+AdditionalResources: null
+CustomS3Bucket: null
+DeploymentSettings: null
+DevSettings:
+  AmiSearchFilters:
+    Owner: self
+    Tags:
+    - Key: build:parallelcluster:cli_ref
+      Value: 62b28264975b1c030a37a39365a4a2496a110f9c
+    - Key: build:parallelcluster:cookbook_ref
+      Value: 949511d1b5689d7964619dfceafc8ea45a1c5b85
+    - Key: build:parallelcluster:node_ref
+      Value: 18cc9113b8ea8b2b185d3c5188e78e8a616a720c
+    - Key: parallelcluster:build_status
+      Value: available
+  AwsBatchCliPackage: https://github.com/aws/aws-parallelcluster/tarball/62b28264975b1c030a37a39365a4a2496a110f9c
+  ClusterTemplate: null
+  Cookbook: null
+  InstanceTypesData: '{"hpc5a.48xlarge": {"InstanceType": "hpc5a.48xlarge", "CurrentGeneration":
+    true, "FreeTierEligible": false, "SupportedUsageClasses": ["on-demand", "spot"],
+    "SupportedRootDeviceTypes": ["ebs"], "SupportedVirtualizationTypes": ["hvm"],
+    "BareMetal": true, "ProcessorInfo": {"SupportedArchitectures": ["x86_64"], "SustainedClockSpeedInGhz":
+    3.6}, "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 96, "DefaultThreadsPerCore":
+    1}, "MemoryInfo": {"SizeInMiB": 196608}, "InstanceStorageSupported": false, "EbsInfo":
+    {"EbsOptimizedSupport": "default", "EncryptionSupport": "supported", "EbsOptimizedInfo":
+    {"BaselineBandwidthInMbps": 19000, "BaselineThroughputInMBps": 2375, "BaselineIops":
+    80000, "MaximumBandwidthInMbps": 19000, "MaximumThroughputInMBps": 2375, "MaximumIops":
+    80000}, "NvmeSupport": "unsupported"}, "NetworkInfo": {"NetworkPerformance": "25
+    Gigabit", "MaximumNetworkInterfaces": 15, "MaximumNetworkCards": 1, "DefaultNetworkCardIndex":
+    0, "NetworkCards": [{"NetworkCardIndex": 0, "NetworkPerformance": "25 Gigabit",
+    "MaximumNetworkInterfaces": 15}], "Ipv4AddressesPerInterface": 50, "Ipv6AddressesPerInterface":
+    50, "Ipv6Supported": true, "EnaSupport": "required", "EfaSupported": true}, "PlacementGroupInfo":
+    {"SupportedStrategies": ["cluster", "partition", "spread"]}, "HibernationSupported":
+    false, "BurstablePerformanceSupported": false, "DedicatedHostsSupported": false,
+    "AutoRecoverySupported": true}}'
+  NodePackage: null
+  Timeouts: null
+DirectoryService:
+  AdditionalSssdConfigs:
+    debug_level: '0x1ff'
+    ldap_auth_disable_tls_never_use_in_production: true
+  DomainAddr: ldap://192.168.97.191,ldap://192.168.67.176
+  DomainName: dc=microsoftad,dc=tktu9z82ms,dc=multiuser,dc=pcluster
+  DomainReadOnlyUser: CN=Admin,OU=Users,OU=NET,dc=microsoftad,dc=tktu9z82ms,dc=multiuser,dc=pcluster
+  GenerateSshKeysForUsers: false
+  LdapAccessFilter: null
+  LdapTlsCaCert: /opt/parallelcluster/shared/directory_service/certificate.crt
+  LdapTlsReqCert: never
+  PasswordSecretArn: arn:aws:secretsmanager:eu-west-1:447714826191:secret:integ-tests-secret-7sdy4zrosllo2g55-3-5-UMCQ1y
+HeadNode:
+  CustomActions: null
+  Dcv: null
+  DisableSimultaneousMultithreading: false
+  Iam:
+    AdditionalIamPolicies: []
+    InstanceProfile: null
+    InstanceRole: null
+    S3Access: null
+  Image: null
+  Imds:
+    Secured: true
+  InstanceType: c5.xlarge
+  LocalStorage:
+    EphemeralVolume: null
+    RootVolume:
+      DeleteOnTermination: true
+      Encrypted: true
+      Iops: 3000
+      Size: null
+      Throughput: 125
+      VolumeType: gp3
+  Networking:
+    AdditionalSecurityGroups: null
+    ElasticIp: null
+    Proxy: null
+    SecurityGroups: null
+    SubnetId: subnet-0b9ff5f2b4b2cdd7d
+  Ssh:
+    AllowedIps: 52.23.87.55/32
+    KeyName: cfncluster-jenkins-kitchen
+Iam: null
+Image:
+  CustomAmi: null
+  Os: centos7
+Imds:
+  ImdsSupport: v2.0
+Monitoring:
+  Dashboards:
+    CloudWatch:
+      Enabled: true
+  DetailedMonitoring: false
+  Logs:
+    CloudWatch:
+      DeletionPolicy: Retain
+      Enabled: true
+      RetentionInDays: 14
+Region: null
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - AllocationStrategy: lowest-price
+    CapacityReservationTarget: null
+    CapacityType: ONDEMAND
+    ComputeResources:
+    - CapacityReservationTarget: null
+      DisableSimultaneousMultithreading: false
+      Efa:
+        Enabled: false
+        GdrSupport: false
+      Instances:
+      - InstanceType: c5.xlarge
+      MaxCount: 150
+      MinCount: 2
+      Name: cit
+      Networking:
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
+      SchedulableMemory: null
+      SpotPrice: null
+    ComputeSettings:
+      LocalStorage:
+        EphemeralVolume: null
+        RootVolume:
+          Encrypted: true
+          Iops: 3000
+          Size: null
+          Throughput: 125
+          VolumeType: gp3
+    CustomActions: null
+    Iam:
+      AdditionalIamPolicies: []
+      InstanceProfile: null
+      InstanceRole: null
+      S3Access: null
+    Image: null
+    Name: compute
+    Networking:
+      AdditionalSecurityGroups: null
+      AssignPublicIp: null
+      PlacementGroup:
+        Enabled: null
+        Id: null
+        Name: null
+      Proxy: null
+      SecurityGroups: null
+      SubnetIds:
+      - subnet-0b2931f781f5b472e
+  SlurmSettings:
+    Database: null
+    Dns:
+      DisableManagedDns: false
+      HostedZoneId: null
+      UseEc2Hostnames: false
+    EnableMemoryBasedScheduling: false
+    QueueUpdateStrategy: COMPUTE_FLEET_STOP
+    ScaledownIdletime: 10
+SharedStorage:
+- FsxLustreSettings:
+    AutoImportPolicy: null
+    AutomaticBackupRetentionDays: null
+    BackupId: null
+    CopyTagsToBackups: null
+    DailyAutomaticBackupStartTime: null
+    DataCompressionType: null
+    DeletionPolicy: Delete
+    DeploymentType: SCRATCH_2
+    DriveCacheType: null
+    ExportPath: null
+    FileSystemId: null
+    ImportPath: null
+    ImportedFileChunkSize: null
+    KmsKeyId: null
+    PerUnitStorageThroughput: null
+    StorageCapacity: 2400
+    StorageType: null
+    WeeklyMaintenanceStartTime: null
+  MountDir: /shared
+  Name: fsx
+  StorageType: FsxLustre
+- EbsSettings:
+    DeletionPolicy: Delete
+    Encrypted: true
+    Iops: 3000
+    KmsKeyId: null
+    Raid: null
+    Size: 35
+    SnapshotId: null
+    Throughput: 125
+    VolumeId: null
+    VolumeType: gp3
+  MountDir: /ebs
+  Name: ebs
+  StorageType: Ebs
+- EfsSettings:
+    DeletionPolicy: Delete
+    Encrypted: false
+    EncryptionInTransit: false
+    FileSystemId: null
+    IamAuthorization: false
+    KmsKeyId: null
+    PerformanceMode: generalPurpose
+    ProvisionedThroughput: null
+    ThroughputMode: bursting
+  MountDir: /efs
+  Name: efs
+  StorageType: Efs
+- FsxOpenZfsSettings:
+    VolumeId: fsvol-07d03c5b85160c539
+  MountDir: /fsxopenzfs
+  Name: existingopenzfs
+  StorageType: FsxOpenZfs
+- FsxOntapSettings:
+    VolumeId: fsvol-082fa3427bda94724
+  MountDir: /fsxontap
+  Name: existingontap
+  StorageType: FsxOntap
+Tags:
+- Key: parallelcluster:cluster-name
+  Value: integ-tests-nn5bsd0ei1rrvm0j-3-5
+- Key: parallelcluster:version
+  Value: 3.5.1

--- a/test/data/instance-types-data.json
+++ b/test/data/instance-types-data.json
@@ -1,0 +1,256 @@
+{
+  "c5.xlarge": {
+    "InstanceType": "c5.xlarge",
+    "CurrentGeneration": true,
+    "FreeTierEligible": false,
+    "SupportedUsageClasses": [
+      "spot",
+      "ondemand"
+    ],
+    "SupportedRootDeviceTypes": [
+      "ebs"
+    ],
+    "SupportedVirtualizationTypes": [
+      "hvm"
+    ],
+    "BareMetal": false,
+    "Hypervisor": "nitro",
+    "ProcessorInfo": {
+      "SupportedArchitectures": [
+        "x86_64"
+      ],
+      "SustainedClockSpeedInGhz": 3.4
+    },
+    "VCpuInfo": {
+      "DefaultVCpus": 4,
+      "DefaultCores": 2,
+      "DefaultThreadsPerCore": 2,
+      "ValidCores": [
+        2
+      ],
+      "ValidThreadsPerCore": [
+        1,
+        2
+      ]
+    },
+    "MemoryInfo": {
+      "SizeInMiB": 8192
+    },
+    "InstanceStorageSupported": false,
+    "EbsInfo": {
+      "EbsOptimizedSupport": "default",
+      "EncryptionSupport": "supported",
+      "EbsOptimizedInfo": {
+        "BaselineBandwidthInMbps": 1150,
+        "BaselineThroughputInMBps": 143.75,
+        "BaselineIops": 6000,
+        "MaximumBandwidthInMbps": 4750,
+        "MaximumThroughputInMBps": 593.75,
+        "MaximumIops": 20000
+      },
+      "NvmeSupport": "unsupported"
+    },
+    "NetworkInfo": {
+      "NetworkPerformance": "Up to 10 Gigabit",
+      "MaximumNetworkInterfaces": 4,
+      "MaximumNetworkCards": 1,
+      "DefaultNetworkCardIndex": 0,
+      "NetworkCards": [
+        {
+          "NetworkCardIndex": 0,
+          "NetworkPerformance": "Up to 10 Gigabit",
+          "MaximumNetworkInterfaces": 4
+        }
+      ],
+      "Ipv4AddressesPerInterface": 15,
+      "Ipv6AddressesPerInterface": 15,
+      "Ipv6Supported": true,
+      "EnaSupport": "required",
+      "EfaSupported": false
+    },
+    "PlacementGroupInfo": {
+      "SupportedStrategies": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
+    },
+    "HibernationSupported": true,
+    "BurstablePerformanceSupported": false,
+    "DedicatedHostsSupported": true,
+    "AutoRecoverySupported": true,
+    "SupportedBootModes": [
+      "uefi",
+      "legacy-bios"
+    ]
+  },
+  "c4.xlarge": {
+    "InstanceType": "c4.xlarge",
+    "CurrentGeneration": true,
+    "FreeTierEligible": false,
+    "SupportedUsageClasses": [
+      "on-demand",
+      "spot"
+    ],
+    "SupportedRootDeviceTypes": [
+      "ebs"
+    ],
+    "SupportedVirtualizationTypes": [
+      "hvm"
+    ],
+    "BareMetal": false,
+    "Hypervisor": "xen",
+    "ProcessorInfo": {
+      "SupportedArchitectures": [
+        "x86_64"
+      ],
+      "SustainedClockSpeedInGhz": 2.9
+    },
+    "VCpuInfo": {
+      "DefaultVCpus": 4,
+      "DefaultCores": 2,
+      "DefaultThreadsPerCore": 2,
+      "ValidCores": [
+        1,
+        2
+      ],
+      "ValidThreadsPerCore": [
+        1,
+        2
+      ]
+    },
+    "MemoryInfo": {
+      "SizeInMiB": 7680
+    },
+    "InstanceStorageSupported": false,
+    "EbsInfo": {
+      "EbsOptimizedSupport": "default",
+      "EncryptionSupport": "supported",
+      "EbsOptimizedInfo": {
+        "BaselineBandwidthInMbps": 750,
+        "BaselineThroughputInMBps": 93.75,
+        "BaselineIops": 6000,
+        "MaximumBandwidthInMbps": 750,
+        "MaximumThroughputInMBps": 93.75,
+        "MaximumIops": 6000
+      },
+      "NvmeSupport": "unsupported"
+    },
+    "NetworkInfo": {
+      "NetworkPerformance": "High",
+      "MaximumNetworkInterfaces": 4,
+      "MaximumNetworkCards": 1,
+      "DefaultNetworkCardIndex": 0,
+      "NetworkCards": [
+        {
+          "NetworkCardIndex": 0,
+          "NetworkPerformance": "High",
+          "MaximumNetworkInterfaces": 4
+        }
+      ],
+      "Ipv4AddressesPerInterface": 15,
+      "Ipv6AddressesPerInterface": 15,
+      "Ipv6Supported": true,
+      "EnaSupport": "unsupported",
+      "EfaSupported": false
+    },
+    "PlacementGroupInfo": {
+      "SupportedStrategies": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
+    },
+    "HibernationSupported": true,
+    "BurstablePerformanceSupported": false,
+    "DedicatedHostsSupported": true,
+    "AutoRecoverySupported": true
+  },
+  "c5a.xlarge": {
+    "InstanceType": "c5a.xlarge",
+    "CurrentGeneration": true,
+    "FreeTierEligible": false,
+    "SupportedUsageClasses": [
+      "on-demand",
+      "spot"
+    ],
+    "SupportedRootDeviceTypes": [
+      "ebs"
+    ],
+    "SupportedVirtualizationTypes": [
+      "hvm"
+    ],
+    "BareMetal": false,
+    "Hypervisor": "nitro",
+    "ProcessorInfo": {
+      "SupportedArchitectures": [
+        "x86_64"
+      ],
+      "SustainedClockSpeedInGhz": 3.3
+    },
+    "VCpuInfo": {
+      "DefaultVCpus": 4,
+      "DefaultCores": 2,
+      "DefaultThreadsPerCore": 2,
+      "ValidCores": [
+        1,
+        2
+      ],
+      "ValidThreadsPerCore": [
+        1,
+        2
+      ]
+    },
+    "MemoryInfo": {
+      "SizeInMiB": 8192
+    },
+    "InstanceStorageSupported": false,
+    "EbsInfo": {
+      "EbsOptimizedSupport": "default",
+      "EncryptionSupport": "supported",
+      "EbsOptimizedInfo": {
+        "BaselineBandwidthInMbps": 400,
+        "BaselineThroughputInMBps": 50.0,
+        "BaselineIops": 1600,
+        "MaximumBandwidthInMbps": 3170,
+        "MaximumThroughputInMBps": 396.25,
+        "MaximumIops": 13300
+      },
+      "NvmeSupport": "required"
+    },
+    "NetworkInfo": {
+      "NetworkPerformance": "Up to 10 Gigabit",
+      "MaximumNetworkInterfaces": 4,
+      "MaximumNetworkCards": 1,
+      "DefaultNetworkCardIndex": 0,
+      "NetworkCards": [
+        {
+          "NetworkCardIndex": 0,
+          "NetworkPerformance": "Up to 10 Gigabit",
+          "MaximumNetworkInterfaces": 4
+        }
+      ],
+      "Ipv4AddressesPerInterface": 15,
+      "Ipv6AddressesPerInterface": 15,
+      "Ipv6Supported": true,
+      "EnaSupport": "required",
+      "EfaSupported": false,
+      "EncryptionInTransitSupported": true
+    },
+    "PlacementGroupInfo": {
+      "SupportedStrategies": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
+    },
+    "HibernationSupported": false,
+    "BurstablePerformanceSupported": false,
+    "DedicatedHostsSupported": false,
+    "AutoRecoverySupported": true,
+    "SupportedBootModes": [
+      "legacy-bios",
+      "uefi"
+    ]
+  }
+}


### PR DESCRIPTION
### Description of changes
By default, when kitchen testing, `cluster-config.yml` and `instance-types-data.json` will be loaded from kitchen data path.
To force reading from S3, set `interact_with_s3 attribute` to `true`.

Also, by default writing on DynamoDB will be skipped when running Kitchen tests. To force writing to DynamoDB, set `interact_with_ddb attribute` to `true`.

### Tests
* ChefSpec test
* Manually tested on EC2

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.