### PR TITLE
Remove dependency on test_dummy

### DIFF
--- a/kitchen.validate-install.yml
+++ b/kitchen.validate-install.yml
@@ -10,9 +10,8 @@ verifier:
 suites:
   - name: aws_parallelcluster_install
     run_list:
-      - recipe[aws-parallelcluster::test_dummy]
       - recipe[aws-parallelcluster-test::docker_mock]
-      - recipe[aws-parallelcluster-install::install]
+      - recipe[aws-parallelcluster]
     verifier:
       controls:
         # We also need to test the effect some files (service config, profile config) have on the system.

--- a/recipes/test_dummy.rb
+++ b/recipes/test_dummy.rb
@@ -1,1 +1,0 @@
-# do nothing, but import aws-parallelcluster cookbook as entry point


### PR DESCRIPTION
### Description of changes
- Remove dependency on `test_dummy` from `aws_parallelcluster_install`.
- Remove `test_dummy` itself, as it's no longer used anywhere.

### Tests
Kitchen tests.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.