### PR TITLE
[WIP] Move awsbatch tests from tests.rb recipe to InSpec

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -195,34 +195,6 @@ else
   end
 end
 
-###################
-# Pcluster AWSBatch CLI
-###################
-if node['cluster']['scheduler'] == 'awsbatch' && node['cluster']['node_type'] == 'HeadNode'
-  # Test that batch commands can be accessed without absolute path
-  batch_cli_commands = %w(awsbkill awsbqueues awsbsub awsbhosts awsbout awsbstat)
-  batch_cli_commands.each do |cli_commmand|
-    bash "test_#{cli_commmand}" do
-      cwd Chef::Config[:file_cache_path]
-      code <<-BATCHCLI
-        set -e
-        source ~/.bash_profile
-        #{cli_commmand} -h
-      BATCHCLI
-      user node['cluster']['cluster_user']
-    end
-  end
-end
-
-###################
-# clusterstatusmgtd
-###################
-if node['cluster']['node_type'] == 'HeadNode' && node['cluster']['scheduler'] != 'awsbatch'
-  execute "check clusterstatusmgtd is configured to be executed by supervisord" do
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl status clusterstatusmgtd | grep RUNNING"
-  end
-end
-
 execute 'unmount /home' do
   command "umount -fl /home"
   retries 10

--- a/test/recipes/controls/aws_parallelcluster_awsbatch/awsbatch_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_awsbatch/awsbatch_spec.rb
@@ -1,0 +1,27 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'tag:config_awsbatch_correctly_configured' do
+  only_if { node['cluster']['scheduler'] == 'awsbatch' }
+
+  # Test that batch commands can be accessed without absolute path
+  %w(awsbkill awsbqueues awsbsub awsbhosts awsbout awsbstat).each do |cli_commmand|
+    describe "#{cli_commmand} can be accessed without absolute path" do
+      subject { bash("sudo -u #{node['cluster']['cluster_user']} -c '. ~/.bash_profile; #{cli_commmand} -h'") }
+      its('exit_status') { should eq 0 }
+    end
+  end
+
+  describe 'clusterstatusmgtd is configured to be executed by supervisord' do
+    subject { bash("#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl status clusterstatusmgtd") }
+    its('stdout') { should match /RUNNING/ }
+  end
+end


### PR DESCRIPTION
### Description of changes
**Move awsbatch tests from tests.rb recipe to InSpec**
Remove them from aws-parallelcluster-test cookbook, add missing tests to
InSpec controls and add tag:config to control names in order to pick them
during final instance validation.

### Tests
* Tested on Jenkins

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.