### PR TITLE
Inject correct region into mysql_client source code control

### DIFF
--- a/test/resources/controls/aws_parallelcluster_install/mysql_client_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/mysql_client_spec.rb
@@ -47,7 +47,7 @@ control 'tag:install_mysql_client_source_code_created' do
     its('content') do
       should eq %(You can get MySQL source code here:
 
-https://#{node['cluster']['region']}-aws-parallelcluster.s3.us-east-1.amazonaws.com/archives/source/mysql-8.0.31.tar.gz
+https://#{node['cluster']['region']}-aws-parallelcluster.s3.#{node['cluster']['region']}.amazonaws.com/archives/source/mysql-8.0.31.tar.gz
 )
     end
   end


### PR DESCRIPTION
### Description of changes
Inject correct region into mysql_client source code control

### Tests
* Tested manually on EC2, setting a region different from `us-east-1`

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.