### PR TITLE
Skip tests requiring GPUDirect RDMA in instances that don't support it.

### DIFF
--- a/cookbooks/aws-parallelcluster-common/test/common/libraries/instance.rb
+++ b/cookbooks/aws-parallelcluster-common/test/common/libraries/instance.rb
@@ -21,6 +21,11 @@ class Instance < Inspec.resource(1)
     !inspec.node['ec2']['instance_type'].start_with?(*unsupported_gpu_accel_list)
   end
 
+  def gpudirect_rdma_supported?
+    unsupported_gpudirect_rdma_list = ["g2."]
+    !inspec.node['ec2']['instance_type'].start_with?(*unsupported_gpudirect_rdma_list)
+  end
+
   def dcv_gpu_accel_supported?
     unsupported_gpu_accel_list = ["g5g."]
     !inspec.node['ec2']['instance_type'].start_with?(*unsupported_gpu_accel_list)

--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -357,7 +357,11 @@ suites:
       instance_type: g4dn.xlarge
     attributes:
       dependencies:
-        - recipe:aws-parallelcluster::test_dummy
+        - recipe:aws-parallelcluster-install::directories
+        - resource:package_repos
+        - resource:install_packages
+        - recipe:aws-parallelcluster-common::node_attributes
+        - recipe:aws-parallelcluster-install::nvidia
       cluster:
         nvidia:
           enabled: true

--- a/test/recipes/controls/aws_parallelcluster_config/nvidia_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/nvidia_spec.rb
@@ -31,10 +31,12 @@ control 'tag:config_gdrcopy_enabled_on_graphic_instances' do
     its('exit_status') { should eq 0 }
   end
 
-  ['sanity', 'copybw', 'copylat', 'apiperf -s 8'].each do |cmd|
-    describe "NVIDIA GDRCopy works properly with #{cmd}" do
-      subject { command(cmd) }
-      its('exit_status') { should eq 0 }
+  if instance.gpudirect_rdma_supported?
+    ['sanity', 'copybw', 'copylat', 'apiperf -s 8'].each do |cmd|
+      describe "NVIDIA GDRCopy works properly with #{cmd}" do
+        subject { command(cmd) }
+        its('exit_status') { should eq 0 }
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of changes
Skip tests requiring GPUDirect RDMA in instances that don't support it.

### Tests
Launched kitchen test with the following configuration:

```
  - name: nvidia
    run_list:
      - recipe[aws-parallelcluster::add_dependencies]
      - recipe[aws-parallelcluster-config::nvidia]
    verifier:
      controls:
        - /nvidia-fabricmanager_enabled/
        - /gdrcopy_enabled/
        - /gdrcopy_disabled/
    driver:
      # nvidia_driver can be executed only on a graphic EC2 instance example: g4dn.xlarge(x86_86) or g5g.xlarge(aarm64)
      instance_type: g2.2xlarge
    attributes:
      dependencies:
        - recipe:aws-parallelcluster-install::directories
        - resource:package_repos
        - resource:install_packages
        - recipe:aws-parallelcluster-common::node_attributes
        - recipe:aws-parallelcluster-install::nvidia
      cluster:
        nvidia:
          enabled: true
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.