### PR TITLE
Move intel mpi tests from tests.rb recipe to InSpec

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -72,7 +72,6 @@ default['cluster']['intelpython3']['version'] = '2020.2-902'
 default['cluster']['intelmpi']['version'] = '2021.6.0'
 default['cluster']['intelmpi']['full_version'] = "#{node['cluster']['intelmpi']['version']}.602"
 default['cluster']['intelmpi']['modulefile'] = "/opt/intel/mpi/#{node['cluster']['intelmpi']['version']}/modulefiles/mpi"
-default['cluster']['intelmpi']['kitchen_test_string'] = 'Version 2021.6'
 default['cluster']['intelmpi']['qt_version'] = '5.15.2'
 
 # Arm Performance Library

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -83,44 +83,6 @@ elsif node['conditions']['ami_bootstrapped']
 end
 
 ###################
-# EFA - Intel MPI
-###################
-if node['conditions']['intel_mpi_supported'] && !redhat8?
-  if node['cluster']['os'] == 'ubuntu1804'
-    case node['cluster']['node_type']
-    when 'HeadNode'
-      execute 'check ptrace protection enabled' do
-        command "sysctl kernel.yama.ptrace_scope | grep 'kernel.yama.ptrace_scope = 1'"
-        user node['cluster']['cluster_user']
-      end
-    when 'ComputeFleet'
-      execute 'check ptrace protection disabled' do
-        command "sysctl kernel.yama.ptrace_scope | grep 'kernel.yama.ptrace_scope = 0'"
-        user node['cluster']['cluster_user']
-      end
-    end
-  end
-
-  # Test only on head node since on compute nodes we mount an empty /opt/intel drive in kitchen tests that
-  # overrides intel binaries.
-  if node['cluster']['node_type'] == 'HeadNode' && !redhat8?
-    bash 'check intel mpi version' do
-      cwd Chef::Config[:file_cache_path]
-      code <<-INTELMPI
-        set -e
-        # Initialize module
-        # Unset MODULEPATH to force search path reinitialization when loading profile
-        unset MODULEPATH
-        # Must execute this in a bash script because source is a bash built-in function
-        source /etc/profile.d/modules.sh
-        module load intelmpi && mpirun --help | grep '#{node['cluster']['intelmpi']['kitchen_test_string']}'
-      INTELMPI
-      user node['cluster']['cluster_user']
-    end
-  end
-end
-
-###################
 # jq
 ###################
 unless node['cluster']['os'].end_with?("-custom")

--- a/kitchen.recipes-install.yml
+++ b/kitchen.recipes-install.yml
@@ -277,7 +277,7 @@ suites:
       - recipe[aws-parallelcluster-install::intel_mpi]
     verifier:
       controls:
-        - intel_mpi_installed
+        - /intel_mpi_installed/
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-install::directories

--- a/kitchen.validate-install.yml
+++ b/kitchen.validate-install.yml
@@ -61,4 +61,4 @@ suites:
         - services_disabled_on_amazon_family
         - services_disabled_on_debian_family
         - stunnel_installed
-        - intel_mpi_installed
+        - /intel_mpi_installed/

--- a/test/recipes/controls/aws_parallelcluster_install/intel_mpi_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/intel_mpi_spec.rb
@@ -9,11 +9,25 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'intel_mpi_installed' do
+control 'tag:config_intel_mpi_installed' do
   title "intel_mpi should be installed with the corresponding environment-modules"
+
+  # Test only on head node since on compute nodes we mount an empty /opt/intel drive in kitchen tests that
+  # overrides intel binaries.
+  only_if { instance.head_node? }
 
   describe bash("unset MODULEPATH && source /etc/profile.d/modules.sh && module load intelmpi && mpirun --help") do
     its('exit_status') { should eq(0) }
     its('stdout')      { should match('Version 2021.6') }
+  end
+end
+
+control 'tag:config_intel_mpi_ptrace_protection_configured_on_ubuntu1804' do
+  only_if { node['conditions']['intel_mpi_supported'] && os_properties.ubuntu1804? }
+
+  ptrace_scope = instance.head_node? ? 1 : 0
+  describe 'check ptrace protection enabled' do
+    subject { bash("sudo -u #{node['cluster']['cluster_user']} sysctl kernel.yama.ptrace_scope") }
+    its('stdout') { should match /kernel.yama.ptrace_scope = #{ptrace_scope}/ }
   end
 end


### PR DESCRIPTION
### Description of changes
**Move intel mpi tests from tests.rb recipe to InSpec**
Remove them from aws-parallelcluster-test cookbook, add missing tests to
InSpec controls and add tag:config to control names in order to pick them
during final instance validation.

### Tests
* Tested on Jenkins

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.