### PR TITLE
Upgrade IntelMPI to 2021.9.0.43482

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade NVIDIA Fabric Manager to version 470.182.03.
 - Upgrade NVIDIA CUDA Toolkit to version 11.8.0.
 - Upgrade NVIDIA CUDA sample to version 11.8.0.
+- Upgrade Intel MPI Library to 2021.9.0.43482.
 - Upgrade NICE DCV to version `2023.0-15022`.
   - server: `2023.0.15022-1`
   - xdcv: `2023.0.547-1`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,10 +69,10 @@ default['cluster']['intelpython2']['version'] = '2019.4-088'
 default['cluster']['intelpython3']['version'] = '2020.2-902'
 
 # Intel MPI
-default['cluster']['intelmpi']['version'] = '2021.6.0'
-default['cluster']['intelmpi']['full_version'] = "#{node['cluster']['intelmpi']['version']}.602"
+default['cluster']['intelmpi']['version'] = '2021.9.0'
+default['cluster']['intelmpi']['full_version'] = "#{node['cluster']['intelmpi']['version']}.43482"
 default['cluster']['intelmpi']['modulefile'] = "/opt/intel/mpi/#{node['cluster']['intelmpi']['version']}/modulefiles/mpi"
-default['cluster']['intelmpi']['qt_version'] = '5.15.2'
+default['cluster']['intelmpi']['qt_version'] = '6.4.2'
 
 # URLs to software packages used during install recipes
 default['cluster']['slurm_plugin_dir'] = '/etc/parallelcluster/slurm_plugin'


### PR DESCRIPTION
### Description of changes
* Upgrade IntelMPI to 2021.9.0.43482
* IntelMPI installer uses qt library, which have to be hosted in our S3. Qt library version 6.4.2

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.