### PR TITLE
Upgrade NVIDIA driver, CUDA and CUDA sample versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Lustre client version to 2.12 on Amazon Linux 2 (same version available on Ubuntu 20.04, 18.04 and CentOS >= 7.7).
 - Upgrade Lustre client version to 2.10.8 on CentOS 7.6.
 - Upgrade `aws-cfn-bootstrap` to version 2.0-24.
+- Upgrade NVIDIA driver to version 470.182.03.
+- Upgrade NVIDIA Fabric Manager to version 470.182.03.
+- Upgrade NVIDIA CUDA Toolkit to version 11.8.0.
+- Upgrade NVIDIA CUDA sample to version 11.8.0.
 
 **BUG FIXES**
 - Fix an issue that was causing misalignment of compute nodes IP on instances with multiple network interfaces.

--- a/cookbooks/aws-parallelcluster-common/attributes/common.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common.rb
@@ -53,10 +53,15 @@ default['cluster']['parallelcluster-awsbatch-cli-version'] = '1.1.0'
 # NVIDIA
 default['cluster']['nvidia']['enabled'] = 'no'
 default['cluster']['nvidia']['driver_version'] = '470.182.03'
-default['cluster']['nvidia']['cuda_version'] = '11.8'
+# Cuda installer from https://developer.nvidia.com/cuda-toolkit-archive
+# Cuda installer naming: cuda_11.8.0_520.61.05_linux
+default['cluster']['nvidia']['cuda']['version'] = '11.8'
+default['cluster']['nvidia']['cuda']['patch'] = '0'
+default['cluster']['nvidia']['cuda']['complete_version'] = "#{node['cluster']['nvidia']['cuda']['version']}.#{node['cluster']['nvidia']['cuda']['patch']}"
+default['cluster']['nvidia']['cuda']['version_suffix'] = '520.61.05'
 default['cluster']['nvidia']['cuda_samples_version'] = '11.8'
 default['cluster']['nvidia']['driver_url_architecture_id'] = arm_instance? ? 'aarch64' : 'x86_64'
-default['cluster']['nvidia']['cuda_url_architecture_id'] = arm_instance? ? 'linux_sbsa' : 'linux'
+default['cluster']['nvidia']['cuda']['url_architecture_id'] = arm_instance? ? 'linux_sbsa' : 'linux'
 default['cluster']['nvidia']['driver_url'] = "https://us.download.nvidia.com/tesla/#{node['cluster']['nvidia']['driver_version']}/NVIDIA-Linux-#{node['cluster']['nvidia']['driver_url_architecture_id']}-#{node['cluster']['nvidia']['driver_version']}.run"
-default['cluster']['nvidia']['cuda_url'] = "https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_#{node['cluster']['nvidia']['cuda_url_architecture_id']}.run"
+default['cluster']['nvidia']['cuda']['url'] = "https://developer.download.nvidia.com/compute/cuda/#{node['cluster']['nvidia']['cuda']['complete_version']}/local_installers/cuda_#{node['cluster']['nvidia']['cuda']['complete_version']}_#{node['cluster']['nvidia']['cuda']['version_suffix']}_#{node['cluster']['nvidia']['cuda']['url_architecture_id']}.run"
 default['cluster']['nvidia']['cuda_samples_url'] = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v#{node['cluster']['nvidia']['cuda_samples_version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-common/attributes/common.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common.rb
@@ -49,3 +49,14 @@ default['cluster']['parallelcluster-version'] = '3.7.0'
 default['cluster']['parallelcluster-cookbook-version'] = '3.7.0'
 default['cluster']['parallelcluster-node-version'] = '3.7.0'
 default['cluster']['parallelcluster-awsbatch-cli-version'] = '1.1.0'
+
+# NVIDIA
+default['cluster']['nvidia']['enabled'] = 'no'
+default['cluster']['nvidia']['driver_version'] = '470.141.03'
+default['cluster']['nvidia']['cuda_version'] = '11.7'
+default['cluster']['nvidia']['cuda_samples_version'] = '11.6'
+default['cluster']['nvidia']['driver_url_architecture_id'] = arm_instance? ? 'aarch64' : 'x86_64'
+default['cluster']['nvidia']['cuda_url_architecture_id'] = arm_instance? ? 'linux_sbsa' : 'linux'
+default['cluster']['nvidia']['driver_url'] = "https://us.download.nvidia.com/tesla/#{node['cluster']['nvidia']['driver_version']}/NVIDIA-Linux-#{node['cluster']['nvidia']['driver_url_architecture_id']}-#{node['cluster']['nvidia']['driver_version']}.run"
+default['cluster']['nvidia']['cuda_url'] = "https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_#{node['cluster']['nvidia']['cuda_url_architecture_id']}.run"
+default['cluster']['nvidia']['cuda_samples_url'] = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v#{node['cluster']['nvidia']['cuda_samples_version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-common/attributes/common.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common.rb
@@ -52,9 +52,9 @@ default['cluster']['parallelcluster-awsbatch-cli-version'] = '1.1.0'
 
 # NVIDIA
 default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '470.141.03'
-default['cluster']['nvidia']['cuda_version'] = '11.7'
-default['cluster']['nvidia']['cuda_samples_version'] = '11.6'
+default['cluster']['nvidia']['driver_version'] = '470.182.03'
+default['cluster']['nvidia']['cuda_version'] = '11.8'
+default['cluster']['nvidia']['cuda_samples_version'] = '11.8'
 default['cluster']['nvidia']['driver_url_architecture_id'] = arm_instance? ? 'aarch64' : 'x86_64'
 default['cluster']['nvidia']['cuda_url_architecture_id'] = arm_instance? ? 'linux_sbsa' : 'linux'
 default['cluster']['nvidia']['driver_url'] = "https://us.download.nvidia.com/tesla/#{node['cluster']['nvidia']['driver_version']}/NVIDIA-Linux-#{node['cluster']['nvidia']['driver_url_architecture_id']}-#{node['cluster']['nvidia']['driver_version']}.run"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
@@ -11,16 +11,6 @@ default['cluster']['modulepath_config_file'] = "#{node['cluster']['moduleshome']
 default['cluster']['chrony']['service'] = "chronyd"
 
 # NVIDIA
-default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '470.141.03'
-default['cluster']['nvidia']['cuda_version'] = '11.7'
-default['cluster']['nvidia']['cuda_samples_version'] = '11.6'
-default['cluster']['nvidia']['driver_url_architecture_id'] = arm_instance? ? 'aarch64' : 'x86_64'
-default['cluster']['nvidia']['cuda_url_architecture_id'] = arm_instance? ? 'linux_sbsa' : 'linux'
-default['cluster']['nvidia']['driver_url'] = "https://us.download.nvidia.com/tesla/#{node['cluster']['nvidia']['driver_version']}/NVIDIA-Linux-#{node['cluster']['nvidia']['driver_url_architecture_id']}-#{node['cluster']['nvidia']['driver_version']}.run"
-default['cluster']['nvidia']['cuda_url'] = "https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_#{node['cluster']['nvidia']['cuda_url_architecture_id']}.run"
-default['cluster']['nvidia']['cuda_samples_url'] = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v#{node['cluster']['nvidia']['cuda_samples_version']}.tar.gz"
-
 # NVIDIA GDRCopy
 default['cluster']['nvidia']['gdrcopy']['version'] = '2.3'
 default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrcopy/archive/refs/tags/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
@@ -11,16 +11,6 @@ default['cluster']['modulepath_config_file'] = "#{node['cluster']['moduleshome']
 default['cluster']['chrony']['service'] = "chronyd"
 
 # NVIDIA
-default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '470.141.03'
-default['cluster']['nvidia']['cuda_version'] = '11.7'
-default['cluster']['nvidia']['cuda_samples_version'] = '11.6'
-default['cluster']['nvidia']['driver_url_architecture_id'] = arm_instance? ? 'aarch64' : 'x86_64'
-default['cluster']['nvidia']['cuda_url_architecture_id'] = arm_instance? ? 'linux_sbsa' : 'linux'
-default['cluster']['nvidia']['driver_url'] = "https://us.download.nvidia.com/tesla/#{node['cluster']['nvidia']['driver_version']}/NVIDIA-Linux-#{node['cluster']['nvidia']['driver_url_architecture_id']}-#{node['cluster']['nvidia']['driver_version']}.run"
-default['cluster']['nvidia']['cuda_url'] = "https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_#{node['cluster']['nvidia']['cuda_url_architecture_id']}.run"
-default['cluster']['nvidia']['cuda_samples_url'] = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v#{node['cluster']['nvidia']['cuda_samples_version']}.tar.gz"
-
 # NVIDIA GDRCopy
 default['cluster']['nvidia']['gdrcopy']['version'] = '2.3'
 default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrcopy/archive/refs/tags/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
@@ -12,16 +12,6 @@ default['cluster']['modulepath_config_file'] = "#{node['cluster']['modulesconfig
 default['cluster']['chrony']['service'] = "chronyd"
 
 # NVIDIA
-default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '470.141.03'
-default['cluster']['nvidia']['cuda_version'] = '11.7'
-default['cluster']['nvidia']['cuda_samples_version'] = '11.6'
-default['cluster']['nvidia']['driver_url_architecture_id'] = arm_instance? ? 'aarch64' : 'x86_64'
-default['cluster']['nvidia']['cuda_url_architecture_id'] = arm_instance? ? 'linux_sbsa' : 'linux'
-default['cluster']['nvidia']['driver_url'] = "https://us.download.nvidia.com/tesla/#{node['cluster']['nvidia']['driver_version']}/NVIDIA-Linux-#{node['cluster']['nvidia']['driver_url_architecture_id']}-#{node['cluster']['nvidia']['driver_version']}.run"
-default['cluster']['nvidia']['cuda_url'] = "https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_#{node['cluster']['nvidia']['cuda_url_architecture_id']}.run"
-default['cluster']['nvidia']['cuda_samples_url'] = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v#{node['cluster']['nvidia']['cuda_samples_version']}.tar.gz"
-
 # NVIDIA GDRCopy
 default['cluster']['nvidia']['gdrcopy']['version'] = '2.3'
 default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrcopy/archive/refs/tags/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu18.rb
@@ -12,16 +12,6 @@ default['cluster']['modulepath_config_file'] = "#{node['cluster']['moduleshome']
 default['cluster']['chrony']['service'] = "chrony"
 
 # NVIDIA
-default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '470.141.03'
-default['cluster']['nvidia']['cuda_version'] = '11.7'
-default['cluster']['nvidia']['cuda_samples_version'] = '11.6'
-default['cluster']['nvidia']['driver_url_architecture_id'] = arm_instance? ? 'aarch64' : 'x86_64'
-default['cluster']['nvidia']['cuda_url_architecture_id'] = arm_instance? ? 'linux_sbsa' : 'linux'
-default['cluster']['nvidia']['driver_url'] = "https://us.download.nvidia.com/tesla/#{node['cluster']['nvidia']['driver_version']}/NVIDIA-Linux-#{node['cluster']['nvidia']['driver_url_architecture_id']}-#{node['cluster']['nvidia']['driver_version']}.run"
-default['cluster']['nvidia']['cuda_url'] = "https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_#{node['cluster']['nvidia']['cuda_url_architecture_id']}.run"
-default['cluster']['nvidia']['cuda_samples_url'] = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v#{node['cluster']['nvidia']['cuda_samples_version']}.tar.gz"
-
 # NVIDIA GDRCopy
 default['cluster']['nvidia']['gdrcopy']['version'] = '2.3'
 default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrcopy/archive/refs/tags/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu20.rb
@@ -12,16 +12,6 @@ default['cluster']['modulepath_config_file'] = "#{node['cluster']['moduleshome']
 default['cluster']['chrony']['service'] = "chrony"
 
 # NVIDIA
-default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '470.141.03'
-default['cluster']['nvidia']['cuda_version'] = '11.7'
-default['cluster']['nvidia']['cuda_samples_version'] = '11.6'
-default['cluster']['nvidia']['driver_url_architecture_id'] = arm_instance? ? 'aarch64' : 'x86_64'
-default['cluster']['nvidia']['cuda_url_architecture_id'] = arm_instance? ? 'linux_sbsa' : 'linux'
-default['cluster']['nvidia']['driver_url'] = "https://us.download.nvidia.com/tesla/#{node['cluster']['nvidia']['driver_version']}/NVIDIA-Linux-#{node['cluster']['nvidia']['driver_url_architecture_id']}-#{node['cluster']['nvidia']['driver_version']}.run"
-default['cluster']['nvidia']['cuda_url'] = "https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_#{node['cluster']['nvidia']['cuda_url_architecture_id']}.run"
-default['cluster']['nvidia']['cuda_samples_url'] = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v#{node['cluster']['nvidia']['cuda_samples_version']}.tar.gz"
-
 # NVIDIA GDRCopy
 default['cluster']['nvidia']['gdrcopy']['version'] = '2.3'
 default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrcopy/archive/refs/tags/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-install/recipes/cuda.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/cuda.rb
@@ -20,11 +20,11 @@ return unless node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['
 # Get CUDA run file
 cuda_tmp_runfile = "/tmp/cuda.run"
 remote_file cuda_tmp_runfile do
-  source node['cluster']['nvidia']['cuda_url']
+  source node['cluster']['nvidia']['cuda']['url']
   mode '0755'
   retries 3
   retry_delay 5
-  not_if { ::File.exist?("/usr/local/cuda-#{node['cluster']['nvidia']['cuda_version']}") }
+  not_if { ::File.exist?("/usr/local/cuda-#{node['cluster']['nvidia']['cuda']['version']}") }
 end
 
 # Install CUDA driver
@@ -37,11 +37,11 @@ bash 'cuda.run advanced' do
     ./cuda.run --silent --toolkit --samples
     rm -f /tmp/cuda.run
   CUDA
-  creates "/usr/local/cuda-#{node['cluster']['nvidia']['cuda_version']}"
+  creates "/usr/local/cuda-#{node['cluster']['nvidia']['cuda']['version']}"
 end
 
 # Get CUDA Sample Files
-cuda_samples_directory = "/usr/local/cuda-#{node['cluster']['nvidia']['cuda_version']}/samples"
+cuda_samples_directory = "/usr/local/cuda-#{node['cluster']['nvidia']['cuda']['version']}/samples"
 cuda_tmp_sample_file = "/tmp/cuda-sample.tar.gz"
 remote_file cuda_tmp_sample_file do
   source node['cluster']['nvidia']['cuda_samples_url']

--- a/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
@@ -29,7 +29,7 @@ control 'tag:config_expected_versions_of_nvidia_cuda_installed' do
       (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
   end
 
-  expected_cuda_version = node['cluster']['nvidia']['cuda_version']
+  expected_cuda_version = node['cluster']['nvidia']['cuda']['version']
   cmd = %(
     export PATH=/usr/local/cuda-#{expected_cuda_version}/bin:${PATH};
     export LD_LIBRARY_PATH=/usr/local/cuda-#{expected_cuda_version}/lib64:${LD_LIBRARY_PATH}


### PR DESCRIPTION
### Description of changes
* Upgrade NVIDIA driver to version 470.182.03.
* Upgrade NVIDIA Fabric Manager to version 470.182.03.
* Upgrade NVIDIA CUDA Toolkit to version 11.8.0.
* Upgrade NVIDIA CUDA sample to version 11.8.0.
* Refactor the naming of CUDA node attributes, to better understand what to change when updating CUDA
* Regrouped NVIDIA common attributes

### Tests
* Local kitchen tests on ec2 

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.