### PR TITLE
Fix Kitchen config for Ubuntu22

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,12 @@ docker rmi \
 
 **dokken** expects that `~/.docker/config.json` contains an `"auths"` key, fails in `docker_config_creds` with NPE
 otherwise, this issue is tracked in upstream as: https://github.com/test-kitchen/kitchen-dokken/issues/290
+
+### Known issues with EC2
+#### Ubuntu22
+
+On Ubuntu22, `kitchen create` keeps trying to connect to the instance via ssh indefinitely.
+If you interrupt it and try to run `kitchen verify`, you see authentication failures. 
+
+This happens because Ubuntu22 does not accept authentication via RSA key. You need to re-create a key pair 
+using `ED25519` key type.

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -52,6 +52,13 @@ platforms:
       cluster:
         base_os: ubuntu2004
         kernel_release: '5.15.0-1028-aws'
+  - name: ubuntu2204
+    driver:
+      image: dokken/ubuntu-22.04
+    attributes:
+      cluster:
+        base_os: ubuntu2004
+        kernel_release: '5.15.0-1028-aws'
   - name: rhel8
     driver:
       image: registry.access.redhat.com/ubi8/ubi

--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -39,7 +39,7 @@ transport:
 provisioner:
   name: chef_zero
   require_chef_omnibus: 17.2.29
-  chef_omnibus_url: https://raw.githubusercontent.com/aws/aws-parallelcluster-cookbook/develop/util/cinc-install.sh
+  chef_omnibus_url: https://omnitruck.cinc.sh/install.sh
   chef_omnibus_root: /opt/cinc
   retry_on_exit_code:
     - 35 # 35 is the exit code signaling that the node is rebooting


### PR DESCRIPTION
### Description of changes
Fix Kitchen config for Ubuntu22.
Custom script installing cinc didn't work on Ubuntu22: replace with the official one.

### Tests
Kitchen tests on Ubuntu22 launched with this configuration

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.