### PR TITLE
Encode instance type in validate config test suite names

### DIFF
--- a/.github/workflows/dokken-system-tests.yml
+++ b/.github/workflows/dokken-system-tests.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actionshub/test-kitchen@main
         with:
           os: ${{ matrix.os }}
-          suite: slurm-config-head-node-x86-64
+          suite: slurm-config-head-node-x86-64-docker
         env:
           CHEF_LICENSE: accept-no-persist
           KITCHEN_YAML: kitchen.docker.yml
@@ -67,4 +67,5 @@ jobs:
           KITCHEN_PHASE: config
           KITCHEN_SAVE_IMAGE: false
           KITCHEN_AWS_REGION: eu-west-1
+          KITCHEN_INSTANCE_TYPE: docker
         continue-on-error: false

--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -56,7 +56,7 @@ provisioner:
     kitchen: true
 
 suites:
-  - name: slurm_config_HeadNode_x86_64
+  - name: slurm_config_HeadNode_x86_64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: &attributes_slurm_config_HeadNode
       cluster:
@@ -67,7 +67,7 @@ suites:
         config:
           log_level: ":debug"
 
-  - name: slurm-config-head-node-x86-64
+  - name: slurm-config-head-node-x86-64-<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: &attributes_slurm_config_HeadNode
       cluster:
@@ -75,11 +75,11 @@ suites:
         scheduler: 'slurm'
         enable_intel_hpc_platform: "<%= ENV['ENABLE_INTEL_HPC_PLATFORM'] || false %>"
 
-  - name: slurm_config_HeadNode_arm64
+  - name: slurm_config_HeadNode_arm64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: *attributes_slurm_config_HeadNode
 
-  - name: awsbatch_config_HeadNode_x86_64
+  - name: awsbatch_config_HeadNode_x86_64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: &attributes_awsbatch_config_HeadNode
       cluster:
@@ -87,11 +87,11 @@ suites:
         scheduler: 'awsbatch'
         custom_awsbatchcli_package: <%= ENV['CUSTOM_AWSBATCHCLI_URL'] %>
 
-  - name: awsbatch_config_HeadNode_arm64
+  - name: awsbatch_config_HeadNode_arm64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: *attributes_awsbatch_config_HeadNode
 
-  - name: slurm_config_ComputeFleet_x86_64
+  - name: slurm_config_ComputeFleet_x86_64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: &attributes_slurm_config_ComputeFleet
       cluster:
@@ -99,6 +99,6 @@ suites:
         scheduler: 'slurm'
         slurm_nodename: 'fake-dy-compute-1'
 
-  - name: slurm_config_ComputeFleet_arm64
+  - name: slurm_config_ComputeFleet_arm64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: *attributes_slurm_config_ComputeFleet

--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -56,17 +56,6 @@ provisioner:
     kitchen: true
 
 suites:
-  - name: slurm_config_HeadNode_x86_64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
-    run_list: *_run_list
-    attributes: &attributes_slurm_config_HeadNode
-      cluster:
-        << : *_head_node_cluster_attributes
-        scheduler: 'slurm'
-        enable_intel_hpc_platform: "<%= ENV['ENABLE_INTEL_HPC_PLATFORM'] || false %>"
-      chef_client:
-        config:
-          log_level: ":debug"
-
   - name: slurm-config-head-node-x86-64-<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: &attributes_slurm_config_HeadNode
@@ -75,11 +64,11 @@ suites:
         scheduler: 'slurm'
         enable_intel_hpc_platform: "<%= ENV['ENABLE_INTEL_HPC_PLATFORM'] || false %>"
 
-  - name: slurm_config_HeadNode_arm64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
+  - name: slurm-config-head-node-arm64-<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: *attributes_slurm_config_HeadNode
 
-  - name: awsbatch_config_HeadNode_x86_64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
+  - name: awsbatch-config-head-node-x86-64-<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: &attributes_awsbatch_config_HeadNode
       cluster:
@@ -87,11 +76,11 @@ suites:
         scheduler: 'awsbatch'
         custom_awsbatchcli_package: <%= ENV['CUSTOM_AWSBATCHCLI_URL'] %>
 
-  - name: awsbatch_config_HeadNode_arm64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
+  - name: awsbatch-config-head-node-arm64-<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: *attributes_awsbatch_config_HeadNode
 
-  - name: slurm_config_ComputeFleet_x86_64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
+  - name: slurm-config-compute-fleet-x86-64-<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: &attributes_slurm_config_ComputeFleet
       cluster:
@@ -99,6 +88,6 @@ suites:
         scheduler: 'slurm'
         slurm_nodename: 'fake-dy-compute-1'
 
-  - name: slurm_config_ComputeFleet_arm64_<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
+  - name: slurm-config-compute-fleet-arm64-<%= ENV['KITCHEN_INSTANCE_TYPE'] || 't2.micro' %>
     run_list: *_run_list
     attributes: *attributes_slurm_config_ComputeFleet


### PR DESCRIPTION
### Description of changes
Encode instance type in validate config test suite names.

### Tests
```
➜  aws-parallelcluster-cookbook git:(develop) ✗ ./kitchen.ec2.sh validate-config list
*** Apply local environment
** KITCHEN_AWS_REGION: eu-west-1
** KITCHEN_KEY_NAME: ermann-jenkins
** KITCHEN_SSH_KEY_PATH: ~/github_sources/ParallelClusterJenkins/ermann-jenkins.pem
** KITCHEN_AVAILABILITY_ZONE: a
** KITCHEN_ARCHITECTURE: x86_64
** KITCHEN_SUBNET_ID: subnet-92d373c9
** KITCHEN_VPC_ID:
** KITCHEN_SECURITY_GROUP_ID: sg-04b12b19ea1cf1ecc
** KITCHEN_IAM_PROFILE:
** KITCHEN_LOCAL_YAML: kitchen.validate-config.yml
** KITCHEN_YAML: /Users/ermann/github_sources/aws-parallelcluster-cookbook/kitchen.ec2.yml
** KITCHEN_GLOBAL_YAML: /Users/ermann/github_sources/aws-parallelcluster-cookbook/kitchen.global.yml
kitchen list
WARNING: Nokogiri was built against libxml version 2.9.4, but has dynamically loaded 2.9.13
Deprecated configuration detected:
require_chef_omnibus
chef_omnibus_url
Run 'kitchen doctor' for details.

Top level ::CompositeIO is deprecated, require 'multipart/post' and use `Multipart::Post::CompositeReadIO` instead!
Top level ::Parts is deprecated, require 'multipart/post' and use `Multipart::Post::Parts` instead!
Instance                                             Driver  Provisioner  Verifier  Transport  Last Action    Last Error
slurm-config-HeadNode-x86-64-t2micro-alinux2         Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-HeadNode-x86-64-t2micro-rhel8           Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-HeadNode-x86-64-t2micro-centos7         Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-HeadNode-x86-64-t2micro-ubuntu1804      Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-HeadNode-x86-64-t2micro-ubuntu2004      Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-HeadNode-x86-64-t2micro-ubuntu2204      Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-HeadNode-arm64-t2micro-alinux2          Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-HeadNode-arm64-t2micro-rhel8            Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-HeadNode-arm64-t2micro-centos7          Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-HeadNode-arm64-t2micro-ubuntu1804       Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-HeadNode-arm64-t2micro-ubuntu2004       Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-HeadNode-arm64-t2micro-ubuntu2204       Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-x86-64-t2micro-alinux2      Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-x86-64-t2micro-rhel8        Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-x86-64-t2micro-centos7      Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-x86-64-t2micro-ubuntu1804   Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-x86-64-t2micro-ubuntu2004   Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-x86-64-t2micro-ubuntu2204   Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-arm64-t2micro-alinux2       Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-arm64-t2micro-rhel8         Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-arm64-t2micro-centos7       Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-arm64-t2micro-ubuntu1804    Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-arm64-t2micro-ubuntu2004    Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
awsbatch-config-HeadNode-arm64-t2micro-ubuntu2204    Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-x86-64-t2micro-alinux2     Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-x86-64-t2micro-rhel8       Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-x86-64-t2micro-centos7     Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-x86-64-t2micro-ubuntu1804  Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-x86-64-t2micro-ubuntu2004  Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-x86-64-t2micro-ubuntu2204  Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-arm64-t2micro-alinux2      Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-arm64-t2micro-rhel8        Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-arm64-t2micro-centos7      Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-arm64-t2micro-ubuntu1804   Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-arm64-t2micro-ubuntu2004   Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
slurm-config-ComputeFleet-arm64-t2micro-ubuntu2204   Ec2     ChefInfra    Inspec    SpeedySsh  <Not Created>  <None>
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.