### PR TITLE
Fix logic to reset Slurm accounting password after queue update

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -167,7 +167,8 @@ execute "update Slurm database password" do
   user 'root'
   group 'root'
   command "#{node['cluster']['scripts_dir']}/slurm/update_slurm_database_password.sh"
-  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
+  # This horrible only_if guard is needed to cover all cases that trigger "generate_pcluster_slurm_settings", in the case Slurm accounting is being used
+  only_if { !(::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated?) && !node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
 end
 
 # Generate custom Slurm settings include files


### PR DESCRIPTION
### Description of changes
* Fix logic to reset Slurm accounting password after queue update
    * the logic introduced in https://github.com/aws/aws-parallelcluster-cookbook/pull/2006 was wrong.

### Tests
* Performed a manual run of:
    * schedulers/test_slurm_accounting.py::test_slurm_accounting
    * schedulers/test_slurm.py::test_slurm_config_update
    * update/test_update.py::test_update_instance_list

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.