### PR TITLE
Move chrony tests from tests.rb recipe to InSpec

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -125,38 +125,6 @@ if node['cluster']['scheduler'] == 'plugin'
 end
 
 ###################
-# Amazon Time Sync
-###################
-get_chrony_status_command = "systemctl show -p SubState #{node['cluster']['chrony']['service']}"
-# $ systemctl show -p SubState <service>
-# SubState=Running
-
-chrony_check_command = "#{get_chrony_status_command} | grep -i running"
-
-ruby_block 'log_chrony_status' do
-  block do
-    get_chrony_service_log_command = "journalctl -u #{node['cluster']['chrony']['service']}"
-    chrony_log = shell_out!(get_chrony_service_log_command).stdout
-    Chef::Log.debug("chrony service log: #{chrony_log}")
-    chrony_status = shell_out!(get_chrony_status_command).stdout
-    Chef::Log.debug("chrony status is #{chrony_status}")
-  end
-end
-
-execute 'check chrony running' do
-  command chrony_check_command
-end
-
-execute 'check chrony service is enabled' do
-  command "systemctl is-enabled #{node['cluster']['chrony']['service']}"
-end
-
-execute 'check chrony conf' do
-  command "chronyc waitsync 30; chronyc tracking | grep -i reference | grep 169.254.169.123"
-  user node['cluster']['cluster_user']
-end
-
-###################
 # DCV
 ###################
 if node['cluster']['node_type'] == "HeadNode" &&

--- a/test/recipes/controls/aws_parallelcluster_config/chrony_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/chrony_spec.rb
@@ -9,12 +9,12 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'chrony_configured' do
+control 'tag:config_chrony_service_configured' do
   title 'Check that chrony is correctly configured'
 
   only_if { !os_properties.virtualized? }
 
-  chrony_service = os_properties.debian_family? ? 'chrony' : 'chronyd'
+  chrony_service = node['cluster']['chrony']['service']
 
   describe service(chrony_service) do
     it { should be_installed }
@@ -24,5 +24,13 @@ control 'chrony_configured' do
 
   describe bash("systemctl show #{chrony_service} | grep 'Restart=no'") do
     its('exit_status') { should eq(0) }
+  end
+
+  describe bash("journalctl -u #{chrony_service}") do
+    its('exit_status') { should eq 0 }
+  end
+
+  describe bash("sudo -u #{node['cluster']['cluster_user']} chronyc waitsync 30; chronyc tracking | grep -i reference | grep 169.254.169.123") do
+    its('exit_status') { should eq 0 }
   end
 end


### PR DESCRIPTION
### Description of changes
Move chrony tests from tests.rb recipe to InSpec

Remove them from aws-parallelcluster-test cookbook, add missing tests to
InSpec controls and add tag:config to control names in order to pick them
during final instance validation.

### Tests
* Tested on Jenkins

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.