### PR TITLE
[RHEL8] Nvidia fix and transformation of the datacenter-gpu-manager installation into a resource

### DIFF
--- a/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
@@ -32,4 +32,4 @@ default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
 default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']
-default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/x86_64"
+default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
@@ -32,4 +32,6 @@ default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
 default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']
-default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/#{arm_instance? ? 'sbsa' : 'x86_64'}"
+
+# Nvidia Repository for fabricmanager and datacenter-gpu-manager
+default['cluster']['nvidia']['cuda']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
@@ -32,4 +32,4 @@ default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
 default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']
-default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/x86_64"
+default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
@@ -32,4 +32,6 @@ default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
 default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']
-default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/#{arm_instance? ? 'sbsa' : 'x86_64'}"
+
+# Nvidia Repository for fabricmanager and datacenter-gpu-manager
+default['cluster']['nvidia']['cuda']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
@@ -33,4 +33,6 @@ default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
 default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']
-default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel8/#{arm_instance? ? 'sbsa' : 'x86_64'}"
+
+# Nvidia Repository for fabricmanager and datacenter-gpu-manager
+default['cluster']['nvidia']['cuda']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel8/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
@@ -33,4 +33,4 @@ default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
 default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']
-default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/x86_64"
+default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel8/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu18.rb
@@ -34,4 +34,4 @@ default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabricmanager
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "3bf863cc.pub"
 # with apt a star is needed to match the package version
 default['cluster']['nvidia']['fabricmanager']['version'] = "#{node['cluster']['nvidia']['driver_version']}*"
-default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cluster']['base_os']}/x86_64"
+default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cluster']['base_os']}/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu18.rb
@@ -34,4 +34,6 @@ default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabricmanager
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "3bf863cc.pub"
 # with apt a star is needed to match the package version
 default['cluster']['nvidia']['fabricmanager']['version'] = "#{node['cluster']['nvidia']['driver_version']}*"
-default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cluster']['base_os']}/#{arm_instance? ? 'sbsa' : 'x86_64'}"
+
+# Nvidia Repository for fabricmanager and datacenter-gpu-manager
+default['cluster']['nvidia']['cuda']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cluster']['base_os']}/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu20.rb
@@ -34,4 +34,4 @@ default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabricmanager
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "3bf863cc.pub"
 # with apt a star is needed to match the package version
 default['cluster']['nvidia']['fabricmanager']['version'] = "#{node['cluster']['nvidia']['driver_version']}*"
-default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cluster']['base_os']}/x86_64"
+default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cluster']['base_os']}/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu20.rb
@@ -34,4 +34,6 @@ default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabricmanager
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "3bf863cc.pub"
 # with apt a star is needed to match the package version
 default['cluster']['nvidia']['fabricmanager']['version'] = "#{node['cluster']['nvidia']['driver_version']}*"
-default['cluster']['nvidia']['fabricmanager']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cluster']['base_os']}/#{arm_instance? ? 'sbsa' : 'x86_64'}"
+
+# Nvidia Repository for fabricmanager and datacenter-gpu-manager
+default['cluster']['nvidia']['cuda']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cluster']['base_os']}/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
@@ -26,6 +26,6 @@ add_package_repository("nvidia-repo", repo_uri, "#{repo_uri}/#{node['cluster']['
 
 fabric_manager 'Install Nvidia Fabric Manager'
 
-package 'datacenter-gpu-manager'
+package 'datacenter-gpu-manager' unless arm_instance?
 
 remove_package_repository("nvidia-repo")

--- a/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
@@ -21,7 +21,7 @@ gdrcopy 'Install Nvidia gdrcopy'
 
 # Install NVIDIA Fabric Manager
 repo_domain = node['cluster']['region'].start_with?("cn-") ? "com" : "cn"
-repo_uri = node['cluster']['nvidia']['fabricmanager']['repository_uri'].gsub('_domain_', repo_domain)
+repo_uri = node['cluster']['nvidia']['cuda']['repository_uri'].gsub('_domain_', repo_domain)
 add_package_repository("nvidia-repo", repo_uri, "#{repo_uri}/#{node['cluster']['nvidia']['fabricmanager']['repository_key']}", "/")
 
 fabric_manager 'Install Nvidia Fabric Manager'

--- a/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
@@ -26,6 +26,6 @@ add_package_repository("nvidia-repo", repo_uri, "#{repo_uri}/#{node['cluster']['
 
 fabric_manager 'Install Nvidia Fabric Manager'
 
-package 'datacenter-gpu-manager' unless arm_instance?
+nvidia_dcgm 'install datacenter-gpu-manager'
 
 remove_package_repository("nvidia-repo")

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_amazon2.rb
@@ -17,6 +17,14 @@ provides :gdrcopy, platform: 'amazon', platform_version: '2'
 use 'partial/_gdrcopy_common.rb'
 use 'partial/_gdrcopy_common_rhel.rb'
 
+unified_mode true
+default_action :setup
+
+action :setup do
+  return unless node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true
+  action_gdrcopy_installation
+end
+
 action_class do
   def gdrcopy_build_dependencies
     %w(dkms rpm-build make check check-devel subunit subunit-devel)

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_centos7.rb
@@ -19,16 +19,10 @@ end
 use 'partial/_gdrcopy_common.rb'
 use 'partial/_gdrcopy_common_rhel.rb'
 
-action_class do
-  def gdrcopy_build_dependencies
-    %w(dkms rpm-build make check check-devel subunit subunit-devel)
-  end
+unified_mode true
+default_action :setup
 
-  def platform
-    '.el7'
-  end
-
-  def arch
-    arm_instance? ? 'arm64' : 'x86_64'
-  end
+action :setup do
+  return if arm_instance? || !(node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
+  action_gdrcopy_installation
 end

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_redhat8.rb
@@ -19,6 +19,14 @@ end
 use 'partial/_gdrcopy_common.rb'
 use 'partial/_gdrcopy_common_rhel.rb'
 
+unified_mode true
+default_action :setup
+
+action :setup do
+  return unless node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true
+  action_gdrcopy_installation
+end
+
 action_class do
   def gdrcopy_build_dependencies
     %w(dkms rpm-build make check check-devel subunit subunit-devel)
@@ -29,6 +37,6 @@ action_class do
   end
 
   def arch
-    arm_instance? ? 'arm64' : 'x86_64'
+    arm_instance? ? 'aarch64' : 'x86_64'
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_ubuntu18.rb
@@ -17,6 +17,14 @@ provides :gdrcopy, platform: 'ubuntu', platform_version: '18.04'
 use 'partial/_gdrcopy_common.rb'
 use 'partial/_gdrcopy_common_debian.rb'
 
+unified_mode true
+default_action :setup
+
+action :setup do
+  return unless node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true
+  action_gdrcopy_installation
+end
+
 action_class do
   def platform
     'Ubuntu18_04'

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_ubuntu20.rb
@@ -17,6 +17,14 @@ provides :gdrcopy, platform: 'ubuntu', platform_version: '20.04'
 use 'partial/_gdrcopy_common.rb'
 use 'partial/_gdrcopy_common_debian.rb'
 
+unified_mode true
+default_action :setup
+
+action :setup do
+  return unless node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true
+  action_gdrcopy_installation
+end
+
 action_class do
   def platform
     'Ubuntu20_04'

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/partial/_gdrcopy_common.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/partial/_gdrcopy_common.rb
@@ -12,12 +12,8 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-unified_mode true
-default_action :setup
 
-action :setup do
-  return unless node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true
-
+action :gdrcopy_installation do
   gdrcopy_version = node['cluster']['nvidia']['gdrcopy']['version']
   gdrcopy_tarball = "#{node['cluster']['sources_dir']}/gdrcopy-#{gdrcopy_version}.tar.gz"
   gdrcopy_checksum = node['cluster']['nvidia']['gdrcopy']['sha256']

--- a/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/nvidia_dcgm_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/nvidia_dcgm_amazon2.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nvidia_dcgm, platform: 'amazon', platform_version: '2'
+
+use 'partial/_nvidia_dcgm_alinux2_centos7.rb'

--- a/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/nvidia_dcgm_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/nvidia_dcgm_centos7.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nvidia_dcgm, platform: 'centos' do |node|
+  node['platform_version'].to_i == 7
+end
+
+use 'partial/_nvidia_dcgm_alinux2_centos7.rb'

--- a/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/nvidia_dcgm_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/nvidia_dcgm_redhat8.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nvidia_dcgm, platform: 'redhat' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_nvidia_dcgm_common.rb'

--- a/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/nvidia_dcgm_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/nvidia_dcgm_ubuntu18.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nvidia_dcgm, platform: 'ubuntu', platform_version: '18.04'
+
+use 'partial/_nvidia_dcgm_common.rb'

--- a/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/nvidia_dcgm_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/nvidia_dcgm_ubuntu20.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nvidia_dcgm, platform: 'ubuntu', platform_version: '20.04'
+
+use 'partial/_nvidia_dcgm_common.rb'

--- a/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/partial/_nvidia_dcgm_alinux2_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/partial/_nvidia_dcgm_alinux2_centos7.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+unified_mode true
+default_action :setup
+
+action :setup do
+  return if arm_instance? || !(node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
+
+  package 'datacenter-gpu-manager' do
+    retries 3
+    retry_delay 5
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/partial/_nvidia_dcgm_common.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/nvidia_dcgm/partial/_nvidia_dcgm_common.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+unified_mode true
+default_action :setup
+
+action :setup do
+  return unless node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true
+
+  package 'datacenter-gpu-manager' do
+    retries 3
+    retry_delay 5
+  end
+end

--- a/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
@@ -44,7 +44,7 @@ end
 
 control 'tag:config_expected_versions_of_nvidia_fabric_manager_installed' do
   only_if do
-    !(os_properties.centos7? && os_properties.arm?) && !instance.custom_ami? &&
+    !(os_properties.centos7? && os_properties.arm?) && !os_properties.arm? && !instance.custom_ami? &&
       (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
   end
 
@@ -70,8 +70,8 @@ end
 
 control 'tag:config_expected_nvidia_datacenter-gpu-manager_installed' do
   only_if do
-    !(os_properties.centos7? && os_properties.arm?) && !instance.custom_ami? &&
-      (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
+    !(os_properties.centos7? && os_properties.arm?) && !(os_properties.alinux2? && os_properties.arm?) && !instance.custom_ami? &&
+    (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
   end
 
   describe package('datacenter-gpu-manager') do


### PR DESCRIPTION
### Description of changes
[Fix gdrcopy installation](https://github.com/aws/aws-parallelcluster-cookbook/pull/1964/commits/ed0bf40098412c710a70ae736dcd3f63281799b3) 
[Fix repository uri for arm](https://github.com/aws/aws-parallelcluster-cookbook/pull/1964/commits/38777d60c6b17a64754a2183a24c6f409c40b341) 
[Transform the datacenter-gpu-manager installation into a resource](https://github.com/aws/aws-parallelcluster-cookbook/pull/1964/commits/4c51580fee87e0ccbfd241e08f7556cb9a58a10d) 
[Change the Nvidia repo variable name to be more general](https://github.com/aws/aws-parallelcluster-cookbook/pull/1964/commits/7bba93eedcfad57bdf4c3fdb0b9acb8b9675e3db)

### Test
* Tested with kitchen in ec2 on arm64 instances

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.