### PR TITLE
Remove test folder from files ignored by Chef

### DIFF
--- a/.github/workflows/dokken-validate.yml
+++ b/.github/workflows/dokken-validate.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           files_ignore: |
             !.*
+            !chefignore
             !CHANGELOG.md
             !README.md
             !**/aws-parallelcluster-*/spec

--- a/.github/workflows/system-tests-centos7.yml
+++ b/.github/workflows/system-tests-centos7.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           files_ignore: |
             !.*
+            !chefignore
             !README.md
             !CHANGELOG.md
             !**/aws-parallelcluster-*/spec

--- a/.github/workflows/system-tests-ubuntu.yml
+++ b/.github/workflows/system-tests-ubuntu.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           files_ignore: |
             !.*
+            !chefignore
             !README.md
             !CHANGELOG.md
             !**/aws-parallelcluster-*/spec

--- a/chefignore
+++ b/chefignore
@@ -49,7 +49,6 @@ a.out
 .rspec
 spec/*
 spec/fixtures/*
-test/*
 features/*
 Guardfile
 Procfile


### PR DESCRIPTION
### Description of changes
Remove test folder from files ignored by Chef.
In order to allow InSpec test execution on AMIs we need berks to vendor test folder as well.

### Tests
* Run berks and checked `test` folder is vendored.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.