### PR TITLE
Create build_tools and modules resources

### DIFF
--- a/cookbooks/aws-parallelcluster-common/recipes/node_attributes.rb
+++ b/cookbooks/aws-parallelcluster-common/recipes/node_attributes.rb
@@ -16,6 +16,12 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+directory '/etc/chef' do
+  owner 'root'
+  group 'root'
+  recursive true
+end
+
 file "/etc/chef/node_attributes.json" do
   content Chef::JSONCompat.to_json_pretty(node)
   owner 'root'

--- a/cookbooks/aws-parallelcluster-common/recipes/node_attributes.rb
+++ b/cookbooks/aws-parallelcluster-common/recipes/node_attributes.rb
@@ -26,4 +26,5 @@ file "/etc/chef/node_attributes.json" do
   content Chef::JSONCompat.to_json_pretty(node)
   owner 'root'
   mode '0644'
+  sensitive true # avoids logging node attributes
 end

--- a/cookbooks/aws-parallelcluster-install/resources/build_tools/build_tools_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/build_tools/build_tools_amazon2.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :build_tools, platform: 'amazon', platform_version: '2'
+
+use 'partial/_build_tools_yum.rb'
+
+action_class do
+  def packages
+    %w(gcc gcc-c++)
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/build_tools/build_tools_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/build_tools/build_tools_centos7.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :build_tools, platform: 'centos' do |node|
+  node['platform_version'].to_i == 7
+end
+
+use 'partial/_build_tools_yum.rb'
+
+action_class do
+  def packages
+    %w(gcc gcc-c++)
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/build_tools/build_tools_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/build_tools/build_tools_redhat8.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :build_tools, platform: 'redhat' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_build_tools_yum.rb'
+
+action_class do
+  def packages
+    %w(gcc gcc-c++ make)
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/build_tools/build_tools_ubuntu.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/build_tools/build_tools_ubuntu.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :build_tools, platform: 'ubuntu'
+
+unified_mode true
+default_action :setup
+
+action :setup do
+  package %w(build-essential) do
+    retries 10
+    retry_delay 5
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/build_tools/partial/_build_tools_yum.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/build_tools/partial/_build_tools_yum.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+unified_mode true
+default_action :setup
+
+action :setup do
+  package packages do
+    retries 10
+    retry_delay 5
+    flush_cache({ before: true })
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/modules/modules_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/modules/modules_amazon2.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :modules, platform: 'amazon', platform_version: '2'
+
+use 'partial/_modules_yum.rb'
+
+action_class do
+  def packages
+    %w(environment-modules)
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/modules/modules_centos7.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/modules/modules_centos7.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :modules, platform: 'centos' do |node|
+  node['platform_version'].to_i == 7
+end
+
+use 'partial/_modules_yum.rb'
+
+action_class do
+  def packages
+    %w(environment-modules)
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/modules/modules_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/modules/modules_redhat8.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :modules, platform: 'redhat' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_modules_yum.rb'
+
+action_class do
+  def packages
+    %w(environment-modules)
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/modules/modules_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/modules/modules_ubuntu18.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :modules, platform: 'ubuntu', platform_version: '18.04'
+
+use 'partial/_modules_apt.rb'
+
+action_class do
+  def packages
+    %w(tcl-dev environment-modules)
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/modules/modules_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/modules/modules_ubuntu20.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :modules, platform: 'ubuntu', platform_version: '20.04'
+
+use 'partial/_modules_apt.rb'
+
+action_class do
+  def packages
+    %w(environment-modules)
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/modules/partial/_modules_apt.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/modules/partial/_modules_apt.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+unified_mode true
+default_action :setup
+
+action :setup do
+  package packages do
+    retries 10
+    retry_delay 5
+  end
+end

--- a/cookbooks/aws-parallelcluster-install/resources/modules/partial/_modules_yum.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/modules/partial/_modules_yum.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+unified_mode true
+default_action :setup
+
+action :setup do
+  package packages do
+    retries 10
+    retry_delay 5
+    flush_cache({ before: true })
+  end
+end

--- a/kitchen.resources-install.yml
+++ b/kitchen.resources-install.yml
@@ -201,6 +201,32 @@ suites:
         - resource:package_repos
         - resource:install_packages
         - recipe:aws-parallelcluster-common::node_attributes
+  - name: build_tools
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-install::test_resource]
+    verifier:
+      controls:
+        - build_tools_installed
+    attributes:
+      resource: build_tools
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - resource:package_repos
+        - recipe:aws-parallelcluster-common::node_attributes
+  - name: modules
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-install::test_resource]
+    verifier:
+      controls:
+        - modules_installed
+    attributes:
+      resource: modules
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - resource:package_repos
+        - recipe:aws-parallelcluster-common::node_attributes
   - name: dcv
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]

--- a/kitchen.resources-install.yml
+++ b/kitchen.resources-install.yml
@@ -201,19 +201,6 @@ suites:
         - resource:package_repos
         - resource:install_packages
         - recipe:aws-parallelcluster-common::node_attributes
-  - name: build_tools
-    run_list:
-      - recipe[aws-parallelcluster::add_dependencies]
-      - recipe[aws-parallelcluster-install::test_resource]
-    verifier:
-      controls:
-        - build_tools_installed
-    attributes:
-      resource: build_tools
-      dependencies:
-        - recipe:aws-parallelcluster-install::directories
-        - resource:package_repos
-        - recipe:aws-parallelcluster-common::node_attributes
   - name: modules
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]
@@ -223,6 +210,19 @@ suites:
         - modules_installed
     attributes:
       resource: modules
+      dependencies:
+        - recipe:aws-parallelcluster-install::directories
+        - resource:package_repos
+        - recipe:aws-parallelcluster-common::node_attributes
+  - name: build_tools
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-install::test_resource]
+    verifier:
+      controls:
+        - build_tools_installed
+    attributes:
+      resource: build_tools
       dependencies:
         - recipe:aws-parallelcluster-install::directories
         - resource:package_repos

--- a/test/resources/controls/aws_parallelcluster_install/build_tools_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/build_tools_spec.rb
@@ -1,0 +1,18 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'build_tools_installed' do
+  title "Check packages to build from source are installed"
+
+  describe command("make") do
+    it { should exist }
+  end
+end

--- a/test/resources/controls/aws_parallelcluster_install/modules_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/modules_spec.rb
@@ -1,0 +1,19 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'modules_installed' do
+  title "Check environment modules installation"
+  desc 'https://modules.readthedocs.io/'
+
+  describe bash("unset MODULEPATH && source /etc/profile.d/modules.sh && module list") do
+    its('exit_status') { should eq(0) }
+  end
+end


### PR DESCRIPTION
### Description of changes
- [Create build_tools resource](https://github.com/aws/aws-parallelcluster-cookbook/pull/2034/commits/743c9e0bbaa308abff39cde38c564eb172022f52) will allow to add a separate, lightweight dependency to code units building libraries

- [Create /etc/chef directory if not existing](https://github.com/aws/aws-parallelcluster-cookbook/pull/2034/commits/abd9f865e70c3fbead8637907e84d92a9317f566) : `node-attributes` creates `node-attributes file in `/etc/chef` and was failing when the directory didn't exites

- [Avoid logging node_attributes.json contents when creating the file](https://github.com/aws/aws-parallelcluster-cookbook/pull/2034/commits/513f5c1cf947e651594ac542d84bfd61e642d9c1): removes annoying logging

- [Create resource installing environment modules](https://github.com/aws/aws-parallelcluster-cookbook/pull/2034/commits/86dd85702117235e9205e679b922cadd17ef7e0c) will allow to add a separate, lightweight dependency to code units relying on environment modules

### Tests
* Kitchen tests run on EC2 for both `build_tools` and `modules` resources

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.