### PR TITLE
Dump node_attributes to be used by InSpec tests

### DIFF
--- a/cookbooks/aws-parallelcluster-tests/recipes/tear_down.rb
+++ b/cookbooks/aws-parallelcluster-tests/recipes/tear_down.rb
@@ -1,0 +1,2 @@
+node.default['cluster']['node_virtualenv_path'] = node_virtualenv_path
+node_attributes 'Save values for InSpec tests'

--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -38,6 +38,7 @@ _run_list: &_run_list
   - recipe[aws-parallelcluster::init]
   - recipe[aws-parallelcluster::config]
   - recipe[aws-parallelcluster::finalize]
+  - recipe[aws-parallelcluster-tests::tear_down]
   - recipe[aws-parallelcluster::unmount_home]
 
 provisioner:


### PR DESCRIPTION
### Description of changes
Dump node_attributes to be used by InSpec tests.

InSpec tests are unable to access production functions, hence the only way to share data with them is by writing it to `node_attributes`.

### Tests
Kitchen test of `config`

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.