### PR TITLE
Fix condition for gdrcopy_disabled_on_non_graphic_instances

### DIFF
--- a/kitchen.validate-install.yml
+++ b/kitchen.validate-install.yml
@@ -12,6 +12,7 @@ suites:
     run_list:
       - recipe[aws-parallelcluster-test::docker_mock]
       - recipe[aws-parallelcluster]
+      - recipe[aws-parallelcluster-tests::tear_down]
     verifier:
       controls:
         # We also need to test the effect some files (service config, profile config) have on the system.

--- a/test/recipes/controls/aws_parallelcluster_config/nvidia_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/nvidia_spec.rb
@@ -65,7 +65,7 @@ control 'tag:config_gdrcopy_disabled_on_non_graphic_instances' do
   only_if do
     !(os_properties.centos7? && os_properties.arm?) &&
       !instance.custom_ami? && !instance.graphic? &&
-      node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true
+      (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
   end
 
   describe 'gdrcopy service should be disabled' do


### PR DESCRIPTION
### Description of changes
* [Add tear_down to validate-install test](https://github.com/aws/aws-parallelcluster-cookbook/commit/c42c18743d29c22eef10ce8df22166540998b1ca)
* [Fix condition for gdrcopy_disabled_on_non_graphic_instances](https://github.com/aws/aws-parallelcluster-cookbook/commit/4690366bb9aa19ac2d26528a80a59004003308de)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.