### PR TITLE
[develop]Set BatchStartTimeout to 3 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Lustre client version to 2.12 on Amazon Linux 2. Lustre client 2.12 has been installed on Ubuntu 20.04, 18.04 and CentOS >= 7.7.  Upgrade Lustre client version to 2.10.8 on CentOS 7.6.
 - Upgrade aws-cfn-bootstrap to version 2.0-24.
 - Set Slurm prolog and epilog configurations to target a directory, /opt/slurm/etc/scripts/prolog.d/ and /opt/slurm/etc/scripts/epilog.d/ respectively.
+- Set Slurm BatchStartTimeout to 3 minutes so to allow max 3 minutes Prolog execution during compute node registration.
 - Upgrade Slurm to version 23.02.1.
 - Upgrade munge to version 0.5.15.
 

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -45,6 +45,7 @@ SuspendRate=0
 Prolog=<%= node['cluster']['slurm']['install_dir'] %>/etc/scripts/prolog.d/*
 Epilog=<%= node['cluster']['slurm']['install_dir'] %>/etc/scripts/epilog.d/*
 SchedulerParameters=nohold_on_prolog_fail
+BatchStartTimeout=180
 #
 # TIMERS
 SlurmctldTimeout=300


### PR DESCRIPTION
### Description of changes
Set BatchStartTimeout to 3 minutes, so to allow 3 minutes Prolog execution in the time interval when the Slurm daemon on the compute node registers state with the slurmctld daemon on the head node

ref https://slurm.schedmd.com/slurm.conf.html#OPT_BatchStartTimeout

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.