### PR TITLE
Create new resource to manage system authentication

### DIFF
--- a/cookbooks/aws-parallelcluster-common/resources/system_authentication/partial/_system_authentication_alinux_centos.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/system_authentication/partial/_system_authentication_alinux_centos.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+action :configure do
+  execute 'Configure Directory Service' do
+    user 'root'
+    # Tell NSS, PAM to use SSSD for system authentication and identity information
+    command "authconfig --enablemkhomedir --enablesssdauth --enablesssd --updateall"
+    sensitive true
+  end
+end

--- a/cookbooks/aws-parallelcluster-common/resources/system_authentication/partial/_system_authentication_common.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/system_authentication/partial/_system_authentication_common.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+unified_mode true
+default_action :setup
+
+action :setup do
+  package required_packages do
+    retries 3
+    retry_delay 5
+  end
+end

--- a/cookbooks/aws-parallelcluster-common/resources/system_authentication/partial/_system_authentication_debian.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/system_authentication/partial/_system_authentication_debian.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+action :configure do
+  execute 'Enable PAM mkhomedir module' do
+    user 'root'
+    command "pam-auth-update --enable mkhomedir"
+    sensitive true
+  end
+end
+
+action_class do
+  def required_packages
+    %w(sssd sssd-tools sssd-ldap)
+  end
+end

--- a/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_alinux2.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_alinux2.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :system_authentication, platform: 'amazon', platform_version: '2'
+
+use 'partial/_system_authentication_common'
+use 'partial/_system_authentication_alinux_centos'
+
+action_class do
+  def required_packages
+    %w(sssd sssd-tools sssd-ldap authconfig)
+  end
+end

--- a/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_centos7.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_centos7.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :system_authentication, platform: 'centos' do |node|
+  node['platform_version'].to_i == 7
+end
+
+use 'partial/_system_authentication_common'
+use 'partial/_system_authentication_alinux_centos'
+
+action_class do
+  def required_packages
+    %w(sssd sssd-tools sssd-ldap authconfig)
+  end
+end

--- a/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_redhat8.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :system_authentication, platform: 'redhat' do |node|
+  node['platform_version'].to_i == 8
+end
+
+unified_mode true
+default_action :setup
+
+action :configure do
+  execute 'Configure Directory Service' do
+    user 'root'
+    # Tell NSS, PAM to use SSSD for system authentication and identity information
+    # authconfig is a compatibility tool, replaced by authselect
+    command "authselect select sssd with-mkhomedir"
+    sensitive true
+  end unless redhat_ubi?
+end
+
+action :setup do
+  package %w(sssd sssd-tools sssd-ldap authselect) do
+    retries 3
+    retry_delay 5
+  end unless redhat_ubi?
+end

--- a/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_ubuntu18.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :system_authentication, platform: 'ubuntu', platform_version: '18.04'
+
+use 'partial/_system_authentication_common'
+use 'partial/_system_authentication_debian'

--- a/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_ubuntu20.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :system_authentication, platform: 'ubuntu', platform_version: '20.04'
+
+use 'partial/_system_authentication_common'
+use 'partial/_system_authentication_debian'

--- a/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/directory_service.rb
@@ -198,24 +198,8 @@ else
   end
 end
 
-case node['platform_family']
-when 'rhel', 'amazon'
-  bash 'Configure Directory Service' do
-    user 'root'
-    # Tell NSS, PAM to use SSSD for system authentication and identity information
-    code <<-AD
-      authconfig --enablemkhomedir --enablesssdauth --enablesssd --updateall
-    AD
-    sensitive true
-  end
-when 'debian'
-  bash 'Enable PAM mkhomedir module' do
-    user 'root'
-    code <<-AD
-      pam-auth-update --enable mkhomedir
-    AD
-    sensitive true
-  end
+system_authentication "Configure system authentication" do
+  action :configure
 end
 
 # Restart modified services

--- a/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
@@ -14,7 +14,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                          gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl
                                          jq wget python-pip NetworkManager-config-routing-rules libibverbs-utils
                                          librdmacm-utils python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                         coreutils moreutils sssd sssd-tools sssd-ldap environment-modules)
+                                         coreutils moreutils environment-modules)
 
 # Install R via amazon linux extras
 default['cluster']['extra_packages'] = ['R3.4']

--- a/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_centos7.rb
@@ -11,7 +11,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                          libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                          mdadm python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
                                          iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                         coreutils moreutils sssd sssd-tools sssd-ldap curl environment-modules)
+                                         coreutils moreutils curl environment-modules)
 
 # TODO: check if it is still relevant. Evaluate if it is worth to remove the package.
 if node['kernel']['machine'] == 'aarch64'

--- a/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_redhat8.rb
@@ -12,7 +12,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                              libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
                                              mdadm python2 python2-pip libgcrypt-devel libevent-devel glibc-static bind-utils
                                              iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-                                             coreutils moreutils sssd sssd-tools sssd-ldap curl environment-modules gcc gcc-c++)
+                                             coreutils moreutils curl environment-modules gcc gcc-c++)
 
 # Needed by hwloc-devel blas-devel libedit-devel and glibc-static packages
 default['cluster']['extra_repos'] = 'codeready-builder-for-rhel-8-rhui-rpms'

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu18.rb
@@ -11,7 +11,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
                                          libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
-                                         coreutils moreutils sssd sssd-tools sssd-ldap curl
+                                         coreutils moreutils curl
                                          python-pip python-parted environment-modules)
 
 default['cluster']['kernel_headers_pkg'] = "linux-headers-#{node['kernel']['release']}"

--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu20.rb
@@ -11,7 +11,7 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
                                          libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
-                                         coreutils moreutils sssd sssd-tools sssd-ldap curl python3-parted environment-modules)
+                                         coreutils moreutils curl python3-parted environment-modules)
 
 default['cluster']['kernel_headers_pkg'] = "linux-headers-#{node['kernel']['release']}"
 

--- a/cookbooks/aws-parallelcluster-install/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/install.rb
@@ -37,6 +37,7 @@ efa 'Install EFA'
 lustre "Install FSx options" # FSx options
 efs 'Install efs-utils'
 stunnel 'Install stunnel'
+system_authentication "Install packages required for directory service integration"
 
 # == SCHEDULER AND COMPUTE FLEET
 include_recipe "aws-parallelcluster-install::clusterstatusmgtd"

--- a/kitchen.resources-config.yml
+++ b/kitchen.resources-config.yml
@@ -74,3 +74,15 @@ suites:
           threads: 10
       dependencies:
         - resource:nfs
+  - name: system_authentication_configured
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-common::test_resource]
+    verifier:
+      controls:
+        - system_authentication_configured
+    attributes:
+      resource: system_authentication:configure
+      dependencies:
+        - resource:package_repos
+        - resource:system_authentication

--- a/kitchen.resources-install.yml
+++ b/kitchen.resources-install.yml
@@ -160,3 +160,14 @@ suites:
         - ephemeral_drives_script_created
         - ephemeral_service_set_up
         - ephemeral_service_after_network_config
+  - name: system_authentication
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-common::test_resource]
+    verifier:
+      controls:
+        - system_authentication_packages_installed
+    attributes:
+      resource: system_authentication
+      dependencies:
+        - resource:package_repos

--- a/kitchen.validate-install.yml
+++ b/kitchen.validate-install.yml
@@ -62,3 +62,4 @@ suites:
         - /services_disabled_on_debian_family/
         - stunnel_installed
         - /intel_mpi_installed/
+        - system_authentication_packages_installed

--- a/test/resources/controls/aws_parallelcluster_config/system_authentication_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_config/system_authentication_spec.rb
@@ -1,0 +1,45 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'system_authentication_packages_installed' do
+  title 'Check that system authentication packages are installed correctly'
+
+  packages = %w(sssd sssd-tools sssd-ldap)
+  packages.each do |pkg|
+    describe package(pkg) do
+      it { should be_installed }
+    end
+  end unless os_properties.redhat_ubi?
+end
+
+control 'system_authentication_configured' do
+  title 'Check that system authentication is configured correctly'
+
+  describe 'Check NSS and PAM to use SSSD for system authentication and identity information'
+  if os_properties.redhat8?
+
+    describe bash("authselect current") do
+      its('exit_status') { should eq 0 }
+      its('stdout') { should match /Profile ID: sssd/ }
+      its('stdout') { should match /with-mkhomedir/ }
+    end unless os_properties.redhat_ubi?
+
+  elsif os_properties.centos7? || os_properties.alinux2?
+
+    describe bash("authconfig --test") do
+      its('exit_status') { should eq 0 }
+      its('stdout') { should match /nss_sss is enabled by default/ }
+      its('stdout') { should match /pam_sss is enabled by default/ }
+      its('stdout') { should match /pam_mkhomedir or pam_oddjob_mkhomedir is enabled/ }
+    end
+
+  end
+end


### PR DESCRIPTION
### Description of changes
The system_authentication resource is used at install time to install SSSD and related tools
and at config time to configure NSS, PAM to use SSSD for system authentication and identity information.

Moved SSSD packages from default attributes to system_authentication.

The `authconfig` tool used on centos7 and alinux2 is now in compatibility mode for rhel8
so it's required to migrate to `authselect`. See https://www.mankier.com/7/authselect-migration
```
authconfig --enablesssd --enablesssdauth --enablemkhomedir --updateall
```
corresponds to:
```
authselect select sssd with-mkhomedir
```
### Tests

Added Inspec tests to verify installation and configuration phases (skipped on docker redhat because sssd cannot be installed).

Note: I'm missing verification test for debian systems.
pam-auth-update command that is used to configure the system cannot be used to verify the changes
because it's an interactive command and I wasn't able to find differences in related files.

Tested on all OSes on EC2 and docker.
