### PR TITLE
Fix Slurm accounting password being overridden at queue update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Fix IP association on instances with multiple network cards.
+- Fix replacement of StoragePass in slurm_parallelcluster_slurmdbd.conf when a queue parameter update is performed and the Slurm accounting configurations are not updated.
 
 **BUG FIXES**
 - Fix issue causing cfn-hup daemon to fail when it gets restarted.

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -167,7 +167,7 @@ execute "update Slurm database password" do
   user 'root'
   group 'root'
   command "#{node['cluster']['scripts_dir']}/slurm/update_slurm_database_password.sh"
-  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil?}
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
 end
 
 # Generate custom Slurm settings include files

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -160,6 +160,16 @@ execute "generate_pcluster_slurm_configs" do
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? }
 end
 
+# The previous execute resource may have overridden the slurmdbd password in slurm_parallelcluster_slurmdbd.conf with
+# a default value, so if it has run and Slurm accounting is enabled we must pull the database password from Secrets
+# Manager once again.
+execute "update Slurm database password" do
+  user 'root'
+  group 'root'
+  command "#{node['cluster']['scripts_dir']}/slurm/update_slurm_database_password.sh"
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil?}
+end
+
 # Generate custom Slurm settings include files
 execute "generate_pcluster_custom_slurm_settings_include_files" do
   command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_custom_slurm_settings_include_file_generator.py" \


### PR DESCRIPTION
### Description of changes
* Fix a bug that caused the slurmdbd database password to be overridden during a cluster update where the queues were being updated and the Slurm accounting configuration was not being modified.
* Relates to https://github.com/aws/aws-parallelcluster/issues/5151

### Tests
* manually run a modified version of `test_slurm_accounting` (see https://github.com/aws/aws-parallelcluster/pull/5197).

### References
* https://github.com/aws/aws-parallelcluster/pull/5196

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.