### PR TITLE
Remove gdrcopy service from InSpec test since duplicate

### DIFF
--- a/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
@@ -21,11 +21,6 @@ control 'tag:config_expected_versions_of_nvidia_driver_installed' do
     subject { command('modinfo -F version nvidia').stdout.strip }
     it { should eq expected_nvidia_driver_version }
   end
-
-  describe service(node['cluster']['nvidia']['gdrcopy']['service']) do
-    it { should_not be_enabled }
-    it { should_not be_running }
-  end
 end
 
 control 'tag:config_expected_versions_of_nvidia_cuda_installed' do


### PR DESCRIPTION
### Description of changes
* Remove gdrcopy service InSpec test since already covered by the `tag:config_gdrcopy_disabled_on_non_graphic_instances`

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.