### PR TITLE
Tag mysql_client controls with tag:install

### DIFF
--- a/kitchen.resources-install.yml
+++ b/kitchen.resources-install.yml
@@ -51,8 +51,7 @@ suites:
       - recipe[aws-parallelcluster-install::test_resource]
     verifier:
       controls:
-        - mysql_client_installed
-        - mysql_client_source_node_created
+        - /mysql_client/
     attributes:
       dependencies:
         - recipe:aws-parallelcluster::test_dummy

--- a/test/resources/controls/aws_parallelcluster_install/mysql_client_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/mysql_client_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'mysql_client_installed' do
+control 'tag:install_mysql_client_installed' do
   title "MySql client is installed"
 
   mysql_packages = []
@@ -36,7 +36,7 @@ control 'mysql_client_installed' do
   end
 end
 
-control 'mysql_client_source_node_created' do
+control 'tag:install_mysql_client_source_code_created' do
   title 'MySql client source code is configured in target dir'
 
   describe file('/opt/parallelcluster/sources/mysql_source_code.txt') do


### PR DESCRIPTION
### Description of changes
Tag mysql_client controls with tag:install in order to execute them to certify an AMI.

### Tests
Tested on EC2, on all OSes/architectures:
```
./kitchen.ec2.sh resources-install verify mysql-client -c 5
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.