### PR TITLE
Enable Dokken system tests and disable the redundant ones

### DIFF
--- a/.github/workflows/dokken-system-tests.yml
+++ b/.github/workflows/dokken-system-tests.yml
@@ -1,13 +1,13 @@
 name: ParallelCluster Cookbook Validation on Docker
 
-on: [workflow_dispatch]
+on: [push, pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  dokken-validate-install:
+  systemtest:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -17,12 +17,9 @@ jobs:
           - ubuntu18
           - ubuntu20
           - rhel8
-        suite:
-          - aws-parallelcluster-install
       fail-fast: false
     steps:
-      - name: Check out code
-        uses: actions/checkout@main
+      - uses: actions/checkout@main
       - name: Get changed files
         id: changed-files-excluding-tests
         uses: tj-actions/changed-files@v35.6.0
@@ -30,22 +27,44 @@ jobs:
           files_ignore: |
             !.*
             !chefignore
-            !CHANGELOG.md
             !README.md
+            !CHANGELOG.md
             !**/aws-parallelcluster-*/spec
             !**/aws-parallelcluster-*/test
       - name: Install Chef
         if: steps.changed-files-excluding-tests.outputs.any_changed == 'true'
         uses: actionshub/chef-install@main
-      - name: Test-Kitchen
+      - name: Kitchen Test Install
         if: steps.changed-files-excluding-tests.outputs.any_changed == 'true'
         uses: actionshub/test-kitchen@main
         with:
           os: ${{ matrix.os }}
-          suite: ${{ matrix.suite }}
         env:
           CHEF_LICENSE: accept-no-persist
           KITCHEN_YAML: kitchen.docker.yml
           KITCHEN_LOCAL_YAML: kitchen.validate-install.yml
           KITCHEN_GLOBAL_YAML: kitchen.global.yml
+          KITCHEN_PHASE: install
+          KITCHEN_SAVE_IMAGE: true
+        continue-on-error: false
+      - name: Set Image Id
+        run: |
+          PLATFORM=$(echo "${{ matrix.os }}"  | tr a-z A-Z)
+          echo "PLATFORM=${PLATFORM}"
+          echo "KITCHEN_${PLATFORM}_IMAGE=pcluster-install/aws-parallelcluster-install-${{ matrix.os }}"
+          echo "KITCHEN_${PLATFORM}_IMAGE=pcluster-install/aws-parallelcluster-install-${{ matrix.os }}" >> $GITHUB_ENV
+      - name: Kitchen Test Config
+        if: steps.changed-files-excluding-tests.outputs.any_changed == 'true'
+        uses: actionshub/test-kitchen@main
+        with:
+          os: ${{ matrix.os }}
+          suite: slurm-config-head-node-x86-64
+        env:
+          CHEF_LICENSE: accept-no-persist
+          KITCHEN_YAML: kitchen.docker.yml
+          KITCHEN_LOCAL_YAML: kitchen.validate-config.yml
+          KITCHEN_GLOBAL_YAML: kitchen.global.yml
+          KITCHEN_PHASE: config
+          KITCHEN_SAVE_IMAGE: false
+          KITCHEN_AWS_REGION: eu-west-1
         continue-on-error: false

--- a/.github/workflows/system-tests-centos7.yml
+++ b/.github/workflows/system-tests-centos7.yml
@@ -1,10 +1,6 @@
 name: ParallelCluster Cookbook System Test CentOS 7
 
-on:
-  push:
-    branches:
-      - develop
-  pull_request:
+on: [workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/system-tests-ubuntu.yml
+++ b/.github/workflows/system-tests-ubuntu.yml
@@ -1,11 +1,6 @@
 name: ParallelCluster Cookbook System Test Ubuntu
 
-on:
-  push:
-    branches:
-      - develop
-  pull_request:
-
+on: [workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/cookbooks/aws-parallelcluster-common/libraries/networking.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/networking.rb
@@ -13,9 +13,13 @@
 
 # Return the VPC CIDR list from node info
 def get_vpc_cidr_list
-  mac = node['ec2']['mac']
-  vpc_cidr_list = node['ec2']['network_interfaces_macs'][mac]['vpc_ipv4_cidr_blocks']
-  vpc_cidr_list.split(/\n+/)
+  if on_docker?
+    []
+  else
+    mac = node['ec2']['mac']
+    vpc_cidr_list = node['ec2']['network_interfaces_macs'][mac]['vpc_ipv4_cidr_blocks']
+    vpc_cidr_list.split(/\n+/)
+  end
 end
 
 def efa_installed?

--- a/cookbooks/aws-parallelcluster-common/resources/cloudwatch/partial/_cloudwatch_common.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/cloudwatch/partial/_cloudwatch_common.rb
@@ -135,7 +135,7 @@ action :configure do
       'CW_LOGS_CONFIGS_PATH' => config_data_path
     )
     command "#{cookbook_virtualenv_path}/bin/python #{validator_script_path}"
-  end
+  end unless redhat_ubi?
 
   execute "cloudwatch-config-creation" do
     user 'root'
@@ -153,7 +153,7 @@ action :configure do
     command "#{cookbook_virtualenv_path}/bin/python #{config_script_path} "\
         "--platform #{node['platform']} --config $CONFIG_DATA_PATH --log-group $LOG_GROUP_NAME "\
         "--scheduler $SCHEDULER --node-role $NODE_ROLE #{cluster_config_path}"
-  end
+  end unless redhat_ubi?
 
   execute "cloudwatch-agent-start" do
     user 'root'

--- a/cookbooks/aws-parallelcluster-common/test/common/libraries/os_properties.rb
+++ b/cookbooks/aws-parallelcluster-common/test/common/libraries/os_properties.rb
@@ -15,8 +15,12 @@ class OsProperties < Inspec.resource(1)
     inspec.virtualization.system == 'docker'
   end
 
+  def on_docker?
+    inspec.virtualization.system == 'docker'
+  end
+
   def redhat_ubi?
-    virtualized? && inspec.os.name == 'redhat'
+    on_docker? && inspec.os.name == 'redhat'
   end
 
   def redhat?

--- a/cookbooks/aws-parallelcluster-computefleet/test/controls/node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/test/controls/node_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'tag:testami_node_virtualenv_created' do
+control 'tag:install_tag:testami_node_virtualenv_created' do
   python_version = node['cluster']['python-version']
   virtualenv_path = node['cluster']['node_virtualenv_path']
   min_pip_version = '19.3'

--- a/cookbooks/aws-parallelcluster-config/recipes/cfnconfig_mixed.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/cfnconfig_mixed.rb
@@ -32,4 +32,4 @@ end
 
 link '/opt/parallelcluster/cfnconfig' do
   to '/etc/parallelcluster/cfnconfig'
-end
+end unless on_docker?

--- a/cookbooks/aws-parallelcluster-config/recipes/clusterstatusmgtd_init_slurm.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/clusterstatusmgtd_init_slurm.rb
@@ -24,7 +24,7 @@ file node['cluster']['computefleet_status_path'] do
   content '{}'
   mode '0755'
   action :create
-end
+end unless on_docker?
 
 # create sudoers entry to let pcluster admin user execute update compute fleet recipe
 template '/etc/sudoers.d/99-parallelcluster-clusterstatusmgtd' do

--- a/cookbooks/aws-parallelcluster-config/recipes/finalize.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/finalize.rb
@@ -23,7 +23,7 @@ fetch_config 'Fetch and load cluster configs'
 service "supervisord" do
   supports restart: true
   action %i(enable start)
-end
+end unless on_docker?
 
 include_recipe 'aws-parallelcluster-scheduler-plugin::finalize' if node['cluster']['scheduler'] == 'plugin'
 include_recipe 'aws-parallelcluster-slurm::finalize' if node['cluster']['scheduler'] == 'slurm'

--- a/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/head_node_base.rb
@@ -23,21 +23,21 @@ manage_ebs "add ebs" do
   vol_array node['cluster']['volume'].split(',')
   action %i(mount export)
   not_if { node['cluster']['ebs_shared_dirs'].split(',').empty? }
-end
+end unless on_docker?
 
 # Export /home
 nfs_export "/home" do
   network get_vpc_cidr_list
   writeable true
   options ['no_root_squash']
-end unless redhat_ubi?
+end unless on_docker?
 
 # Export /opt/parallelcluster/shared
 nfs_export node['cluster']['shared_dir'] do
   network get_vpc_cidr_list
   writeable true
   options ['no_root_squash']
-end unless redhat_ubi?
+end unless on_docker?
 
 # Export /opt/intel if it exists
 nfs_export "/opt/intel" do
@@ -45,7 +45,7 @@ nfs_export "/opt/intel" do
   writeable true
   options ['no_root_squash']
   only_if { ::File.directory?("/opt/intel") }
-end unless redhat_ubi?
+end unless on_docker?
 
 # Setup RAID array on head node
 include_recipe 'aws-parallelcluster-config::head_node_raid'
@@ -91,7 +91,7 @@ if node['cluster']['dcv_enabled'] == "head_node"
   dcv "Configure DCV" do
     action :configure
   end
-end
+end unless on_docker?
 
 unless node['cluster']['scheduler'] == 'awsbatch'
   include_recipe 'aws-parallelcluster-config::head_node_fleet_status'

--- a/cookbooks/aws-parallelcluster-config/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/init.rb
@@ -21,7 +21,7 @@ include_recipe "aws-parallelcluster-config::enable_chef_error_handler"
 validate_os_type
 
 # Validate init system
-raise "Init package #{node['init_package']} not supported." unless systemd?
+raise "Init package #{node['init_package']} not supported." unless systemd? || on_docker?
 
 include_recipe "aws-parallelcluster-config::cfnconfig_mixed"
 
@@ -37,10 +37,10 @@ end
 # ParallelCluster log rotation configuration
 include_recipe "aws-parallelcluster-config::log_rotation"
 
-include_recipe "aws-parallelcluster-config::custom_actions_setup"
+include_recipe "aws-parallelcluster-config::custom_actions_setup" unless on_docker?
 
 # Configure additional Networking Interfaces (if present)
-include_recipe "aws-parallelcluster-config::network_interfaces" unless virtualized?
+include_recipe "aws-parallelcluster-config::network_interfaces" unless on_docker?
 
 include_recipe "aws-parallelcluster-config::clusterstatusmgtd_init_slurm"
 

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cfn_bootstrap_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cfn_bootstrap_spec.rb
@@ -13,7 +13,7 @@ cfn_python_version = '3.7.16'
 base_dir = "/opt/parallelcluster"
 pyenv_dir = "#{base_dir}/pyenv"
 
-control 'cfnbootstrap_virtualenv_created' do
+control 'tag:install_cfnbootstrap_virtualenv_created' do
   title "cfnbootstrap virtualenv should be created on #{cfn_python_version}"
   only_if { !os_properties.redhat_ubi? }
 

--- a/cookbooks/aws-parallelcluster-platform/test/controls/cookbook_virtualenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/cookbook_virtualenv_spec.rb
@@ -1,6 +1,6 @@
 control 'tag:testami_cookbook_virtualenv_created' do
   python_version = node['cluster']['python-version']
-  virtualenv_path = cookbook_virtualenv_path
+  virtualenv_path = node['cluster']['cookbook_virtualenv_path']
   min_pip_version = '19.3'
 
   title "cookbook virtualenv should be created on #{python_version}"
@@ -26,7 +26,7 @@ control 'tag:testami_cookbook_virtualenv_created' do
 end
 
 control 'tag:testami:awscli can be executed as root in cookbook virtualenv' do
-  virtualenv_path = cookbook_virtualenv_path
+  virtualenv_path = node['cluster']['cookbook_virtualenv_path']
 
   describe bash("#{virtualenv_path}/bin/aws --version") do
     its('exit_status') { should eq 0 }

--- a/cookbooks/aws-parallelcluster-platform/test/controls/cookbook_virtualenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/cookbook_virtualenv_spec.rb
@@ -1,4 +1,4 @@
-control 'tag:testami_cookbook_virtualenv_created' do
+control 'tag:install_tag:testami_cookbook_virtualenv_created' do
   python_version = node['cluster']['python-version']
   virtualenv_path = node['cluster']['cookbook_virtualenv_path']
   min_pip_version = '19.3'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize_head_node.rb
@@ -14,6 +14,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+return if on_docker?
 
 execute "check if clustermgtd heartbeat is available" do
   command "cat #{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat"

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
@@ -69,4 +69,4 @@ if node['cluster']['node_type'] == "ComputeFleet"
 end
 
 # Configure hostname and DNS
-include_recipe "aws-parallelcluster-slurm::init_dns"
+include_recipe "aws-parallelcluster-slurm::init_dns" unless on_docker?

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
@@ -1,12 +1,12 @@
 [slurm_resume]
-cluster_name = <%= node['cluster']['stack_name'] %>
-region = <%= node['cluster']['region'] %>
-proxy = <%= node['cluster']['proxy'] %>
-dynamodb_table = <%= node['cluster']['slurm_ddb_table'] %>
-hosted_zone = <%= node['cluster']['hosted_zone'] %>
-dns_domain = <%= node['cluster']['dns_domain'] %>
-use_private_hostname = <%= node['cluster']['use_private_hostname'] %>
-head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
-head_node_hostname = <%= node['ec2']['local_hostname'] %>
-clustermgtd_heartbeat_file_path = <%= node['cluster']['slurm']['install_dir'] %>/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat
-instance_id = <%= node['ec2']['instance_id'] %>
+cluster_name = <%= @cluster_name %>
+region = <%= @region %>
+proxy = <%= @proxy %>
+dynamodb_table = <%= @dynamodb_table %>
+hosted_zone = <%= @hosted_zone %>
+dns_domain = <%= @dns_domain %>
+use_private_hostname = <%= @use_private_hostname %>
+head_node_private_ip = <%= @head_node_private_ip %>
+head_node_hostname = <%= @head_node_hostname %>
+clustermgtd_heartbeat_file_path = <%= @clustermgtd_heartbeat_file_path %>
+instance_id = <%= @instance_id %>

--- a/cookbooks/aws-parallelcluster-tests/recipes/tear_down.rb
+++ b/cookbooks/aws-parallelcluster-tests/recipes/tear_down.rb
@@ -1,2 +1,3 @@
 node.default['cluster']['node_virtualenv_path'] = node_virtualenv_path
+node.default['cluster']['cookbook_virtualenv_path'] = cookbook_virtualenv_path
 node_attributes 'Save values for InSpec tests'

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -26,7 +26,8 @@ verifier:
 lifecycle:
   post_verify:
   - local: |
-      [[ ${KITCHEN_SAVE_IMAGE} == 'true' ]] || exit 0
+      echo "KITCHEN_SAVE_IMAGE=${KITCHEN_SAVE_IMAGE}"
+      [ "${KITCHEN_SAVE_IMAGE}" = true ] || exit 0
       docker_id=$(docker ps -a | grep ${KITCHEN_INSTANCE_NAME} | awk '{ print $1 }')
       docker commit ${docker_id} pcluster-${KITCHEN_PHASE}/${KITCHEN_INSTANCE_NAME}:latest
 
@@ -45,21 +46,21 @@ platforms:
       cluster:
         base_os: centos7
         kernel_release: '3.10.0-1160.76.1.el7.x86_64'
-  - name: ubuntu1804
+  - name: ubuntu18
     driver:
       image: <% if ENV['KITCHEN_UBUNTU18_IMAGE'] %> <%= ENV['KITCHEN_UBUNTU18_IMAGE'] %> <% else %> dokken/ubuntu-18.04 <% end %>
     attributes:
       cluster:
         base_os: ubuntu1804
         kernel_release: '5.4.0-1092-aws'
-  - name: ubuntu2004
+  - name: ubuntu20
     driver:
       image: <% if ENV['KITCHEN_UBUNTU20_IMAGE'] %> <%= ENV['KITCHEN_UBUNTU20_IMAGE'] %> <% else %> dokken/ubuntu-20.04 <% end %>
     attributes:
       cluster:
         base_os: ubuntu2004
         kernel_release: '5.15.0-1028-aws'
-  - name: ubuntu2204
+  - name: ubuntu22
     driver:
       image: <% if ENV['KITCHEN_UBUNTU22_IMAGE'] %> <%= ENV['KITCHEN_UBUNTU22_IMAGE'] %> <% else %> dokken/ubuntu-22.04 <% end %>
     attributes:
@@ -68,7 +69,7 @@ platforms:
         kernel_release: '5.15.0-1028-aws'
   - name: rhel8
     driver:
-      image: <% if ENV['KITCHEN_REDHAT8_IMAGE'] %> <%= ENV['KITCHEN_REDHAT8_IMAGE'] %> <% else %> registry.access.redhat.com/ubi8/ubi <% end %>
+      image: <% if ENV['KITCHEN_RHEL8_IMAGE'] %> <%= ENV['KITCHEN_RHEL8_IMAGE'] %> <% else %> registry.access.redhat.com/ubi8/ubi <% end %>
       intermediate_instructions:
         - RUN chmod +t /tmp
     attributes:

--- a/kitchen.fix-inspec-deps.sh
+++ b/kitchen.fix-inspec-deps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "*** Fix relative paths in dependent cookbooks"
+rm -rf /tmp/cookbooks
+mkdir -p /tmp/cookbooks/aws-parallelcluster-common/test
+mkdir -p /tmp/cookbooks/aws-parallelcluster-platform
+mkdir -p /tmp/cookbooks/aws-parallelcluster-environment
+mkdir -p /tmp/cookbooks/aws-parallelcluster-computefleet
+cp -r cookbooks/aws-parallelcluster-common/test/common /tmp/cookbooks/aws-parallelcluster-common/test
+cp -r cookbooks/aws-parallelcluster-platform/test /tmp/cookbooks/aws-parallelcluster-platform
+cp -r cookbooks/aws-parallelcluster-environment/test /tmp/cookbooks/aws-parallelcluster-environment
+cp -r cookbooks/aws-parallelcluster-computefleet/test /tmp/cookbooks/aws-parallelcluster-computefleet
+sed -i.bak "s#path: ../aws-parallelcluster#path: /tmp/cookbooks/aws-parallelcluster#g" /tmp/cookbooks/aws-parallelcluster-*/test/inspec.yml

--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -1,8 +1,18 @@
 # Validates config recipes
 ---
 verifier:
+  inspec_tests:
+    - test/recipes
+    - test/resources
+    - /tmp/cookbooks/aws-parallelcluster-platform/test
+    - /tmp/cookbooks/aws-parallelcluster-environment/test
+    - /tmp/cookbooks/aws-parallelcluster-computefleet/test
   controls:
     - /tag:config/
+
+lifecycle:
+  pre_verify:
+    - local: . ./kitchen.fix-inspec-deps.sh
 
 _common_cluster_attributes: &_common_cluster_attributes
   stack_name: <%= ENV['AWS_STACK_NAME'] || 'fake_stack' %>

--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -63,6 +63,17 @@ suites:
         << : *_head_node_cluster_attributes
         scheduler: 'slurm'
         enable_intel_hpc_platform: "<%= ENV['ENABLE_INTEL_HPC_PLATFORM'] || false %>"
+      chef_client:
+        config:
+          log_level: ":debug"
+
+  - name: slurm-config-head-node-x86-64
+    run_list: *_run_list
+    attributes: &attributes_slurm_config_HeadNode
+      cluster:
+        << : *_head_node_cluster_attributes
+        scheduler: 'slurm'
+        enable_intel_hpc_platform: "<%= ENV['ENABLE_INTEL_HPC_PLATFORM'] || false %>"
 
   - name: slurm_config_HeadNode_arm64
     run_list: *_run_list

--- a/kitchen.validate-install.yml
+++ b/kitchen.validate-install.yml
@@ -3,9 +3,15 @@
 verifier:
   name: inspec
   inspec_tests:
-    # recipe tests will use controls from these directories
     - test/recipes
     - test/resources
+    - /tmp/cookbooks/aws-parallelcluster-platform/test
+    - /tmp/cookbooks/aws-parallelcluster-environment/test
+    - /tmp/cookbooks/aws-parallelcluster-computefleet/test
+
+lifecycle:
+  pre_verify:
+    - local: . ./kitchen.fix-inspec-deps.sh
 
 suites:
   - name: aws_parallelcluster_install

--- a/test/recipes/controls/aws_parallelcluster_config/imds_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/imds_spec.rb
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 control 'tag:config_only_allowed_users_can_access_imds' do
+  only_if { !os_properties.on_docker? }
+
   allowed_users =
     if node['cluster']['node_type'] == 'HeadNode' &&
        node['cluster']['scheduler'] != 'awsbatch' &&

--- a/test/recipes/controls/aws_parallelcluster_config/ssh_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/ssh_spec.rb
@@ -22,6 +22,8 @@ control 'ssh_target_checker_script_created' do
 end
 
 control 'tag:config_ssh_target_checker_contains_correct_vpc_cidr_list' do
+  only_if { !os_properties.on_docker? }
+
   ssh_target_checker_script = '/usr/bin/ssh_target_checker.sh'
 
   vpc_cidr_list = node['ec2']['network_interfaces_macs'][node['ec2']['mac']]['vpc_ipv4_cidr_blocks']

--- a/test/recipes/controls/aws_parallelcluster_config/sudo_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/sudo_spec.rb
@@ -30,6 +30,8 @@ control 'sudo_configured' do
 end
 
 control 'tag:config_cluster_user_can_sudo' do
+  only_if { !os_properties.on_docker? }
+
   if os_properties.debian_family?
     describe node['cluster']['cluster_user'] do
       it { should eq 'ubuntu' }

--- a/test/recipes/controls/aws_parallelcluster_install/gc_thresh_values_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/gc_thresh_values_spec.rb
@@ -26,6 +26,8 @@ control 'gc_thresh_values_configured' do
 end
 
 control 'tag:config_ipv4_gc_thresh_correctly_configured' do
+  only_if { !os_properties.on_docker? }
+
   (1..3).each do |i|
     describe bash("cat /proc/sys/net/ipv4/neigh/default/gc_thresh#{i}") do
       its('stdout.strip') { should cmp node['cluster']['sysctl']['ipv4']["gc_thresh#{i}"] }

--- a/test/recipes/controls/aws_parallelcluster_install/intel_mpi_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/intel_mpi_spec.rb
@@ -23,7 +23,7 @@ control 'tag:config_intel_mpi_installed' do
 end
 
 control 'tag:config_intel_mpi_ptrace_protection_configured_on_ubuntu1804' do
-  only_if { node['conditions']['intel_mpi_supported'] && os_properties.ubuntu1804? }
+  only_if { node['conditions']['intel_mpi_supported'] && os_properties.ubuntu1804? && !os_properties.on_docker? }
 
   ptrace_scope = instance.head_node? ? 1 : 0
   describe 'check ptrace protection enabled' do

--- a/test/recipes/controls/aws_parallelcluster_install/supervisord_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/supervisord_spec.rb
@@ -34,6 +34,8 @@ control 'supervisord_service_set_up' do
 end
 
 control 'tag:config_supervisord_runs_as_root' do
+  only_if { !os_properties.on_docker? }
+
   describe processes('supervisord') do
     its('count') { should eq 1 }
     its('users') { should eq ['root'] }

--- a/test/recipes/controls/aws_parallelcluster_slurm/slurm_config_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/slurm_config_spec.rb
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 control 'tag:config_slurm_correctly_installed_on_head_node' do
-  only_if { instance.head_node? && node['cluster']['scheduler'] == 'slurm' }
+  only_if { instance.head_node? && node['cluster']['scheduler'] == 'slurm' && !os_properties.on_docker? }
 
   describe service('slurmctld') do
     it { should be_installed }

--- a/test/recipes/controls/aws_parallelcluster_slurm/slurm_processes_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/slurm_processes_spec.rb
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 control 'tag:config_clustermgtd_runs_as_cluster_admin_user' do
-  only_if { instance.head_node? && node['cluster']['scheduler'] == 'slurm' }
+  only_if { instance.head_node? && node['cluster']['scheduler'] == 'slurm' && !os_properties.on_docker? }
 
   describe processes('clustermgtd') do
     its('count') { should eq 1 }

--- a/test/recipes/controls/aws_parallelcluster_slurm/slurm_users_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/slurm_users_spec.rb
@@ -37,7 +37,7 @@ control 'tag:config_slurm_user_and_group_correctly_defined' do
 end
 
 control 'tag:config_munge_user_and_group_correctly_defined' do
-  only_if { node['cluster']['scheduler'] == 'slurm' }
+  only_if { node['cluster']['scheduler'] == 'slurm' && !os_properties.on_docker? }
 
   describe user(node['cluster']['munge']['user']) do
     it { should exist }
@@ -58,6 +58,7 @@ control 'tag:config_slurm_sudoers_correctly_defined' do
 
   install_dir = node['cluster']['slurm']['install_dir']
   venv_bin = "#{node['cluster']['node_virtualenv_path']}/bin"
+  redhat_ubi = os_properties.redhat_ubi?
 
   describe file("/etc/sudoers.d/99-parallelcluster-slurm") do
     it { should exist }
@@ -69,6 +70,6 @@ control 'tag:config_slurm_sudoers_correctly_defined' do
     its('content') { should match /#{node['cluster']['cluster_admin_user']} ALL = \(root\) NOPASSWD: SHUTDOWN/ }
     its('content') { should match %r{Cmnd_Alias SHUTDOWN = /usr/sbin/shutdown} }
     its('content') { should match /#{node['cluster']['slurm']['user']} ALL = \(#{node['cluster']['cluster_admin_user']}\) NOPASSWD: SLURM_HOOKS_COMMANDS/ }
-    its('content') { should match %r{Cmnd_Alias SLURM_HOOKS_COMMANDS = #{venv_bin}/slurm_suspend, #{venv_bin}/slurm_resume, #{venv_bin}/slurm_fleet_status_manager} }
+    its('content') { should match %r{Cmnd_Alias SLURM_HOOKS_COMMANDS = #{venv_bin}/slurm_suspend, #{venv_bin}/slurm_resume, #{venv_bin}/slurm_fleet_status_manager} } unless redhat_ubi
   end
 end

--- a/test/resources/controls/aws_parallelcluster_config/dcv_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_config/dcv_spec.rb
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 control 'tag:config_dcv_external_authenticator_user_and_group_correctly_defined' do
-  only_if { node['conditions']['dcv_supported'] }
+  only_if { node['conditions']['dcv_supported'] && !os_properties.redhat_ubi? }
 
   describe user(node['cluster']['dcv']['authenticator']['user']) do
     it { should exist }
@@ -39,7 +39,8 @@ end
 
 control 'tag:config_dcv_correctly_installed' do
   only_if do
-    instance.head_node? && node['conditions']['dcv_supported'] && ['yes', true].include?(node['cluster']['dcv']['installed'])
+    instance.head_node? && node['conditions']['dcv_supported'] &&
+      ['yes', true].include?(node['cluster']['dcv']['installed']) && !os_properties.redhat_ubi?
   end
 
   describe bash("sudo -u #{node['cluster']['cluster_user']} dcv version") do
@@ -63,7 +64,8 @@ end
 
 control 'tag:config_dcv_services_correctly_configured' do
   only_if do
-    instance.head_node? && node['conditions']['dcv_supported'] && node['cluster']['dcv_enabled'] == "head_node"
+    instance.head_node? && node['conditions']['dcv_supported'] && node['cluster']['dcv_enabled'] == "head_node" &&
+      !os_properties.on_docker?
   end
 
   describe file('/etc/dcv/dcv.conf') do

--- a/test/resources/controls/aws_parallelcluster_config/nfs_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_config/nfs_spec.rb
@@ -30,7 +30,7 @@ control 'nfs_configured' do
 end
 
 control 'tag:config_nfs_correctly_installed_on_head_node' do
-  only_if { instance.head_node? }
+  only_if { instance.head_node? && !os_properties.on_docker? }
 
   describe 'check for nfs server protocol' do
     subject { command "sudo -u #{node['cluster']['cluster_user']} rpcinfo -p localhost | awk '{print $2$5}' | grep 4nfs" }
@@ -39,7 +39,7 @@ control 'tag:config_nfs_correctly_installed_on_head_node' do
 end
 
 control 'tag:config_nfs_correctly_installed_on_compute_node' do
-  only_if { instance.compute_node? }
+  only_if { instance.compute_node? && !os_properties.on_docker? }
 
   describe 'check for nfs server protocol' do
     subject { command "sudo -u #{node['cluster']['cluster_user']} nfsstat -m | grep vers=4" }
@@ -48,6 +48,8 @@ control 'tag:config_nfs_correctly_installed_on_compute_node' do
 end
 
 control 'tag:config_nfs_has_correct_number_of_threads' do
+  only_if { !os_properties.on_docker? }
+
   describe bash("cat /proc/net/rpc/nfsd | grep th | awk '{print$2}'") do
     its('stdout') { should cmp node['cluster']['nfs']['threads'] }
   end

--- a/test/resources/controls/aws_parallelcluster_install/c_states_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/c_states_spec.rb
@@ -36,7 +36,7 @@ control 'c_states_kernel_configured' do
 end
 
 control 'tag:config_c_states_disabled' do
-  only_if { os_properties.x86? }
+  only_if { os_properties.x86? && !os_properties.on_docker? }
 
   describe bash("cat /sys/module/intel_idle/parameters/max_cstate") do
     its('stdout') { should cmp 1 }


### PR DESCRIPTION
### Description of changes
* [Add cookbook_virtualenv_path to the tear down to be able to use it in…](https://github.com/aws/aws-parallelcluster-cookbook/commit/df7f5bad2ea660f1306d29a8cbf9355ee3a5d998) 
 * [Handle Kitchen dependencies](https://github.com/aws/aws-parallelcluster-cookbook/commit/d5da296ef6b42cf1892c8b9ffac234fa3b9ca097) 
* [Add tag:install to the controls that validate the image](https://github.com/aws/aws-parallelcluster-cookbook/commit/3b8370c2629891816c4a8d3a0c3346e3e75235e0)
* [Enable Dokken system tests and disable the redundant ones](https://github.com/aws/aws-parallelcluster-cookbook/commit/b62c6797d6b73ed00c659b6fa1bac04f0c2abc2b)
* [Exclude code from running on Docker](https://github.com/aws/aws-parallelcluster-cookbook/commit/9a3c044c219ae57a9bac9f331f0cd5fc43c0314c)

### Tests
* Tested on GitHub

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.