### PR TITLE
Fix validate-config kitchen tests

### DIFF
--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -34,6 +34,7 @@ _compute_node_cluster_attributes: &_compute_node_cluster_attributes
   head_node_private_ip: <%= ENV['HEAD_NODE_PRIVATE_IP'] %>
 
 _run_list: &_run_list
+  - recipe[aws-parallelcluster::add_dependencies]
   - recipe[aws-parallelcluster::init]
   - recipe[aws-parallelcluster::config]
   - recipe[aws-parallelcluster::finalize]

--- a/recipes/add_dependencies.rb
+++ b/recipes/add_dependencies.rb
@@ -20,7 +20,9 @@
 #      - resource:ec2_udev_rules
 #      - resource:package_repos:update
 
-if defined?(node['dependencies'])
+node_attributes 'dump node attributes'
+
+if defined?(node['dependencies']) && node['dependencies']
   node['dependencies'].each do |dep|
     if dep.start_with?('recipe:')
       include_recipe dep.gsub('recipe:', '')


### PR DESCRIPTION
### Description of changes
Fix validate-config kitchen tests

Kitchen tests rely on attribute values we set in Kitchen config files, but we stopped writing them due to following change: https://github.com/aws/aws-parallelcluster-cookbook/commit/6559638c53c446a02323f1cbf6c7b1f09b699932#diff-5574db547422139b1e984dae2e22ed970d8e4eab81b232ebf3bd387a0d28d4eeL41 .

This change writes node attributes again.

### Tests
Reproduced Kitchen failures, applied this patch, run Kitchen tests successfully on Ubuntu18.04

### References
https://github.com/aws/aws-parallelcluster-cookbook/commit/6559638c53c446a02323f1cbf6c7b1f09b699932#diff-5574db547422139b1e984dae2e22ed970d8e4eab81b232ebf3bd387a0d28d4eeL41

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.