### PR TITLE
Remove attribute set from install_pyenv

### DIFF
--- a/cookbooks/aws-parallelcluster-shared/resources/install_pyenv.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/install_pyenv.rb
@@ -25,6 +25,10 @@ action :run do
   else
     prefix = new_resource.prefix || node['cluster']['system_pyenv_root'] || "#{node['cluster']['base_dir']}/pyenv"
 
+    directory prefix do
+      recursive true
+    end
+
     pyenv_system_install python_version do
       global_prefix prefix
     end

--- a/cookbooks/aws-parallelcluster-shared/resources/install_pyenv.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/install_pyenv.rb
@@ -13,7 +13,7 @@ property :user, String
 default_action :run
 
 action :run do
-  python_version = new_resource.python_version || node['cluster']['python-version'] || '3.9.16'
+  python_version = new_resource.python_version || node['cluster']['python-version']
 
   if new_resource.user_only
     raise "user property is required for resource install_pyenv when user_only is set to true" unless new_resource.user
@@ -23,7 +23,7 @@ action :run do
       user_prefix new_resource.prefix if new_resource.prefix
     end
   else
-    prefix = new_resource.prefix || node['cluster']['system_pyenv_root'] || "#{node['cluster']['base_dir']}/pyenv"
+    prefix = new_resource.prefix || node['cluster']['system_pyenv_root']
 
     directory prefix do
       recursive true
@@ -49,9 +49,4 @@ action :run do
     git_url 'https://github.com/pyenv/pyenv-virtualenv'
     user new_resource.user if new_resource.user_only
   end
-
-  node.default['cluster']['system_pyenv_root'] = prefix
-  node.default['cluster']['python-version'] = python_version
-
-  node_attributes "dump node attributes"
 end

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/resources/install_pyenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/resources/install_pyenv_spec.rb
@@ -1,79 +1,22 @@
 require 'spec_helper'
 
 class ConvergeInstallPyenv
-  def self.run(chef_run, python_version = nil, system_pyenv_root = nil)
+  def self.run(chef_run, python_version: nil, pyenv_root: nil, user_only: nil, user: nil)
     chef_run.converge_dsl('aws-parallelcluster-shared') do
       install_pyenv_new 'run' do
         action :run
         python_version python_version if python_version
-        prefix system_pyenv_root if system_pyenv_root
-      end
-    end
-  end
-
-  def self.run_user_only(chef_run, user, prefix)
-    chef_run.converge_dsl('aws-parallelcluster-shared') do
-      install_pyenv_new 'run' do
-        action :run
-        user_only true
-        user user
-        prefix prefix
+        prefix pyenv_root if pyenv_root
+        user_only true if user_only
+        user user if user
       end
     end
   end
 end
 
-default_python_version = '3.9.16'
-default_system_pyenv_root = '/opt/parallelcluster/pyenv'
-
 describe 'install_pyenv:run' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
-      context "when python version and pyenv root are not set and not overridden through node attributes" do
-        cached(:chef_run) do
-          runner = ChefSpec::Runner.new(
-            platform: platform, version: version,
-            step_into: ['install_pyenv_new']
-          )
-          ConvergeInstallPyenv.run(runner)
-        end
-        cached(:node) { chef_run.node }
-
-        it 'installs pyenv' do
-          # This is a redundant check
-          # Without it ChefSpec coverage sees install_pyenv:run as not covered resource
-          is_expected.to run_install_pyenv_new('run')
-        end
-
-        it 'creates system pyenv root dir' do
-          is_expected.to create_directory(default_system_pyenv_root).with_recursive(true)
-        end
-
-        it 'installs pyenv system with default python version and system pyenv root' do
-          is_expected.to install_pyenv_system_install(default_python_version)
-            .with_global_prefix(default_system_pyenv_root)
-        end
-
-        it 'removes /etc/profile.d/pyenv.sh' do
-          is_expected.to delete_file('/etc/profile.d/pyenv.sh')
-        end
-
-        it 'installs default python version' do
-          is_expected.to install_pyenv_python(default_python_version)
-        end
-
-        it 'installs pyenv plugin virtualenv' do
-          is_expected.to install_pyenv_plugin('virtualenv')
-            .with_git_url('https://github.com/pyenv/pyenv-virtualenv')
-        end
-
-        it 'sets node attributes python-version and system_pyenv_root' do
-          expect(node.default['cluster']['system_pyenv_root']).to eq(default_system_pyenv_root)
-          expect(node.default['cluster']['python-version']).to eq(default_python_version)
-          is_expected.to write_node_attributes('dump node attributes')
-        end
-      end
-
       context "when python version and pyenv root are not set but are overridden through node attributes" do
         cached(:python_version) { 'overridden_python_version' }
         cached(:system_pyenv_root) { 'overridden_pyenv_root' }
@@ -101,12 +44,6 @@ describe 'install_pyenv:run' do
         it 'installs default python version' do
           is_expected.to install_pyenv_python(python_version)
         end
-
-        it 'sets node attributes python-version and system_pyenv_root' do
-          expect(node.default['cluster']['system_pyenv_root']).to eq(system_pyenv_root)
-          expect(node.default['cluster']['python-version']).to eq(python_version)
-          is_expected.to write_node_attributes('dump node attributes')
-        end
       end
 
       context "when python version and pyenv root are set" do
@@ -117,10 +54,10 @@ describe 'install_pyenv:run' do
             platform: platform, version: version,
             step_into: ['install_pyenv_new']
           ) do |node|
-            node.override['cluster']['system_pyenv_root'] = system_pyenv_root
-            node.override['cluster']['python-version'] = python_version
+            node.override['cluster']['system_pyenv_root'] = 'default_system_pyenv_root'
+            node.override['cluster']['python-version'] = 'default_python_version'
           end
-          ConvergeInstallPyenv.run(runner, python_version, system_pyenv_root)
+          ConvergeInstallPyenv.run(runner, python_version: python_version, pyenv_root: system_pyenv_root)
         end
         cached(:node) { chef_run.node }
 
@@ -136,16 +73,10 @@ describe 'install_pyenv:run' do
         it 'installs default python version' do
           is_expected.to install_pyenv_python(python_version)
         end
-
-        it 'sets node attributes python-version and system_pyenv_root' do
-          expect(node.default['cluster']['system_pyenv_root']).to eq(system_pyenv_root)
-          expect(node.default['cluster']['python-version']).to eq(python_version)
-          is_expected.to write_node_attributes('dump node attributes')
-        end
       end
 
       context "when it is a user only installation" do
-        context "when user is not set" do
+        context "and user is not set" do
           cached(:chef_run) do
             ChefSpec::Runner.new(
               platform: platform, version: version,
@@ -154,25 +85,26 @@ describe 'install_pyenv:run' do
           end
 
           it 'raises exception' do
-            expect { ConvergeInstallPyenv.run_user_only(chef_run, nil, 'anything') }.to raise_error(RuntimeError, /user property is required for resource install_pyenv when user_only is set to true/)
+            expect { ConvergeInstallPyenv.run(chef_run, user_only: true) }.to raise_error(RuntimeError, /user property is required for resource install_pyenv when user_only is set to true/)
           end
         end
 
-        context "when user is set" do
+        context "and user is set" do
           cached(:user) { "the_user" }
-          cached(:user_prefix) { "the_user_prefix" }
+          cached(:pyenv_root) { "pyenv_root" }
+          cached(:python_version) { 'python_version' }
           cached(:chef_run) do
             runner = ChefSpec::Runner.new(
               platform: platform, version: version,
               step_into: ['install_pyenv_new']
             )
-            ConvergeInstallPyenv.run_user_only(runner, user, user_prefix)
+            ConvergeInstallPyenv.run(runner, user_only: true, user: user, python_version: python_version, pyenv_root: pyenv_root)
           end
 
           it 'installs pyenv for user' do
-            is_expected.to install_pyenv_user_install(default_python_version).with(
+            is_expected.to install_pyenv_user_install(python_version).with(
               user: user,
-              user_prefix: user_prefix
+              user_prefix: pyenv_root
             )
           end
         end

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/resources/install_pyenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/resources/install_pyenv_spec.rb
@@ -45,6 +45,10 @@ describe 'install_pyenv:run' do
           is_expected.to run_install_pyenv_new('run')
         end
 
+        it 'creates system pyenv root dir' do
+          is_expected.to create_directory(default_system_pyenv_root).with_recursive(true)
+        end
+
         it 'installs pyenv system with default python version and system pyenv root' do
           is_expected.to install_pyenv_system_install(default_python_version)
             .with_global_prefix(default_system_pyenv_root)
@@ -85,6 +89,10 @@ describe 'install_pyenv:run' do
         end
         cached(:node) { chef_run.node }
 
+        it 'creates pyenv root dir' do
+          is_expected.to create_directory(system_pyenv_root).with_recursive(true)
+        end
+
         it 'installs pyenv system' do
           is_expected.to install_pyenv_system_install(python_version)
             .with_global_prefix(system_pyenv_root)
@@ -115,6 +123,10 @@ describe 'install_pyenv:run' do
           ConvergeInstallPyenv.run(runner, python_version, system_pyenv_root)
         end
         cached(:node) { chef_run.node }
+
+        it 'creates pyenv root dir' do
+          is_expected.to create_directory(system_pyenv_root).with_recursive(true)
+        end
 
         it 'installs pyenv system' do
           is_expected.to install_pyenv_system_install(python_version)


### PR DESCRIPTION
### Description of changes
* [Remove attribute set from install_pyenv](https://github.com/aws/aws-parallelcluster-cookbook/commit/c75fd2da7c013f7ff1cb36c0b36c303fb6ca2b91)
  * Since install_pyenv can be called with arbitrary property values, setting node attributes from those values is wrong.
Remove fallback to default values as well: node attributes must exist.
*  [Create pyenv root directory before running install_pyenv](https://github.com/aws/aws-parallelcluster-cookbook/commit/3f614eabbdd48084dad831173b42514f10283bb5)

### Tests
* ChefSpec tests
* Kitchen tests on recipes using this resource

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.