### PR TITLE
Refactor nvidia fabric manager and gdrcopy out of nvidia spec.  Add lustre spec to global config.

### DIFF
--- a/kitchen.recipes-install.yml
+++ b/kitchen.recipes-install.yml
@@ -179,7 +179,9 @@ suites:
       - recipe[aws-parallelcluster-install::nvidia]
     verifier:
       controls:
-        - /tag:install_.*nvidia/
+        - /tag:install_expected_versions_of_nvidia_driver_installed/
+        - /tag:install_expected_versions_of_nvidia_cuda_installed/
+        - /tag:install_expected_nvidia_datacenter-gpu-manager_installed/
     driver:
       # nvidia_driver can be executed only on a graphic EC2 instance example: g5.xlarge(x86_86) or g5g.xlarge(aarm64)
       instance_type: g4dn.2xlarge

--- a/kitchen.resources-install.yml
+++ b/kitchen.resources-install.yml
@@ -245,4 +245,54 @@ suites:
         is_official_ami_build: true
     driver:
       instance_type: t3.medium
-
+  - name: nvidia_fabric_manager
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-install::nvidia]
+    verifier:
+      controls:
+        - /tag:install_expected_versions_of_nvidia_fabric_manager_installed/
+    driver:
+      # nvidia_driver can be executed only on a graphic EC2 instance example: g5.xlarge(x86_86) or g5g.xlarge(aarm64)
+      instance_type: g4dn.2xlarge
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-platform::directories
+        - resource:package_repos
+        - resource:install_packages
+        - resource:node_attributes
+      cluster:
+        nvidia:
+          enabled: true
+  - name: nvidia_gdrcopy
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-install::nvidia]
+    verifier:
+      controls:
+        - /tag:install_expected_versions_of_nvidia_gdrcopy_installed/
+    driver:
+      # nvidia_driver can be executed only on a graphic EC2 instance example: g5.xlarge(x86_86) or g5g.xlarge(aarm64)
+      instance_type: g4dn.2xlarge
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-platform::directories
+        - resource:package_repos
+        - resource:install_packages
+        - resource:node_attributes
+      cluster:
+        nvidia:
+          enabled: true
+  - name: lustre
+    run_list:
+      - recipe[aws-parallelcluster-common::add_dependencies]
+      - recipe[aws-parallelcluster-common::test_resource]
+    verifier:
+      controls:
+        - lustre_client_installed
+        - lnet_kernel_module_enabled
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-test::docker_mock
+        - resource:package_repos
+      resource: lustre

--- a/test/resources/controls/aws_parallelcluster_install/fabric_manager_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/fabric_manager_spec.rb
@@ -1,0 +1,27 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'tag:install_expected_versions_of_nvidia_fabric_manager_installed' do
+  only_if do
+    !(os_properties.centos7? && os_properties.arm?) && !os_properties.arm? && !instance.custom_ami? &&
+      (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
+  end
+
+  describe package(node['cluster']['nvidia']['fabricmanager']['package']) do
+    it { should be_installed }
+    its('version') { should match /#{node['cluster']['nvidia']['fabricmanager']['version']}/ }
+  end
+
+  version_lock_check = os_properties.debian_family? ? 'apt-mark showhold | grep "nvidia-fabric.*manager"' : 'yum versionlock list | grep "nvidia-fabric.*manager"'
+  describe bash(version_lock_check) do
+    its('exit_status') { should eq 0 }
+  end
+end

--- a/test/resources/controls/aws_parallelcluster_install/gdrcopy_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/gdrcopy_spec.rb
@@ -1,0 +1,24 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'tag:install_expected_versions_of_nvidia_gdrcopy_installed' do
+  only_if do
+    !(os_properties.centos7? && os_properties.arm?) && !instance.custom_ami? &&
+      (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
+  end
+
+  expected_gdrcopy_version = node['cluster']['nvidia']['gdrcopy']['version']
+
+  describe "gdrcopy version is expected to be #{expected_gdrcopy_version}" do
+    subject { command('modinfo -F version gdrdrv').stdout.strip() }
+    it { should eq expected_gdrcopy_version }
+  end
+end

--- a/test/resources/controls/aws_parallelcluster_install/lustre_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/lustre_spec.rb
@@ -1,0 +1,69 @@
+control 'lustre_client_installed' do
+  title "Verify that lustre client is installed"
+  minimal_lustre_client_version = '2.12'
+  if (os_properties.centos? && inspec.os.release.to_f >= 7.5) || os_properties.redhat?
+    describe package('kmod-lustre-client') do
+      it { should be_installed }
+    end
+
+    describe package('lustre-client') do
+      it { should be_installed }
+    end
+
+    if (os_properties.centos? && inspec.os.release.to_f >= 7.7) || os_properties.redhat?
+      describe package('kmod-lustre-client') do
+        its('version') { should cmp >= minimal_lustre_client_version }
+      end
+
+      describe package('lustre-client') do
+        its('version') { should cmp >= minimal_lustre_client_version }
+      end
+
+      describe yum.repo('aws-fsx') do
+        it { should exist }
+        it { should be_enabled }
+        its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
+      end
+    end
+  end
+
+  if os_properties.debian_family?
+    describe apt('https://fsx-lustre-client-repo.s3.amazonaws.com/ubuntu') do
+      it { should exist }
+      it { should be_enabled }
+    end
+
+    describe package('lustre-client-modules-aws') do
+      it { should be_installed }
+      its('version') { should cmp >= minimal_lustre_client_version }
+    end
+
+    kernel_release = os_properties.ubuntu2004? ? '5.15.0-1028-aws' : '5.4.0-1092-aws'
+    describe package("lustre-client-modules-#{kernel_release}") do
+      it { should be_installed }
+      its('version') { should cmp >= minimal_lustre_client_version }
+    end
+  end
+
+  if os_properties.alinux2?
+    describe package('lustre-client') do
+      it { should be_installed }
+      its('version') { should cmp >= minimal_lustre_client_version }
+    end
+
+    describe yum.repo('amzn2extra-lustre') do
+      it { should exist }
+      it { should be_enabled }
+    end
+  end
+end
+
+control 'lnet_kernel_module_enabled' do
+  title "Verify that lnet kernel module is enabled"
+  only_if { !os_properties.virtualized? && !os_properties.alinux2? }
+  describe kernel_module("lnet") do
+    it { should be_loaded }
+    it { should_not be_disabled }
+    it { should_not be_blacklisted }
+  end
+end

--- a/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/nvidia_spec.rb
@@ -42,37 +42,6 @@ control 'tag:install_expected_versions_of_nvidia_cuda_installed' do
   end
 end
 
-control 'tag:install_expected_versions_of_nvidia_fabric_manager_installed' do
-  only_if do
-    !(os_properties.centos7? && os_properties.arm?) && !os_properties.arm? && !instance.custom_ami? &&
-      (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
-  end
-
-  describe package(node['cluster']['nvidia']['fabricmanager']['package']) do
-    it { should be_installed }
-    its('version') { should match /#{node['cluster']['nvidia']['fabricmanager']['version']}/ }
-  end
-
-  version_lock_check = os_properties.debian_family? ? 'apt-mark showhold | grep "nvidia-fabric.*manager"' : 'yum versionlock list | grep "nvidia-fabric.*manager"'
-  describe bash(version_lock_check) do
-    its('exit_status') { should eq 0 }
-  end
-end
-
-control 'tag:install_expected_versions_of_nvidia_gdrcopy_installed' do
-  only_if do
-    !(os_properties.centos7? && os_properties.arm?) && !instance.custom_ami? &&
-      (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
-  end
-
-  expected_gdrcopy_version = node['cluster']['nvidia']['gdrcopy']['version']
-
-  describe "gdrcopy version is expected to be #{expected_gdrcopy_version}" do
-    subject { command('modinfo -F version gdrdrv').stdout.strip() }
-    it { should eq expected_gdrcopy_version }
-  end
-end
-
 control 'tag:install_expected_nvidia_datacenter-gpu-manager_installed' do
   only_if do
     !(os_properties.centos7? && os_properties.arm?) && !(os_properties.alinux2? && os_properties.arm?) && !instance.custom_ami? &&


### PR DESCRIPTION

The nvidia spec covered too much code and did too many things.  This refactoring splits out the fabric manager and gdrcopy components into their own specs for testing.  The lustre spec was not being used from the common cookbook by the testing framework so moved the spec up to the global resources-install config file

A slight coupling of components here.  Can be split into two separate PRs if necessary

### Tests
* Ran kitchen tests for fabric manager, gdrcopy and lustre

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.