### PR TITLE
Add support for RHEL8 to 3.6.0 changelog

### DIFF
--- a/.github/workflows/dokken-validate.yml
+++ b/.github/workflows/dokken-validate.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           files_ignore: |
             !.github
+            !CHANGELOG.md
             !**/aws-parallelcluster-*/spec
             !**/aws-parallelcluster-*/test
       - name: Install Chef

--- a/.github/workflows/system-tests-centos7.yml
+++ b/.github/workflows/system-tests-centos7.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           files_ignore: |
             !.github
+            !CHANGELOG.md
             !**/aws-parallelcluster-*/spec
             !**/aws-parallelcluster-*/test
       - name: Set up Docker Buildx

--- a/.github/workflows/system-tests-ubuntu.yml
+++ b/.github/workflows/system-tests-ubuntu.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           files_ignore: |
             !.github
+            !CHANGELOG.md
             !**/aws-parallelcluster-*/spec
             !**/aws-parallelcluster-*/test
       - name: Set up Docker Buildx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **ENHANCEMENTS**
+- Add support for RHEL8.
 - Enforce the DCV Authenticator Server to use at least `TLS-1.2` protocol when creating the SSL Socket.
 - Track head node memory and root volume disk utilization using the `mem_used_percent` and `disk_used_percent` metrics collected through the CloudWatch Agent.
 - Add log rotation support for ParallelCluster managed logs.


### PR DESCRIPTION
### Description of changes
* [Add support for RHEL8 to 3.6.0 changelog](https://github.com/aws/aws-parallelcluster-cookbook/pull/2023/commits/d5058c06b2f0f7f924ac5e8d92f394ec61bd8e00)
* [Avoid running system and kitchen tests due to changes to CHANGELOG.md](https://github.com/aws/aws-parallelcluster-cookbook/pull/2023/commits/e043f4787594f8d53f6b26f546ba2aff5dab9ca7)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.