### PR TITLE
Remove dependency on test_dummy from fs_update_default_values

### DIFF
--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -62,7 +62,7 @@ suites:
         - fs_data_file_with_default_values
     attributes:
       dependencies:
-        - recipe:aws-parallelcluster::test_dummy
+        - recipe:aws-parallelcluster-platform::directories
       cluster:
         ebs_shared_dirs: '/shared'
         volume: ''


### PR DESCRIPTION
### Description of changes
Remove dependency on `test_dummy` from `fs_update_default_values`.

### Tests
Kitchen tests.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.