### PR TITLE
3.x Remove lazy evaluation and conditional include

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -83,8 +83,7 @@ unless virtualized?
   end
 
   # If defined in the config, retrieve a remote Custom Slurm Settings file and overrides the existing one
-  custom_settings_file = lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile) }
-  include_recipe 'aws-parallelcluster-slurm::retrieve_remote_custom_settings_file' if custom_settings_file
+  include_recipe 'aws-parallelcluster-slurm::retrieve_remote_custom_settings_file'
 
   # Generate pcluster fleet config
   execute "generate_pcluster_fleet_config" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/retrieve_remote_custom_settings_file.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/retrieve_remote_custom_settings_file.rb
@@ -26,4 +26,5 @@ local_path = if kitchen_test?
 remote_object 'Retrieve Custom Slurm Settings' do
   url(lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile) })
   destination(local_path)
+  only_if { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile) }
 end


### PR DESCRIPTION
### Description of changes
* `lazy` was being used outside of a resource as variable value and then a resource was being used to conditional include a recipe during compile time. 
* Apparently, `lazy` is only supported inside a resource block?
* Moved conditional into the resource that was added to the run list by the recipe instead of conditionally including the recipe.

### Tests
* Manually deployed cluster with cookbook changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.