### PR TITLE
Enable check intel mpi version for redhat8

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -234,7 +234,7 @@ if node['conditions']['intel_mpi_supported'] && !redhat8?
 
   # Test only on head node since on compute nodes we mount an empty /opt/intel drive in kitchen tests that
   # overrides intel binaries.
-  if node['cluster']['node_type'] == 'HeadNode' && !redhat8?
+  if node['cluster']['node_type'] == 'HeadNode'
     bash 'check intel mpi version' do
       cwd Chef::Config[:file_cache_path]
       code <<-INTELMPI


### PR DESCRIPTION
### Description of changes
* Enable check intel mpi version for redhat8

### Tests
* On my personal Jenkins 

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.