### PR TITLE
Replace node['cluster']['cookbook_virtualenv_path'] with function

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
@@ -36,7 +36,7 @@ if !node['cluster']['custom_awsbatchcli_package'].nil? && !node['cluster']['cust
     code <<-CLI
       set -e
       if [[ "#{node['cluster']['custom_awsbatchcli_package']}" =~ ^s3:// ]]; then
-        custom_package_url=$(#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3 presign #{node['cluster']['custom_awsbatchcli_package']} --region #{node['cluster']['region']})
+        custom_package_url=$(#{cookbook_virtualenv_path}/bin/aws s3 presign #{node['cluster']['custom_awsbatchcli_package']} --region #{node['cluster']['region']})
       else
         custom_package_url=#{node['cluster']['custom_awsbatchcli_package']}
       fi

--- a/cookbooks/aws-parallelcluster-common/resources/cloudwatch/partial/_cloudwatch_common.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/cloudwatch/partial/_cloudwatch_common.rb
@@ -134,7 +134,7 @@ action :configure do
       'CW_LOGS_CONFIGS_SCHEMA_PATH' => config_schema_path,
       'CW_LOGS_CONFIGS_PATH' => config_data_path
     )
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{validator_script_path}"
+    command "#{cookbook_virtualenv_path}/bin/python #{validator_script_path}"
   end
 
   execute "cloudwatch-config-creation" do
@@ -150,7 +150,7 @@ action :configure do
 
     cluster_config_path = node['cluster']['scheduler'] == 'plugin' ? "--cluster-config-path #{node['cluster']['cluster_config_path']}" : ""
 
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{config_script_path} "\
+    command "#{cookbook_virtualenv_path}/bin/python #{config_script_path} "\
         "--platform #{node['platform']} --config $CONFIG_DATA_PATH --log-group $LOG_GROUP_NAME "\
         "--scheduler $SCHEDULER --node-role $NODE_ROLE #{cluster_config_path}"
   end

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/node.rb
@@ -44,7 +44,7 @@ if !node['cluster']['custom_node_package'].nil? && !node['cluster']['custom_node
       source #{virtualenv_path}/bin/activate
       pip uninstall --yes aws-parallelcluster-node
       if [[ "#{node['cluster']['custom_node_package']}" =~ ^s3:// ]]; then
-        custom_package_url=$(#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3 presign #{node['cluster']['custom_node_package']} --region #{node['cluster']['region']})
+        custom_package_url=$(#{cookbook_virtualenv_path}/bin/aws s3 presign #{node['cluster']['custom_node_package']} --region #{node['cluster']['region']})
       else
         custom_package_url=#{node['cluster']['custom_node_package']}
       fi

--- a/cookbooks/aws-parallelcluster-config/recipes/head_node_fleet_status.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/head_node_fleet_status.rb
@@ -47,7 +47,7 @@ end
 unless virtualized? || kitchen_test? && !node['interact_with_ddb']
   execute 'initialize compute fleet status in DynamoDB' do
     # Initialize the status of the compute fleet in the DynamoDB table. Set it to RUNNING.
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/aws dynamodb put-item --table-name #{node['cluster']['ddb_table']}"\
+    command "#{cookbook_virtualenv_path}/bin/aws dynamodb put-item --table-name #{node['cluster']['ddb_table']}"\
             " --item '{\"Id\": {\"S\": \"COMPUTE_FLEET\"}, \"Data\": {\"M\": {\"status\": {\"S\": \"RUNNING\"}, \"lastStatusUpdatedTime\": {\"S\": \"#{Time.now.utc}\"}}}}'" \
             " --region #{node['cluster']['region']}"
     retries 3

--- a/cookbooks/aws-parallelcluster-config/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/fetch_config.rb
@@ -41,7 +41,7 @@ action_class do # rubocop:disable Metrics/BlockLength
   end
 
   def fetch_s3_object(command_label, key, output, version_id = nil)
-    fetch_s3_object_command = "#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3api get-object" \
+    fetch_s3_object_command = "#{cookbook_virtualenv_path}/bin/aws s3api get-object" \
                          " --bucket #{node['cluster']['cluster_s3_bucket']}" \
                          " --key #{key}" \
                          " --region #{node['cluster']['region']}" \

--- a/cookbooks/aws-parallelcluster-config/resources/manage_ebs.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_ebs.rb
@@ -37,7 +37,7 @@ action :mount do
 
     # Attach EBS volume
     execute "attach_volume_#{index}" do
-      command "#{node.default['cluster']['cookbook_virtualenv_path']}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volumeid} --attach"
+      command "#{cookbook_virtualenv_path}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volumeid} --attach"
       creates dev_path[index]
     end
 
@@ -163,7 +163,7 @@ action :unmount do
 
     # Detach EBS volume
     execute "detach_volume_#{index}" do
-      command "#{node.default['cluster']['cookbook_virtualenv_path']}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volumeid} --detach"
+      command "#{cookbook_virtualenv_path}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volumeid} --detach"
     end
 
     # Delete the shared directories

--- a/cookbooks/aws-parallelcluster-config/resources/manage_raid/partial/_raid_configuration.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/manage_raid/partial/_raid_configuration.rb
@@ -33,7 +33,7 @@ action :mount do
 
     # Attach RAID EBS volume
     execute "attach_raid_volume_#{index}" do
-      command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volumeid} --attach"
+      command "#{cookbook_virtualenv_path}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volumeid} --attach"
       creates raid_dev_path[index]
     end
 
@@ -168,7 +168,7 @@ action :unmount do
   raid_vol_array.each_with_index do |volumeid, index|
     # Detach RAID EBS volume
     execute "detach_raid_volume_#{index}" do
-      command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volumeid} --detach"
+      command "#{cookbook_virtualenv_path}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volumeid} --detach"
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-config/resources/volume/volume.rb
+++ b/cookbooks/aws-parallelcluster-config/resources/volume/volume.rb
@@ -13,7 +13,7 @@ action :attach do
   dev_path = "/dev/disk/by-ebs-volumeid/#{volume_id}"
 
   execute "attach_volume_#{volume_id}" do
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volume_id} --attach"
+    command "#{cookbook_virtualenv_path}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volume_id} --attach"
     creates dev_path
   end
 
@@ -31,7 +31,7 @@ action :detach do
   volume_id = new_resource.volume_id.strip
   # Detach EBS volume
   execute "detach_volume_#{volume_id}" do
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volume_id} --detach"
+    command "#{cookbook_virtualenv_path}/bin/python /usr/local/sbin/manageVolume.py --volume-id #{volume_id} --detach"
   end
 end
 

--- a/cookbooks/aws-parallelcluster-config/spec/unit/resources/manage_raid_mount_unmount_spec.rb
+++ b/cookbooks/aws-parallelcluster-config/spec/unit/resources/manage_raid_mount_unmount_spec.rb
@@ -17,9 +17,8 @@ describe 'manage_raid:mount' do
         runner = ChefSpec::Runner.new(
           platform: platform, version: version,
           step_into: ['manage_raid']
-        ) do |node|
-          node.override['cluster']['cookbook_virtualenv_path'] = venv_path
-        end
+        )
+        allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(venv_path)
         runner.converge_dsl do
           manage_raid 'mount' do
             action :mount
@@ -123,9 +122,8 @@ describe 'manage_raid:unmount' do
         runner = ChefSpec::Runner.new(
           platform: platform, version: version,
           step_into: ['manage_raid']
-        ) do |node|
-          node.override['cluster']['cookbook_virtualenv_path'] = venv_path
-        end
+        )
+        allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(venv_path)
         runner.converge_dsl do
           manage_raid 'unmount' do
             action :unmount

--- a/cookbooks/aws-parallelcluster-config/spec/unit/resources/volume_spec.rb
+++ b/cookbooks/aws-parallelcluster-config/spec/unit/resources/volume_spec.rb
@@ -195,9 +195,8 @@ describe 'volume:attach' do
         runner = ChefSpec::Runner.new(
           platform: platform, version: version,
           step_into: ['volume']
-        ) do |node|
-          node.override['cluster']['cookbook_virtualenv_path'] = '/cookbook_venv'
-        end
+        )
+        allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return('/cookbook_venv')
         runner.converge_dsl do
           volume 'attach' do
             volume_id 'volumeid'
@@ -229,9 +228,8 @@ describe 'volume:detach' do
         runner = ChefSpec::Runner.new(
           platform: platform, version: version,
           step_into: ['volume']
-        ) do |node|
-          node.override['cluster']['cookbook_virtualenv_path'] = '/cookbook_venv'
-        end
+        )
+        allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return('/cookbook_venv')
         runner.converge_dsl do
           volume 'detach' do
             volume_id 'volumeid'

--- a/cookbooks/aws-parallelcluster-config/templates/default/base/parallelcluster_supervisord.conf.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/base/parallelcluster_supervisord.conf.erb
@@ -23,7 +23,7 @@ stdout_logfile_maxbytes = 0
 <% end -%>
 <% unless node['cluster']['scheduler'] == 'awsbatch' -%>
 [program:clusterstatusmgtd]
-command = <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/python /opt/parallelcluster/scripts/clusterstatusmgtd.py
+command = <%= cookbook_virtualenv_path %>/bin/python /opt/parallelcluster/scripts/clusterstatusmgtd.py
 user = <%= node['cluster']['cluster_admin_user'] %>
 environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"<% if @region.start_with?('us-iso') -%>,AWS_CA_BUNDLE="<%= @aws_ca_bundle %>"<% end -%>
 redirect_stderr = true

--- a/cookbooks/aws-parallelcluster-config/templates/default/compute_fleet_status/get-compute-fleet-status.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/compute_fleet_status/get-compute-fleet-status.erb
@@ -23,7 +23,7 @@ main() {
         shift
     done
 
-    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/python <%= node['cluster']['scripts_dir'] %>/compute_fleet_status.py --table-name <%= node['cluster']['ddb_table'] %> --region <%= node['cluster']['region'] %> --action get
+    <%= cookbook_virtualenv_path %>/bin/python <%= node['cluster']['scripts_dir'] %>/compute_fleet_status.py --table-name <%= node['cluster']['ddb_table'] %> --region <%= node['cluster']['region'] %> --action get
 }
 
 main "$@"

--- a/cookbooks/aws-parallelcluster-config/templates/default/compute_fleet_status/update-compute-fleet-status.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/compute_fleet_status/update-compute-fleet-status.erb
@@ -43,7 +43,7 @@ main() {
     fi
 
 
-    <%= node['cluster']['cookbook_virtualenv_path'] %>/bin/python <%= node['cluster']['scripts_dir'] %>/compute_fleet_status.py --table-name <%= node['cluster']['ddb_table'] %> --region <%= node['cluster']['region'] %> --status "${_status}" --action update
+    <%= cookbook_virtualenv_path %>/bin/python <%= node['cluster']['scripts_dir'] %>/compute_fleet_status.py --table-name <%= node['cluster']['ddb_table'] %> --region <%= node['cluster']['region'] %> --status "${_status}" --action update
 }
 
 main "$@"

--- a/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/init/fetch_and_run.erb
@@ -20,7 +20,7 @@ source /etc/parallelcluster/cfnconfig
 
 # please note that this env setup has potential independent but relevant duplication with:
 # build_env in cookbooks/aws-parallelcluster-scheduler-plugin/resources/execute_event_handler.rb
-PCLUSTER_COOKBOOK_VIRTUALENV_PATH="<%= node['cluster']['cookbook_virtualenv_path'] %>"
+PCLUSTER_COOKBOOK_VIRTUALENV_PATH="<%= cookbook_virtualenv_path %>"
 PCLUSTER_SCRIPTS_DIR="<%= node['cluster']['scripts_dir'] %>"
 PCLUSTER_CONFIG_PATH="<%= node['cluster']['cluster_config_path'] %>"
 PCLUSTER_NODE_TYPE="<%= node['cluster']['node_type'] %>"

--- a/cookbooks/aws-parallelcluster-install/recipes/awscli.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/awscli.rb
@@ -24,6 +24,6 @@ bash "install awscli" do
     set -e
     curl --retry 5 --retry-delay 5 "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
     unzip awscli-bundle.zip
-    #{node['cluster']['cookbook_virtualenv_path']}/bin/python awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+    #{cookbook_virtualenv_path}/bin/python awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
   CLI
 end unless ::File.exist?("/usr/local/bin/aws") || redhat_ubi?

--- a/cookbooks/aws-parallelcluster-install/templates/default/base/supervisord-service.erb
+++ b/cookbooks/aws-parallelcluster-install/templates/default/base/supervisord-service.erb
@@ -6,9 +6,9 @@ Documentation=http://supervisord.org
 After=network.target
 
 [Service]
-ExecStart=<%= node['cluster']['cookbook_virtualenv_path'] %>/bin/supervisord -n -c /etc/supervisord.conf
-ExecStop=<%= node['cluster']['cookbook_virtualenv_path'] %>/bin/supervisorctl $OPTIONS shutdown
-ExecReload=<%= node['cluster']['cookbook_virtualenv_path'] %>/bin/supervisorctl -c /etc/supervisord.conf $OPTIONS reload
+ExecStart=<%= cookbook_virtualenv_path %>/bin/supervisord -n -c /etc/supervisord.conf
+ExecStop=<%= cookbook_virtualenv_path %>/bin/supervisorctl $OPTIONS shutdown
+ExecReload=<%= cookbook_virtualenv_path %>/bin/supervisorctl -c /etc/supervisord.conf $OPTIONS reload
 KillMode=process
 Restart=on-failure
 RestartSec=50s

--- a/cookbooks/aws-parallelcluster-install/templates/default/ec2_udev_rules/ec2-volid.rules.erb
+++ b/cookbooks/aws-parallelcluster-install/templates/default/ec2_udev_rules/ec2-volid.rules.erb
@@ -1,4 +1,4 @@
-KERNEL=="xvd*", ENV{DEVTYPE}=="disk", PROGRAM="<%= node['cluster']['cookbook_virtualenv_path'] %>/bin/python /sbin/ec2_dev_2_volid.py %k", SYMLINK+="disk/by-ebs-volumeid/%c"
-KERNEL=="xvd*", ENV{DEVTYPE}=="partition", PROGRAM="<%= node['cluster']['cookbook_virtualenv_path'] %>/bin/python /sbin/ec2_dev_2_volid.py %k", SYMLINK+="disk/by-ebs-volumeid/%c-p%n"
-KERNEL=="nvme*", ENV{DEVTYPE}=="disk", PROGRAM="<%= node['cluster']['cookbook_virtualenv_path'] %>/bin/python /sbin/ec2_dev_2_volid.py %k", SYMLINK+="disk/by-ebs-volumeid/%c"
-KERNEL=="nvme*", ENV{DEVTYPE}=="partition", PROGRAM="<%= node['cluster']['cookbook_virtualenv_path'] %>/bin/python /sbin/ec2_dev_2_volid.py %k", SYMLINK+="disk/by-ebs-volumeid/%c-p%n"
+KERNEL=="xvd*", ENV{DEVTYPE}=="disk", PROGRAM="<%= cookbook_virtualenv_path %>/bin/python /sbin/ec2_dev_2_volid.py %k", SYMLINK+="disk/by-ebs-volumeid/%c"
+KERNEL=="xvd*", ENV{DEVTYPE}=="partition", PROGRAM="<%= cookbook_virtualenv_path %>/bin/python /sbin/ec2_dev_2_volid.py %k", SYMLINK+="disk/by-ebs-volumeid/%c-p%n"
+KERNEL=="nvme*", ENV{DEVTYPE}=="disk", PROGRAM="<%= cookbook_virtualenv_path %>/bin/python /sbin/ec2_dev_2_volid.py %k", SYMLINK+="disk/by-ebs-volumeid/%c"
+KERNEL=="nvme*", ENV{DEVTYPE}=="partition", PROGRAM="<%= cookbook_virtualenv_path %>/bin/python /sbin/ec2_dev_2_volid.py %k", SYMLINK+="disk/by-ebs-volumeid/%c-p%n"

--- a/cookbooks/aws-parallelcluster-install/templates/default/ec2_udev_rules/parallelcluster-ebsnvme-id.erb
+++ b/cookbooks/aws-parallelcluster-install/templates/default/ec2_udev_rules/parallelcluster-ebsnvme-id.erb
@@ -1,4 +1,4 @@
-#!<%= node['cluster']['cookbook_virtualenv_path'] %>/bin/python
+#!<%= cookbook_virtualenv_path %>/bin/python
 
 # Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
 #

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/cookbook_virtualenv.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/cookbook_virtualenv.rb
@@ -11,11 +11,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-virtualenv_name = 'cookbook_virtualenv'
-pyenv_root = node['cluster']['system_pyenv_root']
-python_version = node['cluster']['python-version']
-
-virtualenv_path = "#{pyenv_root}/versions/#{python_version}/envs/#{virtualenv_name}"
+virtualenv_path = cookbook_virtualenv_path
 
 node.default['cluster']['cookbook_virtualenv_path'] = virtualenv_path
 node_attributes "dump node attributes"
@@ -25,9 +21,9 @@ return if redhat_ubi?
 
 install_pyenv_new 'pyenv for default python version'
 
-activate_virtual_env virtualenv_name do
-  pyenv_path virtualenv_path
-  python_version python_version
+activate_virtual_env cookbook_virtualenv_name do
+  pyenv_path cookbook_virtualenv_path
+  python_version cookbook_python_version
   requirements_path "cookbook_virtualenv/requirements.txt"
-  not_if { ::File.exist?("#{virtualenv_path}/bin/activate") }
+  not_if { ::File.exist?("#{cookbook_virtualenv_path}/bin/activate") }
 end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/cookbook_virtualenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/cookbook_virtualenv_spec.rb
@@ -1,6 +1,6 @@
 control 'tag:testami_cookbook_virtualenv_created' do
   python_version = node['cluster']['python-version']
-  virtualenv_path = node['cluster']['cookbook_virtualenv_path']
+  virtualenv_path = cookbook_virtualenv_path
   min_pip_version = '19.3'
 
   title "cookbook virtualenv should be created on #{python_version}"
@@ -26,7 +26,7 @@ control 'tag:testami_cookbook_virtualenv_created' do
 end
 
 control 'tag:testami:awscli can be executed as root in cookbook virtualenv' do
-  virtualenv_path = node['cluster']['cookbook_virtualenv_path']
+  virtualenv_path = cookbook_virtualenv_path
 
   describe bash("#{virtualenv_path}/bin/aws --version") do
     its('exit_status') { should eq 0 }

--- a/cookbooks/aws-parallelcluster-scheduler-plugin/resources/fetch_artifacts.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/resources/fetch_artifacts.rb
@@ -38,7 +38,7 @@ action :run do
         if artifact_source_url.start_with?("s3")
           # download artifacts from s3
           bucket_name, object_key = artifact_source_url.match(%r{^s3:\/\/(.*?)\/(.*)}).captures
-          fetch_artifact_command = "#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3api get-object" \
+          fetch_artifact_command = "#{cookbook_virtualenv_path}/bin/aws s3api get-object" \
                          " --bucket #{bucket_name}" \
                          " --key #{object_key}" \
                          " --region #{node['cluster']['region']}" \

--- a/cookbooks/aws-parallelcluster-shared/libraries/environment.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/environment.rb
@@ -21,6 +21,22 @@ def virtualenv_path(pyenv_root:, python_version:, virtualenv_name:)
   "#{pyenv_root}/versions/#{python_version}/envs/#{virtualenv_name}"
 end
 
+def cookbook_virtualenv_name
+  'cookbook_virtualenv'
+end
+
+def cookbook_python_version
+  node['cluster']['python-version']
+end
+
+def cookbook_pyenv_root
+  node['cluster']['system_pyenv_root']
+end
+
+def cookbook_virtualenv_path
+  virtualenv_path(pyenv_root: cookbook_pyenv_root, python_version: cookbook_python_version, virtualenv_name: cookbook_virtualenv_name)
+end
+
 def node_virtualenv_name
   'node_virtualenv'
 end

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -25,7 +25,7 @@ end
 # Retrieve compute and head node info from dynamo db (Slurm only)
 #
 def dynamodb_info(aws_connection_timeout_seconds: 30, aws_read_timeout_seconds: 60, shell_timout_seconds: 300)
-  output = Mixlib::ShellOut.new("#{node['cluster']['cookbook_virtualenv_path']}/bin/aws dynamodb " \
+  output = Mixlib::ShellOut.new("#{cookbook_virtualenv_path}/bin/aws dynamodb " \
                       "--region #{node['cluster']['region']} query --table-name #{node['cluster']['slurm_ddb_table']} " \
                       "--index-name InstanceId --key-condition-expression 'InstanceId = :instanceid' " \
                       "--expression-attribute-values '{\":instanceid\": {\"S\":\"#{node['ec2']['instance_id']}\"}}' " \

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -64,7 +64,7 @@ unless virtualized?
   # Generate pcluster specific configs
   no_gpu = nvidia_installed? ? "" : "--no-gpu"
   execute "generate_pcluster_slurm_configs" do
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_slurm_config_generator.py"\
+    command "#{cookbook_virtualenv_path}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_slurm_config_generator.py"\
             " --output-directory #{node['cluster']['slurm']['install_dir']}/etc/"\
             " --template-directory #{node['cluster']['scripts_dir']}/slurm/templates/"\
             " --input-file #{node['cluster']['cluster_config_path']}"\
@@ -77,7 +77,7 @@ unless virtualized?
 
   # Generate custom Slurm settings include files
   execute "generate_pcluster_custom_slurm_settings_include_files" do
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_custom_slurm_settings_include_file_generator.py"\
+    command "#{cookbook_virtualenv_path}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_custom_slurm_settings_include_file_generator.py"\
             " --output-directory #{node['cluster']['slurm']['install_dir']}/etc/"\
             " --input-file #{node['cluster']['cluster_config_path']}"
   end
@@ -92,7 +92,7 @@ unless virtualized?
 
   # Generate pcluster fleet config
   execute "generate_pcluster_fleet_config" do
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_fleet_config_generator.py"\
+    command "#{cookbook_virtualenv_path}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_fleet_config_generator.py"\
             " --output-file #{node['cluster']['slurm']['fleet_config_path']}"\
             " --input-file #{node['cluster']['cluster_config_path']}"
   end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -81,7 +81,7 @@ bash 'make install' do
     set -e
 
     # python3 is required to build slurm >= 20.02
-    source #{node['cluster']['cookbook_virtualenv_path']}/bin/activate
+    source #{cookbook_virtualenv_path}/bin/activate
 
     tar xf #{slurm_tarball}
     cd slurm-#{slurm_tar_name}

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_computefleet_status_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_computefleet_status_head_node.rb
@@ -19,8 +19,8 @@ bash 'update compute fleet' do
   user 'root'
   code <<-UPDATE_COMPUTE_FLEET
       set -xe
-      #{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl stop clustermgtd
+      #{cookbook_virtualenv_path}/bin/supervisorctl stop clustermgtd
       #{node['cluster']['scripts_dir']}/slurm/slurm_fleet_status_manager -cf #{node['cluster']['computefleet_status_path']}
-      #{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl start clustermgtd
+      #{cookbook_virtualenv_path}/bin/supervisorctl start clustermgtd
   UPDATE_COMPUTE_FLEET
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 execute 'stop clustermgtd' do
-  command "#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl stop clustermgtd"
+  command "#{cookbook_virtualenv_path}/bin/supervisorctl stop clustermgtd"
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && !are_bulk_custom_slurm_settings_updated? }
 end
 
@@ -147,7 +147,7 @@ ruby_block "replace slurm queue nodes" do
 end
 
 execute "generate_pcluster_slurm_configs" do
-  command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_slurm_config_generator.py" \
+  command "#{cookbook_virtualenv_path}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_slurm_config_generator.py" \
           " --output-directory #{node['cluster']['slurm']['install_dir']}/etc/" \
           " --template-directory #{node['cluster']['scripts_dir']}/slurm/templates/" \
           " --input-file #{node['cluster']['cluster_config_path']}" \
@@ -162,7 +162,7 @@ end
 
 # Generate custom Slurm settings include files
 execute "generate_pcluster_custom_slurm_settings_include_files" do
-  command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_custom_slurm_settings_include_file_generator.py" \
+  command "#{cookbook_virtualenv_path}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_custom_slurm_settings_include_file_generator.py" \
             " --output-directory #{node['cluster']['slurm']['install_dir']}/etc/"\
             " --input-file #{node['cluster']['cluster_config_path']}"
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_bulk_custom_slurm_settings_updated? }
@@ -177,7 +177,7 @@ ruby_block "Override Custom Slurm Settings with remote file" do
 end
 
 execute "generate_pcluster_fleet_config" do
-  command "#{node['cluster']['cookbook_virtualenv_path']}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_fleet_config_generator.py"\
+  command "#{cookbook_virtualenv_path}/bin/python #{node['cluster']['scripts_dir']}/slurm/pcluster_fleet_config_generator.py"\
           " --output-file #{node['cluster']['slurm']['fleet_config_path']}"\
           " --input-file #{node['cluster']['cluster_config_path']}"
   not_if { ::File.exist?(node['cluster']['slurm']['fleet_config_path']) && !are_queues_updated? }
@@ -238,7 +238,7 @@ end
 chef_sleep '15'
 
 execute 'start clustermgtd' do
-  command "#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl start clustermgtd"
+  command "#{cookbook_virtualenv_path}/bin/supervisorctl start clustermgtd"
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && !are_bulk_custom_slurm_settings_updated? }
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/resources/remote_object/remote_object.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/remote_object/remote_object.rb
@@ -33,7 +33,7 @@ action :get do
     if source_url.start_with?("s3")
       Chef::Log.debug("Retrieving remote Object from #{source_url} to #{local_path} using S3 protocol")
       # download file using s3 protocol
-      fetch_command = "#{node['cluster']['cookbook_virtualenv_path']}/bin/aws s3 cp" \
+      fetch_command = "#{cookbook_virtualenv_path}/bin/aws s3 cp" \
                   " --region #{node['cluster']['region']}" \
                   " #{no_sign_request}" \
                   " #{source_url}" \

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/90_pcluster_health_check_manager.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/health_check/90_pcluster_health_check_manager.erb
@@ -46,7 +46,7 @@ if [ "${DEBUG}" = true ]; then
  set -x
 fi
 
-PCLUSTER_COOKBOOK_VIRTUALENV_PATH="<%= node['cluster']['cookbook_virtualenv_path'] %>"
+PCLUSTER_COOKBOOK_VIRTUALENV_PATH="<%= cookbook_virtualenv_path %>"
 PCLUSTER_SCRIPTS_DIR="<%= node['cluster']['slurm']['install_dir'] %>/etc/pcluster/.slurm_plugin/scripts"
 PCLUSTER_CONFIG_PATH="<%= node['cluster']['cluster_config_path'] %>"
 PCLUSTER_DNA_JSON_PATH="/etc/chef/dna.json"

--- a/cookbooks/aws-parallelcluster-test/recipes/tests.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/tests.rb
@@ -23,10 +23,10 @@ bash 'check awscli regions' do
   code <<-AWSREGIONS
     set -e
     export PATH="/usr/local/bin:/usr/bin/:$PATH"
-    regions=($(#{node['cluster']['cookbook_virtualenv_path']}/bin/aws ec2 describe-regions --region #{node['cluster']['region']} --query "Regions[].{Name:RegionName}" --output text))
+    regions=($(#{cookbook_virtualenv_path}/bin/aws ec2 describe-regions --region #{node['cluster']['region']} --query "Regions[].{Name:RegionName}" --output text))
     for region in "${regions[@]}"
     do
-      #{node['cluster']['cookbook_virtualenv_path']}/bin/aws ec2 describe-regions --region "${region}"
+      #{cookbook_virtualenv_path}/bin/aws ec2 describe-regions --region "${region}"
     done
   AWSREGIONS
 end
@@ -119,6 +119,6 @@ end
 ###################
 if node['cluster']['node_type'] == 'HeadNode' && node['cluster']['scheduler'] != 'awsbatch'
   execute "check clusterstatusmgtd is configured to be executed by supervisord" do
-    command "#{node['cluster']['cookbook_virtualenv_path']}/bin/supervisorctl status clusterstatusmgtd | grep RUNNING"
+    command "#{cookbook_virtualenv_path}/bin/supervisorctl status clusterstatusmgtd | grep RUNNING"
   end
 end


### PR DESCRIPTION
node['cluster']['cookbook_virtualenv_path'] is set during cookbook_virtualenv creation. However, `config` phase does't have access to this attribute anymore, so we need to replace it with a function which is available everywhere.


### Description of changes
Replace `node['cluster']['cookbook_virtualenv_path']` with function

`node['cluster']['cookbook_virtualenv_path']` is set during `cookbook_virtualenv` creation. However, `config` phase does't have access to this attribute anymore, so we need to replace it with a function which is available everywhere.

### Tests
* Kitchen test including `install` and `config` phases.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.