### PR TITLE
3.x Add error event reporting to custom compute actions

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/custom_actions_setup.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/custom_actions_setup.rb
@@ -20,6 +20,17 @@ template "#{node['cluster']['scripts_dir']}/fetch_and_run" do
   owner "root"
   group "root"
   mode "0755"
+  variables(
+    sheduler: node['cluster']['scheduler'],
+    instance_id: node['ec2']['instance_id'],
+    instance_type: node['ec2']['instance_type'],
+    availability_zone: node['ec2']['availability_zone'],
+    ip_address: node['ipaddress'],
+    hostname: node['ec2']['hostname'],
+    compute_resource: node['cluster']['scheduler_compute_resource_name'],
+    # TODO: This needs to be abstracted somehow since this resource should be scheduler independent
+    node_spec_file: "#{node['cluster']['slurm_plugin_dir']}/slurm_nodename"
+  )
 end
 
 cookbook_file "#{node['cluster']['scripts_dir']}/custom_action_executor.py" do

--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -33,4 +33,13 @@ PCLUSTER_REGION="<%= node['cluster']['region'] %>"
   --node-type "${PCLUSTER_NODE_TYPE}" \
   --queue-name "${PCLUSTER_SCHEDULER_QUEUE_NAME}" \
   --cluster-configuration "${PCLUSTER_CONFIG_PATH}" \
+  --instance-id "<%= @instance_id %>" \
+  --instance-type "<%= @instance_type %>" \
+  --ip-address "<%= @ip_address %>" \
+  --hostname "<%= @hostname %>" \
+  --resource  "<%= @compute_resource %>" \
+  --availability-zone "<%= @availability_zone %>" \
+  --scheduler "<%= @cluster_sheduler %>" \
+  --node-spec-file "<%= @node_spec_file %>" \
+  --verbose \
   "$@"

--- a/cookbooks/aws-parallelcluster-slurm/libraries/emit_chef_error_event.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/emit_chef_error_event.rb
@@ -56,7 +56,7 @@ module WriteChefError
         "version" => 0,
         "cluster-name" => node["cluster"]["stack_name"],
         "scheduler" => node["cluster"]["scheduler"],
-        "node-role" => "ComputeNode",
+        "node-role" => "ComputeFleet",
         "level" => "ERROR",
         "instance-id" => node["ec2"]["instance_id"],
         "event-type" => "chef-recipe-exception",

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv =
     GITHUB_*
 deps =
     -rtest/unit/requirements.txt
-    py{37,38}: pytest-asyncio
+    py{37,38,39,310}: pytest-asyncio
     cov: codecov
 setenv =
     PYTHONPATH = \


### PR DESCRIPTION
### Description of changes
* This change add structured error event reporting for custom actions running on the compute fleet.
* The error events are written to /var/log/parallelcluster/bootstrap_error_msg where the should be published to CloudWatch Logs.
* This will enable us to create metric filters on these events to graph custom action errors in the cluster dashboard.

### Tests
* Added unit tests for generating the error events.
* Manually tested by deploying a cluster with custom compute fleet actions that would cause an error and verified that the event was published to CloudWatch Logs.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.