### PR TITLE
[BugFix] Fix issue causing IP misalignment on multi NICS instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade aws-cfn-bootstrap to version 2.0-24.
 - Set Slurm prolog and epilog configurations to target a directory, /opt/slurm/etc/scripts/prolog.d/ and /opt/slurm/etc/scripts/epilog.d/ respectively.
 
+**BUG FIXES**
+- Fix an issue that was causing misalignment of compute nodes IP on multi NICS instances.
+
 3.5.1
 ------
 

--- a/cookbooks/aws-parallelcluster-config/recipes/network_interfaces.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/network_interfaces.rb
@@ -15,12 +15,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-def network_interface_macs(token)
-  uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs")
-  res = get_metadata_with_token(token, uri)
-  res.delete("/").split("\n")
-end
-
 def device_name(mac)
   cmd = Mixlib::ShellOut.new("ip -o link | grep #{mac} | awk '{print substr($2, 1, length($2) -1)}'")
   cmd.run_command

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init_dns.rb
@@ -77,10 +77,17 @@ ohai 'reload_hostname' do
   action :nothing
 end
 
+# Delete all local ips in /etc/hosts
+node['ec2']['network_interfaces_macs'].each_value do |mac|
+  delete_lines "delete #{mac['local_ipv4s']} in the /etc/hosts" do
+    path "/etc/hosts"
+    pattern "^#{mac['local_ipv4s']}\s+"
+  end
+end
+
 # Configure fqdn in /etc/hosts
-replace_or_add "set fqdn in the /etc/hosts" do
+append_if_no_line "Append primary ip to /etc/hosts" do
   path "/etc/hosts"
-  pattern "^#{node['ec2']['local_ipv4']}\s+"
-  line(lazy { "#{node['ec2']['local_ipv4']} #{node['cluster']['assigned_hostname'].chomp('.')} #{node['cluster']['assigned_short_hostname']}" })
+  line(lazy { "#{get_primary_ip} #{node['cluster']['assigned_hostname'].chomp('.')} #{node['cluster']['assigned_short_hostname']}" })
   notifies :reload, "ohai[reload_hostname]"
 end

--- a/cookbooks/aws-parallelcluster-test/recipes/test_primary_ip.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/test_primary_ip.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-test
+# Recipe:: test_primary_ip
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+bash "check primary ip" do
+  cwd Chef::Config[:file_cache_path]
+  code <<-TEST
+  TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+  macs=`curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/network/interfaces/macs`
+  if [[ $(echo $macs | wc -w) > 1 ]]
+  then
+    for mac in $macs
+    do
+      device_number=`curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/network/interfaces/macs/${mac}/device-number"`
+      network_card=`curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/network/interfaces/macs/${mac}/network-card"`
+      if [[ $device_number == '0' && $network_card == '0' ]]
+      then
+        IP_HOSTS="$(grep "$HOSTNAME" /etc/hosts | awk '{print $1}')"
+        mac_ip=`curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/network/interfaces/macs/${mac}/local-ipv4s"`
+        for word in $IP_HOSTS
+        do
+          if [[ ${word} == ${mac_ip} ]]
+          then
+            exit 0
+          fi
+        done
+      fi
+    done
+    echo "Primary ip ${mac_ip} not in file /etc/hosts"
+    echo "cat /etc/hosts"
+    cat /etc/hosts
+    exit 1
+  fi
+  TEST
+end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -330,6 +330,7 @@ def are_mount_or_unmount_required?
   change_set = JSON.load_file("#{node['cluster']['shared_dir']}/change-set.json")
   change_set["changeSet"].each do |change|
     next unless change["updatePolicy"] == "SHARED_STORAGE_UPDATE_POLICY"
+
     return true
   end
   Chef::Log.info("No shared storages operation required.")
@@ -391,4 +392,34 @@ def parse_arn(arn_string)
     account_id: parts[4],
     resource: parts[5],
   }
+end
+
+def network_interface_macs(token)
+  uri = URI("http://169.254.169.254/latest/meta-data/network/interfaces/macs")
+  res = get_metadata_with_token(token, uri)
+  res.delete("/").split("\n")
+end
+
+def get_primary_ip
+  primary_ip = node['ec2']['local_ipv4']
+
+  # TODO: We should use instance info stored in node['ec2'] by Ohai, rather than calling IMDS.
+  # We cannot use MAC related data because we noticed a mismatch in the info returned by Ohai and IMDS.
+  # In particular, the data returned by Ohai is missing the 'network-card' information.
+  token = get_metadata_token
+  macs = network_interface_macs(token)
+
+  if macs.length > 1
+    macs.each do |mac|
+      mac_metadata_uri = "http://169.254.169.254/latest/meta-data/network/interfaces/macs/#{mac}"
+      device_number = get_metadata_with_token(token, URI("#{mac_metadata_uri}/device-number"))
+      network_card = get_metadata_with_token(token, URI("#{mac_metadata_uri}/network-card"))
+      next unless device_number == '0' && network_card == '0'
+
+      primary_ip = get_metadata_with_token(token, URI("#{mac_metadata_uri}/local-ipv4s"))
+      break
+    end
+  end
+
+  primary_ip
 end


### PR DESCRIPTION
### Description of changes
Fix issue causing IP misalignment on multi NICS instances.
In particular, we consider as the instance primary IP address the one of the network interface with NetworkCardIndex 0 and DeviceIndex 0, returned by IMDS.

### Tests
1. Regression tests: `test_trainium`, `test_slurm`, `test_awsbatch`, `test_mpi`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>