### PR TITLE
Fix minor errors on nvidia

### DIFF
--- a/cookbooks/aws-parallelcluster-install/resources/nvidia_driver/nvidia_driver_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/nvidia_driver/nvidia_driver_centos7.rb
@@ -16,6 +16,8 @@ provides :nvidia_driver, platform: 'centos' do |node|
   node['platform_version'].to_i == 7
 end
 
+unified_mode true
+
 return if arm_instance?
 
 use 'partial/_nvidia_driver_common.rb'

--- a/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
@@ -49,7 +49,7 @@ end
 
 control 'tag:config_expected_versions_of_nvidia_fabric_manager_installed' do
   only_if do
-    !(os_properties.centos7? && os_properties.arm?) && !os_properties.arm? && !instance.custom_ami? &&
+    !(os_properties.centos7? && os_properties.arm?) && !os_properties.redhat8? && !os_properties.arm? && !instance.custom_ami? &&
       (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
   end
 

--- a/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
@@ -21,6 +21,11 @@ control 'tag:config_expected_versions_of_nvidia_driver_installed' do
     subject { command('modinfo -F version nvidia').stdout.strip }
     it { should eq expected_nvidia_driver_version }
   end
+
+  describe service(node['cluster']['nvidia']['gdrcopy']['service']) do
+    it { should_not be_enabled }
+    it { should_not be_running }
+  end
 end
 
 control 'tag:config_expected_versions_of_nvidia_cuda_installed' do


### PR DESCRIPTION
### Description of changes
* Skip fabric manager InSpec test for redhat8 since the installation has been skipped due to a bug in the Nvidia Repo. https://github.com/aws/aws-parallelcluster-cookbook/commit/0527eb38798a080be180ac1e6b2b7212590ee89c
* Add test to verify if gdrcopy service is disabled
* Add unified_mode in nvidia_driver_centos7

### Tests
* Tested on local kitchen on EC2

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.