### PR TITLE
Create test suite definition for both x86_64 and arm64 and remove scheduler_plugin

### DIFF
--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -40,14 +40,6 @@ _run_list: &_run_list
   - recipe[aws-parallelcluster::tests]
   - recipe[aws-parallelcluster-common::node_attributes]
 
-_run_list_with_mocks: &_run_list_with_mocks
-  - recipe[aws-parallelcluster::tests_mock]
-  - recipe[aws-parallelcluster::init]
-  - recipe[aws-parallelcluster::config]
-  - recipe[aws-parallelcluster::finalize]
-  - recipe[aws-parallelcluster::tests]
-  - recipe[aws-parallelcluster-common::node_attributes]
-
 provisioner:
   attributes:
     kitchen: true
@@ -60,14 +52,6 @@ suites:
         << : *_head_node_cluster_attributes
         scheduler: 'slurm'
         enable_intel_hpc_platform: "<%= ENV['ENABLE_INTEL_HPC_PLATFORM'] || false %>"
-
-  - name: scheduler_plugin_config_HeadNode
-    run_list: *_run_list_with_mocks
-    attributes:
-      cluster:
-        << : *_head_node_cluster_attributes
-        scheduler: 'plugin'
-        enable_intel_hpc_platform: "<%= ENV['ENABLE_INTEL_HPC_PLATFORM'] %>"
 
   - name: awsbatch_config_HeadNode
     run_list: *_run_list
@@ -84,11 +68,3 @@ suites:
         << : *_compute_node_cluster_attributes
         scheduler: 'slurm'
         slurm_nodename: 'fake-dy-compute-1'
-
-  - name: scheduler_plugin_config_ComputeFleet
-    run_list: *_run_list_with_mocks
-    attributes:
-      cluster:
-        << : *_compute_node_cluster_attributes
-        scheduler: 'plugin'
-        scheduler_plugin_nodename: 'fake-dy-compute-1'

--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -45,26 +45,38 @@ provisioner:
     kitchen: true
 
 suites:
-  - name: slurm_config_HeadNode
+  - name: slurm_config_HeadNode_x86_64
     run_list: *_run_list
-    attributes:
+    attributes: &attributes_slurm_config_HeadNode
       cluster:
         << : *_head_node_cluster_attributes
         scheduler: 'slurm'
         enable_intel_hpc_platform: "<%= ENV['ENABLE_INTEL_HPC_PLATFORM'] || false %>"
 
-  - name: awsbatch_config_HeadNode
+  - name: slurm_config_HeadNode_arm64
     run_list: *_run_list
-    attributes:
+    attributes: *attributes_slurm_config_HeadNode
+
+  - name: awsbatch_config_HeadNode_x86_64
+    run_list: *_run_list
+    attributes: &attributes_awsbatch_config_HeadNode
       cluster:
         << : *_head_node_cluster_attributes
         scheduler: 'awsbatch'
         custom_awsbatchcli_package: <%= ENV['CUSTOM_AWSBATCHCLI_URL'] %>
 
-  - name: slurm_config_ComputeFleet
+  - name: awsbatch_config_HeadNode_arm64
     run_list: *_run_list
-    attributes:
+    attributes: *attributes_awsbatch_config_HeadNode
+
+  - name: slurm_config_ComputeFleet_x86_64
+    run_list: *_run_list
+    attributes: &attributes_slurm_config_ComputeFleet
       cluster:
         << : *_compute_node_cluster_attributes
         scheduler: 'slurm'
         slurm_nodename: 'fake-dy-compute-1'
+
+  - name: slurm_config_ComputeFleet_arm64
+    run_list: *_run_list
+    attributes: *attributes_slurm_config_ComputeFleet


### PR DESCRIPTION
### Description of changes
* Tests for the two architectures are executed in parallel so we cannot use the same name for x86 and arm64 test suites, otherwise a running suite will be terminated to start the same suite for the other architecture with the same name.
* scheduler-plugin tests are no running

### Tests
```
[2023-04-14T14:25:05.420Z]        Finished destroying <slurm-config-HeadNode-arm64-alinux2> (0m0.00s).
[2023-04-14T14:25:05.420Z] -----> Testing <slurm-config-HeadNode-arm64-alinux2>
```

```
[2023-04-14T14:29:06.927Z]        Finished destroying <slurm-config-HeadNode-x86-64-alinux2> (0m0.21s).
[2023-04-14T14:29:06.927Z] -----> Test Kitchen is finished. (4m1.98s)
```