### PR TITLE
[develop] Health Check Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Track head node memory and root volume disk utilization using the `mem_used_percent` and `disk_used_percent` metrics collected through the CloudWatch Agent.
 - Add log rotation support for ParallelCluster managed logs.
 - Add support for customizing the cluster Slurm configuration via the ParallelCluster configuration YAML file.
+- Add health check manager and GPU health check, which can be activated through cluster configuration. 
+  Health check manager execution is triggered by a Slurm prolog script. GPU check verifies healthiness of a node by executing NVIDIA DCGM L2 diagnostic.   
 
 **CHANGES**
 - Upgrade EFA installer to `1.22.1`
@@ -23,6 +25,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Open MPI: `openmpi40-aws-4.1.5-1`
 - Upgrade Lustre client version to 2.12 on Amazon Linux 2. Lustre client 2.12 has been installed on Ubuntu 20.04, 18.04 and CentOS >= 7.7.  Upgrade Lustre client version to 2.10.8 on CentOS 7.6.
 - Upgrade aws-cfn-bootstrap to version 2.0-24.
+- Set Slurm prolog and epilog configurations to target a directory, /opt/slurm/etc/scripts/prolog.d/ and /opt/slurm/etc/scripts/epilog.d/ respectively.
 
 3.5.1
 ------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -352,6 +352,7 @@ default['cluster']['realmemory_to_ec2memory_ratio'] = 0.95
 default['cluster']['slurm_node_reg_mem_percent'] = 75
 default['cluster']['slurmdbd_response_retries'] = 30
 default['cluster']['slurm_plugin_console_logging']['sample_size'] = 1
+default["cluster"]["scheduler_compute_resource_name"] = nil
 
 # Official ami build
 default['cluster']['is_official_ami_build'] = false

--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent/cloudwatch_agent_config.json
@@ -658,6 +658,24 @@
     },
     {
       "timestamp_format_key": "default",
+      "file_path": "/var/log/parallelcluster/slurm_health_check.log",
+      "log_stream_name": "slurm_health_check",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "centos",
+        "redhat",
+        "ubuntu",
+        "amazon"
+      ],
+      "node_roles": [
+        "ComputeFleet"
+      ],
+      "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "default",
       "file_path": "/var/log/parallelcluster/clusterstatusmgtd",
       "log_stream_name": "clusterstatusmgtd",
       "schedulers": [

--- a/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/epilog.d/90_pcluster_noop
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/epilog.d/90_pcluster_noop
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# noop epilog
+exit 0

--- a/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_check_manager.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_check_manager.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import os
+import shlex
+
+# A nosec comment is appended to the following line in order to disable the B404 check.
+# In this file the input of the module subprocess is trusted.
+import subprocess  # nosec B404
+from builtins import Exception, KeyError, SystemExit, TypeError, bool, int, next, repr, staticmethod, str
+from configparser import ConfigParser
+from dataclasses import dataclass
+from enum import Enum
+from io import StringIO
+from logging.config import fileConfig
+from typing import List
+
+import yaml
+
+CONFIG_FILE_DIR = os.path.join(os.path.dirname(__file__), "conf")
+FILE_READ_TIMEOUT = 30
+
+log = logging.getLogger(__name__)
+
+
+class ManagedHealthCheckName(Enum):
+    """Enum that identifies the managed Health Checks and their command script."""
+
+    GPU = "gpu_health_check.sh"
+
+    def get_health_check_path(self, managed_health_check_dir: str) -> str:
+        """Return the file path of the health check."""
+        return os.path.join(managed_health_check_dir, self.value)
+
+
+def _read_file(file_path: str) -> str:
+    # Use subprocess command to get shared file content to prevent hanging when NFS is down
+    # The command in this subprocess call is built as literal
+    result = subprocess.run(
+        shlex.split(f"cat {str(file_path)}"),
+        timeout=FILE_READ_TIMEOUT,
+        stdout=subprocess.PIPE,
+        encoding="utf-8",
+        check=False,
+        shell=False,  # nosec B603
+    )
+    return result.stdout if hasattr(result, "stdout") else ""
+
+
+class HealthCheckManagerConfig:
+    """Class that identifies the Health Check Manager configuration."""
+
+    DEFAULTS = {
+        "health_check_timeout": 600,
+        "logging_config": os.path.join(os.path.dirname(__file__), "logging", "health_check_manager_logging.conf"),
+        "managed_health_check_dir": os.path.join(os.path.dirname(__file__), "health_checks"),
+    }
+
+    def __init__(self, config_file_path):
+        self._get_config(config_file_path)
+
+    def __repr__(self):
+        """Return Health Check Manager configuration representation."""
+        attrs = ", ".join([f"{key}={repr(value)}" for key, value in self.__dict__.items()])
+        return f"{self.__class__.__name__}({attrs})"
+
+    def __eq__(self, other):
+        """Return true if both objects are equal."""
+        if type(other) is type(self):
+            return self._config == other._config
+        return False
+
+    def __ne__(self, other):
+        """Return true if both objects are not equal."""
+        return not self.__eq__(other)
+
+    def _get_config(self, config_file_path: str):
+        """Get health check manager configuration."""
+        log.info("Reading '%s'", config_file_path)
+
+        self._config = ConfigParser()
+        try:
+            self._config.read_file(StringIO(_read_file(config_file_path)))
+        except Exception as err:
+            if hasattr(err, "message"):
+                err = err.message
+            log.error(
+                "Cannot read Health Check Manager config file: %s, falling back to default settings. Error is: %s",
+                config_file_path,
+                err,
+            )
+
+        self.health_check_timeout = self._config.getint(
+            "health_check_manager", "health_check_timeout", fallback=self.DEFAULTS.get("health_check_timeout")
+        )
+        self.logging_config = self._config.get(
+            "health_check_manager", "logging_config", fallback=self.DEFAULTS.get("logging_config")
+        )
+        self.managed_health_check_dir = self._config.get(
+            "health_check_manager", "managed_health_check_dir", fallback=self.DEFAULTS.get("managed_health_check_dir")
+        )
+
+        log.debug(repr(self))
+
+
+@dataclass
+class HealthCheckDefinition:
+    """
+    Health Check definition.
+
+    Contains all the configuration relevant to a specific health check.
+    """
+
+    name: str
+    is_managed: bool
+    is_enabled: bool
+    check_path: str
+
+
+@dataclass
+class HealthCheckConfig:
+    """
+    Health Check configuration.
+
+    Contains all the configuration relevant to all the health checks.
+    """
+
+    node_type: str
+    queue_name: str
+    compute_resource_name: str
+    health_checks: List[HealthCheckDefinition]
+
+
+class HealthCheckConfigLoader:
+    """
+    Health Check configuration loader.
+
+    Loads Health Check configuration from cluster configuration file according to the node type,
+    queue and compute resource.
+    """
+
+    @staticmethod
+    def _load_cluster_config(input_file_path: str) -> str:
+        """Load cluster config file."""
+        return yaml.load(StringIO(_read_file(input_file_path)), Loader=yaml.SafeLoader)
+
+    def load_configuration(
+        self, health_check_manager_config: HealthCheckManagerConfig, args: List[str]
+    ) -> HealthCheckConfig:
+        """
+        Load Health Check configuration.
+
+        :param health_check_manager_config: Health Check Manager configuration
+        :param args: command line arguments
+        :return: Health Check configuration object
+        """
+        cluster_config = self._load_cluster_config(args.cluster_configuration)
+
+        log.debug("Cluster config: %s", cluster_config)
+
+        health_checks = []
+        try:
+            if args.node_type == "ComputeFleet":
+                queues = cluster_config["Scheduling"]["SlurmQueues"]
+
+                queue = next((queue for queue in queues if queue["Name"] == args.queue_name), None)
+                compute_resource = next(
+                    (
+                        compute_resource
+                        for compute_resource in queue["ComputeResources"]
+                        if compute_resource["Name"] == args.compute_resource_name
+                    ),
+                    None,
+                )
+
+                for health_check_key, health_check_value in compute_resource["HealthChecks"].items():
+                    if health_check_key == "CustomChecks":
+                        # not yet implemented
+                        pass
+                    else:
+                        health_check = HealthCheckDefinition(
+                            name=health_check_key,
+                            is_managed=True,
+                            is_enabled=bool(
+                                health_check_value.get("Enabled")
+                                if health_check_value.get("Enabled") is not None
+                                else queue["HealthChecks"][health_check_key].get("Enabled", False)
+                            ),
+                            check_path=ManagedHealthCheckName[health_check_key.upper()].get_health_check_path(
+                                health_check_manager_config.managed_health_check_dir
+                            ),
+                        )
+                        health_checks.append(health_check)
+
+        except (KeyError, TypeError) as err:
+            if hasattr(err, "message"):
+                err = err.message
+            log.warning("Ignore missing %s in config", err)
+
+        health_check_conf = HealthCheckConfig(
+            node_type=args.node_type,
+            queue_name=args.queue_name,
+            compute_resource_name=args.compute_resource_name,
+            health_checks=health_checks,
+        )
+
+        log.debug("HealthCheck config %s: ", health_check_conf)
+        return health_check_conf
+
+
+def _execute_health_checks(health_check_manager_config: HealthCheckManagerConfig, args: List[str]) -> int:
+    """Execute all Health Check."""
+    health_check_conf = HealthCheckConfigLoader().load_configuration(health_check_manager_config, args)
+
+    exit_code_sum = 0
+
+    for health_check in health_check_conf.health_checks:
+        if health_check.is_enabled:
+            try:
+                log.info(
+                    "Executing Health Check '%s' for queue '%s' and compute resource '%s'",
+                    health_check.name,
+                    health_check_conf.queue_name,
+                    health_check_conf.compute_resource_name,
+                )
+
+                # The command in this subprocess call is built as literal
+                result = subprocess.run(
+                    health_check.check_path,
+                    timeout=health_check_manager_config.health_check_timeout,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    encoding="utf-8",
+                    check=False,
+                    shell=False,  # nosec B603
+                )
+                exit_code_sum += result.returncode
+                if result.stdout:
+                    output = f":\n{result.stdout}"
+                else:
+                    output = " empty"
+                log.info("Output of Health Check '%s' execution is%s", health_check.name, output)
+            except (subprocess.SubprocessError, OSError) as err:
+                if hasattr(err, "message"):
+                    err = err.message
+                log.error(
+                    "Failure when executing Health Check '%s' for queue '%s' and compute resource '%s', with error: %s",
+                    health_check.name,
+                    health_check_conf.queue_name,
+                    health_check_conf.compute_resource_name,
+                    err,
+                )
+    if not health_check_conf.health_checks:
+        log.info("No Health Check enabled found")
+
+    return exit_code_sum
+
+
+def _parse_arguments() -> List[str]:
+    parser = argparse.ArgumentParser(description="Health Check Manager")
+    parser.add_argument(
+        "-n",
+        "--node-type",
+        required=False,
+        help="Node type",
+    )
+    parser.add_argument(
+        "-q",
+        "--queue-name",
+        required=False,
+        help="Scheduler queue name",
+    )
+    parser.add_argument(
+        "-cr",
+        "--compute-resource-name",
+        required=False,
+        help="Scheduler compute resource name",
+    )
+    parser.add_argument(
+        "-j",
+        "--job-id",
+        required=False,
+        help="Job ID",
+    )
+    parser.add_argument(
+        "-c",
+        "--cluster-configuration",
+        required=True,
+        help="Path to cluster configuration",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    default_log_file = "/var/log/parallelcluster/slurm_health_check.log"
+    logging.basicConfig(
+        filename=default_log_file,
+        level=logging.INFO,
+        format="%(asctime)s - [%(filename)s:%(funcName)s] - %(levelname)s - JobID %(job_id)s - %(message)s",
+    )
+
+    try:
+        args = _parse_arguments()
+        # Override global log object
+        global log  # pylint: disable=W0603
+        log = logging.LoggerAdapter(log, {"job_id": args.job_id})
+        log.info("HealthCheckManager startup.")
+
+        config_file = os.environ.get("CONFIG_FILE", os.path.join(CONFIG_FILE_DIR, "health_check_manager.conf"))
+        health_check_manager_config = HealthCheckManagerConfig(config_file)
+        try:
+            # Configure root logger
+            fileConfig(health_check_manager_config.logging_config, disable_existing_loggers=False)
+        except Exception as err:
+            if hasattr(err, "message"):
+                err = err.message
+            log.warning(
+                "Unable to configure logging from %s, using default settings and writing to %s.\nException: %s",
+                health_check_manager_config.logging_config,
+                default_log_file,
+                err,
+            )
+        log.info(f"HealthCheckManager config: {health_check_manager_config}")
+        exit_code = _execute_health_checks(health_check_manager_config, args)
+        log.info(f"HealthCheckManager finished with exit code '{exit_code}'.")
+        raise SystemExit(exit_code)
+
+    except Exception as err:
+        if hasattr(err, "message"):
+            err = err.message
+        log.exception("Encountered exception when running Health Check Manager, exiting gracefully: %s", err)
+        raise SystemExit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_checks/gpu_health_check.sh
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_checks/gpu_health_check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "I'm the GPU check"
+exit 0

--- a/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_checks/gpu_health_check.sh
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_checks/gpu_health_check.sh
@@ -11,5 +11,207 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "I'm the GPU check"
-exit 0
+# GPU Health Check
+# Check GPU healthiness by executing NVIDIA DCGM diagnostic tool
+# If GPU_DEVICE_ORDINAL is set, the diagnostic check targets the GPU listed in the variable
+# Prerequisite for the diagnostic check are:
+#   * node has NVIDIA GPU
+#   * DCGM service is running
+#   * fabric manager service is running (if node is NVSwitch enabled)
+#   * persistent mode is enabled for the target GPU
+
+## DCGMI run level
+# 1 - Quick (System Validation)
+# 2 - Medium (Extended System Validation)
+# 3 - Long (System HW Diagnostics)
+# 4 - Extended (Longer-running System HW Diagnostics)
+DCGMI_LEVEL=2
+
+function main() {
+
+  ## Identify full path of lspci command
+  lspci_fullpath=$(PATH=$PATH:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin command -v lspci)
+
+  ## Check if the instance has an NVIDIA acceleration
+  is_nvidia
+  fast_success_exit "$?" "The GPU Health Check is running in an instance without a supported GPU: skipping its execution."
+
+  ## Check if the nvidia-smi command is available
+  command -v nvidia-smi &>/dev/null
+  fast_success_exit "$?" "The GPU Health Check has been executed but the nvidia-smi tool is not available in this system or is located in a different file path. Please consider using an official ParallelCluster AMI."
+
+  ## Check if the DCGM Diagnostic tool is available
+  command -v dcgmi  &>/dev/null
+  fast_success_exit "$?" "The Gpu Health Check has been executed but the NVIDIA DCGM Diagnostic tool is not available in this system or is located in a different file path. Please consider using an official ParallelCluster AMI."
+
+  ## Check if there are GPU associated to the job
+
+  if [ -z "$GPU_DEVICE_ORDINAL" ]; then
+    nvidia_smi_output=$(nvidia-smi -L)
+    nvidia_smi_exit_code=$(echo $?)
+    fast_success_exit $nvidia_smi_exit_code "The nvidia-smi tool failed its execution."
+    # The "nvidia-smi -L" return the list of GPUs available on the node:
+    # $nvidia-smi -L
+    # GPU 0: NVIDIA A100-SXM4-80GB (UUID: GPU-e57350fc-1789-b69a-0637-18a3025b1da2)
+    # GPU 1: NVIDIA A100-SXM4-80GB (UUID: GPU-c4798aff-efab-68a7-1a52-107a0d6775fd)
+    # ...
+    # for each line in the output the ID is removing all characters after the colon symbol and the "GPU " string
+    # $nvidia-smi -L | while IFS= read -r gpu ; do echo $gpu | cut -d ':' -f1 | sed s/"GPU "//; done
+    # 0
+    # 1
+    # Then the newline is replaced by a comma
+    # $nvidia-smi -L | while IFS= read -r gpu ; do echo $gpu | cut -d ':' -f1 | sed s/"GPU "//; done | tr '\n' ','
+    # 0,1,
+    # and then we remove the last char
+    # $nvidia-smi -L | while IFS= read -r gpu ; do echo $gpu | cut -d ':' -f1 | sed s/"GPU "//; done | tr '\n' ',' | sed 's/.$//'
+    # 0,1
+    GPU_DEVICE_ORDINAL=$(echo "$nvidia_smi_output" | while IFS= read -r gpu ; do echo $gpu | cut -d ':' -f1 | sed s/"GPU "//; done | tr '\n' ',' | sed 's/.$//')
+    log_info "The variable GPU_DEVICE_ORDINAL has been initialized using information provided by nvidia-smi"
+  fi
+  log_info "The value of GPU_DEVICE_ORDINAL is '${GPU_DEVICE_ORDINAL}'"
+
+  ## Services Initialization
+  local dcgm_service_started
+  initialize_dcgm
+  fast_success_exit "$?" "Skipping execution of the GPU Health Check"
+
+  local nvidia_fabricmanager_service_started
+  initialize_nvidia_fabricmanager
+  fast_success_exit "$?" "Skipping execution of the GPU Health Check"
+
+  ## Retrieve gpus information and enable them to run the health check
+  local gpus_list
+  gpus_list=${GPU_DEVICE_ORDINAL//,/$'\n'}
+  for gpu_id in $gpus_list
+  do
+    # Retrieve gpu information. This check will exit in following cases:
+    # - the nvidia-smi command is not available
+    # - the nvidia-smi command is available but it fails its execution
+    nvidia_smi_out=$(nvidia-smi -q -i $gpu_id)
+    nvidia_smi_exit_code=$(echo $?)
+    fast_success_exit $nvidia_smi_exit_code "The nvidia-smi tool failed its execution."
+
+    ## Enable persistence mode in target GPU, required by the DCGM Diagnostic tool
+    local persistence_mode_enabled_$gpu_id
+    persistence_mode=$(echo "$nvidia_smi_out" | grep "Persistence Mode")
+    if [[ ! ${persistence_mode} == *"Enabled"* ]]; then
+      nvidia-smi -i $gpu_id -pm 1 >/dev/null
+      log_info "Persistence mode has been enabled by the GPU Health Check in target GPU '${gpu_id}'"
+      declare persistence_mode_enabled_$gpu_id=true
+    else
+      log_info "Persistence mode already enabled for target GPU '${gpu_id}'"
+    fi
+
+    ## Log useful GPU information
+    gpu_identifier=$(echo "$nvidia_smi_out" | grep "^GPU " | xargs)
+    gpu_uuid=$(echo "$nvidia_smi_out" | grep "GPU UUID" | xargs)
+    gpu_serial_number=$(echo "$nvidia_smi_out" | grep "Serial Number" | xargs)
+    # This command logs the GPU information in the format
+    # Details for GPU '0'. 'GPU 00000000:00:1E.0', 'GPU UUID : GPU-931c0765-01f6-f7af-00df-fb4202cec8b9', 'Serial Number : 0322817127524'
+    log_info "Details for GPU '${gpu_id}': '${gpu_identifier}', '${gpu_uuid}', '${gpu_serial_number}'"
+  done
+
+  ## Run GPUs Health Check test
+  log_info "Running GPU Health Check with DCGMI level $DCGMI_LEVEL"
+  dcgmi diag -i $GPU_DEVICE_ORDINAL -r $DCGMI_LEVEL
+  dcgmi_exit_code=$(echo $?)
+
+  if [ $dcgmi_exit_code -ne 0 ]; then
+    log_error "The GPU Health Check failed"
+  else
+    log_info "The GPU Health Check succeeded"
+  fi
+  tear_down
+  return $dcgmi_exit_code
+}
+
+function _log() {
+  echo "$(date +"%Y-%m-%d %H-%M-%S,%3N") - [${0##*/}] - $1 - JobID $SLURM_JOB_ID - ${*:2}"
+}
+
+function log_info() {
+  _log "INFO" "$@"
+}
+
+function log_error() {
+  _log "ERROR" "$@"
+}
+
+function fast_success_exit() {
+  if [ $1 -ne 0 ]; then
+    log_info "$2"
+    tear_down
+    exit 0
+  fi
+}
+
+function is_nvidia() {
+  $lspci_fullpath | grep -i -o 'NVIDIA' &>/dev/null
+  return $?
+}
+
+function start_service() {
+  systemctl start $1
+  if [ $? -ne 0 ]; then
+    log_info "Unable to start service $1"
+    return 1
+  fi
+}
+
+function initialize_dcgm() {
+  systemctl show nvidia-dcgm.service -p ActiveState | grep "=active"
+  if [ $? -ne 0 ]; then
+    log_info "Starting nvidia-dcgm service since it is not running"
+    start_service nvidia-dcgm
+    if [ $? -ne 0 ]; then
+      return 1
+    fi
+    dcgm_service_started=true
+  else
+    log_info "nvidia-dcgm service if already running"
+  fi
+}
+
+function initialize_nvidia_fabricmanager() {
+  log_info "Verifying if the check is running on a NVSwitch enabled system"
+  nvswitch_check=$($lspci_fullpath -d 10de:1af1 | wc -l)
+  if [ "${nvswitch_check}" -gt 1 ]; then
+    systemctl show nvidia-fabricmanager.service -p ActiveState | grep "=active"
+    if [ $? -ne 0 ]; then
+      log_info "Starting nvidia-fabricmanager since it is not running"
+      start_service nvidia-fabricmanager
+      if [ $? -ne 0 ]; then
+        return 1
+      fi
+      nvidia_fabricmanager_service_started=true
+    else
+      log_info "nvidia-fabricmanager is already running"
+    fi
+  fi
+}
+
+function tear_down() {
+  log_info "Restoring previous configurations"
+
+  ## Restore previous persistence mode
+  for gpu_id in $gpus_list
+  do
+      persistence_mode_variable=persistence_mode_enabled_$gpu_id
+      if [ "${!persistence_mode_variable}" = true ] ; then
+        log_info "Disabling persistence mode on GPU '$gpu_id'"
+        nvidia-smi -i $gpu_id -pm 0 >/dev/null
+      fi
+  done
+
+  if [ "$nvidia_fabricmanager_service_started" = true ] ; then
+    log_info "Stopping nvidia-fabricmanager service"
+    systemctl stop nvidia-fabricmanager
+  fi
+
+  if [ "$dcgm_service_started" = true ] ; then
+    log_info "Stopping nvidia-dcgm service"
+    systemctl stop nvidia-dcgm
+  fi
+}
+
+main "$@"

--- a/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/logging/health_check_manager_logging.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/logging/health_check_manager_logging.conf
@@ -1,0 +1,37 @@
+[loggers]
+keys=root,events
+
+[handlers]
+keys=fileHandler,eventsHandler
+
+[formatters]
+keys=defaultFormatter,eventsFormatter
+
+[logger_root]
+level=INFO
+handlers=fileHandler
+qualname=slurm_plugin.health_check_manager
+
+[formatter_defaultFormatter]
+format=%(asctime)s - [%(filename)s:%(funcName)s] - %(levelname)s - JobID %(job_id)s - %(message)s
+
+[handler_fileHandler]
+class=FileHandler
+level=INFO
+formatter=defaultFormatter
+args=('/var/log/parallelcluster/slurm_health_check.log', 'a', None, False)
+
+[logger_events]
+level=WARNING
+handlers=eventsHandler
+propagate=0
+qualname=slurm_plugin.prolog.events
+
+[formatter_eventsFormatter]
+format=%(message)s
+
+[handler_eventsHandler]
+class=FileHandler
+level=WARNING
+formatter=eventsFormatter
+args=('/var/log/parallelcluster/slurm_health_check.events', 'a', None, False)

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -238,6 +238,8 @@ template '/etc/systemd/system/slurmdbd.service' do
   action :create
 end
 
+include_recipe 'aws-parallelcluster-slurm::config_health_check'
+
 ruby_block "Configure Slurm Accounting" do
   block do
     run_context.include_recipe "aws-parallelcluster-slurm::config_slurm_accounting"

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_health_check.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_health_check.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-slurm
+# Recipe:: config_health_check
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+directory "#{node['cluster']['slurm']['install_dir']}/etc/scripts/prolog.d" do
+  user 'root'
+  group 'root'
+  mode '0755'
+  recursive true
+end
+
+directory "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/prolog.d" do
+  user 'root'
+  group 'root'
+  mode '0755'
+  recursive true
+end
+
+directory "#{node['cluster']['slurm']['install_dir']}/etc/scripts/epilog.d" do
+  user 'root'
+  group 'root'
+  mode '0755'
+end
+
+directory "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/epilog.d" do
+  user 'root'
+  group 'root'
+  mode '0755'
+end
+
+cookbook_file "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/health_check_manager.py" do
+  source 'config_slurm/scripts/health_check_manager.py'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
+directory "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/logging" do
+  user 'root'
+  group 'root'
+  mode '0755'
+end
+
+cookbook_file "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/logging/health_check_manager_logging.conf" do
+  source 'config_slurm/scripts/logging/health_check_manager_logging.conf'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end
+
+directory "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/conf" do
+  user 'root'
+  group 'root'
+  mode '0755'
+end
+
+template "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/conf/health_check_manager.conf" do
+  source 'slurm/head_node/health_check/health_check_manager.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end
+
+directory "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/health_checks" do
+  user 'root'
+  group 'root'
+  mode '0755'
+end
+
+cookbook_file "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/health_checks/gpu_health_check.sh" do
+  source 'config_slurm/scripts/health_checks/gpu_health_check.sh'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
+template "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/prolog.d/90_pcluster_health_check_manager" do
+  source 'slurm/head_node/health_check/90_pcluster_health_check_manager.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
+link "#{node['cluster']['slurm']['install_dir']}/etc/scripts/prolog.d/90_pcluster_health_check_manager" do
+  to "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/prolog.d/90_pcluster_health_check_manager"
+end
+
+cookbook_file "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/epilog.d/90_pcluster_noop" do
+  source 'config_slurm/scripts/epilog.d/90_pcluster_noop'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
+link "#{node['cluster']['slurm']['install_dir']}/etc/scripts/epilog.d/90_pcluster_noop" do
+  to "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/epilog.d/90_pcluster_noop"
+end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/90_pcluster_health_check_manager.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/90_pcluster_health_check_manager.erb
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+WAIT_EXEC=false
+DEBUG=false
+
+LOG_FILE_PATH="/var/log/parallelcluster/slurm_health_check.log"
+FLOCK_FILE_DESCRIPTOR_NUMBER=10
+
+flock_params=(-n)
+if [ "${WAIT_EXEC}" = true ]; then
+  flock_params=(-w 600)
+fi
+
+function _log() {
+  LOG_LEVEL=$1
+  shift
+  echo "$(date +"%Y-%m-%d %H-%M-%S,%3N") - [$(basename $0)] - ${LOG_LEVEL} - Job ${SLURM_JOB_ID} - $*" >> "${LOG_FILE_PATH}"
+}
+
+function log_info() {
+  _log "INFO" "$@"
+}
+
+function log_error() {
+  _log "ERROR" "$@"
+}
+
+function manage_concurrency() {
+  log_info "There is another running instance of ParallelCluster Health Check Manager for queue (${PCLUSTER_SCHEDULER_QUEUE_NAME}) and compute resource (${PCLUSTER_SCHEDULER_COMPUTE_RESOURCE_NAME}), exiting gracefully..."
+  exit 0
+}
+
+exec >>"${LOG_FILE_PATH}" 2>&1
+if [ "${DEBUG}" = true ]; then
+ set -x
+fi
+
+PCLUSTER_COOKBOOK_VIRTUALENV_PATH="<%= node['cluster']['cookbook_virtualenv_path'] %>"
+PCLUSTER_SCRIPTS_DIR="<%= node['cluster']['slurm']['install_dir'] %>/etc/pcluster/.slurm_plugin/scripts"
+PCLUSTER_CONFIG_PATH="<%= node['cluster']['cluster_config_path'] %>"
+PCLUSTER_DNA_JSON_PATH="/etc/chef/dna.json"
+
+PCLUSTER_NODE_TYPE="$(cat "${PCLUSTER_DNA_JSON_PATH}" | jq -r ".cluster.node_type")"
+PCLUSTER_SCHEDULER_QUEUE_NAME="$(cat "${PCLUSTER_DNA_JSON_PATH}" | jq -r ".cluster.scheduler_queue_name")"
+PCLUSTER_SCHEDULER_COMPUTE_RESOURCE_NAME="$(cat "${PCLUSTER_DNA_JSON_PATH}" | jq -r ".cluster.scheduler_compute_resource_name")"
+
+( flock "${flock_params[@]}" ${FLOCK_FILE_DESCRIPTOR_NUMBER} || manage_concurrency
+  log_info "Calling ParallelCluster Health Check Manager for queue (${PCLUSTER_SCHEDULER_QUEUE_NAME}) and compute resource (${PCLUSTER_SCHEDULER_COMPUTE_RESOURCE_NAME})"
+
+  "${PCLUSTER_COOKBOOK_VIRTUALENV_PATH}"/bin/python \
+    "${PCLUSTER_SCRIPTS_DIR}/health_check_manager.py" \
+    --node-type "${PCLUSTER_NODE_TYPE}" \
+    --queue-name "${PCLUSTER_SCHEDULER_QUEUE_NAME}" \
+    --compute-resource-name "${PCLUSTER_SCHEDULER_COMPUTE_RESOURCE_NAME}" \
+    --job-id "${SLURM_JOB_ID}" \
+    --cluster-configuration "${PCLUSTER_CONFIG_PATH}"
+) {FLOCK_FILE_DESCRIPTOR_NUMBER}>/var/lock/health_check.lock

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/health_check_manager.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/health_check_manager.conf.erb
@@ -1,0 +1,2 @@
+[health_check_manager]
+managed_health_check_dir = <%= node['cluster']['slurm']['install_dir'] %>/etc/pcluster/.slurm_plugin/scripts/health_checks

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -41,6 +41,11 @@ PrivateData=cloud
 ResumeRate=0
 SuspendRate=0
 #
+# PROLOG AND EPILOG
+Prolog=<%= node['cluster']['slurm']['install_dir'] %>/etc/scripts/prolog.d/*
+Epilog=<%= node['cluster']['slurm']['install_dir'] %>/etc/scripts/epilog.d/*
+SchedulerParameters=nohold_on_prolog_fail
+#
 # TIMERS
 SlurmctldTimeout=300
 SlurmdTimeout=180

--- a/cookbooks/aws-parallelcluster-test/recipes/slurm_mock.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/slurm_mock.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-test
+# Recipe:: slurm_mock
+#
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+directory "/opt/slurm/etc/pcluster/.slurm_plugin" do
+  owner 'root'
+  group 'root'
+  mode '0755'
+  recursive true
+end

--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -373,3 +373,14 @@ suites:
       cluster:
         nvidia:
           enabled: true
+  - name: health_check
+    run_list:
+      - recipe[aws-parallelcluster-test::slurm_mock]
+      - recipe[aws-parallelcluster-slurm::config_health_check]
+    verifier:
+      controls:
+        - health_check_configured
+    attributes:
+      cluster:
+        slurm:
+          install_dir: "/opt/slurm"

--- a/test/recipes/controls/aws_parallelcluster_slurm/config_health_check_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/config_health_check_spec.rb
@@ -1,0 +1,45 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'health_check_configured' do
+  title 'Check health check setup is configured'
+  slurm_install_dir = "/opt/slurm"
+
+  describe file("#{slurm_install_dir}/etc/pcluster/.slurm_plugin/scripts/health_check_manager.py") do
+    it { should exist }
+  end
+  describe file("#{slurm_install_dir}/etc/pcluster/.slurm_plugin/scripts/logging/health_check_manager_logging.conf") do
+    it { should exist }
+  end
+  describe file("#{slurm_install_dir}/etc/pcluster/.slurm_plugin/scripts/conf/health_check_manager.conf") do
+    it { should exist }
+  end
+  describe file("#{slurm_install_dir}/etc/pcluster/.slurm_plugin/scripts/health_checks/gpu_health_check.sh") do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+  end
+  describe file("#{slurm_install_dir}/etc/pcluster/.slurm_plugin/scripts/prolog.d/90_pcluster_health_check_manager") do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+  end
+  describe file("#{slurm_install_dir}/etc/pcluster/.slurm_plugin/scripts/epilog.d/90_pcluster_noop") do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+  end
+  describe file("#{slurm_install_dir}/etc/scripts/prolog.d/90_pcluster_health_check_manager") do
+    it { should be_symlink }
+    it { should be_linked_to "#{slurm_install_dir}/etc/pcluster/.slurm_plugin/scripts/prolog.d/90_pcluster_health_check_manager" }
+  end
+  describe file("#{slurm_install_dir}/etc/scripts/epilog.d/90_pcluster_noop") do
+    it { should be_symlink }
+    it { should be_linked_to "#{slurm_install_dir}/etc/pcluster/.slurm_plugin/scripts/epilog.d/90_pcluster_noop" }
+  end
+end

--- a/test/unit/health_check/test_health_check_manager.py
+++ b/test/unit/health_check/test_health_check_manager.py
@@ -1,0 +1,589 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from types import SimpleNamespace
+
+import health_check_manager
+import pytest
+from assertpy import assert_that
+from health_check_manager import (
+    HealthCheckConfig,
+    HealthCheckConfigLoader,
+    HealthCheckDefinition,
+    HealthCheckManagerConfig,
+    ManagedHealthCheckName,
+)
+
+
+class TestManagedHealthCheckName:
+    """Class to test ManagedHealthCheckName."""
+
+    @pytest.mark.parametrize(
+        ("check_name", "health_check_dir", "expected_path"),
+        [
+            (
+                "gpu",
+                "/my/path/",
+                "/my/path/gpu_health_check.sh",
+            ),
+            ("gpu", "/my/other/path/", "/my/other/path/gpu_health_check.sh"),
+        ],
+    )
+    def test_get_health_check_path(self, check_name, health_check_dir, expected_path):
+        """Test get_health_check_path method."""
+        assert_that(ManagedHealthCheckName[check_name.upper()].get_health_check_path(health_check_dir)).is_equal_to(
+            expected_path
+        )
+
+
+class TestHealthCheckManagerConfig:
+    """Class to test HealthCheckManagerConfig."""
+
+    @pytest.mark.parametrize(
+        ("config_file", "expected_attributes"),
+        [
+            (
+                "default.conf",
+                {
+                    "health_check_timeout": 600,
+                    "logging_config": os.path.join(
+                        os.path.dirname(health_check_manager.__file__), "logging", "health_check_manager_logging.conf"
+                    ),
+                    "managed_health_check_dir": "/my/health_checks/",
+                },
+            ),
+            (
+                "all_options.conf",
+                {
+                    "health_check_timeout": 100,
+                    "logging_config": "/my/logging/config",
+                    "managed_health_check_dir": "/my/checks/",
+                },
+            ),
+            (
+                "non-existent",
+                {
+                    "health_check_timeout": 600,
+                    "logging_config": os.path.join(
+                        os.path.dirname(health_check_manager.__file__), "logging", "health_check_manager_logging.conf"
+                    ),
+                    "managed_health_check_dir": os.path.join(
+                        os.path.dirname(health_check_manager.__file__), "health_checks"
+                    ),
+                },
+            ),
+        ],
+        ids=["default", "all_options", "fallback_default"],
+    )
+    def test_config_parsing(self, config_file, expected_attributes, test_datadir):
+        """Test config_parsing method."""
+        sync_config = HealthCheckManagerConfig(test_datadir / config_file)
+        for key in expected_attributes:
+            assert_that(sync_config.__dict__.get(key)).is_equal_to(expected_attributes.get(key))
+
+    def test_config_comparison(self, test_datadir):
+        """Test configs comparison."""
+        config = test_datadir / "config.conf"
+        config_modified = test_datadir / "config_modified.conf"
+
+        assert_that(HealthCheckManagerConfig(config)).is_equal_to(HealthCheckManagerConfig(config))
+        assert_that(HealthCheckManagerConfig(config)).is_not_equal_to(HealthCheckManagerConfig(config_modified))
+
+
+class TestHealthCheckConfigLoader:
+    """Class to test HealthCheckConfigLoader."""
+
+    @pytest.mark.parametrize(
+        ("conf_file_content", "health_check_dir_path", "params", "expected_health_check_conf"),
+        [
+            (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [
+                            {
+                                "Name": "q1",
+                                "HealthChecks": {"Gpu": {"Enabled": None}},
+                                "ComputeResources": [
+                                    {
+                                        "Name": "c1",
+                                        "HealthChecks": {"Gpu": {"Enabled": None}},
+                                    }
+                                ],
+                            },
+                        ]
+                    }
+                },
+                "/my/path/for/checks",
+                {
+                    "cluster_configuration": "mocked",
+                    "node_type": "ComputeFleet",
+                    "queue_name": "q1",
+                    "compute_resource_name": "c1",
+                },
+                HealthCheckConfig(
+                    node_type="ComputeFleet",
+                    queue_name="q1",
+                    compute_resource_name="c1",
+                    health_checks=[
+                        HealthCheckDefinition(
+                            name="Gpu",
+                            is_managed=True,
+                            is_enabled=False,
+                            check_path="/my/path/for/checks/gpu_health_check.sh",
+                        )
+                    ],
+                ),
+            ),
+            (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [
+                            {
+                                "Name": "q1",
+                                # missing HealthChecks definition
+                                "ComputeResources": [
+                                    {
+                                        "Name": "c1",
+                                        # missing HealthChecks definition
+                                    }
+                                ],
+                            },
+                        ]
+                    }
+                },
+                "/my/path/for/checks",
+                {
+                    "cluster_configuration": "mocked",
+                    "node_type": "ComputeFleet",
+                    "queue_name": "q1",
+                    "compute_resource_name": "c1",
+                },
+                HealthCheckConfig(
+                    node_type="ComputeFleet",
+                    queue_name="q1",
+                    compute_resource_name="c1",
+                    health_checks=[],
+                ),
+            ),
+            (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [
+                            {
+                                "Name": "q1",
+                                "HealthChecks": {"Gpu": {"Enabled": True}},
+                                "ComputeResources": [
+                                    {
+                                        "Name": "c1",
+                                        # missing HealthChecks definition
+                                    }
+                                ],
+                            },
+                        ]
+                    }
+                },
+                "/my/path/for/checks",
+                {
+                    "cluster_configuration": "mocked",
+                    "node_type": "ComputeFleet",
+                    "queue_name": "q1",
+                    "compute_resource_name": "c1",
+                },
+                HealthCheckConfig(
+                    node_type="ComputeFleet",
+                    queue_name="q1",
+                    compute_resource_name="c1",
+                    health_checks=[],
+                ),
+            ),
+            (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [
+                            {
+                                "Name": "q1",
+                                "HealthChecks": {"Gpu": {"Enabled": False}},
+                                "ComputeResources": [
+                                    {
+                                        "Name": "c1",
+                                        "HealthChecks": {"Gpu": {"Enabled": True}},
+                                    }
+                                ],
+                            },
+                        ]
+                    }
+                },
+                "/my/path/for/checks",
+                {
+                    "cluster_configuration": "mocked",
+                    "node_type": "ComputeFleet",
+                    "queue_name": "q1",
+                    "compute_resource_name": "c1",
+                },
+                HealthCheckConfig(
+                    node_type="ComputeFleet",
+                    queue_name="q1",
+                    compute_resource_name="c1",
+                    health_checks=[
+                        HealthCheckDefinition(
+                            name="Gpu",
+                            is_managed=True,
+                            is_enabled=True,
+                            check_path="/my/path/for/checks/gpu_health_check.sh",
+                        )
+                    ],
+                ),
+            ),
+            (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [
+                            {
+                                "Name": "q1",
+                                "HealthChecks": {"Gpu": {"Enabled": True}},
+                                "ComputeResources": [
+                                    {
+                                        "Name": "c1",
+                                        "HealthChecks": {"Gpu": {"Enabled": False}},
+                                    }
+                                ],
+                            },
+                        ]
+                    }
+                },
+                "/my/path/for/checks",
+                {
+                    "cluster_configuration": "mocked",
+                    "node_type": "ComputeFleet",
+                    "queue_name": "q1",
+                    "compute_resource_name": "c1",
+                },
+                HealthCheckConfig(
+                    node_type="ComputeFleet",
+                    queue_name="q1",
+                    compute_resource_name="c1",
+                    health_checks=[
+                        HealthCheckDefinition(
+                            name="Gpu",
+                            is_managed=True,
+                            is_enabled=False,
+                            check_path="/my/path/for/checks/gpu_health_check.sh",
+                        )
+                    ],
+                ),
+            ),
+            (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [
+                            {
+                                "Name": "q1",
+                                "HealthChecks": {"Gpu": {"Enabled": True}},
+                                "ComputeResources": [
+                                    {
+                                        "Name": "c1",
+                                        "HealthChecks": {"Gpu": {"Enabled": True}},
+                                    }
+                                ],
+                            },
+                        ]
+                    }
+                },
+                "/my/path/for/checks",
+                {
+                    "cluster_configuration": "mocked",
+                    "node_type": "ComputeFleet",
+                    "queue_name": "q1",
+                    "compute_resource_name": "c1",
+                },
+                HealthCheckConfig(
+                    node_type="ComputeFleet",
+                    queue_name="q1",
+                    compute_resource_name="c1",
+                    health_checks=[
+                        HealthCheckDefinition(
+                            name="Gpu",
+                            is_managed=True,
+                            is_enabled=True,
+                            check_path="/my/path/for/checks/gpu_health_check.sh",
+                        )
+                    ],
+                ),
+            ),
+            (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [
+                            {
+                                "Name": "q1",
+                                "HealthChecks": {"Gpu": {"Enabled": True}},
+                                "ComputeResources": [
+                                    {
+                                        "Name": "c1",
+                                        "HealthChecks": {"Gpu": {"Enabled": None}},
+                                    },
+                                    {
+                                        "Name": "c2",
+                                        "HealthChecks": {"Gpu": {"Enabled": True}},
+                                    },
+                                ],
+                            },
+                        ]
+                    }
+                },
+                "/my/path/for/checks",
+                {
+                    "cluster_configuration": "mocked",
+                    "node_type": "ComputeFleet",
+                    "queue_name": "q1",
+                    "compute_resource_name": "c1",
+                },
+                HealthCheckConfig(
+                    node_type="ComputeFleet",
+                    queue_name="q1",
+                    compute_resource_name="c1",
+                    health_checks=[
+                        HealthCheckDefinition(
+                            name="Gpu",
+                            is_managed=True,
+                            is_enabled=True,
+                            check_path="/my/path/for/checks/gpu_health_check.sh",
+                        )
+                    ],
+                ),
+            ),
+            (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [
+                            {
+                                "Name": "q1",
+                                "HealthChecks": {"Gpu": {"Enabled": True}},
+                                "ComputeResources": [
+                                    {
+                                        "Name": "c1",
+                                        "HealthChecks": {"Gpu": {"Enabled": False}},
+                                    },
+                                    {
+                                        "Name": "c2",
+                                        "HealthChecks": {"Gpu": {"Enabled": True}},
+                                    },
+                                ],
+                            },
+                        ]
+                    }
+                },
+                "/my/path/for/checks",
+                {
+                    "cluster_configuration": "mocked",
+                    "node_type": "ComputeFleet",
+                    "queue_name": "q1",
+                    "compute_resource_name": "c1",
+                },
+                HealthCheckConfig(
+                    node_type="ComputeFleet",
+                    queue_name="q1",
+                    compute_resource_name="c1",
+                    health_checks=[
+                        HealthCheckDefinition(
+                            name="Gpu",
+                            is_managed=True,
+                            is_enabled=False,
+                            check_path="/my/path/for/checks/gpu_health_check.sh",
+                        )
+                    ],
+                ),
+            ),
+        ],
+    )
+    def test_load_configuration(
+        self, mocker, conf_file_content, health_check_dir_path, params, expected_health_check_conf
+    ):
+        """Test load_configuration method."""
+        args = SimpleNamespace(**params)
+        mocker.patch(
+            "health_check_manager.HealthCheckConfigLoader._load_cluster_config", return_value=conf_file_content
+        )
+        health_check_manager_config = mocker.Mock(spec=HealthCheckManagerConfig)
+        health_check_manager_config.managed_health_check_dir = health_check_dir_path
+
+        health_check_conf = HealthCheckConfigLoader().load_configuration(health_check_manager_config, args)
+        assert_that(expected_health_check_conf).is_equal_to(health_check_conf)
+
+    @pytest.mark.parametrize(
+        ("config_file", "expected_queue_name"),
+        [
+            (
+                "config.yaml",
+                "q1",
+            ),
+        ],
+    )
+    def test_load_cluster_config(self, test_datadir, config_file, expected_queue_name):
+        """Test _load_cluster_config method."""
+        cluster_config = HealthCheckConfigLoader()._load_cluster_config(test_datadir / config_file)
+        assert_that(cluster_config["Scheduling"]["SlurmQueues"][0]["Name"]).is_equal_to(expected_queue_name)
+
+
+@pytest.mark.parametrize(
+    ("health_check_conf", "expected_exit_code", "expect_execution", "expect_failure"),
+    [
+        (
+            HealthCheckConfig(
+                node_type="ComputeFleet",
+                queue_name="q1",
+                compute_resource_name="c1",
+                health_checks=[
+                    HealthCheckDefinition(
+                        name="Gpu",
+                        is_managed=True,
+                        is_enabled=True,
+                        check_path="success.sh",
+                    )
+                ],
+            ),
+            0,
+            True,
+            False,
+        ),
+        (
+            HealthCheckConfig(
+                node_type="ComputeFleet",
+                queue_name="q1",
+                compute_resource_name="c1",
+                health_checks=[
+                    HealthCheckDefinition(
+                        name="Gpu",
+                        is_managed=True,
+                        is_enabled=False,
+                        check_path="success.sh",
+                    )
+                ],
+            ),
+            0,
+            False,
+            False,
+        ),
+        (
+            HealthCheckConfig(
+                node_type="ComputeFleet",
+                queue_name="q1",
+                compute_resource_name="c1",
+                health_checks=[
+                    HealthCheckDefinition(
+                        name="Gpu",
+                        is_managed=True,
+                        is_enabled=True,
+                        check_path="failure.sh",
+                    )
+                ],
+            ),
+            125,
+            True,
+            False,
+        ),
+        (
+            HealthCheckConfig(
+                node_type="ComputeFleet",
+                queue_name="q1",
+                compute_resource_name="c1",
+                health_checks=[
+                    HealthCheckDefinition(
+                        name="Gpu",
+                        is_managed=True,
+                        is_enabled=True,
+                        check_path="non-executable.sh",
+                    )
+                ],
+            ),
+            0,
+            False,
+            True,
+        ),
+        (
+            HealthCheckConfig(
+                node_type="ComputeFleet",
+                queue_name="q1",
+                compute_resource_name="c1",
+                health_checks=[
+                    HealthCheckDefinition(
+                        name="Gpu",
+                        is_managed=True,
+                        is_enabled=True,
+                        check_path="not-found",
+                    )
+                ],
+            ),
+            0,
+            False,
+            True,
+        ),
+        (
+            HealthCheckConfig(
+                node_type="ComputeFleet",
+                queue_name="q1",
+                compute_resource_name="c1",
+                health_checks=[
+                    HealthCheckDefinition(
+                        name="Gpu",
+                        is_managed=True,
+                        is_enabled=True,
+                        check_path="success.sh",
+                    ),
+                    HealthCheckDefinition(
+                        name="Another",
+                        is_managed=True,
+                        is_enabled=True,
+                        check_path="failure.sh",
+                    ),
+                ],
+            ),
+            125,
+            True,
+            False,
+        ),
+        (
+            HealthCheckConfig(
+                node_type="ComputeFleet",
+                queue_name="q1",
+                compute_resource_name="c1",
+                health_checks=[],
+            ),
+            0,
+            False,
+            False,
+        ),
+    ],
+)
+def test_execute_health_checks(
+    mocker, health_check_conf, expected_exit_code, expect_execution, expect_failure, test_datadir, caplog
+):
+    """Test _execute_health_checks method."""
+    caplog.set_level(logging.INFO)
+    health_check_manager_config = mocker.Mock(spec=HealthCheckManagerConfig)
+    health_check_manager_config.health_check_timeout = 100
+    mocker.patch("health_check_manager.HealthCheckConfigLoader.load_configuration", return_value=health_check_conf)
+    for health_check in health_check_conf.health_checks:
+        health_check.check_path = str(test_datadir / health_check.check_path)
+    exit_code = health_check_manager._execute_health_checks(health_check_manager_config, [])
+    assert_that(exit_code).is_equal_to(expected_exit_code)
+    if expect_execution:
+        assert_that(caplog.text).contains("err to stderr")
+        assert_that(caplog.text).contains("output to stdout")
+    else:
+        assert_that(caplog.text).does_not_contain("err to stderr")
+        assert_that(caplog.text).does_not_contain("output to stdout")
+    if expect_failure:
+        assert_that(caplog.text).contains("Failure when executing Health Check")
+    else:
+        assert_that(caplog.text).does_not_contain("Failure when executing Health Check")

--- a/test/unit/health_check/test_health_check_manager/TestHealthCheckConfigLoader/test_load_cluster_config/config.yaml
+++ b/test/unit/health_check/test_health_check_manager/TestHealthCheckConfigLoader/test_load_cluster_config/config.yaml
@@ -1,0 +1,148 @@
+AdditionalPackages: null
+AdditionalResources: null
+CustomS3Bucket: null
+DeploymentSettings: null
+DevSettings: null
+DirectoryService: null
+HeadNode:
+  CustomActions: null
+  Dcv: null
+  DisableSimultaneousMultithreading: false
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    InstanceProfile: null
+    InstanceRole: null
+    S3Access: null
+  Image: null
+  Imds:
+    Secured: true
+  InstanceType: c5.2xlarge
+  LocalStorage:
+    EphemeralVolume: null
+    RootVolume:
+      DeleteOnTermination: true
+      Encrypted: true
+      Iops: 3000
+      Size: null
+      Throughput: 125
+      VolumeType: gp3
+  Networking:
+    AdditionalSecurityGroups: null
+    ElasticIp: null
+    Proxy: null
+    SecurityGroups: null
+    SubnetId: subnet-044bb58d0b594c6ac
+  Ssh:
+    AllowedIps: 0.0.0.0/0
+    KeyName: carrogu-us-east-1
+Iam: null
+Image:
+  CustomAmi: null
+  Os: alinux2
+Imds:
+  ImdsSupport: v1.0
+Monitoring:
+  Dashboards:
+    CloudWatch:
+      Enabled: true
+  DetailedMonitoring: false
+  Logs:
+    CloudWatch:
+      DeletionPolicy: Retain
+      Enabled: true
+      RetentionInDays: 14
+Region: eu-west-1
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - AllocationStrategy: lowest-price
+      CapacityReservationTarget: null
+      CapacityType: ONDEMAND
+      ComputeResources:
+        - CapacityReservationTarget: null
+          DisableSimultaneousMultithreading: false
+          Efa:
+            Enabled: false
+            GdrSupport: false
+          Instances:
+            - InstanceType: g4dn.12xlarge
+          MaxCount: 4
+          MinCount: 0
+          Name: c1
+          Networking:
+            PlacementGroup:
+              Enabled: null
+              Id: null
+              Name: null
+          SchedulableMemory: null
+          SpotPrice: null
+          HealthChecks:
+            Gpu:
+              Enabled: true
+        - CapacityReservationTarget: null
+          DisableSimultaneousMultithreading: false
+          Efa:
+            Enabled: false
+            GdrSupport: false
+          Instances:
+            - InstanceType: c5.12xlarge
+          MaxCount: 1
+          MinCount: 0
+          Name: c2
+          Networking:
+            PlacementGroup:
+              Enabled: null
+              Id: null
+              Name: null
+          SchedulableMemory: null
+          SpotPrice: null
+          HealthChecks:
+            Gpu:
+              Enabled: true
+      ComputeSettings:
+        LocalStorage:
+          EphemeralVolume: null
+          RootVolume:
+            Encrypted: true
+            Iops: 3000
+            Size: null
+            Throughput: 125
+            VolumeType: gp3
+      CustomActions: null
+      Iam:
+        AdditionalIamPolicies: []
+        InstanceProfile: null
+        InstanceRole: null
+        S3Access: null
+      Image: null
+      Name: q1
+      Networking:
+        AdditionalSecurityGroups: null
+        AssignPublicIp: null
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
+        Proxy: null
+        SecurityGroups: null
+        SubnetIds:
+          - subnet-044bb58d0b594c6ac
+      HealthChecks:
+        Gpu:
+          Enabled: null
+  SlurmSettings:
+    Database: null
+    Dns:
+      DisableManagedDns: false
+      HostedZoneId: null
+      UseEc2Hostnames: false
+    EnableMemoryBasedScheduling: false
+    QueueUpdateStrategy: COMPUTE_FLEET_STOP
+    ScaledownIdletime: 10
+SharedStorage: null
+Tags:
+  - Key: parallelcluster:cluster-name
+    Value: ui-test
+  - Key: parallelcluster:version
+    Value: 3.5.0

--- a/test/unit/health_check/test_health_check_manager/TestHealthCheckManagerConfig/test_config_comparison/config.conf
+++ b/test/unit/health_check/test_health_check_manager/TestHealthCheckManagerConfig/test_config_comparison/config.conf
@@ -1,0 +1,4 @@
+[health_check_manager]
+health_check_timeout = 200
+logging_config = /my/logging/config
+managed_health_check_dir = /my/checks/

--- a/test/unit/health_check/test_health_check_manager/TestHealthCheckManagerConfig/test_config_comparison/config_modified.conf
+++ b/test/unit/health_check/test_health_check_manager/TestHealthCheckManagerConfig/test_config_comparison/config_modified.conf
@@ -1,0 +1,4 @@
+[health_check_manager]
+health_check_timeout = 300
+logging_config = /my/logging/config
+managed_health_check_dir = /my/checks/

--- a/test/unit/health_check/test_health_check_manager/TestHealthCheckManagerConfig/test_config_parsing/all_options.conf
+++ b/test/unit/health_check/test_health_check_manager/TestHealthCheckManagerConfig/test_config_parsing/all_options.conf
@@ -1,0 +1,4 @@
+[health_check_manager]
+health_check_timeout = 100
+logging_config = /my/logging/config
+managed_health_check_dir = /my/checks/

--- a/test/unit/health_check/test_health_check_manager/TestHealthCheckManagerConfig/test_config_parsing/default.conf
+++ b/test/unit/health_check/test_health_check_manager/TestHealthCheckManagerConfig/test_config_parsing/default.conf
@@ -1,0 +1,2 @@
+[health_check_manager]
+managed_health_check_dir = /my/health_checks/

--- a/test/unit/health_check/test_health_check_manager/test_execute_health_checks/failure.sh
+++ b/test/unit/health_check/test_health_check_manager/test_execute_health_checks/failure.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# do some check
+>&2 echo "err to stderr"
+echo "output to stdout"
+exit 125

--- a/test/unit/health_check/test_health_check_manager/test_execute_health_checks/non-executable.sh
+++ b/test/unit/health_check/test_health_check_manager/test_execute_health_checks/non-executable.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# non executable
+exit 1

--- a/test/unit/health_check/test_health_check_manager/test_execute_health_checks/success.sh
+++ b/test/unit/health_check/test_health_check_manager/test_execute_health_checks/success.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# do some check
+>&2 echo "err to stderr"
+echo "output to stdout"
+exit 0

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,8 @@ setenv =
         {toxinidir}/cookbooks/aws-parallelcluster-install/files/default/cloudwatch_agent:\
         {toxinidir}/cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd:\
         {toxinidir}/cookbooks/aws-parallelcluster-install/files/default/ec2_udev_rules:\
-        {toxinidir}/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm
+        {toxinidir}/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm:\
+        {toxinidir}/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts
 commands =
     nocov: pytest -l -v --basetemp={envtmpdir} --html=report.html {[vars]test_dirs}
     cov: pytest -l -v --basetemp={envtmpdir} --html=report.html --cov-report=xml --cov={[vars]cov_dirs} --cov-append {[vars]test_dirs}
@@ -40,7 +41,8 @@ src_dirs =
     {toxinidir}/cookbooks/aws-parallelcluster-install/files/default/cloudwatch_agent \
     {toxinidir}/cookbooks/aws-parallelcluster-install/files/default/clusterstatusmgtd \
     {toxinidir}/cookbooks/aws-parallelcluster-install/files/default/ec2_udev_rules \
-    {toxinidir}/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm
+    {toxinidir}/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm \
+    {toxinidir}/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts
 cov_dirs =
     {toxinidir}/cookbooks/
 test_dirs = {toxinidir}/test/unit/


### PR DESCRIPTION
### Description of changes
* Add node Health Check Manager

  The Health Check Manager execution is triggered by a Slurm prolog script and executes the health checks sequentially (today only GPU check). It logs the checks output and error to a new dedicated log and exit with the sum of the exit codes of the checks.
  
  Health Check Manager code and Health Check scripts are shared from head node, so to be better maintainable.
  
  Health Check Manager related changes are:
    * code `cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_check_manager.py`
    * config `cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/health_check_manager.conf.erb`
    * logging config `cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/logging/health_check_manager_logging.conf`
    * setup `cookbooks/aws-parallelcluster-slurm/recipes/config_health_check.rb`
    * Slurm prolog hook `cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/90_pcluster_health_check_manager.erb`

* Add GPU health check

  The GPU check checks for prerequisites and then trigger NVIDIA DCGM level 2.

  GPU health check code is `cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_checks/gpu_health_check.sh`

* Config Slurm prolog/epilog to target a directory

  Slurm prolog and epilog configurations are set to target a folder.

  Changes related to Slurm prolog/epilog are in `cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb`

---

Example of Health Check execution output
```
2023-04-11 13-26-43,578 - [90_pcluster_health_check_manager] - INFO - Job 117 - Calling ParallelCluster Health Check Manager for queue (q1) and compute resource (c1)
2023-04-11 13:26:43,653 - [health_check_manager.py:main] - INFO - JobID 117 - HealthCheckManager startup.
2023-04-11 13:26:43,653 - [health_check_manager.py:_get_config] - INFO - JobID 117 - Reading '/opt/slurm/etc/pcluster/.slurm_plugin/scripts/conf/health_check_manager.conf'
2023-04-11 13:26:43,656 - [health_check_manager.py:main] - INFO - JobID 117 - HealthCheckManager config: HealthCheckManagerConfig(_config=<configparser.ConfigParser object at 0x145761b36520>, health_check_timeout=600, logging_config='/opt/slurm/etc/pcluster/.slurm_plugin/scripts/logging/health_check_manager_logging.conf', managed_health_check_dir='/opt/slurm/etc/pcluster/.slurm_plugin/scripts/health_checks')
2023-04-11 13:26:43,682 - [health_check_manager.py:_execute_health_checks] - INFO - JobID 117 - Executing Health Check 'Gpu' for queue 'q1' and compute resource 'c1'
2023-04-11 13:27:38,813 - [health_check_manager.py:_execute_health_checks] - INFO - JobID 117 - Output of Health Check 'Gpu' execution is:
2023-04-11 13-26-46,155 - [gpu_health_check.sh] - INFO - JobID 117 -  The variable GPU_DEVICE_ORDINAL has been initialized using information provided by nvidia-smi
2023-04-11 13-26-46,156 - [gpu_health_check.sh] - INFO - JobID 117 -  The value of GPU_DEVICE_ORDINAL is '0,1,2,3'
2023-04-11 13-26-46,161 - [gpu_health_check.sh] - INFO - JobID 117 -  Starting nvidia-dcgm service since it is not running
2023-04-11 13-26-46,166 - [gpu_health_check.sh] - INFO - JobID 117 -  Verifying if the check is running on a NVSwitch enabled system
2023-04-11 13-26-48,419 - [gpu_health_check.sh] - INFO - JobID 117 -  Persistence mode has been enabled by the GPU Health Check in target GPU '0'
2023-04-11 13-26-48,426 - [gpu_health_check.sh] - INFO - JobID 117 -  Details for GPU '0': 'GPU 00000000:00:1B.0', 'GPU UUID : GPU-cdb93378-20b3-0972-69be-dfcd107c08ef', 'Serial Number : 1563320009051'
2023-04-11 13-26-48,643 - [gpu_health_check.sh] - INFO - JobID 117 -  Persistence mode has been enabled by the GPU Health Check in target GPU '1'
2023-04-11 13-26-48,650 - [gpu_health_check.sh] - INFO - JobID 117 -  Details for GPU '1': 'GPU 00000000:00:1C.0', 'GPU UUID : GPU-eef73963-75ce-7331-a363-00428a4864b1', 'Serial Number : 1563320007669'
2023-04-11 13-26-48,763 - [gpu_health_check.sh] - INFO - JobID 117 -  Persistence mode has been enabled by the GPU Health Check in target GPU '2'
2023-04-11 13-26-48,770 - [gpu_health_check.sh] - INFO - JobID 117 -  Details for GPU '2': 'GPU 00000000:00:1D.0', 'GPU UUID : GPU-d831bb1e-e91d-5a32-a347-17827bb9e92a', 'Serial Number : 1563320007188'
2023-04-11 13-26-48,906 - [gpu_health_check.sh] - INFO - JobID 117 -  Persistence mode has been enabled by the GPU Health Check in target GPU '3'
2023-04-11 13-26-48,913 - [gpu_health_check.sh] - INFO - JobID 117 -  Details for GPU '3': 'GPU 00000000:00:1E.0', 'GPU UUID : GPU-a8b807e5-e3f3-f0ca-aafd-e7121e99c16c', 'Serial Number : 1563320008754'
2023-04-11 13-26-48,914 - [gpu_health_check.sh] - INFO - JobID 117 -  Running GPU Health Check with DCGMI level 2
Successfully ran diagnostic for group.
+---------------------------+------------------------------------------------+
| Diagnostic                | Result                                         |
+===========================+================================================+
|-----  Metadata  ----------+------------------------------------------------|
| DCGM Version              | 3.1.7                                          |
| Driver Version Detected   | 470.141.03                                     |
| GPU Device IDs Detected   | 1eb8,1eb8,1eb8,1eb8                            |
|-----  Deployment  --------+------------------------------------------------|
| Denylist                  | Pass                                           |
| NVML Library              | Pass                                           |
| CUDA Main Library         | Pass                                           |
| Permissions and OS Blocks | Pass                                           |
| Persistence Mode          | Pass                                           |
| Environment Variables     | Pass                                           |
| Page Retirement/Row Remap | Pass                                           |
| Graphics Processes        | Pass                                           |
| Inforom                   | Pass                                           |
+-----  Integration  -------+------------------------------------------------+
| PCIe                      | Pass - All                                     |
+-----  Hardware  ----------+------------------------------------------------+
| GPU Memory                | Pass - All                                     |
+-----  Stress  ------------+------------------------------------------------+
+---------------------------+------------------------------------------------+
2023-04-11 13-27-37,549 - [gpu_health_check.sh] - INFO - JobID 117 -  The GPU Health Check succeeded
2023-04-11 13-27-37,550 - [gpu_health_check.sh] - INFO - JobID 117 -  Restoring previous configurations
2023-04-11 13-27-37,551 - [gpu_health_check.sh] - INFO - JobID 117 -  Disabling persistence mode on GPU '0'
2023-04-11 13-27-37,562 - [gpu_health_check.sh] - INFO - JobID 117 -  Disabling persistence mode on GPU '1'
2023-04-11 13-27-37,572 - [gpu_health_check.sh] - INFO - JobID 117 -  Disabling persistence mode on GPU '2'
2023-04-11 13-27-37,583 - [gpu_health_check.sh] - INFO - JobID 117 -  Disabling persistence mode on GPU '3'
2023-04-11 13-27-37,594 - [gpu_health_check.sh] - INFO - JobID 117 -  Stopping nvidia-dcgm service

2023-04-11 13:27:38,813 - [health_check_manager.py:main] - INFO - JobID 117 - HealthCheckManager finished with exit code '0'.
```

### Tests
* Unit tests added, folder `test/unit/health_check/`
* Cookbook tests added, file `test/recipes/controls/aws_parallelcluster_slurm/config_health_check_spec.rb`

### References
* https://github.com/aws/aws-parallelcluster/pull/5118

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.