### PR TITLE
Add recipe: qualifier to aws-parallelcluster-platform::cookbook_virtualenv dependency

### DIFF
--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -305,7 +305,7 @@ suites:
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-platform::directories
-        - aws-parallelcluster-platform::cookbook_virtualenv
+        - recipe:aws-parallelcluster-platform::cookbook_virtualenv
       cluster:
         config:
           Scheduling:
@@ -324,7 +324,7 @@ suites:
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-platform::directories
-        - aws-parallelcluster-platform::cookbook_virtualenv
+        - recipe:aws-parallelcluster-platform::cookbook_virtualenv
       cluster:
         config:
           Scheduling:

--- a/kitchen.recipes-install.yml
+++ b/kitchen.recipes-install.yml
@@ -156,7 +156,7 @@ suites:
         - resource:package_repos
         - resource:install_packages
         - resource:mysql_client
-        - aws-parallelcluster-platform::cookbook_virtualenv
+        - recipe:aws-parallelcluster-platform::cookbook_virtualenv
         - recipe:aws-parallelcluster-slurm::install_jwt
         - recipe:aws-parallelcluster-slurm::install_pmix
         - resource:munge

--- a/kitchen.resources-config.yml
+++ b/kitchen.resources-config.yml
@@ -99,7 +99,7 @@ suites:
       dependencies:
         - recipe:aws-parallelcluster-test::docker_mock
         - recipe:aws-parallelcluster-platform::directories
-        - aws-parallelcluster-platform::cookbook_virtualenv
+        - recipe:aws-parallelcluster-platform::cookbook_virtualenv
         - resource:cloudwatch:setup
         - resource:node_attributes
       cluster:
@@ -120,7 +120,7 @@ suites:
       dependencies:
         - recipe:aws-parallelcluster-test::docker_mock
         - recipe:aws-parallelcluster-platform::directories
-        - aws-parallelcluster-platform::cookbook_virtualenv
+        - recipe:aws-parallelcluster-platform::cookbook_virtualenv
         - resource:package_repos
         - resource:install_packages
         - recipe:aws-parallelcluster-install::nvidia


### PR DESCRIPTION
### Description of changes
Add `recipe:` qualifier to `aws-parallelcluster-platform::cookbook_virtualenv` dependency.

### References
* [Link to related PRs in other packages (i.e. cookbook, node).](https://github.com/aws/aws-parallelcluster-cookbook/commit/ad1c88d7e1f748bdc339e4f802cda67cfee6fd72#r113104176)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.