### PR TITLE
Generate ChefSpec coverage report

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,3 +99,6 @@ AllCops:
   NewCops: enable
   Exclude:
     - 'third-party/**/*'
+
+Chef/Deprecations/ChefSpecCoverageReport:
+  Enabled: false

--- a/cookbooks/aws-parallelcluster-common/spec/spec_helper.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/spec_helper.rb
@@ -65,3 +65,5 @@ end
 def expect_to_include_recipe_from_resource(recipe, cookbook = 'any')
   expect_any_instance_of(Chef::RunContext).to receive(:include_recipe).with(recipe, { current_cookbook: cookbook })
 end
+
+at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
### Description of changes
Generate ChefSpec coverage report

This report is not integrated into GitHub Actions. 
You need to run chef exec rspec manually and verify the output.


### Tests
Output from a manual `chef exec rspec` run:
```
ChefSpec Coverage report generated...

  Total Resources:   106
  Touched Resources: 81
  Touch Coverage:    76.42%

Untouched Resources:

  ruby_block[Configure environment variable for recipes context: PATH]   aws-parallelcluster-common/recipes/setup_envars.rb:23
  efa[setup]                         /spec/unit/resources/efa_spec.rb:6
  efa[configure]                     /spec/unit/resources/efa_spec.rb:15
  efs[install_utils]                 /spec/unit/resources/efs_spec.rb:6
  apt_package[]                      (eval):17
  efs[mount]                         /spec/unit/resources/efs_spec.rb:266
  directory[/shared_dir_3]           (eval):45
  efs[unmount]                       /spec/unit/resources/efs_spec.rb:348
  lustre[mount]                      /spec/unit/resources/lustre_mount_spec.rb:15
  directory[/lustre_shared_dir_with_no_mount]   (eval):24
  directory[/lustre_shared_dir_with_mount]   (eval):24
  directory[change permissions for /openzfs_shared_dir_1]   (eval):59
  directory[change permissions for /openzfs_shared_dir_2]   (eval):59
  directory[/ontap_shared_dir_1]     (eval):24
  directory[/ontap_shared_dir_2]     (eval):24
  lustre[unmount]                    /spec/unit/resources/lustre_mount_spec.rb:246
  execute[unmount fsx /shared_dir_1]   (eval):73
  lustre[setup]                      /spec/unit/resources/lustre_setup_spec.rb:6
  network_service[restart]           /spec/unit/resources/network_service_spec.rb:6
  network_service[reload]            /spec/unit/resources/network_service_spec.rb:14
  nfs[setup]                         /spec/unit/resources/nfs_spec.rb:6
  nfs[configure]                     /spec/unit/resources/nfs_spec.rb:14
  node_attributes[write file]        /spec/unit/resources/node_attributes_spec.rb:10
  directory[/etc/chef]               aws-parallelcluster-common/resources/node_attributes.rb:27
  package_repos[setup]               /spec/unit/resources/package_repos_spec.rb:6
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.