### PR TITLE
Check MySQL package version

### DIFF
--- a/cookbooks/aws-parallelcluster-common/test/common/libraries/os_properties.rb
+++ b/cookbooks/aws-parallelcluster-common/test/common/libraries/os_properties.rb
@@ -27,6 +27,10 @@ class OsProperties < Inspec.resource(1)
     inspec.os.name == 'centos'
   end
 
+  def ubuntu?
+    inspec.os.name == 'ubuntu'
+  end
+
   def redhat8?
     redhat? && inspec.os.release.to_i == 8
   end

--- a/test/resources/controls/aws_parallelcluster_install/mysql_client_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/mysql_client_spec.rb
@@ -16,20 +16,22 @@ control 'mysql_client_installed' do
   if os.redhat?
     mysql_packages.concat %w(mysql-community-client-plugins mysql-community-common
        mysql-community-devel mysql-community-libs mysql-community-libs-compat)
-  elsif os.debian?
-    if os.release == '18.04'
-      mysql_packages.concat %w(libmysqlclient-dev libmysqlclient20)
-    else
-      mysql_packages.concat %w(libmysqlclient-dev libmysqlclient21)
-    end
+  elsif os_properties.ubuntu1804?
+    mysql_packages.concat %w(libmysqlclient-dev libmysqlclient20)
+  elsif os_properties.ubuntu2004?
+    mysql_packages.concat %w(libmysqlclient-dev libmysqlclient21)
   else
     describe "unsupported OS" do
       pending "support for #{os.name}-#{os.release} needs to be implemented"
     end
   end
+
+  ubuntu = os_properties.ubuntu?
+
   mysql_packages.each do |pkg|
     describe package(pkg) do
       it { should be_installed }
+      its('version') { should match /^8.0.31-/ } unless ubuntu
     end
   end
 end


### PR DESCRIPTION
### Description of changes
AMI builder validation step verifies mysql packages version for every OS but Ubuntu.

Adding version check to InSpec control in order to replace current AMI validation with it.

### Tests
* Tested on EC2 for all OSes and architectures.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.