### PR TITLE
[develop] Change default TreeWidth value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Set Slurm BatchStartTimeout to 3 minutes so to allow max 3 minutes Prolog execution during compute node registration.
 - Upgrade Slurm to version 23.02.1.
 - Upgrade munge to version 0.5.15.
+- Set Slurm default `TreeWidth` to 30. 
 
 **BUG FIXES**
 - Fix IP association on instances with multiple network cards.

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -30,6 +30,7 @@ SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,node_reg_mem
 TreeWidth=65533
 <% else -%>
 SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,cloud_dns,node_reg_mem_percent=<%= node['cluster']['slurm_node_reg_mem_percent'] %>
+TreeWidth=30
 <% end -%>
 CommunicationParameters=NoAddrCache
 SuspendProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_suspend


### PR DESCRIPTION
### Description of changes
* Change default value to TreeWidth
 
As a result of fanout investigation we decided to set the default TreeWidth value to 30 since it is the best balance between performances and robustness

### Tests
* Tests were made during the fanout investigation

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.