### PR TITLE
Temporary skip fabric manager installation on rhel8

### DIFF
--- a/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/nvidia.rb
@@ -24,7 +24,7 @@ repo_domain = node['cluster']['region'].start_with?("cn-") ? "cn" : "com"
 repo_uri = node['cluster']['nvidia']['cuda']['repository_uri'].gsub('_domain_', repo_domain)
 add_package_repository("nvidia-repo", repo_uri, "#{repo_uri}/#{node['cluster']['nvidia']['fabricmanager']['repository_key']}", "/")
 
-fabric_manager 'Install Nvidia Fabric Manager'
+fabric_manager 'Install Nvidia Fabric Manager' unless redhat8?
 
 nvidia_dcgm 'install datacenter-gpu-manager'
 


### PR DESCRIPTION
The installation of the specific version does not work even if the repository seems configured correctly.
