### PR TITLE
[release-3.6] Fix EFA installation on RHEL8

### DIFF
--- a/cookbooks/aws-parallelcluster-common/resources/efa/efa_alinux2.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/efa_alinux2.rb
@@ -27,3 +27,9 @@ action_class do
     %w(openmpi-devel openmpi)
   end
 end
+
+action_class do
+  def prerequisites
+    %w(environment-modules libibverbs-utils librdmacm-utils)
+  end
+end

--- a/cookbooks/aws-parallelcluster-common/resources/efa/efa_centos7.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/efa_centos7.rb
@@ -30,3 +30,9 @@ action_class do
     %w(openmpi-devel openmpi)
   end
 end
+
+action_class do
+  def prerequisites
+    %w(environment-modules)
+  end
+end

--- a/cookbooks/aws-parallelcluster-common/resources/efa/efa_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/efa_redhat8.rb
@@ -40,3 +40,13 @@ action_class do
     %w(openmpi-devel openmpi)
   end
 end
+
+action_class do
+  def prerequisites
+    if redhat_ubi?
+      %w(environment-modules)
+    else
+      %w(environment-modules libibverbs-utils librdmacm-utils rdma-core-devel)
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-common/resources/efa/efa_ubuntu1804.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/efa_ubuntu1804.rb
@@ -28,3 +28,9 @@ action_class do
     %w(libopenmpi-dev)
   end
 end
+
+action_class do
+  def prerequisites
+    %w(environment-modules)
+  end
+end

--- a/cookbooks/aws-parallelcluster-common/resources/efa/efa_ubuntu2004.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/efa_ubuntu2004.rb
@@ -28,3 +28,9 @@ action_class do
     %w(libopenmpi-dev)
   end
 end
+
+action_class do
+  def prerequisites
+    %w(environment-modules)
+  end
+end

--- a/cookbooks/aws-parallelcluster-common/resources/efa/partial/_setup.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/partial/_setup.rb
@@ -42,7 +42,7 @@ action :setup do
     package_repos 'update package repos' do
       action :update
     end
-    package %w(environment-modules) do
+    package prerequisites do
       retries 3
       retry_delay 5
     end

--- a/cookbooks/aws-parallelcluster-common/spec/unit/resources/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/unit/resources/efa_spec.rb
@@ -46,6 +46,14 @@ describe 'efa:setup' do
         end
       end
 
+      prerequisites = if platform == 'redhat'
+                        %w(environment-modules libibverbs-utils librdmacm-utils rdma-core-devel)
+                      elsif platform == 'amazon'
+                        %w(environment-modules libibverbs-utils librdmacm-utils)
+                      else
+                        "environment-modules"
+                      end
+
       context 'when efa installed' do
         before do
           mock_efa_installed(true)
@@ -75,7 +83,7 @@ describe 'efa:setup' do
             is_expected.not_to write_log('efa installed')
             is_expected.not_to remove_package(%w(openmpi-devel openmpi))
             is_expected.to update_package_repos('update package repos')
-            is_expected.to install_package("environment-modules")
+            is_expected.to install_package(prerequisites)
             is_expected.to create_if_missing_remote_file("#{source_dir}/aws-efa-installer.tar.gz")
             is_expected.not_to run_bash('install efa')
           end
@@ -97,7 +105,7 @@ describe 'efa:setup' do
             is_expected.not_to write_log('efa installed')
             is_expected.to remove_package(platform == 'ubuntu' ? ['libopenmpi-dev'] : %w(openmpi-devel openmpi))
             is_expected.to update_package_repos('update package repos')
-            is_expected.to install_package("environment-modules")
+            is_expected.to install_package(prerequisites)
             is_expected.to create_if_missing_remote_file("#{source_dir}/aws-efa-installer.tar.gz")
               .with(source: "https://efa-installer.amazonaws.com/aws-efa-installer-#{efa_version}.tar.gz")
               .with(mode: '0644')
@@ -124,7 +132,7 @@ describe 'efa:setup' do
           it 'installs EFA skipping kmod' do
             is_expected.to remove_package(platform == 'ubuntu' ? ['libopenmpi-dev'] : %w(openmpi-devel openmpi))
             is_expected.to update_package_repos('update package repos')
-            is_expected.to install_package("environment-modules")
+            is_expected.to install_package(prerequisites)
             is_expected.to create_if_missing_remote_file("#{source_dir}/aws-efa-installer.tar.gz")
               .with(source: "https://efa-installer.amazonaws.com/aws-efa-installer-#{efa_version}.tar.gz")
               .with(mode: '0644')

--- a/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default_amazon2.rb
@@ -12,8 +12,8 @@ default['cluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-
                                          libxml2-devel perl-devel tar gzip bison flex gcc gcc-c++ patch
                                          rpm-build rpm-sign system-rpm-config cscope ctags diffstat doxygen elfutils
                                          gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl
-                                         jq wget python-pip NetworkManager-config-routing-rules libibverbs-utils
-                                         librdmacm-utils python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
+                                         jq wget python-pip NetworkManager-config-routing-rules
+                                         python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
                                          coreutils moreutils environment-modules bzip2)
 
 # Install R via amazon linux extras

--- a/test/resources/controls/aws_parallelcluster_install/efa_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_install/efa_spec.rb
@@ -32,7 +32,13 @@ end
 control 'efa_prereq_packages_installed' do
   title "EFA prereq packages are installed"
 
-  efa_prereq_packages = %w(environment-modules)
+  efa_prereq_packages = if os_properties.redhat8? && !os_properties.redhat_ubi?
+                          %w(environment-modules libibverbs-utils librdmacm-utils rdma-core-devel)
+                        elsif os_properties.alinux2?
+                          %w(environment-modules libibverbs-utils librdmacm-utils)
+                        else
+                          %w(environment-modules)
+                        end
   efa_prereq_packages.each do |pkg|
     describe package(pkg) do
       it { should be_installed }


### PR DESCRIPTION
### Description of changes

Fix EFA installation on RHEL8

There is a conflicts between `libibverbs` and `librdmacm` packages provided by EFA bundle and
same packages coming from OS repository.

`libibverbs` and `librdmacm` are installed as dependencies of the `hwloc-devel` and `iptables` package by our recipes (latest available version)
EFA installer is installing `libibverbs`, `librdmacm`, `libibverbs-utils`, `librdmacm-utils` and `rdma-core-devel` version 43, included in the bundle.

If the system already has `libibverbs` or `librdmacm` installed EFA installer will skip them
but will install the `*-utils` packages causing a misalignment on the version.

Error message from the EFA installer is:
```
- nothing provides libibverbs(x86-64) = 43.0-1.el8 needed by libibverbs-utils-43.0-1.el8.x86_64
- nothing provides librdmacm(x86-64) = 43.0-1.el8 needed by librdmacm-utils-43.0-1.el8.x86_64
- nothing provides libibverbs(x86-64) = 43.0-1.el8 needed by rdma-core-devel-43.0-1.el8.x86_64
- nothing provides librdmacm(x86-64) = 43.0-1.el8 needed by rdma-core-devel-43.0-1.el8.x86_64
```

With this patch we're explicitly installing `*-utils` and `rdma-core-devel` packages from the OS to avoid the conflict at EFA installation time.
EFA will skip installation of all of them and there are no issues.

With this patch I'm also moving the two packages from `default_amazon2.rb` to `efa_alinxu2` to clarify they are required for EFA.

Note that:
`hwloc-devel` is required for Slurm
`iptables` is required for IMDS configuration

### Tests
* Tested installation of EFA after installing `libibverbs` or `librdmacm` --> KO (before the patch, to confirm the issue)
* Tested installation of EFA after installing also the two `-utils` packages --> OK
* Launched kitchen tests on EC2 for all the OSes `bash kitchen.ec2.sh resources-install test efa-setup -c 5`
```
  ✔  efa_conflicting_packages_removed: Check packages conflicting with EFA are not installed
     ✔  System Package openmpi-devel is expected not to be installed
     ✔  System Package openmpi is expected not to be installed
  ✔  efa_prereq_packages_installed: EFA prereq packages are installed
     ✔  System Package environment-modules is expected to be installed
     ✔  System Package libibverbs-utils is expected to be installed
     ✔  System Package librdmacm-utils is expected to be installed
     ✔  System Package rdma-core-devel is expected to be installed
```

### References
* Same fix for Alinux2: https://github.com/aws/aws-parallelcluster-cookbook/commit/04fb07b01389e685ff261911a0f37290bc11e9de
* Slurm documentation mentioning hwloc: https://slurm.schedmd.com/quickstart_admin.html

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

