### PR TITLE
Restore efs dependencies

### DIFF
--- a/kitchen.resources-config.yml
+++ b/kitchen.resources-config.yml
@@ -45,9 +45,9 @@ suites:
     attributes:
       resource: efs
       dependencies:
-        #- recipe:aws-parallelcluster-install::directories
-        #- resource:package_repos
-        #- resource:install_packages
+        - recipe:aws-parallelcluster-platform::directories
+        - resource:package_repos
+        - resource:install_packages
   - name: dns_domain_configured
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]


### PR DESCRIPTION
### Description of changes
Restore efs dependencies
It allows to run config tests before building an AMI, since we don't have one for Ubuntu22 yet.

### Tests
* Kitchen test of `efs`

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.