### PR TITLE
Modify comment in slurm_parallelcluster.conf

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster.conf
@@ -1,6 +1,7 @@
 # slurm_parallelcluster.conf is managed by the pcluster processes.
 # Do not modify.
-# Please add user-specific slurm configuration options in slurm.conf
+# Please use CustomSlurmSettings in the ParallelCluster configuration file to add user-specific slurm configuration
+# options
 {% set ns = namespace(has_static=false) %}
 
 SlurmctldHost={{ head_node_config.head_node_hostname }}({{ head_node_config.head_node_ip }})

--- a/test/unit/slurm/test_slurm_config_generator.py
+++ b/test/unit/slurm/test_slurm_config_generator.py
@@ -164,7 +164,10 @@ def test_generating_slurm_config_flexible_instance_types(mocker, test_datadir, t
         _assert_files_are_equal(tmpdir / file_name, test_datadir / "expected_outputs" / output_file_name)
 
 
-def test_generate_slurm_config_with_custom_settings(test_datadir, tmpdir):
+def test_generate_slurm_config_with_custom_settings(mocker, test_datadir, tmpdir):
+    mocker.patch("pcluster_slurm_config_generator.gethostname", return_value="ip-1-0-0-0", autospec=True)
+    mocker.patch("pcluster_slurm_config_generator._get_head_node_private_ip", return_value="ip.1.0.0.0", autospec=True)
+
     input_file = os.path.join(test_datadir, "sample_input.yaml")
     instance_types_data = os.path.join(test_datadir, "sample_instance_types_data.json")
 

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_memory_scheduling/expected_outputs/slurm_parallelcluster.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_memory_scheduling/expected_outputs/slurm_parallelcluster.conf
@@ -1,6 +1,7 @@
 # slurm_parallelcluster.conf is managed by the pcluster processes.
 # Do not modify.
-# Please add user-specific slurm configuration options in slurm.conf
+# Please use CustomSlurmSettings in the ParallelCluster configuration file to add user-specific slurm configuration
+# options
 
 SlurmctldHost=ip-1-0-0-0(ip.1.0.0.0)
 SuspendTime=600

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_memory_scheduling/expected_outputs/slurm_parallelcluster_mem_sched.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_memory_scheduling/expected_outputs/slurm_parallelcluster_mem_sched.conf
@@ -1,6 +1,7 @@
 # slurm_parallelcluster.conf is managed by the pcluster processes.
 # Do not modify.
-# Please add user-specific slurm configuration options in slurm.conf
+# Please use CustomSlurmSettings in the ParallelCluster configuration file to add user-specific slurm configuration
+# options
 
 SlurmctldHost=ip-1-0-0-0(ip.1.0.0.0)
 SuspendTime=600

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_nogpu/expected_outputs/slurm_parallelcluster.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_nogpu/expected_outputs/slurm_parallelcluster.conf
@@ -1,6 +1,7 @@
 # slurm_parallelcluster.conf is managed by the pcluster processes.
 # Do not modify.
-# Please add user-specific slurm configuration options in slurm.conf
+# Please use CustomSlurmSettings in the ParallelCluster configuration file to add user-specific slurm configuration
+# options
 
 SlurmctldHost=ip-1-0-0-0(ip.1.0.0.0)
 SuspendTime=600

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster.conf
@@ -1,6 +1,7 @@
 # slurm_parallelcluster.conf is managed by the pcluster processes.
 # Do not modify.
-# Please add user-specific slurm configuration options in slurm.conf
+# Please use CustomSlurmSettings in the ParallelCluster configuration file to add user-specific slurm configuration
+# options
 
 SlurmctldHost=ip-1-0-0-0(ip.1.0.0.0)
 SuspendTime=600

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_slurm_accounting.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_slurm_accounting.conf
@@ -1,6 +1,7 @@
 # slurm_parallelcluster.conf is managed by the pcluster processes.
 # Do not modify.
-# Please add user-specific slurm configuration options in slurm.conf
+# Please use CustomSlurmSettings in the ParallelCluster configuration file to add user-specific slurm configuration
+# options
 
 SlurmctldHost=ip-1-0-0-0(ip.1.0.0.0)
 SuspendTime=600

--- a/test/unit/slurm/test_slurm_config_generator/test_generating_slurm_config_flexible_instance_types/expected_outputs/slurm_parallelcluster.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generating_slurm_config_flexible_instance_types/expected_outputs/slurm_parallelcluster.conf
@@ -1,6 +1,7 @@
 # slurm_parallelcluster.conf is managed by the pcluster processes.
 # Do not modify.
-# Please add user-specific slurm configuration options in slurm.conf
+# Please use CustomSlurmSettings in the ParallelCluster configuration file to add user-specific slurm configuration
+# options
 
 SlurmctldHost=ip-1-0-0-0(ip.1.0.0.0)
 SuspendTime=600


### PR DESCRIPTION
### Description of changes
* Modify comment to tell users to use CustomSlurmSettings to modify the Slurm configuration rather than manually appending parameters to slurm.conf.

### References
* Related to #1958 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.