### PR TITLE
[release-3.6] Set dependency between slurmd and nvidia-persistenced

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_compute.rb
@@ -39,19 +39,15 @@ end
 Chef::Log.warn("GPU instance but no Nvidia drivers found") if graphic_instance? && !nvidia_installed?
 
 # Run nvidia-smi triggers loading of the kernel module and creation of the device files
+# This should become useless with the configuration of the systemd dependency between
+# nvidia-persistenced and slurmd
 if graphic_instance? && nvidia_installed?
   execute "run_nvidiasmi" do
     command 'nvidia-smi'
   end
 end
 
-template '/etc/systemd/system/slurmd.service' do
-  source 'slurm/compute/slurmd.service.erb'
-  owner 'root'
-  group 'root'
-  mode '0644'
-  action :create
-end
+include_recipe 'aws-parallelcluster-slurm::config_slurmd_systemd_service'
 
 if node['cluster']['enable_nss_slurm'] == 'true'
   nsswitch_path = '/etc/nsswitch.conf'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_slurmd_systemd_service.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_slurmd_systemd_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-slurm
+# Recipe:: config_compute
+#
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create systemd service file for slurmd
+template '/etc/systemd/system/slurmd.service' do
+  source 'slurm/compute/slurmd.service.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
+end
+
+# Add systemd dependency between slurmd and nvidia-persistenced for NVIDIA GPU nodes
+if graphic_instance? && nvidia_installed?
+  directory '/etc/systemd/system/slurmd.service.d' do
+    user 'root'
+    group 'root'
+    mode '0755'
+  end
+  template '/etc/systemd/system/slurmd.service.d/slurmd_nvidia_persistenced.conf' do
+    source 'slurm/compute/slurmd_nvidia_persistenced.conf.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    action :create
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurmd_nvidia_persistenced.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurmd_nvidia_persistenced.conf.erb
@@ -1,0 +1,3 @@
+[Unit]
+After=nvidia-persistenced.service
+Requires=nvidia-persistenced.service

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurmd_nvidia_persistenced.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurmd_nvidia_persistenced.conf.erb
@@ -1,3 +1,3 @@
 [Unit]
 After=nvidia-persistenced.service
-Requires=nvidia-persistenced.service
+Wants=nvidia-persistenced.service

--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -264,6 +264,29 @@ suites:
         nfs:
           hard_mount_options: hard,_netdev,noatime
         head_node_private_ip: '127.0.0.1'
+  - name: compute_slurmd_systemd
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-slurm::config_slurmd_systemd_service]
+    verifier:
+      controls:
+        - systemd_slurmd_service
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster::test_dummy
+  - name: compute_slurmd_systemd_gpu
+    driver:
+      instance_type: g4dn.xlarge
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-slurm::config_slurmd_systemd_service]
+    verifier:
+      controls:
+        - systemd_slurmd_service
+        - systemd_slurmd_service_nvidia_gpu_nodes
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster::test_dummy
   - name: network_interfaces
     # Verifies multiple Network Interfaces recipes
     # These recipes can be tested on EC2 on instance type with multiple network interfaces

--- a/test/recipes/controls/aws_parallelcluster_slurm/config_slurmd_systemd_service_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/config_slurmd_systemd_service_spec.rb
@@ -1,0 +1,37 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'systemd_slurmd_service' do
+  title 'Check the basic configuration of the systemd slurmd service'
+
+  describe 'Check that slurmd service is defined'
+  describe service('slurmd') do
+    it { should be_installed }
+  end
+
+  describe 'Check slurmd systemd "after" dependencies'
+  describe command('systemctl list-dependencies --after --plain slurmd.service') do
+    its('stdout') { should include "munge.service" }
+  end
+end
+
+control 'systemd_slurmd_service_nvidia_gpu_nodes' do
+  title 'Check the systemd slurmd service dependencies on NVIDIA GPU compute nodes'
+
+  describe 'Check slurmd systemd "after" dependencies'
+  describe command('systemctl list-dependencies --after --plain slurmd.service') do
+    its('stdout') { should include "nvidia-persistenced.service" }
+  end
+  describe 'Check slurmd systemd requirement dependencies'
+  describe command('systemctl list-dependencies --plain slurmd.service') do
+    its('stdout') { should include "nvidia-persistenced.service" }
+  end
+end


### PR DESCRIPTION
### Description of changes
* Configure systemd dependency between slurmd and nvidia-persistenced services in order to make sure NVIDIA device files are available under /dev before slurmd starts.

### Tests
* Add kitchen tests for the modified code to validate the systemd dependencies configured for the slurmd service.
* Manually ran the added kitchen tests on all EC2 platforms.
* Manually created a cluster with a patch to verify that the dependency is successfully configured on GPU nodes and not on non-GPU ones.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2100

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.