### PR TITLE
Fix Nvidia GDRCopy installation on CentOS7

### DIFF
--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_amazon2.rb
@@ -30,7 +30,7 @@ action_class do
     %w(dkms rpm-build make check check-devel subunit subunit-devel)
   end
 
-  def platform
+  def gdrcopy_platform
     'unknown_distro'
   end
 

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_centos7.rb
@@ -26,3 +26,9 @@ action :setup do
   return if arm_instance? || !(node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
   action_gdrcopy_installation
 end
+
+action_class do
+  def gdrcopy_platform
+    '.el7'
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_redhat8.rb
@@ -32,7 +32,7 @@ action_class do
     %w(dkms rpm-build make check check-devel subunit subunit-devel)
   end
 
-  def platform
+  def gdrcopy_platform
     '.el8'
   end
 

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_ubuntu18.rb
@@ -26,7 +26,7 @@ action :setup do
 end
 
 action_class do
-  def platform
+  def gdrcopy_platform
     'Ubuntu18_04'
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_ubuntu20.rb
@@ -26,7 +26,7 @@ action :setup do
 end
 
 action_class do
-  def platform
+  def gdrcopy_platform
     'Ubuntu20_04'
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/partial/_gdrcopy_common_debian.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/partial/_gdrcopy_common_debian.rb
@@ -28,10 +28,10 @@ action_class do
   def installation_code
     <<~COMMAND
     CUDA=/usr/local/cuda ./build-deb-packages.sh
-    dpkg -i gdrdrv-dkms_#{gdrcopy_version_extended}_#{arch}.#{platform}.deb
-    dpkg -i libgdrapi_#{gdrcopy_version_extended}_#{arch}.#{platform}.deb
-    dpkg -i gdrcopy-tests_#{gdrcopy_version_extended}_#{arch}.#{platform}.deb
-    dpkg -i gdrcopy_#{gdrcopy_version_extended}_#{arch}.#{platform}.deb
+    dpkg -i gdrdrv-dkms_#{gdrcopy_version_extended}_#{arch}.#{gdrcopy_platform}.deb
+    dpkg -i libgdrapi_#{gdrcopy_version_extended}_#{arch}.#{gdrcopy_platform}.deb
+    dpkg -i gdrcopy-tests_#{gdrcopy_version_extended}_#{arch}.#{gdrcopy_platform}.deb
+    dpkg -i gdrcopy_#{gdrcopy_version_extended}_#{arch}.#{gdrcopy_platform}.deb
     COMMAND
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/partial/_gdrcopy_common_rhel.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/partial/_gdrcopy_common_rhel.rb
@@ -20,9 +20,9 @@ action_class do
   def installation_code
     <<~COMMAND
     CUDA=/usr/local/cuda ./build-rpm-packages.sh
-    rpm -i gdrcopy-kmod-#{gdrcopy_version_extended}dkms.noarch#{platform}.rpm
-    rpm -i gdrcopy-#{gdrcopy_version_extended}.#{arch}#{platform}.rpm
-    rpm -i gdrcopy-devel-#{gdrcopy_version_extended}.noarch#{platform}.rpm
+    rpm -i gdrcopy-kmod-#{gdrcopy_version_extended}dkms.noarch#{gdrcopy_platform}.rpm
+    rpm -i gdrcopy-#{gdrcopy_version_extended}.#{arch}#{gdrcopy_platform}.rpm
+    rpm -i gdrcopy-devel-#{gdrcopy_version_extended}.noarch#{gdrcopy_platform}.rpm
     COMMAND
   end
 end


### PR DESCRIPTION
### Description of changes
* Rename platform action_class used by gdrcopy resource. In this way in case of errors it's easier to distinguish if the issue is in `gdrcopy_platform` action_class and not in the Chef `platform` variable.
* Add missing grdcopy_platform for CentOS7

Previously it was:
```
platform = value_for_platform(
  'ubuntu' => {
    '18.04' => 'Ubuntu18_04',
    '20.04' => 'Ubuntu20_04',
  },
  'amazon' => { 'default' => 'unknown_distro' },
  'default' => '.el7'
)
```
