### PR TITLE
[3.x] Move unmount from tests.rb to a separate file

### DIFF
--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -114,14 +114,6 @@ if platform?('centos')
   end
 end
 
-execute 'unmount /home' do
-  command "umount -fl /home"
-  retries 10
-  retry_delay 6
-  timeout 60
-  only_if { node['cluster']['node_type'] == 'ComputeFleet' }
-end
-
 ###################
 # clusterstatusmgtd
 ###################

--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -38,7 +38,7 @@ _run_list: &_run_list
   - recipe[aws-parallelcluster::init]
   - recipe[aws-parallelcluster::config]
   - recipe[aws-parallelcluster::finalize]
-  - recipe[aws-parallelcluster::tests]
+  - recipe[aws-parallelcluster::unmount_home]
 
 provisioner:
   attributes:

--- a/recipes/unmount_home.rb
+++ b/recipes/unmount_home.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster
+# Recipe:: unmount_home
+#
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Needed to unmount the home directory in compute nodes to avoid Kitchen test to fail in the verify step.
+# Without this, the verify step cannot connect to the instance as it cannot find the key
+
+execute 'unmount /home' do
+  command "umount -fl /home"
+  retries 10
+  retry_delay 6
+  timeout 60
+  only_if { node['cluster']['node_type'] == 'ComputeFleet' }
+end


### PR DESCRIPTION
### Description of changes
* Move unmount from tests.rb to a separate file

### Tests
* Removed the unmount from tests.rb
* Confirmed `verify` could not connect by running `kitchen verify slurm-config-ComputeFleet-x86-64-alinux2`
* Substituted test recipe with the new unmount recipe
* Confirmed `verify` could not connect by running `kitchen verify slurm-config-ComputeFleet-x86-64-alinux2`

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.