### PR TITLE
Remove lazy attribute set

### DIFF
--- a/cookbooks/aws-parallelcluster-common/attributes/common.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common.rb
@@ -72,7 +72,7 @@ default['conditions']['dcv_supported'] = platform_supports_dcv?
 
 # IMDS
 default['cluster']['head_node_imds_secured'] = 'true'
-default['cluster']['head_node_imds_allowed_users'] = ['root', lazy { node['cluster']['cluster_admin_user'] }, lazy { node['cluster']['cluster_user'] }]
+default['cluster']['head_node_imds_allowed_users'] = ['root', node['cluster']['cluster_admin_user'], node['cluster']['cluster_user'] ]
 default['cluster']['head_node_imds_allowed_users'].append('dcv') if node['cluster']['dcv_enabled'] == 'head_node' && platform_supports_dcv?
 default['cluster']['head_node_imds_allowed_users'].append(lazy { node['cluster']['scheduler_plugin']['user'] }) if node['cluster']['scheduler'] == 'plugin'
 


### PR DESCRIPTION
### Description of changes
Remove lazy attribute set

It was used in
```
command(lazy { "bash #{imds_access_script} --flush && bash #{imds_access_script} --allow #{node['cluster']['head_node_imds_allowed_users'].join(',')}" })
```
and it wasn't resolved correctly.

We can remove `lazy` in this case because `node['cluster']['cluster_admin_user']` and `node['cluster']['cluster_user']` are defined in `shared` cookbook which `common` depends on, so we can rely on the fact they are resolved before `default['cluster']['head_node_imds_allowed_users']` is defined.

### Tests
* Kitchen-tested `install` and then `config`

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.