### PR TITLE
[Fix] Specify region name in S3 client used by ScriptRunner to download Custom Actions scripts.

### DIFF
--- a/cookbooks/aws-parallelcluster-config/files/default/custom_action_executor/custom_action_executor.py
+++ b/cookbooks/aws-parallelcluster-config/files/default/custom_action_executor/custom_action_executor.py
@@ -65,8 +65,9 @@ class ExecutableScript(ScriptDefinition):
 class ScriptRunner:
     """Performs download and execution of scripts."""
 
-    def __init__(self, event_name):
+    def __init__(self, event_name, region_name):
         self.event_name = event_name
+        self.region_name = region_name
 
     async def download_and_execute_scripts(self, scripts):
         """
@@ -101,7 +102,7 @@ class ScriptRunner:
         return ExecutableScript(script.url, script.args, step_num, path)
 
     async def _download_s3_script(self, exe_script: ExecutableScript):
-        s3_client = boto3.resource("s3")
+        s3_client = boto3.resource("s3", region_name=self.region_name)
         bucket_name, key = self._parse_s3_url(exe_script.url)
         with tempfile.NamedTemporaryFile(delete=False) as file:
             try:
@@ -587,7 +588,11 @@ class ActionRunner:
             for script in self.conf.script_sequence:
                 print(f"  {script.url} with args {script.args}")
         else:
-            asyncio.run(ScriptRunner(self.conf.event_name).download_and_execute_scripts(self.conf.script_sequence))
+            asyncio.run(
+                ScriptRunner(self.conf.event_name, self.conf.region_name).download_and_execute_scripts(
+                    self.conf.script_sequence
+                )
+            )
 
     def _get_stack_status(self) -> str:
         stack_status = "UNKNOWN"

--- a/test/unit/custom_action_executor/test_custom_action_executor.py
+++ b/test/unit/custom_action_executor/test_custom_action_executor.py
@@ -40,7 +40,7 @@ from mock.mock import AsyncMock
 
 @pytest.fixture
 def script_runner():
-    return ScriptRunner("OnMockTestEvent")
+    return ScriptRunner("OnMockTestEvent", "OnMockTestRegionName")
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description of changes
Specify region name in S3 client used by ScriptRunner to download Custom Actions scripts.

This change is required to make ScriptRunner able to download Custom Action scripts from S3 in non Classic partitions, such as aws-cn and aws-gov.

### Tests
1. Without this fix, the call to `/opt/parallelcluster/scripts/custom_action_executor.py` made by `fetch_and_run` fails due to HTTP error on the S3 endpoint.
2. With this fix, the call to `/opt/parallelcluster/scripts/custom_action_executor.py` made by `fetch_and_run` succeeds.
3. Checked that the previsou implementatiopn of the `fetch_and_run` was actually specifying the region, that was instead omitted in the ScriptRunner implementation. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.