### PR TITLE
Transform node_attributes into a resource

### DIFF
--- a/cookbooks/aws-parallelcluster-common/resources/node_attributes.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/node_attributes.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook:: aws-parallelcluster-install
-# Recipe:: node_attributes
+# Resource:: node_attributes
 #
 # Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
@@ -16,15 +16,24 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-directory '/etc/chef' do
-  owner 'root'
-  group 'root'
-  recursive true
-end
+provides :node_attributes
+unified_mode true
 
-file "/etc/chef/node_attributes.json" do
-  content Chef::JSONCompat.to_json_pretty(node)
-  owner 'root'
-  mode '0644'
-  sensitive true # avoids logging node attributes
+property :file, String, default: '/etc/chef/node_attributes.json'
+
+default_action :write
+
+action :write do
+  directory '/etc/chef' do
+    owner 'root'
+    group 'root'
+    recursive true
+  end
+
+  file "/etc/chef/node_attributes.json" do
+    content Chef::JSONCompat.to_json_pretty(node)
+    owner 'root'
+    mode '0644'
+    sensitive true # avoids logging node attributes
+  end
 end

--- a/cookbooks/aws-parallelcluster-common/spec/spec_helper.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/spec_helper.rb
@@ -7,6 +7,9 @@ RSpec.configure do |c|
     allow_any_instance_of(Object).to receive(:aws_domain).and_return("test_aws_domain")
     allow_any_instance_of(Object).to receive(:aws_region).and_return("test_region")
   end
+  # This will be used by default when platform doesn't matter
+  # When it matters, platform value must be overridden for a specific test
+  c.platform = 'ubuntu'
 end
 
 module ChefSpec

--- a/cookbooks/aws-parallelcluster-common/spec/unit/resources/node_attributes_spec.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/unit/resources/node_attributes_spec.rb
@@ -3,9 +3,12 @@ require 'spec_helper'
 describe 'aws-parallelcluster-common::node_attributes' do
   context 'Sets up environment variables' do
     cached(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'ubuntu') do |node|
+      runner = ChefSpec::Runner.new(step_into: ['node_attributes']) do |node|
         node.override['test']['attr'] = 'attr_value'
-      end.converge(described_recipe)
+      end
+      runner.converge_dsl do
+        node_attributes 'write file'
+      end
     end
 
     it 'creates file /etc/chef/node_attributes.json with all the node attributes' do

--- a/cookbooks/aws-parallelcluster-install/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/install.rb
@@ -49,4 +49,4 @@ include_recipe 'aws-parallelcluster-awsbatch::install'
 # used to build the schedulers packages
 dcv "Install DCV"
 
-include_recipe "aws-parallelcluster-common::node_attributes"
+node_attributes "dump node attributes"

--- a/cookbooks/aws-parallelcluster-install/resources/arm_pl/partial/_arm_pl_common.rb
+++ b/cookbooks/aws-parallelcluster-install/resources/arm_pl/partial/_arm_pl_common.rb
@@ -160,5 +160,5 @@ action :setup do
   node.default['cluster']['armpl']['gcc']['patch_version'] = new_resource.gcc_patch_version
   node.default['cluster']['armpl']['gcc']['version'] = gcc_version
 
-  include_recipe "aws-parallelcluster-common::node_attributes"
+  node_attributes "dump node attributes"
 end

--- a/kitchen.recipes-install.yml
+++ b/kitchen.recipes-install.yml
@@ -297,7 +297,7 @@ suites:
         - recipe:aws-parallelcluster-install::directories
         - resource:package_repos
         - resource:install_packages
-        - recipe:aws-parallelcluster-common::node_attributes
+        - resource:aws-parallelcluster-common::node_attributes
       cluster:
         nvidia:
           enabled: true

--- a/kitchen.resources-config.yml
+++ b/kitchen.resources-config.yml
@@ -101,7 +101,7 @@ suites:
         - recipe:aws-parallelcluster-install::directories
         - recipe:aws-parallelcluster-install::python
         - resource:cloudwatch:setup
-        - recipe:aws-parallelcluster-common::node_attributes
+        - resource:aws-parallelcluster-common::node_attributes
       cluster:
         node_type: HeadNode
         scheduler: slurm
@@ -124,7 +124,7 @@ suites:
         - resource:install_packages
         - recipe:aws-parallelcluster-install::nvidia
         - resource:dcv:setup
-        - recipe:aws-parallelcluster-common::node_attributes
+        - resource:aws-parallelcluster-common::node_attributes
       cluster:
         node_type: HeadNode
         dcv_enabled: "head_node"

--- a/kitchen.resources-install.yml
+++ b/kitchen.resources-install.yml
@@ -183,7 +183,7 @@ suites:
       dependencies:
         - recipe:aws-parallelcluster-test::docker_mock
         - recipe:aws-parallelcluster-install::directories
-        - recipe:aws-parallelcluster-common::node_attributes
+        - resource:aws-parallelcluster-common::node_attributes
   - name: arm_pl
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]
@@ -211,7 +211,7 @@ suites:
       dependencies:
         - recipe:aws-parallelcluster-install::directories
         - resource:package_repos
-        - recipe:aws-parallelcluster-common::node_attributes
+        - resource:aws-parallelcluster-common::node_attributes
   - name: build_tools
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]
@@ -224,7 +224,7 @@ suites:
       dependencies:
         - recipe:aws-parallelcluster-install::directories
         - resource:package_repos
-        - recipe:aws-parallelcluster-common::node_attributes
+        - resource:aws-parallelcluster-common::node_attributes
   - name: dcv
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]


### PR DESCRIPTION
### Description of changes
Transform node_attributes into a resource.

Recipes run just once, while a resource can be called multiple times, updating the file when attributes change.

A simple test showing this behavior.

**recipe1**:
```
node.default['a'] = 'value a'
```

**recipe2**:
```
node.default['b'] = 'value b'
```

**failing recipe**:
```
include_recipe "aws-parallelcluster-install::recipe1"
include_recipe "aws-parallelcluster-common::node_attributes"
include_recipe "aws-parallelcluster-install::recipe2"
include_recipe "aws-parallelcluster-common::node_attributes"
```

**control**:
```
control 'node_attributes_written_correctly' do
  describe "node['a']" do
    subject { node['a'] }
    it { should_not be_nil }
  end
  describe "node['b']" do
    subject { node['b'] }
    it { should_not be_nil }
  end
end
```

The first test passes, the second one fails.

**working recipe**:
```
include_recipe "aws-parallelcluster-install::recipe1"
node_attributes "dump A"
include_recipe "aws-parallelcluster-install::recipe2"
node_attributes "dump B"
```
Both tests from the control above pass on last recipe.

### Tests
* Successfully built an AMI using this code.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.