### PR TITLE
Don't look for VPC_ID if already defined

### DIFF
--- a/kitchen.ec2.sh
+++ b/kitchen.ec2.sh
@@ -93,11 +93,15 @@ if [ "$1" == "create" ] || [ "$1" == "converge" ] || [ "$1" == "verify" ] || [ "
   fi
 
   # VPC
-  KITCHEN_VPC_ID=$(aws ec2 describe-subnets --region "${KITCHEN_AWS_REGION}" \
-      --subnet-ids "${KITCHEN_SUBNET_ID}" \
-      --query 'Subnets[0].VpcId' --output text)
+  if [ -z "${KITCHEN_VPC_ID}" ]; then
+    echo "** KITCHEN_VPC_ID not explicitly set: deriving from subnet"
 
-  echo "** KITCHEN_VPC_ID: ${KITCHEN_VPC_ID}"
+    KITCHEN_VPC_ID=$(aws ec2 describe-subnets --region "${KITCHEN_AWS_REGION}" \
+        --subnet-ids "${KITCHEN_SUBNET_ID}" \
+        --query 'Subnets[0].VpcId' --output text)
+
+    echo "** KITCHEN_VPC_ID: ${KITCHEN_VPC_ID}"
+  fi
 
   # Security Group
   if [ -z "${KITCHEN_SECURITY_GROUP_ID}" ]; then


### PR DESCRIPTION
### Description of changes
When launching kitchen tests, avoid inferring VPC_ID from the subnet if VPC_ID variable is already set.

### Tests
* Tested manually

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.