### PR TITLE
[3.x] Enable nvidia config recipe and tests on redhat8

### DIFF
--- a/cookbooks/aws-parallelcluster-common/test/common/libraries/instance.rb
+++ b/cookbooks/aws-parallelcluster-common/test/common/libraries/instance.rb
@@ -42,6 +42,10 @@ class Instance < Inspec.resource(1)
     !inspec.command("lspci | grep -i -o 'NVIDIA'").stdout.strip.empty?
   end
 
+  def nvs_switch_enabled?
+    inspec.command("lspci -d 10de:1af1 | wc -l").stdout.strip.to_i > 1
+  end
+
   def custom_ami?
     inspec.node['cluster']['os'] && inspec.node['cluster']['os'].end_with?("-custom")
   end

--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -32,7 +32,7 @@ include_recipe 'aws-parallelcluster-config::networking'
 include_recipe 'aws-parallelcluster-config::chrony'
 
 # NVIDIA services (fabric manager)
-include_recipe "aws-parallelcluster-config::nvidia" unless redhat8?
+include_recipe "aws-parallelcluster-config::nvidia"
 
 # EFA runtime configuration
 efa 'Configure system for EFA' do

--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -355,3 +355,21 @@ suites:
         - recipe:aws-parallelcluster-install::directories
         - resource:package_repos
         - resource:system_authentication
+  - name: nvidia
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-config::nvidia]
+    verifier:
+      controls:
+        - /nvidia-fabricmanager_enabled/
+        - /gdrcopy_enabled/
+        - /gdrcopy_disabled/
+    driver:
+      # nvidia_driver can be executed only on a graphic EC2 instance example: g4dn.xlarge(x86_86) or g5g.xlarge(aarm64)
+      instance_type: g4dn.xlarge
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster::test_dummy
+      cluster:
+        nvidia:
+          enabled: true

--- a/test/recipes/controls/aws_parallelcluster_config/nvidia_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/nvidia_spec.rb
@@ -9,9 +9,20 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+control 'tag:config_nvidia-fabricmanager_enabled' do
+  only_if do
+    instance.nvs_switch_enabled?
+  end
+
+  describe service('nvidia-fabricmanager') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end
+
 control 'tag:config_gdrcopy_enabled_on_graphic_instances' do
   only_if do
-    !(os_properties.centos7? && os_properties.arm?) && !os_properties.redhat8? &&
+    !(os_properties.centos7? && os_properties.arm?) &&
       !instance.custom_ami? && instance.graphic?
   end
 
@@ -30,7 +41,7 @@ end
 
 control 'tag:config_gdrcopy_disabled_on_non_graphic_instances' do
   only_if do
-    !(os_properties.centos7? && os_properties.arm?) && !os_properties.redhat8? &&
+    !(os_properties.centos7? && os_properties.arm?) &&
       !instance.custom_ami? && !instance.graphic?
   end
 


### PR DESCRIPTION
### Description of changes
* Enable nvidia config recipe and tests on redhat8

### Tests
* Run nvidia config ec2 test with g4dn.xlarge (x86), g5g.xlarge (arm) and t3.xlarge (non-graphic) - IN PROGRESS
* Haven't run with p4d because of low capacity, we have an integ test for that

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.