### PR TITLE
Fix code coverage upload to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,13 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e ${{ matrix.toxenv }}
+      - name: Upload code coverage report to Codecov
+        uses: codecov/codecov-action@v3
+        if: ${{ endsWith(matrix.toxenv, '-cov') }}
+        with:
+          files: coverage.xml
+          flags: unittests
+          verbose: true
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ passenv =
 deps =
     -rtest/unit/requirements.txt
     py{37,38,39,310}: pytest-asyncio
-    cov: codecov
 setenv =
     PYTHONPATH = \
         {toxinidir}/cookbooks/aws-parallelcluster-config/files/default/cloudwatch_agent:\
@@ -29,7 +28,6 @@ setenv =
 commands =
     nocov: pytest -l -v --basetemp={envtmpdir} --html=report.html {[vars]test_dirs}
     cov: pytest -l -v --basetemp={envtmpdir} --html=report.html --cov-report=xml --cov={[vars]cov_dirs} --cov-append {[vars]test_dirs}
-    cov: codecov -e TOXENV -f coverage.xml
 
 # Section used to define common variables used by multiple testenvs.
 [vars]


### PR DESCRIPTION
### Description of changes
1. Remove the upload of the code coverage report to Codecov from Tox steps.
2. Add to CI workflow: upload of the code coverage report to Codecov.


### Tests
1. Verified locally that the tox env py310-cov works.
3. Tox checks executed by GH checks in this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.