### PR TITLE
Fix repo_domain used for Fabric Manager installation

### DIFF
--- a/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
@@ -28,7 +28,7 @@ default['cluster']['nvidia']['gdrcopy']['sha256'] = 'b85d15901889aa42de6c4a92337
 default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 
 # NVIDIA fabric-manager
-# The package name of Fabric Manager for alinux2 and centos7 is nvidia-fabric-manager-version
+# The package name of Fabric Manager for alinux2 is nvidia-fabric-manager-version
 default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
 default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']

--- a/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
@@ -28,7 +28,7 @@ default['cluster']['nvidia']['gdrcopy']['sha256'] = 'b85d15901889aa42de6c4a92337
 default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 
 # NVIDIA fabric-manager
-# The package name of Fabric Manager for alinux2 and centos7 is nvidia-fabric-manager-version
+# The package name of Fabric Manager for centos7 is nvidia-fabric-manager-version
 default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
 default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']

--- a/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
@@ -29,7 +29,7 @@ default['cluster']['nvidia']['gdrcopy']['sha256'] = 'b85d15901889aa42de6c4a92337
 default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 
 # NVIDIA fabric-manager
-# The package name of Fabric Manager for alinux2 and centos7 is nvidia-fabric-manager-version
+# The package name of Fabric Manager for rhel8 is nvidia-fabric-manager-version
 default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
 default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
 default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']

--- a/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
@@ -20,7 +20,7 @@ include_recipe "aws-parallelcluster-install::cuda"
 gdrcopy 'Install Nvidia gdrcopy'
 
 # Install NVIDIA Fabric Manager
-repo_domain = node['cluster']['region'].start_with?("cn-") ? "com" : "cn"
+repo_domain = node['cluster']['region'].start_with?("cn-") ? "cn" : "com"
 repo_uri = node['cluster']['nvidia']['cuda']['repository_uri'].gsub('_domain_', repo_domain)
 add_package_repository("nvidia-repo", repo_uri, "#{repo_uri}/#{node['cluster']['nvidia']['fabricmanager']['repository_key']}", "/")
 


### PR DESCRIPTION
Previously it was:
```
repo_domain = "com"
repo_domain = "cn" if node['cluster']['region'].start_with?("cn-")
```

Improve Fabric Manager comments to be OS specific