### PR TITLE
3.x Fix failing integration tests

### DIFF
--- a/test/unit/custom_action_executor/test_custom_action_executor.py
+++ b/test/unit/custom_action_executor/test_custom_action_executor.py
@@ -602,6 +602,14 @@ def test_compute_fleet_logger(mocker, node_name, action, expected_event):
             + "ComputeFleetQueueBatch0QueueGroup0NestedStackQueueGroup0N-VC66PPA3U8IR",
             "integ-tests-j3v1lgb0rx4uvt5y-ComputeFleetQueueBatch0QueueGroup0NestedStackQueueGroup0N-VC66PPA3U8IR",
         ),
+        (
+            "integ-tests-ddladsmelz9ytvwp-develop-ComputeFleetQueueBatch0QueueGroup0NestedStackQueu-1J01OX5L1J502",
+            "integ-tests-ddladsmelz9ytvwp-develop",
+        ),
+        (
+            "integ-tests-ddladsmelz9ytvwp-develop-super-long-maximum-name-ComputeFleetQueueBatch0Qu-1J01OX5L1J502",
+            "integ-tests-ddladsmelz9ytvwp-develop-super-long-maximum-name",
+        ),
     ],
     ids=[
         "empty string",
@@ -609,6 +617,8 @@ def test_compute_fleet_logger(mocker, node_name, action, expected_event):
         "matches pattern",
         "matches pattern with larger numbers",
         "repeated matching suffix strips last matching suffix",
+        "failing-integ-test-001",
+        "60 character cluster name",
     ],
 )
 def test_cluster_name_parsing(stack_name, expected_cluster_name):


### PR DESCRIPTION
### Description of changes
* This change fixes an integration test where the child-stack name did not match the parsing pattern used to extract the cluster name.
* This change also fixes an issue where the expected suffix text was not being added to the bootstrap_error_msg file.

### Tests
* Added unit test for maximum cluster name length parsing.


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.