### PR TITLE
remove missing package from deps for pyenv in ubuntu 22

### DIFF
--- a/third-party/pyenv-3.5.1/attributes/default.rb
+++ b/third-party/pyenv-3.5.1/attributes/default.rb
@@ -4,7 +4,11 @@ default['pyenv']['git_ref'] = 'master'
 
 default['pyenv']['prerequisites'] = case node['platform_family']
                                     when 'debian'
-                                      %w(make libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git)
+                                      if node['platform_version'].to_i >= 22
+                                        %w(make libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev git)
+                                      else
+                                        %w(make libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git)
+                                      end
                                     when 'rhel', 'fedora', 'amazon' # oracle, centos, amazon, fedora
                                       %w(git zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel xz xz-devel libffi-devel findutils)
                                     when 'suse'


### PR DESCRIPTION
python-openssl is removed in ubuntu2204.  It is also not listed as a requirement for pyenv.


### Description of changes
* remove the missing package `python-openssl` from deps for pyenv on ubuntu 22.  It does not exist

### Tests
* Ran kitchen tests for Ubuntu 18-22 to verify the cookbook env builds
* cloudwatch-config-ubuntu*

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.