### PR TITLE
Move disable_services from aws-parallelcluster-install to aws-parallelcluster-platform

### DIFF
--- a/cookbooks/aws-parallelcluster-install/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-install/libraries/helpers.rb
@@ -15,14 +15,6 @@
 #
 # Disable service
 #
-def disable_service(service, platform_families = node['platform_family'], operations = :disable)
-  if platform_family?(platform_families)
-    service service do
-      action operations
-    end
-  end
-end
-
 def validate_file_hash(file_path, expected_hash)
   hash_function = yield
   checksum = hash_function.file(file_path).hexdigest

--- a/cookbooks/aws-parallelcluster-install/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/base.rb
@@ -18,7 +18,7 @@
 include_recipe "aws-parallelcluster-common::setup_envars"
 include_recipe "aws-parallelcluster-platform::sudo_install"
 include_recipe "aws-parallelcluster-platform::users"
-include_recipe "aws-parallelcluster-install::disable_services"
+include_recipe "aws-parallelcluster-platform::disable_services"
 
 package_repos 'setup the repositories'
 

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
@@ -31,4 +31,9 @@ suites:
     verifier:
       controls:
         - /patch_isolated_instance_script_created/
-
+  - name: disable_services
+    run_list:
+      - recipe[aws-parallelcluster-platform::disable_services]
+    verifier:
+      controls:
+        - /services_disabled/

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/disable_services.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/disable_services.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
+# Cookbook:: aws-parallelcluster-platform
 # Recipe:: disable_services
 #
 # Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -15,11 +15,15 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Disable DLAMI multi eni helper
-# no only_if statement because if the service is not present the action disable does not return error
-disable_service('aws-ubuntu-eni-helper', 'debian', %i(disable stop mask)) unless virtualized?
+# If the service does not exist the action disable does not return error.
+# Masking the service in order to prevent it from being automatically enabled if not installed yet.
 
-# Disable log4j-cve-2021-44228-hotpatch
-# masking the service in order to prevent it from being automatically enabled
-# if not installed yet
-disable_service('log4j-cve-2021-44228-hotpatch', 'amazon', %i(disable stop mask)) unless virtualized?
+# on ubuntu, disable DLAMI multi eni helper
+service 'aws-ubuntu-eni-helper' do
+  action %i(disable stop mask)
+end unless on_docker?
+
+# on alinux, disable log4j-cve-2021-44228-hotpatch
+service 'log4j-cve-2021-44228-hotpatch' do
+  action %i(disable stop mask)
+end unless on_docker?

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-platform::disable_services' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        ChefSpec::Runner.new(platform: platform, version: version).converge(described_recipe)
+      end
+
+      it 'disables DLAMI multi eni helper' do
+        is_expected.to disable_service('aws-ubuntu-eni-helper')
+        is_expected.to stop_service('aws-ubuntu-eni-helper')
+        is_expected.to mask_service('aws-ubuntu-eni-helper')
+      end
+
+      it 'disables log4j CVE 2021-44228 hotpatch' do
+        is_expected.to disable_service('log4j-cve-2021-44228-hotpatch')
+        is_expected.to stop_service('log4j-cve-2021-44228-hotpatch')
+        is_expected.to mask_service('log4j-cve-2021-44228-hotpatch')
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'tag:config_services_disabled_on_debian_family' do
+control 'tag:testami_tag:config_services_disabled_on_debian_family' do
   title 'Test that DLAMI multi eni helper is disabled and masked on debian family'
 
   only_if { os_properties.debian_family? && !os_properties.virtualized? }
@@ -25,7 +25,7 @@ control 'tag:config_services_disabled_on_debian_family' do
   end
 end
 
-control 'tag:config_services_disabled_on_amazon_family' do
+control 'tag:testami_tag:config_services_disabled_on_amazon_family' do
   title 'Test that log4j-cve-2021-44228-hotpatch is disabled and masked on amazon family'
 
   only_if { os_properties.amazon_family? && !os_properties.virtualized? }
@@ -38,5 +38,10 @@ control 'tag:config_services_disabled_on_amazon_family' do
   describe bash('systemctl list-unit-files --state=masked --no-legend') do
     its(:exit_status) { should eq 0 }
     its(:stdout) { should match /log4j-cve-2021-44228-hotpatch.service\s*masked/ }
+  end
+
+  describe bash('systemctl show -p LoadState log4j-cve-2021-44228-hotpatch') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match /LoadState=masked/ }
   end
 end

--- a/cookbooks/aws-parallelcluster-shared/libraries/test.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/test.rb
@@ -1,0 +1,8 @@
+def on_docker?
+  # Check if we are running in a Docker System Tests
+  node.include?('virtualized') and node['virtualized']
+end
+
+def redhat_ubi?
+  on_docker? && platform?('redhat')
+end

--- a/kitchen.recipes-install.yml
+++ b/kitchen.recipes-install.yml
@@ -175,13 +175,6 @@ suites:
     verifier:
       controls:
         - ami_cleanup_file_created
-  - name: disable_services
-    run_list:
-      - recipe[aws-parallelcluster-install::disable_services]
-    verifier:
-      controls:
-        - /services_disabled_on_debian_family/
-        - /services_disabled_on_amazon_family/
   - name: license_readme
     run_list:
       - recipe[aws-parallelcluster-tests::setup]


### PR DESCRIPTION
### Description of changes
Move disable_services from aws-parallelcluster-install to aws-parallelcluster-platform

This PR enables removal of Log4jPatcher step from Test phase of image build. Add InSpec tests for recipes and platform to AMI validation

### Tests
- Kitchen-tested on EC2 and on Docker
- AMI built from this code

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.