### PR TITLE
Add publishing of GPU failure metrics

### DIFF
--- a/cookbooks/aws-parallelcluster-config/files/default/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-config/files/default/cloudwatch/cloudwatch_agent_config.json
@@ -675,6 +675,24 @@
       "feature_conditions": []
     },
     {
+      "timestamp_format_key": "json",
+      "file_path": "/var/log/parallelcluster/slurm_health_check.events",
+      "log_stream_name": "slurm_health_check_events",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "centos",
+        "redhat",
+        "ubuntu",
+        "amazon"
+      ],
+      "node_roles": [
+        "ComputeFleet"
+      ],
+      "feature_conditions": []
+    },
+    {
       "timestamp_format_key": "default",
       "file_path": "/var/log/parallelcluster/clusterstatusmgtd",
       "log_stream_name": "clusterstatusmgtd",

--- a/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/event_utils.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/event_utils.py
@@ -1,0 +1,185 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import logging
+import sys
+import traceback
+from collections import ChainMap
+from datetime import datetime, timezone
+from typing import Callable, Dict, Iterable
+
+logger = logging.getLogger(__name__)
+logger = logging.LoggerAdapter(logger, {"job_id": ""})
+
+
+class EventPublisher:
+    """Class for generating structured log events for cluster."""
+
+    def __init__(
+        self,
+        event_logger: any,
+        cluster_name: str,
+        node_role: str,
+        component: str,
+        instance_id: str,
+        **kwargs: Dict[str, any],
+    ):
+        self.event_publisher = EventPublisher._make_event_publisher(
+            event_logger=event_logger,
+            cluster_name=cluster_name,
+            node_role=node_role,
+            component=component,
+            instance_id=instance_id,
+            **kwargs,
+        )
+
+    @property
+    def publish_event(self):
+        """Return event publisher to publish an event."""
+        return self.event_publisher
+
+    @staticmethod
+    def current_time() -> datetime:
+        """Return current time in UTC."""
+        return datetime.now(timezone.utc)
+
+    @staticmethod
+    def timestamp() -> str:
+        """Return ISO formatted UTC timestamp."""
+        return EventPublisher.current_time().isoformat(timespec="milliseconds")
+
+    @staticmethod
+    def _make_event_publisher(
+        event_logger: any,
+        cluster_name: str,
+        node_role: str,
+        component: str,
+        instance_id: str,
+        **global_args: Dict[str, any],
+    ) -> Callable:
+        def event_publisher(
+            event_level, event_type, event_message, timestamp: str = None, event_supplier: Iterable = None, **kwargs
+        ):
+            if event_logger.isEnabledFor(event_level):
+                try:
+                    now = timestamp if timestamp else EventPublisher.timestamp()
+                    if not event_supplier:
+                        event_supplier = (kwargs,)
+                    for event in event_supplier:
+                        default_properties = {
+                            "datetime": now,
+                            "version": 0,
+                            "scheduler": "slurm",
+                            "cluster-name": cluster_name,
+                            "node-role": node_role,
+                            "component": component,
+                            "level": logging.getLevelName(event_level),
+                            "instance-id": instance_id,
+                            "event-type": event_type,
+                            "message": event_message,
+                            "detail": {},
+                        }
+                        event = ChainMap(event, kwargs, default_properties, global_args)
+                        event_logger.log(event_level, "%s", json.dumps(dict(event)))
+                except Exception as e:
+                    extraction = traceback.extract_stack()
+                    logger.error(
+                        "Failed to publish event `%s`: %s\n%s\n%s",
+                        event_type,
+                        e,
+                        "".join(traceback.format_exception(*sys.exc_info())),
+                        "".join(traceback.format_list(extraction)),
+                    )
+
+        return event_publisher
+
+
+def publish_health_check_result(
+    event_publisher: EventPublisher,
+    job_id: str,
+    health_check_name: str,
+    health_check_result: int,
+    health_check_output: str,
+):
+    def detail_supplier():
+        yield {
+            "detail": {
+                "job-id": job_id,
+                "health-check-name": health_check_name,
+                "health-check-result": health_check_result,
+                "health-check-output": f"{health_check_output}".split("\n") if health_check_output else None,
+            },
+        }
+
+    try:
+        event_publisher.publish_event(
+            datetime=event_publisher.timestamp(),
+            event_level=logging.WARNING if health_check_result else logging.INFO,
+            event_type="compute-node-health-check",
+            event_message=f"Result of compute node health check {health_check_name}",
+            event_supplier=detail_supplier(),
+        )
+    except Exception as err:
+        logger.error("Exception while publishing event: %s", repr(err))
+
+
+def publish_health_check_exception(
+    event_publisher: EventPublisher,
+    job_id: str,
+    health_check_name: str,
+    err: Exception,
+):
+    try:
+        event_publisher.publish_event(
+            datetime=event_publisher.timestamp(),
+            event_level=logging.ERROR,
+            event_type="compute-node-health-check-exception",
+            event_message=f"Failure when executing health check {health_check_name}",
+            detail={
+                "job-id": job_id,
+                "health-check-name": health_check_name,
+                "error": repr(err),
+            },
+        )
+    except Exception as e:
+        logger.error("Exception while publishing event: %s", repr(e))
+
+
+def get_node_spec_from_file(node_spec_file: str) -> Dict[str, any]:
+    if node_spec_file:
+        try:
+            return _read_node_spec(node_spec_file)
+        except Exception as e:
+            logger.error("Failed to load node spec file: %s", e)
+    return {
+        "region": "error",
+        "cluster_name": "error",
+        "scheduler": "error",
+        "node_role": "ComputeFleet",
+        "instance_id": "error",
+        "compute": {
+            "queue-name": "error",
+            "compute-resource": "error",
+            "name": "error",
+            "node-type": "error",
+            "instance-id": "error",
+            "instance-type": "error",
+            "availability-zone": "error",
+            "address": "error",
+            "hostname": "error",
+        },
+    }
+
+
+def _read_node_spec(node_spec_path: str) -> Dict[str, any]:
+    with open(node_spec_path, "r", encoding="utf-8") as file:
+        return json.load(file)

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_health_check.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_health_check.rb
@@ -41,6 +41,13 @@ directory "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin
   mode '0755'
 end
 
+cookbook_file "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/event_utils.py" do
+  source 'config_slurm/scripts/event_utils.py'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
 cookbook_file "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/scripts/health_check_manager.py" do
   source 'config_slurm/scripts/health_check_manager.py'
   owner 'root'
@@ -92,6 +99,9 @@ template "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/
   owner 'root'
   group 'root'
   mode '0755'
+  variables(
+    node_spec_file: "#{node['cluster']['slurm_plugin_dir']}/slurm_node_spec.json"
+  )
 end
 
 link "#{node['cluster']['slurm']['install_dir']}/etc/scripts/prolog.d/90_pcluster_health_check_manager" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
@@ -44,6 +44,28 @@ if node['cluster']['node_type'] == "ComputeFleet"
     owner 'root'
     group 'root'
   end
+
+  template "#{node['cluster']['slurm_plugin_dir']}/slurm_node_spec.json" do
+    source 'slurm/compute/slurm_node_spec.json.erb'
+    owner "root"
+    group "root"
+    mode "0644"
+    variables(
+      region: node['cluster']['region'],
+      cluster_name: node['cluster']['cluster_name'] || node['cluster']['stack_name'],
+      scheduler: node['cluster']['scheduler'],
+      node_role: "ComputeFleet",
+      queue_name: node['cluster']['scheduler_queue_name'],
+      compute_resource: node['cluster']['scheduler_compute_resource_name'],
+      node_name: lazy { node['cluster']['slurm_nodename'] },
+      node_type: lazy { is_static_node?(node['cluster']['slurm_nodename']) ? "static" : "dynamic" },
+      instance_id: node['ec2']['instance_id'],
+      instance_type: node['ec2']['instance_type'],
+      availability_zone: node['ec2']['availability_zone'],
+      ip_address: node['ipaddress'],
+      hostname: node['ec2']['hostname']
+    )
+  end
 end
 
 # Configure hostname and DNS

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurm_node_spec.json.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurm_node_spec.json.erb
@@ -1,0 +1,18 @@
+{
+  "region": "<%= @region %>",
+  "cluster_name": "<%= @cluster_name %>",
+  "scheduler": "<%= @scheduler %>",
+  "node_role": "<%= @node_role %>",
+  "instance_id": "<%= @instance_id %>",
+  "compute": {
+    "queue-name": "<%= @queue_name %>",
+    "compute-resource": "<%= @compute_resource %>",
+    "name": "<%= @node_name %>",
+    "node-type": "<%= @node_type %>",
+    "instance-id": "<%= @instance_id %>",
+    "instance-type": "<%= @instance_type %>",
+    "availability-zone": "<%= @availability_zone %>",
+    "address": "<%= @ip_address %>",
+    "hostname": "<%= @hostname %>"
+  }
+}

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/90_pcluster_health_check_manager.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/90_pcluster_health_check_manager.erb
@@ -64,5 +64,6 @@ PCLUSTER_SCHEDULER_COMPUTE_RESOURCE_NAME="$(cat "${PCLUSTER_DNA_JSON_PATH}" | jq
     --queue-name "${PCLUSTER_SCHEDULER_QUEUE_NAME}" \
     --compute-resource-name "${PCLUSTER_SCHEDULER_COMPUTE_RESOURCE_NAME}" \
     --job-id "${SLURM_JOB_ID}" \
-    --cluster-configuration "${PCLUSTER_CONFIG_PATH}"
+    --cluster-configuration "${PCLUSTER_CONFIG_PATH}" \
+    --node-spec-file "<%= @node_spec_file %>"
 ) {FLOCK_FILE_DESCRIPTOR_NUMBER}>/var/lock/health_check.lock

--- a/test/unit/health_check/test_event_utils.py
+++ b/test/unit/health_check/test_event_utils.py
@@ -1,0 +1,236 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+from assertpy import assert_that
+from event_utils import EventPublisher, publish_health_check_exception, publish_health_check_result
+
+
+@pytest.mark.parametrize(
+    ("log_level", "result_code", "result_output", "expected_events"),
+    [
+        (
+            logging.INFO,
+            0,
+            None,
+            [
+                {
+                    "region": "us-east-1",
+                    "scheduler": "slurm",
+                    "compute": {
+                        "queue-name": "queue",
+                        "compute-resource": "compute",
+                        "name": "queue-st-compute-1",
+                        "node-type": "static",
+                        "instance-id": "i-instance-id",
+                        "instance-type": "g5.xlarge",
+                        "availability-zone": "us-east-1c",
+                        "address": "127.0.0.1",
+                        "hostname": "ip-127-0-0-0.ec2.internal",
+                    },
+                    "datetime": "2023-04-19T01:57:56.410+00:00",
+                    "version": 0,
+                    "cluster-name": "cluster",
+                    "node-role": "ComputeFleet",
+                    "component": "test",
+                    "level": "INFO",
+                    "instance-id": "i-instance-id",
+                    "event-type": "compute-node-health-check",
+                    "message": "Result of compute node health check Gpu",
+                    "detail": {
+                        "job-id": 1,
+                        "health-check-name": "Gpu",
+                        "health-check-result": 0,
+                        "health-check-output": None,
+                    },
+                }
+            ],
+        ),
+        (
+            logging.WARNING,
+            0,
+            "This message should not be present",
+            [],
+        ),
+        (
+            logging.WARNING,
+            23,
+            "Hello\nThis should\nbe an array\nof results",
+            [
+                {
+                    "region": "us-east-1",
+                    "scheduler": "slurm",
+                    "compute": {
+                        "queue-name": "queue",
+                        "compute-resource": "compute",
+                        "name": "queue-st-compute-1",
+                        "node-type": "static",
+                        "instance-id": "i-instance-id",
+                        "instance-type": "g5.xlarge",
+                        "availability-zone": "us-east-1c",
+                        "address": "127.0.0.1",
+                        "hostname": "ip-127-0-0-0.ec2.internal",
+                    },
+                    "datetime": "2023-04-19T01:57:29.511+00:00",
+                    "version": 0,
+                    "cluster-name": "cluster",
+                    "node-role": "ComputeFleet",
+                    "component": "test",
+                    "level": "WARNING",
+                    "instance-id": "i-instance-id",
+                    "event-type": "compute-node-health-check",
+                    "message": "Result of compute node health check Gpu",
+                    "detail": {
+                        "job-id": 1,
+                        "health-check-name": "Gpu",
+                        "health-check-result": 23,
+                        "health-check-output": ["Hello", "This should", "be an array", "of results"],
+                    },
+                }
+            ],
+        ),
+    ],
+)
+def test_publish_health_check_result(log_level, result_code, result_output, expected_events):
+    def is_enabled_for(level):
+        return level >= log_level
+
+    def capture_log(event_level, format_string, json_string):
+        assert_that(event_level).is_greater_than_or_equal_to(log_level)
+        assert_that(format_string).is_not_none()
+        captured_events.append(json.loads(json_string))
+
+    node_spec = {
+        "region": "us-east-1",
+        "cluster_name": "cluster",
+        "scheduler": "slurm",
+        "node_role": "ComputeFleet",
+        "instance_id": "i-instance-id",
+        "compute": {
+            "queue-name": "queue",
+            "compute-resource": "compute",
+            "name": "queue-st-compute-1",
+            "node-type": "static",
+            "instance-id": "i-instance-id",
+            "instance-type": "g5.xlarge",
+            "availability-zone": "us-east-1c",
+            "address": "127.0.0.1",
+            "hostname": "ip-127-0-0-0.ec2.internal",
+        },
+    }
+
+    captured_events = []
+
+    event_logger = SimpleNamespace(isEnabledFor=is_enabled_for, log=capture_log)
+
+    event_publisher = EventPublisher(event_logger, component="test", **node_spec)
+
+    publish_health_check_result(event_publisher, 1, "Gpu", result_code, result_output)
+
+    assert_that(captured_events).is_length(len(expected_events))
+    for actual, expected in zip(captured_events, expected_events):
+        assert_that(actual).is_equal_to(expected, ignore="datetime")
+
+
+@pytest.mark.parametrize(
+    "expected_events",
+    [
+        [
+            {
+                "region": "us-east-1",
+                "scheduler": "slurm",
+                "compute": {
+                    "queue-name": "queue",
+                    "compute-resource": "compute",
+                    "name": "queue-st-compute-1",
+                    "node-type": "static",
+                    "instance-id": "i-instance-id",
+                    "instance-type": "g5.xlarge",
+                    "availability-zone": "us-east-1c",
+                    "address": "127.0.0.1",
+                    "hostname": "ip-127-0-0-0.ec2.internal",
+                },
+                "datetime": "2023-04-19T01:57:06.030+00:00",
+                "version": 0,
+                "cluster-name": "cluster",
+                "node-role": "ComputeFleet",
+                "component": "test",
+                "level": "ERROR",
+                "instance-id": "i-instance-id",
+                "event-type": "compute-node-health-check-exception",
+                "message": "Failure when executing health check Gpu",
+                "detail": {"job-id": 1, "health-check-name": "Gpu", "error": "Exception('What happened?')"},
+            }
+        ]
+    ],
+)
+def test_publish_health_check_exception(expected_events):
+    def is_enabled_for(*args):
+        return True
+
+    def capture_log(event_level, format_string, json_string):
+        assert_that(event_level).is_greater_than_or_equal_to(logging.DEBUG)
+        assert_that(format_string).is_not_none()
+        captured_events.append(json.loads(json_string))
+
+    node_spec = {
+        "region": "us-east-1",
+        "cluster_name": "cluster",
+        "scheduler": "slurm",
+        "node_role": "ComputeFleet",
+        "instance_id": "i-instance-id",
+        "compute": {
+            "queue-name": "queue",
+            "compute-resource": "compute",
+            "name": "queue-st-compute-1",
+            "node-type": "static",
+            "instance-id": "i-instance-id",
+            "instance-type": "g5.xlarge",
+            "availability-zone": "us-east-1c",
+            "address": "127.0.0.1",
+            "hostname": "ip-127-0-0-0.ec2.internal",
+        },
+    }
+
+    captured_events = []
+
+    event_logger = SimpleNamespace(isEnabledFor=is_enabled_for, log=capture_log)
+
+    event_publisher = EventPublisher(event_logger, component="test", **node_spec)
+
+    publish_health_check_exception(event_publisher, 1, "Gpu", Exception("What happened?"))
+
+    assert_that(captured_events).is_length(len(expected_events))
+    for actual, expected in zip(captured_events, expected_events):
+        assert_that(actual).is_equal_to(expected, ignore="datetime")
+
+
+def test_exception_gets_swallowed():
+    def is_enabled_for(*args):
+        return True
+
+    def raise_it(*args):
+        nonlocal called
+        called = True
+        raise ValueError("Hello")
+
+    called = False
+
+    event_logger = SimpleNamespace(isEnabledFor=is_enabled_for, log=raise_it)
+    event_publisher = EventPublisher(event_logger, "cluster", "ComputeFleet", "test", "id-instance")
+
+    event_publisher.publish_event(event_level=logging.INFO, event_type="event-type", event_message="Message", detail={})
+
+    assert_that(called).is_true()


### PR DESCRIPTION
### Description of changes
* This change adds generating structured log messages for GPU health check results.
* The default configuration only generates events if the health check fails.
* This change updates the CloudWatch Configuration to publish the health check event log to CloudWatch.

### Tests
* Added unit tests to cover event generation.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.