### PR TITLE
[develop] Fix condition for custom settings file override

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -87,7 +87,7 @@ unless virtualized?
     block do
       run_context.include_recipe 'aws-parallelcluster-slurm::retrieve_remote_custom_settings_file'
     end
-    not_if { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile).nil? }
+    not_if { node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :CustomSlurmSettingsIncludeFile).nil? }
   end
 
   # Generate pcluster fleet config

--- a/cookbooks/aws-parallelcluster-slurm/recipes/retrieve_remote_custom_settings_file.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/retrieve_remote_custom_settings_file.rb
@@ -18,13 +18,13 @@
 # Overrides destination while testing since remote_file expect the destination path to already exist
 # To keep the test dependencies at the minimum we use /tmp as destination
 local_path = if kitchen_test?
-               node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :LocalPath)
+               node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :LocalPath)
              else
-               "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/custom_slurm_settings_include_slurm.conf"
+               "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/custom_slurm_settings_include_file_slurm.conf"
              end
 
 remote_object 'Retrieve Custom Slurm Settings' do
-  url(lazy { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile) })
-  destination(local_path)
-  only_if { node['cluster']['config'].dig(:Scheduling, :SchedulerSettings, :CustomSlurmSettingsIncludeFile) }
+  url(lazy { node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :CustomSlurmSettingsIncludeFile) })
+  destination local_path
+  sensitive true
 end

--- a/cookbooks/aws-parallelcluster-slurm/resources/remote_object/remote_object.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/remote_object/remote_object.rb
@@ -17,6 +17,9 @@ property :url, required: true,
          description: 'Source URI of the remote file'
 property :destination, required: true,
          description: 'Local destination path where to store the file'
+property :sensitive, [true, false],
+         default: false,
+         description: 'mark the resource as senstive'
 
 default_action :get
 
@@ -49,6 +52,7 @@ action :get do
       remote_file "retrieve_object" do
         path local_path
         source source_url
+        sensitive new_resource.sensitive
         retries 3
         retry_delay 5
       end

--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -306,10 +306,10 @@ suites:
       cluster:
         config:
           Scheduling:
-            SchedulerSettings:
+            SlurmSettings:
               # here we are just interested in testing that we can retrieve a file from S3 through S3 protocol
               CustomSlurmSettingsIncludeFile: 's3://us-east-1-aws-parallelcluster/templates/1-click/serverless-database.yaml'
-              LocalPath: '/tmp/custom_slurm_settings_include_slurm.conf'
+              LocalPath: '/tmp/custom_slurm_settings_include_file_slurm.conf'
   - name: custom_slurm_settings_file_via_https
     # check that we can retrieve a custom slurm settings file from internet through HTTP/S
     run_list:
@@ -325,10 +325,10 @@ suites:
       cluster:
         config:
           Scheduling:
-            SchedulerSettings:
+            SlurmSettings:
               # here we are just interested in testing that we can retrieve a file from S3 through https protocol
               CustomSlurmSettingsIncludeFile: 'https://us-east-1-aws-parallelcluster.s3.amazonaws.com/templates/1-click/serverless-database.yaml'
-              LocalPath: '/tmp/custom_slurm_settings_include_slurm.conf'
+              LocalPath: '/tmp/custom_slurm_settings_include_file_slurm.conf'
   - name: directory_service
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]

--- a/test/recipes/controls/aws_parallelcluster_slurm/retrieve_remote_custom_settings_file_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/retrieve_remote_custom_settings_file_spec.rb
@@ -18,7 +18,7 @@
 control 'custom_settings_file_retrieved' do
   title 'Checks that customs settings file has been retrieved if specified in the config'
 
-  describe file("/tmp/custom_slurm_settings_include_slurm.conf") do
+  describe file("/tmp/custom_slurm_settings_include_file_slurm.conf") do
     it { should exist }
   end
 end


### PR DESCRIPTION
### Description of changes
* Fix condition of including a remote file with Custom Slurm Settings
* Fix the path where the sub-recipe will store the custom settings file
* add `sensitive` property to `remote_file` to avoid logging customer data while including a remote file

### Tests
* Launched Kitchen tests using both S3 and HTTPS protocols
* Created a cluster with a customs Slurm settings file

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.