### PR TITLE
Improve kitchen tests for slurmd systemd configuration

### DIFF
--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -264,27 +264,21 @@ suites:
         head_node_private_ip: '127.0.0.1'
   - name: compute_slurmd_systemd
     run_list:
-      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-slurm::config_slurmd_systemd_service]
     verifier:
       controls:
         - systemd_slurmd_service
-    attributes:
-      dependencies:
-        - recipe:aws-parallelcluster::test_dummy
+        - systemd_slurmd_service_files
   - name: compute_slurmd_systemd_gpu
     driver:
       instance_type: g4dn.xlarge
     run_list:
-      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-slurm::config_slurmd_systemd_service]
     verifier:
       controls:
         - systemd_slurmd_service
+        - systemd_slurmd_service_files
         - systemd_slurmd_service_nvidia_gpu_nodes
-    attributes:
-      dependencies:
-        - recipe:aws-parallelcluster::test_dummy
   - name: network_interfaces
     # Verifies multiple Network Interfaces recipes
     # These recipes can be tested on EC2 on instance type with multiple network interfaces

--- a/test/recipes/controls/aws_parallelcluster_slurm/config_slurmd_systemd_service_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/config_slurmd_systemd_service_spec.rb
@@ -11,6 +11,7 @@
 
 control 'systemd_slurmd_service' do
   title 'Check the basic configuration of the systemd slurmd service'
+  only_if { !os_properties.virtualized? }
 
   describe 'Check that slurmd service is defined'
   describe service('slurmd') do
@@ -23,15 +24,34 @@ control 'systemd_slurmd_service' do
   end
 end
 
+control 'systemd_slurmd_service_files' do
+  title 'Check the basic configuration of the systemd slurmd service'
+
+  describe 'Check that slurmd service file exists'
+  describe file('/etc/systemd/system/slurmd.service') do
+    it { should exist }
+  end
+end
+
 control 'systemd_slurmd_service_nvidia_gpu_nodes' do
   title 'Check the systemd slurmd service dependencies on NVIDIA GPU compute nodes'
+  only_if { !os_properties.virtualized? }
 
   describe 'Check slurmd systemd "after" dependencies'
   describe command('systemctl list-dependencies --after --plain slurmd.service') do
     its('stdout') { should include "nvidia-persistenced.service" }
   end
+
   describe 'Check slurmd systemd requirement dependencies'
   describe command('systemctl list-dependencies --plain slurmd.service') do
     its('stdout') { should include "nvidia-persistenced.service" }
+  end
+
+  describe 'Check that slurmd systemd drop-in configuration exists'
+  describe directory('/etc/systemd/system/slurmd.service.d') do
+    it { should exist }
+  end
+  describe file('/etc/systemd/system/slurmd.service.d/slurmd_nvidia_persistenced.conf') do
+    it { should exist }
   end
 end


### PR DESCRIPTION
### Description of changes
* Make inspec tests more robust towards changes in the driver where tests are executed (e.g. ec2 vs docker).
* Remove deprecated test_dummy dependency previously necessary in the kitchen tests

### Tests
* Ran tests on both EC2 and dokken drivers.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.