### PR TITLE
Add missing "arch" action class for centos7 gdrcopy resource

### DIFF
--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_amazon2.rb
@@ -34,7 +34,7 @@ action_class do
     'unknown_distro'
   end
 
-  def arch
+  def gdrcopy_arch
     arm_instance? ? 'aarch64' : 'x86_64'
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_centos7.rb
@@ -32,7 +32,7 @@ action_class do
     '.el7'
   end
 
-  def arch
+  def gdrcopy_arch
     arm_instance? ? 'arm64' : 'x86_64'
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_centos7.rb
@@ -31,4 +31,8 @@ action_class do
   def gdrcopy_platform
     '.el7'
   end
+
+  def arch
+    arm_instance? ? 'arm64' : 'x86_64'
+  end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/gdrcopy_redhat8.rb
@@ -36,7 +36,7 @@ action_class do
     '.el8'
   end
 
-  def arch
+  def gdrcopy_arch
     arm_instance? ? 'aarch64' : 'x86_64'
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/partial/_gdrcopy_common_debian.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/partial/_gdrcopy_common_debian.rb
@@ -17,7 +17,7 @@ action_class do
     %w(build-essential devscripts debhelper check libsubunit-dev fakeroot pkg-config dkms)
   end
 
-  def arch
+  def gdrcopy_arch
     arm_instance? ? 'arm64' : 'amd64'
   end
 
@@ -28,10 +28,10 @@ action_class do
   def installation_code
     <<~COMMAND
     CUDA=/usr/local/cuda ./build-deb-packages.sh
-    dpkg -i gdrdrv-dkms_#{gdrcopy_version_extended}_#{arch}.#{gdrcopy_platform}.deb
-    dpkg -i libgdrapi_#{gdrcopy_version_extended}_#{arch}.#{gdrcopy_platform}.deb
-    dpkg -i gdrcopy-tests_#{gdrcopy_version_extended}_#{arch}.#{gdrcopy_platform}.deb
-    dpkg -i gdrcopy_#{gdrcopy_version_extended}_#{arch}.#{gdrcopy_platform}.deb
+    dpkg -i gdrdrv-dkms_#{gdrcopy_version_extended}_#{gdrcopy_arch}.#{gdrcopy_platform}.deb
+    dpkg -i libgdrapi_#{gdrcopy_version_extended}_#{gdrcopy_arch}.#{gdrcopy_platform}.deb
+    dpkg -i gdrcopy-tests_#{gdrcopy_version_extended}_#{gdrcopy_arch}.#{gdrcopy_platform}.deb
+    dpkg -i gdrcopy_#{gdrcopy_version_extended}_#{gdrcopy_arch}.#{gdrcopy_platform}.deb
     COMMAND
   end
 end

--- a/cookbooks/aws-parallelcluster-install/resources/gdrcopy/partial/_gdrcopy_common_rhel.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/gdrcopy/partial/_gdrcopy_common_rhel.rb
@@ -21,7 +21,7 @@ action_class do
     <<~COMMAND
     CUDA=/usr/local/cuda ./build-rpm-packages.sh
     rpm -i gdrcopy-kmod-#{gdrcopy_version_extended}dkms.noarch#{gdrcopy_platform}.rpm
-    rpm -i gdrcopy-#{gdrcopy_version_extended}.#{arch}#{gdrcopy_platform}.rpm
+    rpm -i gdrcopy-#{gdrcopy_version_extended}.#{gdrcopy_arch}#{gdrcopy_platform}.rpm
     rpm -i gdrcopy-devel-#{gdrcopy_version_extended}.noarch#{gdrcopy_platform}.rpm
     COMMAND
   end


### PR DESCRIPTION
* Rename "arch" action class to "gdrcopy_arch"
* In the original code it was:
``` 
arch = value_for_platform(
  'ubuntu' => { 'default' => arm_instance? ? 'arm64' : 'amd64' },
  'amazon' => { 'default' => arm_instance? ? 'aarch64' : 'x86_64' },
  'default' => arm_instance? ? 'arm64' : 'x86_64'
)
```