### PR TITLE
Add RHEL8 support for Active Directory and test directory_service recipe

### DIFF
--- a/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/directory_service/sssd.conf.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 [domain/local]
-id_provider = local
+id_provider = files
 enumerate = True
 
 [sssd]

--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -291,3 +291,29 @@ suites:
         - network_interfaces_configuration_script_created
         - network_interfaces_configured
         - multiple_network_interfaces_can_ping_gateway
+  - name: directory_service
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::directory_service]
+    verifier:
+      controls:
+        - sssd_configured_correctly
+    attributes:
+      cluster:
+        node_type: HeadNode
+        directory_service:
+          enabled: 'true'
+          domain_name: corp.something.com
+          domain_addr: ldaps://corp.something.com
+          password_secret_arn: arn:aws:secretsmanager:eu-west-1:123456789:secret:a-secret-name
+          domain_read_only_user: cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=something,dc=com
+          ldap_tls_ca_cert: /path/to/domain-certificate.crt
+          ldap_tls_req_cert: never
+          ldap_access_filter: filter-string
+          generate_ssh_keys_for_users: 'true'
+          additional_sssd_configs:
+            debug_level: "0x1ff"
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - resource:package_repos
+        - resource:system_authentication

--- a/test/recipes/controls/aws_parallelcluster_config/directory_service_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/directory_service_spec.rb
@@ -1,0 +1,90 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'sssd_configured_correctly' do
+  describe file('/etc/sssd/sssd.conf') do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0600' }
+    # Mandatory properties
+    its('content') { should match /id_provider = ldap/ }
+    its('content') { should match /ldap_schema = AD/ }
+    # Mandatory properties that can be overwritten by DirectoryService/AdditionalSssdConfigs
+    its('content') { should match /ldap_default_bind_dn = cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=something,dc=com/ }
+    its('content') { should match /ldap_default_authtok = fake-secret/ }
+    its('content') { should match /ldap_tls_reqcert = never/ }
+    # Optional properties that can be overwritten by DirectoryService/AdditionalSssdConfigs
+    its('content') { should match /cache_credentials = True/ }
+    its('content') { should match /ldap_id_mapping = True/ }
+    its('content') { should match /use_fully_qualified_names = False/ }
+    # Optional properties that are meant to be set via dedicated cluster config properties
+    its('content') { should match %r{ldap_tls_cacert = /path/to/domain-certificate\.crt} }
+    its('content') { should match /ldap_access_filter = filter-string/ }
+    # Optional properties that are meant to be set via DirectoryService/AdditionalSssdConfigs
+    its('content') { should match /debug_level = 0x1ff/ }
+  end
+
+  shared_dir = "/opt/parallelcluster/shared/directory_service"
+  describe directory(shared_dir) do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0600' }
+  end
+
+  desc 'Check SSH password authentication is enabled on head node'
+  describe file('/etc/ssh/sshd_config') do
+    it { should exist }
+    its('content') { should match /PasswordAuthentication yes/ }
+  end
+
+  scripts_dir = "/opt/parallelcluster/scripts"
+  describe directory("#{scripts_dir}/directory_service") do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0744' }
+  end
+
+  describe file("#{scripts_dir}/directory_service/update_directory_service_password.sh") do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0744' }
+    its('content') { should match /SECRET_ARN="arn:aws:secretsmanager:eu-west-1:123456789:secret:a-secret-name"/ }
+    its('content') { should match %r{SSSD_SHARED_CONFIG_FILE="#{shared_dir}/sssd.conf"} }
+  end
+
+  describe file("#{scripts_dir}/generate_ssh_key.sh") do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0755' }
+    its('content') { should match /ssh-keygen -q -t rsa/ }
+  end
+
+  pam_services = %w(sudo su sshd)
+  pam_services.each do |pam_service|
+    describe file("/etc/pam.d/#{pam_service}") do
+      it { should exist }
+      its('content') { should match %r{session\s+optional\s+pam_exec\.so\s+log=/var/log/parallelcluster/pam_ssh_key_generator\.log} }
+    end
+  end
+
+  %w(sssd sshd).each do |daemon|
+    describe service(daemon) do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
* Use `id_provider = files` rather than `local` since it has been deprecated The local ID provider, used to serve user information from the local SSSD cache, was deprecated in RHEL 7 and is no longer supported in RHEL 8.

### Tests
* Executed the directory_service recipe in all OSes with id_provider file,  converge and verify steps are passing.
* Define Inspec test for directory_service recipe
  * I have to define a new function get_ldap_password to avoid contacting secret manager during inspec tests execution

### References
* https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/migrating_to_identity_management_on_rhel_8/upgrading-an-idm-client-from-rhel-7-to-rhel-8_migrating
* https://manpages.ubuntu.com/manpages/impish/man5/sssd-files.5.html
