### PR TITLE
3.x Fix date format to match CWA configuration

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_checks/gpu_health_check.sh
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_checks/gpu_health_check.sh
@@ -126,7 +126,7 @@ function main() {
 }
 
 function _log() {
-  echo "$(date +"%Y-%m-%d %H-%M-%S,%3N") - [${0##*/}] - $1 - JobID $SLURM_JOB_ID - ${*:2}"
+  echo "$(date +"%Y-%m-%d %H:%M:%S,%3N") - [${0##*/}] - $1 - JobID $SLURM_JOB_ID - ${*:2}"
 }
 
 function log_info() {

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/90_pcluster_health_check_manager.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/90_pcluster_health_check_manager.erb
@@ -25,7 +25,7 @@ fi
 function _log() {
   LOG_LEVEL=$1
   shift
-  echo "$(date +"%Y-%m-%d %H-%M-%S,%3N") - [$(basename $0)] - ${LOG_LEVEL} - Job ${SLURM_JOB_ID} - $*" >> "${LOG_FILE_PATH}"
+  echo "$(date +"%Y-%m-%d %H:%M:%S,%3N") - [$(basename $0)] - ${LOG_LEVEL} - Job ${SLURM_JOB_ID} - $*" >> "${LOG_FILE_PATH}"
 }
 
 function log_info() {


### PR DESCRIPTION
### Description of changes
* The date format for the shell scripts did not match what was configured for the log file in CloudWatch Agent.
* Because the date formats didn't match, the timestamps in the CloudWatch stream did not align with the log event timestamp.
* Changed the date format for both shell scripts to match the configured date pattern.
* Python module was already conformant to the configured format.


### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.