### PR TITLE
Copy package_repos suite into main resources-install

### DIFF
--- a/kitchen.resources-install.yml
+++ b/kitchen.resources-install.yml
@@ -16,6 +16,14 @@ verifier:
 # then define a dependencies attribute, listing them with recipe: or resource: prefix.
 # You can find an example in the add_depdendencies.rb file.
 suites:
+  - name: package_repos
+    run_list:
+      - recipe[aws-parallelcluster-install::test_resource]
+    verifier:
+      controls:
+        - package_repos
+    attributes:
+      resource: package_repos
   - name: install_packages
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]

--- a/test/resources/controls/aws_parallelcluster_install/package_repos_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/package_repos_spec.rb
@@ -1,0 +1,43 @@
+# Use the name matching the resource type
+control 'package_repos' do
+  # describe the resource
+  title 'Configure package manager repository'
+
+  # in this case, different OSes produce different outcomes, to be tested differently
+  if os.redhat? # redhat includes amazon
+
+    # see https://docs.chef.io/inspec/resources/ for InSpec resources reference
+    describe yum.repo('epel') do
+      it { should exist }
+      it { should be_enabled }
+    end
+
+    if os[:name] == 'redhat' && virtualization.system != 'docker'
+      describe yum.repo('codeready-builder-for-rhel-8-rhui-rpms') do
+        it { should exist }
+        it { should be_enabled }
+      end
+    end
+
+    if os[:name] == 'centos'
+      describe bash('yum-config-manager --enable | grep skip_if_unavailable | grep -v True') do
+        its('exit_status') { should eq 1 }
+      end
+    end
+
+  elsif os.debian?
+
+    # apt_update touches this file: if it exists it means apt_update has been performed
+    describe file('/var/lib/apt/periodic/update-success-stamp') do
+      it { should exist }
+    end
+
+  else
+    describe "unsupported OS" do
+      # this produces a skipped control (ignore-like)
+      # adding a new OS to kitchen platform list and running the tests,
+      # it would surface the fact this recipe does not support this OS.
+      pending "support for #{os.name}-#{os.release} needs to be implemented"
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
Copy `package_repos` suite into main `resources-install`.
This suite wasn't easily discoverable and runnable under common. The duplication will be cleaned up during ongoing refactoring.

### Tests
* Kitchen-tested `package_repos`

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.