### PR TITLE
Enable oddjobd daemon as part of rhel8 Active directory configuration

### DIFF
--- a/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/system_authentication/system_authentication_redhat8.rb
@@ -20,6 +20,11 @@ unified_mode true
 default_action :setup
 
 action :configure do
+  # oddjobd service is required for creating homedir
+  service "oddjobd" do
+    action %i(start enable)
+  end unless virtualized?
+
   execute 'Configure Directory Service' do
     user 'root'
     # Tell NSS, PAM to use SSSD for system authentication and identity information
@@ -30,7 +35,7 @@ action :configure do
 end
 
 action :setup do
-  package %w(sssd sssd-tools sssd-ldap authselect) do
+  package %w(sssd sssd-tools sssd-ldap authselect oddjob-mkhomedir) do
     retries 3
     retry_delay 5
   end unless redhat_ubi?

--- a/kitchen.resources-config.yml
+++ b/kitchen.resources-config.yml
@@ -81,6 +81,7 @@ suites:
     verifier:
       controls:
         - system_authentication_configured
+        - system_authentication_services_enabled
     attributes:
       resource: system_authentication:configure
       dependencies:

--- a/test/resources/controls/aws_parallelcluster_config/system_authentication_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_config/system_authentication_spec.rb
@@ -13,11 +13,36 @@ control 'system_authentication_packages_installed' do
   title 'Check that system authentication packages are installed correctly'
 
   packages = %w(sssd sssd-tools sssd-ldap)
+
+  if os_properties.redhat8?
+    packages.append("authselect")
+    packages.append("oddjob-mkhomedir")
+  end
+
   packages.each do |pkg|
     describe package(pkg) do
       it { should be_installed }
     end
   end unless os_properties.redhat_ubi?
+end
+
+control 'system_authentication_services_enabled' do
+  title 'Check that system authentication services are enabled and running'
+
+  only_if { !os_properties.virtualized? }
+
+  services = %w(sssd)
+
+  if os_properties.redhat8?
+    services.append("oddjobd")
+  end
+
+  services.each do |service|
+    describe service(service) do
+      it { should be_installed }
+      it { should be_enabled }
+    end
+  end
 end
 
 control 'system_authentication_configured' do


### PR DESCRIPTION
### Description of changes
* According to official documentation oddjob-mkhomedir is required for authselect and the service must be enabled.

### Tests
* Extended tests to verify both sssd and addjobd are enabled.
* Tested on both EC2 and docker for rhel8
```
  ✔  system_authentication_services_enabled: Check that system authentication services are enabled and running
     ✔  Service sssd is expected to be installed
     ✔  Service sssd is expected to be enabled
     ✔  Service oddjobd is expected to be installed
     ✔  Service oddjobd is expected to be enabled
  ✔  system_authentication_configured: Check that system authentication is configured correctly
     ✔  Bash command authselect current exit_status is expected to eq 0
     ✔  Bash command authselect current stdout is expected to match /Profile ID: sssd/
     ✔  Bash command authselect current stdout is expected to match /with-mkhomedir/
```

### References
* https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_authentication_and_authorization_in_rhel/index
