### PR TITLE
Fix dcv-gl, IntelMPI and EFA Inspec tests

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -185,6 +185,11 @@ default['cluster']['nvidia']['gdrcopy']['service'] = value_for_platform(
   'default' => 'gdrcopy'
 )
 
+# EFA
+default['cluster']['efa']['installer_version'] = '1.21.0'
+default['cluster']['efa']['sha256'] = 'c64e6ca34ccfc3ebe8e82d08899ae8442b3ef552541cf5429c43d11a04333050'
+default['cluster']['efa']['unsupported_aarch64_oses'] = %w(centos7)
+
 # EFS Utils
 default['cluster']['efs_utils']['version'] = '1.34.1'
 default['cluster']['efs_utils']['url'] = "https://github.com/aws/efs-utils/archive/v#{node['cluster']['efs_utils']['version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-common/attributes/common.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common.rb
@@ -49,8 +49,3 @@ default['cluster']['parallelcluster-version'] = '3.6.0'
 default['cluster']['parallelcluster-cookbook-version'] = '3.6.0'
 default['cluster']['parallelcluster-node-version'] = '3.6.0'
 default['cluster']['parallelcluster-awsbatch-cli-version'] = '1.1.0'
-
-# EFA
-default['cluster']['efa']['installer_version'] = '1.21.0'
-default['cluster']['efa']['sha256'] = 'c64e6ca34ccfc3ebe8e82d08899ae8442b3ef552541cf5429c43d11a04333050'
-default['cluster']['efa']['unsupported_aarch64_oses'] = %w(centos7)

--- a/test/recipes/controls/aws_parallelcluster_config/dcv_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/dcv_spec.rb
@@ -33,7 +33,7 @@ control 'tag:config_expected_versions_of_nice-dcv-gl_installed' do
 
   describe package('nice-dcv-gl') do
     it { should be_installed }
-    its('version') { should eq node['cluster']['dcv']['gl']['version'] }
+    its('version') { should match /#{node['cluster']['dcv']['gl']['version']}/ }
   end
 end
 

--- a/test/recipes/controls/aws_parallelcluster_install/intel_mpi_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/intel_mpi_spec.rb
@@ -14,7 +14,7 @@ control 'tag:config_intel_mpi_installed' do
 
   # Test only on head node since on compute nodes we mount an empty /opt/intel drive in kitchen tests that
   # overrides intel binaries.
-  only_if { instance.head_node? }
+  only_if { node['conditions']['intel_mpi_supported'] && instance.head_node? }
 
   describe bash("unset MODULEPATH && source /etc/profile.d/modules.sh && module load intelmpi && mpirun --help") do
     its('exit_status') { should eq(0) }


### PR DESCRIPTION
### Fix dcv-gl Inspec test

It was failing with: 
```
System Package nice-dcv-gl version is expected to eq "2022.1.973-1"
expected: "2022.1.973-1"
got: "2022.1.973-1.el7"
```

### Fix EFA Inspec test

It was failing with `undefined local variable or method 'node'`.
This was due to the fact that the variable was defined in the aws-parallelcluster-common attributes
so they weren't loaded at inspec execution time.

### Fix Intel MPI Inspec test

The test was missing the condition to skip unsupported platforms (ARM)
