### PR TITLE
[develop]Fix import of custom slurm settings file recipe

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -83,8 +83,12 @@ unless virtualized?
   end
 
   # If defined in the config, retrieve a remote Custom Slurm Settings file and overrides the existing one
-  custom_settings_file = lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile) }
-  include_recipe 'aws-parallelcluster-slurm::retrieve_remote_custom_settings_file' if custom_settings_file
+  ruby_block "Override Custom Slurm Settings with remote file" do
+    block do
+      run_context.include_recipe 'aws-parallelcluster-slurm::retrieve_remote_custom_settings_file'
+    end
+    not_if { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile).nil? }
+  end
 
   # Generate pcluster fleet config
   execute "generate_pcluster_fleet_config" do


### PR DESCRIPTION
### Description of changes
Lazy evaluation cannot be used for conditional import, rewriting the logic with a ruby block and a not_if construct.

### Tests
N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.