### PR TITLE
[develop] Add logic to retrieve custom slurm settings file from S3

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -82,6 +82,10 @@ unless virtualized?
             " --input-file #{node['cluster']['cluster_config_path']}"
   end
 
+  # If defined in the config, retrieve a remote Custom Slurm Settings file and overrides the existing one
+  custom_settings_file = lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile) }
+  include_recipe 'aws-parallelcluster-slurm::retrieve_remote_custom_settings_file' if custom_settings_file
+
   # Generate pcluster fleet config
   execute "generate_pcluster_fleet_config" do
     command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_fleet_config_generator.py"\

--- a/cookbooks/aws-parallelcluster-slurm/recipes/retrieve_remote_custom_settings_file.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/retrieve_remote_custom_settings_file.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-slurm
+# Recipe:: config_head_node
+#
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Overrides destination while testing since remote_file expect the destination path to already exist
+# To keep the test dependencies at the minimum we use /tmp as destination
+local_path = if kitchen_test?
+               node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :LocalPath)
+             else
+               "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/custom_slurm_settings_include_slurm.conf"
+             end
+
+remote_object 'Retrieve Custom Slurm Settings' do
+  url(lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile) })
+  destination(local_path)
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/remote_object/remote_object.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/remote_object/remote_object.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource_name :remote_object
+provides :remote_object
+unified_mode true
+
+# Resource to retrieve a remote object either using the S3 or HTTPS protocol
+property :url, required: true,
+         description: 'Source URI of the remote file'
+property :destination, required: true,
+         description: 'Local destination path where to store the file'
+
+default_action :get
+
+action :get do
+  if !new_resource.url.blank? && !new_resource.destination.blank?
+    source_url = new_resource.url
+    local_path = new_resource.destination
+    # if running a test skip credential check
+    no_sign_request = kitchen_test? ? "--no-sign-request" : ""
+
+    if source_url.start_with?("s3")
+      Chef::Log.debug("Retrieving remote Object from #{source_url} to #{local_path} using S3 protocol")
+      # download file using s3 protocol
+      fetch_command = "#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3 cp" \
+                  " --region #{node['cluster']['region']}" \
+                  " #{no_sign_request}" \
+                  " #{source_url}" \
+                  " #{local_path}"
+
+      Chef::Log.warn("executing command #{fetch_command} ")
+      execute "retrieve_object_with_s3_protocol" do
+        command fetch_command
+        retries 3
+        retry_delay 5
+      end
+    else
+      Chef::Log.debug("Retrieving remote Object from #{source_url} to #{local_path}")
+
+      # download file using standard chef behavior
+      remote_file "retrieve_object" do
+        path local_path
+        source source_url
+        retries 3
+        retry_delay 5
+      end
+    end
+  else
+    Chef::Log.warn("Either source or destination is not defined: #{new_resource.url} to #{new_resource.destination}")
+  end
+end

--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -291,3 +291,41 @@ suites:
         - network_interfaces_configuration_script_created
         - network_interfaces_configured
         - multiple_network_interfaces_can_ping_gateway
+  - name: custom_slurm_settings_file_via_s3
+    # check that we can retrieve a custom slurm settings file using the S3 protocol
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-slurm::retrieve_remote_custom_settings_file]
+    verifier:
+      controls:
+        - custom_settings_file_retrieved
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - recipe:aws-parallelcluster-install::python
+      cluster:
+        config:
+          Scheduling:
+            SchedulerSettings:
+              # here we are just interested in testing that we can retrieve a file from S3 through S3 protocol
+              CustomSlurmSettingsIncludeFile: 's3://us-east-1-aws-parallelcluster/templates/1-click/serverless-database.yaml'
+              LocalPath: '/tmp/custom_slurm_settings_include_slurm.conf'
+  - name: custom_slurm_settings_file_via_https
+    # check that we can retrieve a custom slurm settings file from internet through HTTP/S
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-slurm::retrieve_remote_custom_settings_file]
+    verifier:
+      controls:
+        - custom_settings_file_retrieved
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - recipe:aws-parallelcluster-install::python
+      cluster:
+        config:
+          Scheduling:
+            SchedulerSettings:
+              # here we are just interested in testing that we can retrieve a file from S3 through https protocol
+              CustomSlurmSettingsIncludeFile: 'https://us-east-1-aws-parallelcluster.s3.amazonaws.com/templates/1-click/serverless-database.yaml'
+              LocalPath: '/tmp/custom_slurm_settings_include_slurm.conf'

--- a/test/recipes/controls/aws_parallelcluster_slurm/retrieve_remote_custom_settings_file_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/retrieve_remote_custom_settings_file_spec.rb
@@ -1,0 +1,24 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+# Checks that the recipe is able to retrieve a Custom SlurmSettings files from S3
+# using the remote_object resource both with the S3 protocol and the HTTPS protocol
+# Since the content of the file can be "anything" we only check that it exists
+# To keep the test as simple as possible, keeping the dependency at its minimum
+# and set the destination folder to /tmp that already exists
+# So we only check that the file exists
+control 'custom_settings_file_retrieved' do
+  title 'Checks that customs settings file has been retrieved if specified in the config'
+
+  describe file("/tmp/custom_slurm_settings_include_slurm.conf") do
+    it { should exist }
+  end
+end


### PR DESCRIPTION
### Description of changes
* Add a resource to get remote file from internet using either the S3 protocol or HTTP/S
* Add a recipe that uses the resource to retrieve a Custom Slurm Settings file from internet
* Add two kitchen tests to validate that both protocols can be used to retrieve the file

### Tests
* Kitchen tests successfully launched both with docker and EC2.

### References
* [Bulk Slurm Settings](https://github.com/aws/aws-parallelcluster-cookbook/pull/1958)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.