### PR TITLE
Remove python package from Ubuntu22 default packages, align stunnel test name with our current pattern

### DIFF
--- a/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu22.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_ubuntu22.rb
@@ -7,7 +7,7 @@ return unless platform?('ubuntu') && node['platform_version'] == "22.04"
 default['cluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-tools libhwloc-dev dkms
                                          tcl-dev automake autoconf libtool librrd-dev libapr1-dev libconfuse-dev
                                          apache2 libboost-dev libdb-dev libncurses5-dev libpam0g-dev libxt-dev
-                                         libmotif-dev libxmu-dev libxft-dev man-db python
+                                         libmotif-dev libxmu-dev libxft-dev man-db
                                          r-base libblas-dev libffi-dev libxml2-dev mdadm
                                          libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
                                          libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev

--- a/kitchen.resources-install.yml
+++ b/kitchen.resources-install.yml
@@ -133,7 +133,7 @@ suites:
         - recipe:aws-parallelcluster-platform::directories
         - resource:package_repos
         - resource:install_packages
-  - name: stunnel_installed
+  - name: stunnel
     run_list:
       - recipe[aws-parallelcluster-tests::setup]
       - recipe[aws-parallelcluster-install::test_resource]


### PR DESCRIPTION
### Description of changes
* `Python` is no longer a package in canonical Ubuntu, so removed from default packages in Ub22

### Tests
* Ran kitchen tests that were trying to install python, so far they have succeeded.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.