### PR TITLE
Add ubuntu2204? method, add ubuntu2204 to the sticky bits resource test, add the comment to include a custom ubuntu22 image

### DIFF
--- a/cookbooks/aws-parallelcluster-common/test/common/libraries/os_properties.rb
+++ b/cookbooks/aws-parallelcluster-common/test/common/libraries/os_properties.rb
@@ -55,6 +55,10 @@ class OsProperties < Inspec.resource(1)
     inspec.os.name == 'ubuntu' && inspec.os.release == '20.04'
   end
 
+  def ubuntu2204?
+    inspec.os.name == 'ubuntu' && inspec.os.release == '22.04'
+  end
+
   def debian_family?
     inspec.os.family == 'debian'
   end

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -65,7 +65,7 @@ platforms:
       image: <% if ENV['KITCHEN_UBUNTU22_IMAGE'] %> <%= ENV['KITCHEN_UBUNTU22_IMAGE'] %> <% else %> dokken/ubuntu-22.04 <% end %>
     attributes:
       cluster:
-        base_os: ubuntu2004
+        base_os: ubuntu2204
         kernel_release: '5.15.0-1028-aws'
   - name: rhel8
     driver:

--- a/kitchen.ec2.sh
+++ b/kitchen.ec2.sh
@@ -44,6 +44,9 @@
 # KITCHEN_UBUNTU20_AMI:       specific AMI to use for ubuntu20.04
 #                             if not specified, will look for the latest suitable ParallelCluster AMI
 #
+# KITCHEN_UBUNTU22_AMI:       specific AMI to use for ubuntu22.04
+#                             if not specified, will look for the latest suitable ParallelCluster AMI
+#
 
 source kitchen.local-yml.sh
 

--- a/test/resources/controls/aws_parallelcluster_config/sticky_bits_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_config/sticky_bits_spec.rb
@@ -1,7 +1,7 @@
 control 'sticky_bits_configured' do
   title 'Check sticky bits configuration'
 
-  if os_properties.ubuntu2004? && !os_properties.virtualized?
+  if (os_properties.ubuntu2004? || os_properties.ubuntu2204?) && !os_properties.virtualized?
     # This test passes on Mac but doesn't work as GitHub action.
     describe kernel_parameter('fs.protected_regular') do
       its('value') { should eq 0 }


### PR DESCRIPTION
The pattern of OS specific checks needs to include one for the latest ubuntu we are planning to support, as it is being used in the sticky bits resource and likely other resources and recipes to follow.  The comment to include a new KITCHEN_UBUNTU22_AMI also follows the pattern for the existing operating systems

### Tests
* Ran kitchen test for sticky bits on ub2204

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.