### PR TITLE
Include Kitchen InSpec profiles in GitHub tarball 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /spec export-ignore
-/test export-ignore
+/test/unit export-ignore
+/test/integration export-ignore
 .kitchen* export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/.github/workflows/dokken-validate.yml
+++ b/.github/workflows/dokken-validate.yml
@@ -28,7 +28,7 @@ jobs:
         uses: tj-actions/changed-files@v35.6.0
         with:
           files_ignore: |
-            !.github
+            !.*
             !CHANGELOG.md
             !README.md
             !**/aws-parallelcluster-*/spec

--- a/.github/workflows/system-tests-centos7.yml
+++ b/.github/workflows/system-tests-centos7.yml
@@ -26,7 +26,7 @@ jobs:
         uses: tj-actions/changed-files@v35.6.0
         with:
           files_ignore: |
-            !.github
+            !.*
             !README.md
             !CHANGELOG.md
             !**/aws-parallelcluster-*/spec

--- a/.github/workflows/system-tests-ubuntu.yml
+++ b/.github/workflows/system-tests-ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
         uses: tj-actions/changed-files@v35.6.0
         with:
           files_ignore: |
-            !.github
+            !.*
             !README.md
             !CHANGELOG.md
             !**/aws-parallelcluster-*/spec


### PR DESCRIPTION
### Description of changes
Include Kitchen InSpec profiles in GitHub tarball in order to allow InSpec test execution on AMIs.
See https://git-scm.com/docs/gitattributes

### Tests
* Downloaded the tarball from https://github.com/awslitvit/aws-parallelcluster-cookbook/tarball/9e27d2f8bd1df7ab849d4ac7a8dbd2532a2917af and checked that it contains InSpec profiles.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.