### PR TITLE
Move intel_mpi to platform cookbook

### DIFF
--- a/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
@@ -4,9 +4,6 @@ return unless platform?('amazon') && node['platform_version'] == "2"
 
 # Modulefile Directory
 default['cluster']['modulefile_dir'] = "/usr/share/Modules/modulefiles"
-# MODULESHOME
-default['cluster']['moduleshome'] = "/usr/share/Modules"
-default['cluster']['modulepath_config_file'] = "#{node['cluster']['moduleshome']}/init/.modulespath"
 
 # NVIDIA
 # NVIDIA GDRCopy

--- a/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
@@ -4,9 +4,6 @@ return unless platform?('centos') && node['platform_version'].to_i == 7
 
 # Modulefile Directory
 default['cluster']['modulefile_dir'] = "/usr/share/Modules/modulefiles"
-# MODULESHOME
-default['cluster']['moduleshome'] = "/usr/share/Modules"
-default['cluster']['modulepath_config_file'] = "#{node['cluster']['moduleshome']}/init/.modulespath"
 
 # NVIDIA
 # NVIDIA GDRCopy

--- a/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
@@ -4,10 +4,6 @@ return unless platform?('redhat') && node['platform_version'].to_i == 8
 
 # Modulefile Directory
 default['cluster']['modulefile_dir'] = "/usr/share/Modules/modulefiles"
-# MODULESHOME
-default['cluster']['moduleshome'] = "/usr/share/Modules"
-default['cluster']['modulesconfig'] = "/etc/environment-modules"
-default['cluster']['modulepath_config_file'] = "#{node['cluster']['modulesconfig']}/modulespath"
 
 # NVIDIA
 # NVIDIA GDRCopy

--- a/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu.rb
@@ -4,10 +4,6 @@ return unless platform?('ubuntu')
 
 # Modulefile Directory
 default['cluster']['modulefile_dir'] = "/usr/share/modules/modulefiles"
-# MODULESHOME
-default['cluster']['moduleshome'] = "/usr/share/modules"
-# Config file used to set default MODULEPATH list
-default['cluster']['modulepath_config_file'] = "#{node['cluster']['moduleshome']}/init/.modulespath"
 
 # NVIDIA
 # NVIDIA GDRCopy

--- a/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
@@ -27,13 +27,6 @@ def x86?
   node['kernel']['machine'] == 'x86_64'
 end
 
-#
-# Check if this is an ARM instance
-#
-def arm_instance?
-  node['kernel']['machine'] == 'aarch64'
-end
-
 def get_metadata_token
   # generate the token for retrieving IMDSv2 metadata
   token_uri = URI("http://169.254.169.254/latest/api/token")

--- a/cookbooks/aws-parallelcluster-install/attributes/default.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default.rb
@@ -1,12 +1,5 @@
 # aws-parallelcluster-install attributes
 
-# Intel MPI
-default['conditions']['intel_mpi_supported'] = !arm_instance?
-default['cluster']['intelmpi']['version'] = '2021.9.0'
-default['cluster']['intelmpi']['full_version'] = "#{node['cluster']['intelmpi']['version']}.43482"
-default['cluster']['intelmpi']['modulefile'] = "/opt/intel/mpi/#{node['cluster']['intelmpi']['version']}/modulefiles/mpi"
-default['cluster']['intelmpi']['qt_version'] = '6.4.2'
-
 # stunnel
 default['cluster']['stunnel']['version'] = '5.67'
 default['cluster']['stunnel']['url'] = lazy { "#{node['cluster']['artifacts_s3_url']}/stunnel/stunnel-#{node['cluster']['stunnel']['version']}.tar.gz" }

--- a/cookbooks/aws-parallelcluster-install/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-install/recipes/install.rb
@@ -25,7 +25,7 @@ include_recipe 'aws-parallelcluster-install::base'
 
 # == PLATFORM - FEATURES
 include_recipe "aws-parallelcluster-install::nvidia"
-include_recipe "aws-parallelcluster-install::intel_mpi"
+include_recipe "aws-parallelcluster-platform::intel_mpi"
 cloudwatch 'Install amazon-cloudwatch-agent'
 arm_pl 'Install ARM Performance Library'
 include_recipe "aws-parallelcluster-install::intel_hpc" # Intel HPC libraries

--- a/cookbooks/aws-parallelcluster-install/templates/default/intel_mpi/qt_source_code.erb
+++ b/cookbooks/aws-parallelcluster-install/templates/default/intel_mpi/qt_source_code.erb
@@ -1,3 +1,0 @@
-You can get Qt source code here:
-
-https://<%= node['cluster']['region'] %>-aws-parallelcluster.s3.<%= node['cluster']['region'] %>.<%= node['cluster']['aws_domain'] %>/archives/impi/qt-src-<%= node['cluster']['intelmpi']['qt_version'] %>-linux.src.tgz

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
@@ -113,3 +113,13 @@ suites:
         - modules_installed
     attributes:
       resource: modules
+  - name: intel_mpi
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-platform::intel_mpi]
+    verifier:
+      controls:
+        - /tag:install_.*intel_mpi/
+    attributes:
+      cluster:
+        node_type: 'HeadNode'

--- a/cookbooks/aws-parallelcluster-platform/resources/modules/modules_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/modules/modules_amazon2.rb
@@ -14,6 +14,7 @@
 
 provides :modules, platform: 'amazon', platform_version: '2'
 
+use 'partial/_modules_common.rb'
 use 'partial/_modules_yum.rb'
 
 action_class do

--- a/cookbooks/aws-parallelcluster-platform/resources/modules/modules_centos7.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/modules/modules_centos7.rb
@@ -16,6 +16,7 @@ provides :modules, platform: 'centos' do |node|
   node['platform_version'].to_i == 7
 end
 
+use 'partial/_modules_common.rb'
 use 'partial/_modules_yum.rb'
 
 action_class do

--- a/cookbooks/aws-parallelcluster-platform/resources/modules/modules_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/modules/modules_redhat8.rb
@@ -16,10 +16,15 @@ provides :modules, platform: 'redhat' do |node|
   node['platform_version'].to_i == 8
 end
 
+use 'partial/_modules_common.rb'
 use 'partial/_modules_yum.rb'
 
 action_class do
   def packages
     %w(environment-modules)
+  end
+
+  def modulepath_config_file
+    '/etc/environment-modules/modulespath'
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/modules/modules_ubuntu18.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/modules/modules_ubuntu18.rb
@@ -14,10 +14,15 @@
 
 provides :modules, platform: 'ubuntu', platform_version: '18.04'
 
+use 'partial/_modules_common.rb'
 use 'partial/_modules_apt.rb'
 
 action_class do
   def packages
     %w(tcl-dev environment-modules)
+  end
+
+  def modules_home
+    '/usr/share/modules'
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/modules/modules_ubuntu20+.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/modules/modules_ubuntu20+.rb
@@ -16,10 +16,15 @@ provides :modules, platform: 'ubuntu' do |node|
   node['platform_version'].to_i >= 20
 end
 
+use 'partial/_modules_common.rb'
 use 'partial/_modules_apt.rb'
 
 action_class do
   def packages
     %w(environment-modules)
+  end
+
+  def modules_home
+    '/usr/share/modules'
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/modules/partial/_modules_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/modules/partial/_modules_common.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 #
 # Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
@@ -13,13 +12,25 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-action :setup do
-  package_repos 'update package repos' do
-    action :update
+unified_mode true
+
+property :line, String, required: %i(append_to_config)
+
+default_action :setup
+
+action :append_to_config do
+  append_if_no_line new_resource.name do
+    path modulepath_config_file
+    line new_resource.line
+  end
+end
+
+action_class do
+  def modulepath_config_file
+    "#{modules_home}/init/.modulespath"
   end
 
-  package packages do
-    retries 10
-    retry_delay 5
+  def modules_home
+    "/usr/share/Modules"
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/modules/partial/_modules_yum.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/modules/partial/_modules_yum.rb
@@ -13,9 +13,6 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-unified_mode true
-default_action :setup
-
 action :setup do
   package packages do
     retries 10

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/intel_mpi_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/intel_mpi_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-platform::intel_mpi' do
+  cached(:source_dir) { 'source_dir_for_tests' }
+  cached(:aws_region) { 'region_for_tests' }
+  cached(:chef_run) do
+    runner = ChefSpec::Runner.new do |node|
+      node.override['cluster']['sources_dir'] = source_dir
+      node.override['cluster']['region'] = aws_region
+    end
+    runner.converge(described_recipe)
+  end
+
+  it 'sets up intel mpi' do
+    is_expected.to write_node_attributes('dump node attributes')
+  end
+
+  it 'installs modules' do
+    is_expected.to setup_modules('Prerequisite: Environment modules')
+  end
+
+  it 'fetches intel mpi installer script' do
+    is_expected.to create_remote_file("#{source_dir}/l_mpi_oneapi_p_2021.9.0.43482_offline.sh").with(
+      source: "https://#{aws_region}-aws-parallelcluster.s3.#{aws_region}.test_aws_domain/archives/impi/l_mpi_oneapi_p_2021.9.0.43482_offline.sh",
+      mode: '0744',
+      retries: 3,
+      retry_delay: 5
+    )
+  end
+
+  it 'installs intel mpi' do
+    is_expected.to run_bash('install intel mpi').with(
+      cwd: source_dir,
+      creates: '/opt/intel/mpi/2021.9.0'
+    ).with_code(%r{chmod +x l_mpi_oneapi_p_2021.9.0.43482_offline.sh --remove-extracted-files yes -a --silent --eula accept --install-dir /opt/intel})
+                                                .with_code(/rm -f l_mpi_oneapi_p_2021.9.0.43482_offline.sh/)
+  end
+
+  it 'appends intel module file dir to modules config' do
+    is_expected.to append_to_config_modules('append intel modules file dir to modules conf')
+      .with_line('/opt/intel/mpi/2021.9.0/modulefiles/')
+  end
+
+  it 'renames intel mpi module' do
+    is_expected.to run_execute('rename intel mpi modules file name').with(
+      command: "mv /opt/intel/mpi/2021.9.0/modulefiles/mpi /opt/intel/mpi/2021.9.0/modulefiles/intelmpi",
+      creates: '/opt/intel/mpi/2021.9.0/modulefiles/intelmpi'
+    )
+  end
+
+  it 'adds Qt source file' do
+    is_expected.to create_template("/opt/intel/mpi/2021.9.0/qt_source_code.txt").with(
+      source: 'intel_mpi/qt_source_code.erb',
+      owner: 'root',
+      group: 'root',
+      mode: '0644',
+      variables: {
+        aws_region: aws_region,
+        aws_domain: 'test_aws_domain',
+        intelmpi_qt_version: '6.4.2',
+      }
+    )
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/modules_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/modules_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+for_all_oses do |platform, version|
+  context "on #{platform}#{version}" do
+    describe 'aws-parallelcluster-platform::modules setup' do
+      cached(:chef_run) do
+        ChefSpec::Runner.new(
+          platform: platform, version: version, step_into: ['modules']
+        ).converge_dsl('aws-parallelcluster-platform') do
+          modules 'setup' do
+            action :setup
+          end
+        end
+      end
+
+      it 'sets up modules' do
+        is_expected.to setup_modules('setup')
+      end
+
+      if platform == 'ubuntu'
+        it 'updates package repositories' do
+          is_expected.to update_package_repos('update package repos')
+        end
+
+        it 'installs packages' do
+          is_expected.to install_package(version.to_i == 18 ? %w(tcl-dev environment-modules) : 'environment-modules')
+        end
+      else
+        it 'installs packages' do
+          is_expected.to install_package('environment-modules')
+        end
+      end
+    end
+
+    describe 'aws-parallelcluster-platform::modules append_to_config' do
+      cached(:line) { 'line_to_append' }
+      cached(:modulepath_config_file) do
+        case platform
+        when 'ubuntu'
+          "/usr/share/modules/init/.modulespath"
+        when 'redhat'
+          '/etc/environment-modules/modulespath'
+        else
+          "/usr/share/Modules/init/.modulespath"
+        end
+      end
+
+      cached(:chef_run) do
+        the_line = line
+        ChefSpec::Runner.new(
+          platform: platform, version: version, step_into: ['modules']
+        ).converge_dsl('aws-parallelcluster-platform') do
+          modules 'append_to_config' do
+            line the_line
+            action :append_to_config
+          end
+        end
+      end
+
+      it 'appends to config' do
+        is_expected.to append_to_config_modules('append_to_config')
+      end
+
+      it 'appends line to config file' do
+        is_expected.to edit_append_if_no_line('append_to_config').with(
+          path: modulepath_config_file,
+          line: line
+        )
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/templates/intel_mpi/qt_source_code.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/intel_mpi/qt_source_code.erb
@@ -1,0 +1,3 @@
+You can get Qt source code here:
+
+https://<%= @aws_region %>-aws-parallelcluster.s3.<%= @aws_region %>.<%= @aws_domain %>/archives/impi/qt-src-<%= @intelmpi_qt_version %>-linux.src.tgz

--- a/cookbooks/aws-parallelcluster-platform/test/controls/intel_mpi_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/intel_mpi_spec.rb
@@ -9,7 +9,23 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'tag:config_intel_mpi_installed' do
+control 'tag:install_intel_mpi_modules_file_dir_is_appended_to_modules_conf' do
+  title "intel_mpi should be installed with the corresponding environment-modules"
+
+  # Test only on head node since on compute nodes we mount an empty /opt/intel drive in kitchen tests that
+  # overrides intel binaries.
+  only_if { node['conditions']['intel_mpi_supported'] && instance.head_node? }
+
+  modules_home = os_properties.ubuntu? ? "/usr/share/modules" : "/usr/share/Modules"
+  modulepath_config_file = os_properties.redhat? ? '/etc/environment-modules/modulespath' : "#{modules_home}/init/.modulespath"
+
+  describe file(modulepath_config_file) do
+    it { should exist }
+    its('content') { should match %r{/opt/intel/mpi/#{node['cluster']['intelmpi']['version']}/modulefiles/} }
+  end
+end
+
+control 'tag:install_tag:config_intel_mpi_installed' do
   title "intel_mpi should be installed with the corresponding environment-modules"
 
   # Test only on head node since on compute nodes we mount an empty /opt/intel drive in kitchen tests that

--- a/cookbooks/aws-parallelcluster-shared/libraries/environment.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/environment.rb
@@ -52,3 +52,10 @@ end
 def node_virtualenv_path
   virtualenv_path(pyenv_root: node_pyenv_root, python_version: node_python_version, virtualenv_name: node_virtualenv_name)
 end
+
+#
+# Check if this is an ARM instance
+#
+def arm_instance?
+  node['kernel']['machine'] == 'aarch64'
+end

--- a/kitchen.recipes-install.yml
+++ b/kitchen.recipes-install.yml
@@ -131,19 +131,6 @@ suites:
         - recipe:aws-parallelcluster-slurm::install_jwt
         - recipe:aws-parallelcluster-slurm::install_pmix
         - resource:munge
-  - name: intel_mpi
-    run_list:
-      - recipe[aws-parallelcluster-tests::setup]
-      - recipe[aws-parallelcluster-install::intel_mpi]
-    verifier:
-      controls:
-        - /intel_mpi_installed/
-    attributes:
-      dependencies:
-        - recipe:aws-parallelcluster-platform::directories
-        - resource:package_repos:update
-      cluster:
-        node_type: 'HeadNode'
   - name: nvidia
     run_list:
       - recipe[aws-parallelcluster-tests::setup]

--- a/kitchen.validate-install.yml
+++ b/kitchen.validate-install.yml
@@ -48,7 +48,6 @@ suites:
         - /services_disabled_on_amazon_family/
         - /services_disabled_on_debian_family/
         - stunnel_installed
-        - /intel_mpi_installed/
         - system_authentication_packages_installed
         - /nvidia_driver/
         - /fabric_manager/


### PR DESCRIPTION
### Description of changes
* [Add modules:append_to_config action](https://github.com/aws/aws-parallelcluster-cookbook/commit/d616e53c303cbad8b8534e5370012a583af2d033)
* [Move intel_mpi to platform cookbook](https://github.com/aws/aws-parallelcluster-cookbook/commit/a1acda7101f42273da8d786aec8ae44a2fd5cc3d)

### Tests
* `./kitchen.ec2.sh platform-install verify intel-mpi -c 6`
* `./kitchen.docker.sh platform-install verify intel-mpi -c 6` not working due to failing connection to S3. However, it might be due to my local Docker configuration. Considering it out of scope for this PR, I will investigate later.
* alinux2 AMI built on this code.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.