### PR TITLE
Move ulimit test from tests.rb recipe to InSpec

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -115,16 +115,6 @@ if platform?('centos')
 end
 
 ###################
-# ulimit
-###################
-unless node['cluster']['os'].end_with?("-custom")
-  bash 'test soft ulimit nofile' do
-    code "if (($(ulimit -Sn) < 8192)); then exit 1; fi"
-    user node['cluster']['cluster_user']
-  end
-end
-
-###################
 # instance store
 ###################
 

--- a/test/recipes/controls/aws_parallelcluster_install/users_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/users_spec.rb
@@ -33,3 +33,11 @@ control 'tag:config_admin_user_and_group_correctly_defined' do
     its('gid') { should eq node['cluster']['cluster_admin_group_id'] }
   end
 end
+
+control 'tag:config_ulimit_is_not_lower_than_8192' do
+  only_if { !instance.custom_ami? }
+
+  describe bash("ulimit -Sn") do
+    its('stdout') { should cmp >= '8192' }
+  end
+end


### PR DESCRIPTION
### Description of changes
**Move ulimit test from tests.rb recipe to InSpec**
Remove them from aws-parallelcluster-test cookbook, add missing tests to
InSpec controls and add tag:config to control names in order to pick them
during final instance validation.

### Tests
* Tested on Jenkins

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.