### PR TITLE
Rename t:config to tag:config

### DIFF
--- a/cookbooks/aws-parallelcluster-common/test/recipes/controls/setup_envars_spec.rb
+++ b/cookbooks/aws-parallelcluster-common/test/recipes/controls/setup_envars_spec.rb
@@ -12,7 +12,7 @@
 # directories = %w(/usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin /opt/aws/bin)
 directories = %w(/usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin)
 
-control 't:config_system_path_contains_required_directories' do
+control 'tag:config_system_path_contains_required_directories' do
   title 'System path contains required directories'
 
   describe file('/etc/profile.d/path.sh') do
@@ -31,7 +31,7 @@ control 't:config_system_path_contains_required_directories' do
   end
 end
 
-control "t:config_paths_for_notable_users_contain_required_directories" do
+control "tag:config_paths_for_notable_users_contain_required_directories" do
   title "Path for notable users contain required directories"
 
   %W(root #{node['cluster']['cluster_admin_user']} #{node['cluster']['slurm']['user']}).each do |user|

--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -2,7 +2,7 @@
 ---
 verifier:
   controls:
-    - /t:config/
+    - /tag:config/
 
 _common_cluster_attributes: &_common_cluster_attributes
   stack_name: <%= ENV['AWS_STACK_NAME'] || 'fake_stack' %>

--- a/test/recipes/controls/aws_parallelcluster_config/dcv_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/dcv_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 't:config_dcv_external_authenticator_user_and_group_correctly_defined' do
+control 'tag:config_dcv_external_authenticator_user_and_group_correctly_defined' do
   only_if { node['conditions']['dcv_supported'] }
 
   describe user(node['cluster']['dcv']['authenticator']['user']) do

--- a/test/recipes/controls/aws_parallelcluster_install/users_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/users_spec.rb
@@ -20,7 +20,7 @@ control 'ulimit_configured' do
   end
 end
 
-control 't:config_admin_user_and_group_correctly_defined' do
+control 'tag:config_admin_user_and_group_correctly_defined' do
   describe user(node['cluster']['cluster_admin_user']) do
     it { should exist }
     its('uid') { should eq node['cluster']['cluster_admin_user_id'] }

--- a/test/recipes/controls/aws_parallelcluster_slurm/slurm_users_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/slurm_users_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 't:config_slurm_plugin_permissions_correctly_defined_on_head_node' do
+control 'tag:config_slurm_plugin_permissions_correctly_defined_on_head_node' do
   only_if { instance.head_node? && node['cluster']['scheduler'] == 'slurm' }
 
   describe file("#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin") do
@@ -20,7 +20,7 @@ control 't:config_slurm_plugin_permissions_correctly_defined_on_head_node' do
   end
 end
 
-control 't:config_slurm_user_and_group_correctly_defined' do
+control 'tag:config_slurm_user_and_group_correctly_defined' do
   only_if { node['cluster']['scheduler'] == 'slurm' }
 
   describe user(node['cluster']['slurm']['user']) do
@@ -36,7 +36,7 @@ control 't:config_slurm_user_and_group_correctly_defined' do
   end
 end
 
-control 't:config_munge_user_and_group_correctly_defined' do
+control 'tag:config_munge_user_and_group_correctly_defined' do
   only_if { node['cluster']['scheduler'] == 'slurm' }
 
   describe user(node['cluster']['munge']['user']) do
@@ -53,7 +53,7 @@ control 't:config_munge_user_and_group_correctly_defined' do
   end
 end
 
-control 't:config_slurm_sudoers_correctly_defined' do
+control 'tag:config_slurm_sudoers_correctly_defined' do
   only_if { node['cluster']['scheduler'] == 'slurm' }
 
   install_dir = node['cluster']['slurm']['install_dir']


### PR DESCRIPTION
### Description of changes
We use tags to identify all the controls to run in a context. 
We agreed that `tag:tagname` is clearer than `t:tagname`, and we are willing to sacrifice shortness in favor of clarity.

### Tests
* Tested on Jenkins

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.