### PR TITLE
[Dependencies] Upgrade aws-cfn-bootstrap to version 2.0-24.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Rdma-core: `rdma-core-43.0-1`
   - Open MPI: `openmpi40-aws-4.1.5-1`
 - Upgrade Lustre client version to 2.12 on Amazon Linux 2. Lustre client 2.12 has been installed on Ubuntu 20.04, 18.04 and CentOS >= 7.7.  Upgrade Lustre client version to 2.10.8 on CentOS 7.6.
+- Upgrade aws-cfn-bootstrap to version 2.0-24.
 
 3.5.1
 ------

--- a/cookbooks/aws-parallelcluster-common/attributes/common.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common.rb
@@ -41,7 +41,7 @@ default['cluster']['awsbatch_virtualenv_path'] = "#{node['cluster']['system_pyen
 default['cluster']['cfn_bootstrap_virtualenv_path'] = "#{node['cluster']['system_pyenv_root']}/versions/#{node['cluster']['python-version-cfn_bootstrap_virtualenv']}/envs/#{node['cluster']['cfn_bootstrap_virtualenv']}"
 
 # cfn-bootstrap
-default['cluster']['cfn_bootstrap']['version'] = '2.0-10'
+default['cluster']['cfn_bootstrap']['version'] = '2.0-24'
 default['cluster']['cfn_bootstrap']['package'] = "aws-cfn-bootstrap-py3-#{node['cluster']['cfn_bootstrap']['version']}.tar.gz"
 
 # Python packages

--- a/system_tests/install_cinc.sh
+++ b/system_tests/install_cinc.sh
@@ -31,22 +31,6 @@ elif [ `echo "${OS}" | grep -E '^ubuntu'` ]; then
   PLATFORM='DEBIAN'
 fi
 
-AWS_DOMAIN="amazonaws.com"
-[[ ${AWS_Region} =~ ^cn- ]] && AWS_DOMAIN="amazonaws.com.cn"
-[[ ${AWS_Region} =~ ^us-iso- ]] && AWS_DOMAIN="c2s.ic.gov"
-[[ ${AWS_Region} =~ ^us-isob- ]] && AWS_DOMAIN="sc2s.sgov.gov"
-
-S3_ENDPOINT="s3.${AWS_Region}.${AWS_DOMAIN}"
-
-BUCKET="cloudformation-examples"
-[[ ${AWS_DOMAIN} != "amazonaws.com" ]] && BUCKET="${AWS_Region}-aws-parallelcluster/cloudformation-examples"
-if [[ ${OS} =~ ^(ubuntu2004)$ ]]; then
-  PACKAGE_NAME="aws-cfn-bootstrap-py3-latest.tar.gz"
-else
-  PACKAGE_NAME="aws-cfn-bootstrap-latest.tar.gz"
-fi
-CfnBootstrapUrl="https://${S3_ENDPOINT}/${BUCKET}/${PACKAGE_NAME}"
-
 ARCH=$(uname -m)
 if [ "$ARCH" == "aarch64" ]; then
     ARCH=arm64


### PR DESCRIPTION
### Description of changes
Upgrade `aws-cfn-bootstrap` to version 2.0-24.
Removed dead code related to aws.cfn-bootstrap from `install_cinc.sh`.

### Tests
* AMI build
* Kitchen Tests
* Integration Tests: `test_mpi`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.