### PR TITLE
Unmount home dir from compute node before kitchen verify

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -567,3 +567,11 @@ if node['kernel']['machine'] == 'x86_64'
     command 'test "$(cat /sys/module/intel_idle/parameters/max_cstate)" = "1"'
   end
 end
+
+execute 'unmount /home' do
+  command "umount -fl /home"
+  retries 10
+  retry_delay 6
+  timeout 60
+  only_if { node['cluster']['node_type'] == 'ComputeFleet' }
+end


### PR DESCRIPTION
### Description of changes
* Unmount home dir from compute node before `kitchen verify`

Mounting home dir on the compute node changes the authentication key and prevents Kitchen
from connecting to the node.

### Tests
* Tested on Jenkins

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.