### PR TITLE
Upgrade Slurm to version 23.02.1 and munge to version 0.5.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Lustre client version to 2.12 on Amazon Linux 2. Lustre client 2.12 has been installed on Ubuntu 20.04, 18.04 and CentOS >= 7.7.  Upgrade Lustre client version to 2.10.8 on CentOS 7.6.
 - Upgrade aws-cfn-bootstrap to version 2.0-24.
 - Set Slurm prolog and epilog configurations to target a directory, /opt/slurm/etc/scripts/prolog.d/ and /opt/slurm/etc/scripts/epilog.d/ respectively.
+- Upgrade Slurm to version 23.02.1.
+- Upgrade munge to version 0.5.15.
 
 **BUG FIXES**
 - Fix IP association on instances with multiple network cards.

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -1,4 +1,4 @@
 # Slurm attributes shared between install_slurm and configure_slurm_accounting
 default['cluster']['slurm']['commit'] = ''
-default['cluster']['slurm']['sha256'] = '8c8f6a26a5d51e6c63773f2e02653eb724540ee8b360125c8d7732314ce737d6'
+default['cluster']['slurm']['sha256'] = 'd827553496ee9158bbf6a862b563cfd48566e6d815ad2f8349950fe6f04934da'
 default['cluster']['slurm']['install_dir'] = '/opt/slurm'

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -1,4 +1,4 @@
 # Slurm
-default['cluster']['slurm']['version'] = '22-05-8-1'
+default['cluster']['slurm']['version'] = '23-02-1-1'
 # Munge
 default['cluster']['munge']['munge_version'] = '0.5.14'

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -1,4 +1,4 @@
 # Slurm
 default['cluster']['slurm']['version'] = '23-02-1-1'
 # Munge
-default['cluster']['munge']['munge_version'] = '0.5.14'
+default['cluster']['munge']['munge_version'] = '0.5.15'


### PR DESCRIPTION
### Description of changes
* Upgrade Slurm to version 23.02.1 and munge to version 0.5.15

### Tests
* Ran subset of integration tests with the newer version of Slurm and munge.

### References
* https://github.com/aws/aws-parallelcluster/pull/5182

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.