### PR TITLE
Lock fabricmanager version in rhel8

### DIFF
--- a/cookbooks/aws-parallelcluster-common/resources/fabric_manager/fabric_manager_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/fabric_manager/fabric_manager_redhat8.rb
@@ -37,5 +37,6 @@ action :install_package do
     retries 3
     retry_delay 5
     source rpm_package
+    action %i(install lock)
   end
 end

--- a/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
@@ -52,6 +52,11 @@ control 'tag:config_expected_versions_of_nvidia_fabric_manager_installed' do
     it { should be_installed }
     its('version') { should match /#{node['cluster']['nvidia']['fabricmanager']['version']}/ }
   end
+
+  version_lock_check = os_properties.debian_family? ? 'apt-mark showhold | grep "nvidia-fabric.*manager"' : 'yum versionlock list | grep "nvidia-fabric.*manager"'
+  describe bash(version_lock_check) do
+    its('exit_status') { should eq 0 }
+  end
 end
 
 control 'tag:config_expected_versions_of_nvidia_gdrcopy_installed' do


### PR DESCRIPTION
### Description of changes
This patch locks the version of fabricmanager for rhel8 as we do for all other OSs, and adds a check in the Kitchen test to verify that it is locked.

### Tests
Kitchen tests

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.