### PR TITLE
Use tag:config_chrony controls on the config path

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
@@ -11,7 +11,7 @@ suites:
       - recipe[aws-parallelcluster-tests::test_resource]
     verifier:
       controls:
-        - /tag:install_chrony/
+        - /tag:config_chrony/
     attributes:
       resource: chrony:enable
       dependencies:

--- a/cookbooks/aws-parallelcluster-platform/test/controls/chrony_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/chrony_spec.rb
@@ -48,9 +48,9 @@ end
 control 'tag:config_chrony_service_configured' do
   title 'Check that chrony is correctly configured'
 
-  only_if { !os_properties.virtualized? }
+  only_if { !os_properties.on_docker? }
 
-  chrony_service = node['cluster']['chrony']['service']
+  chrony_service = os_properties.ubuntu? ? 'chrony' : 'chronyd'
 
   describe service(chrony_service) do
     it { should be_installed }


### PR DESCRIPTION
### Description of changes
Use tag:config_chrony controls on the config path

### Tests
* `./kitchen.ec2.sh platform-config verify chrony -c 6`
* `./kitchen.docker.sh platform-config verify chrony -c 6`

### References
* Follow-up of https://github.com/aws/aws-parallelcluster-cookbook/pull/2161#discussion_r1197505141

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.