### PR TITLE
Move tests for disabled services from tests.rb recipe to InSpec

### DIFF
--- a/cookbooks/aws-parallelcluster-test/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-test/libraries/helpers.rb
@@ -201,17 +201,6 @@ def check_run_level_script(script_name, levels_on, levels_off)
   end
 end
 
-#
-# Check if a service is disabled
-#
-def is_service_disabled(service, platform_families = node['platform_family'])
-  if platform_family?(platform_families)
-    execute "check #{service} service is disabled" do
-      command "systemctl is-enabled #{service} && exit 1 || exit 0"
-    end
-  end
-end
-
 def validate_package_source(package, expected_source)
   case node['platform']
   when 'amazon', 'centos'

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -296,16 +296,6 @@ unless node['cluster']['base_os'] == 'centos7'
 end
 
 ###################
-# Verify that aws-ubuntu-eni-helper service is disabled
-###################
-is_service_disabled('aws-ubuntu-eni-helper', 'debian')
-
-###################
-# Verify that log4j-cve-2021-44228-hotpatch service is disabled
-###################
-is_service_disabled('log4j-cve-2021-44228-hotpatch', 'amazon')
-
-###################
 # clusterstatusmgtd
 ###################
 if node['cluster']['node_type'] == 'HeadNode' && node['cluster']['scheduler'] != 'awsbatch'

--- a/kitchen.recipes-install.yml
+++ b/kitchen.recipes-install.yml
@@ -211,8 +211,8 @@ suites:
       - recipe[aws-parallelcluster-install::disable_services]
     verifier:
       controls:
-        - services_disabled_on_debian_family
-        - services_disabled_on_amazon_family
+        - /services_disabled_on_debian_family/
+        - /services_disabled_on_amazon_family/
   - name: license_readme
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]

--- a/kitchen.validate-install.yml
+++ b/kitchen.validate-install.yml
@@ -58,7 +58,7 @@ suites:
         - mysql_client_installed
         - mysql_client_source_node_created
         - node_attributes_created
-        - services_disabled_on_amazon_family
-        - services_disabled_on_debian_family
+        - /services_disabled_on_amazon_family/
+        - /services_disabled_on_debian_family/
         - stunnel_installed
         - /intel_mpi_installed/

--- a/test/recipes/controls/aws_parallelcluster_install/disable_services_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/disable_services_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'services_disabled_on_debian_family' do
+control 'tag:config_services_disabled_on_debian_family' do
   title 'Test that DLAMI multi eni helper is disabled and masked on debian family'
 
   only_if { os_properties.debian_family? && !os_properties.virtualized? }
@@ -21,11 +21,11 @@ control 'services_disabled_on_debian_family' do
 
   describe bash('systemctl list-unit-files --state=masked --no-legend') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match /aws-ubuntu-eni-helper.service masked/ }
+    its(:stdout) { should match /aws-ubuntu-eni-helper.service\s*masked/ }
   end
 end
 
-control 'services_disabled_on_amazon_family' do
+control 'tag:config_services_disabled_on_amazon_family' do
   title 'Test that log4j-cve-2021-44228-hotpatch is disabled and masked on amazon family'
 
   only_if { os_properties.amazon_family? && !os_properties.virtualized? }
@@ -37,6 +37,6 @@ control 'services_disabled_on_amazon_family' do
 
   describe bash('systemctl list-unit-files --state=masked --no-legend') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match /log4j-cve-2021-44228-hotpatch.service masked/ }
+    its(:stdout) { should match /log4j-cve-2021-44228-hotpatch.service\s*masked/ }
   end
 end


### PR DESCRIPTION
### Description of changes
**Move tests for disabled services from tests.rb recipe to InSpec**
Remove them from aws-parallelcluster-test cookbook, add missing tests to
InSpec controls and add tag:config to control names in order to pick them
during final instance validation.

### Tests
* Tested on Jenkins

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.