### PR TITLE
[develop] Use junit2 to collect Inspec results

### DIFF
--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -5,7 +5,7 @@ verifier:
     - test/resources
   reporter:
     - cli
-    - junit:.kitchen/inspec/results/%{platform}_%{suite}_inspec.xml
+    - junit2:.kitchen/inspec/results/%{platform}_%{suite}_inspec.xml
 
 provisioner:
   data_path: test/data


### PR DESCRIPTION
### Description of changes

According to documentation:
* junit2: outputs the standard JUnit spec in XML format and is recommended for all new users of JUnit. 
* junit: is a legacy reporter and outputs nonstandard JUnit XML and is provided only for backward compatibility.

### Tests
Example of output for junit:
```
  <testsuite name='resources unit tests' tests='2' failed='0' failures='0'>
    <testcase name='System Package libopenmpi-dev is expected not to be installed' classname='resources unit tests.efa_conflicting_packages_removed' target='docker://...' time='...'/>
    <testcase name='System Package environment-modules is expected to be installed' classname='resources unit tests.efa_prereq_packages_installed' target='docker://79fab2f5ce68c4315c8b7387f9297a63f89d215ae1a8a2317964c4640c773c8d' time='...'/>
  </testsuite>
```

vs junit2:
``` 
  <testsuite name='resources unit tests' tests='2' id='1' errors='0' failures='0' skipped='0' hostname='docker://...' timestamp='2023-05-05T14:59:32' package='' time='0.166256'>
    <properties/>
    <testcase name='System Package libopenmpi-dev is expected not to be installed' classname='resources unit tests.efa_conflicting_packages_removed' time='...'/>
    <testcase name='System Package environment-modules is expected to be installed' classname='resources unit tests.efa_prereq_packages_installed' time='...'/>
    <system-out/>
    <system-err/>
  </testsuite>
```


### References
* https://docs.chef.io/inspec/reporters/
