### PR TITLE
3.x Remove top level usage of lazy

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -82,9 +82,7 @@ unless virtualized?
             " --input-file #{node['cluster']['cluster_config_path']}"
   end
 
-  # If defined in the config, retrieve a remote Custom Slurm Settings file and overrides the existing one
-  custom_settings_file = lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile) }
-  include_recipe 'aws-parallelcluster-slurm::retrieve_remote_custom_settings_file' if custom_settings_file
+  include_recipe 'aws-parallelcluster-slurm::retrieve_remote_custom_settings_file'
 
   # Generate pcluster fleet config
   execute "generate_pcluster_fleet_config" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/retrieve_remote_custom_settings_file.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/retrieve_remote_custom_settings_file.rb
@@ -23,6 +23,7 @@ local_path = if kitchen_test?
                "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/custom_slurm_settings_include_slurm.conf"
              end
 
+# If defined in the config, retrieve a remote Custom Slurm Settings file and overrides the existing one
 remote_object 'Retrieve Custom Slurm Settings' do
   url(lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile) })
   destination(local_path)


### PR DESCRIPTION
### Description of changes
* The change re-applies a previous commit that removed `lazy` usage from top level recipe.
* This usage seems to cause chef execution failures.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.