### PR TITLE
Add Ubuntu22.04 capability to ChefSpec tests

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/spec/spec_helper.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/spec_helper.rb
@@ -1,4 +1,4 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-require_relative '../../aws-parallelcluster-common/spec/spec_helper'
+require_relative '../../aws-parallelcluster-shared/spec/spec_helper'

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/cfn_bootstrap_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/cfn_bootstrap_spec.rb
@@ -11,7 +11,7 @@ describe 'aws-parallelcluster-environment::cfn_bootstrap' do
 
       context "when cfn_bootstrap virtualenv not installed yet" do
         cached(:chef_run) do
-          runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
+          runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['region'] = 'non_china'
           end
@@ -78,7 +78,7 @@ describe 'aws-parallelcluster-environment::cfn_bootstrap' do
 
       context "when cfn_bootstrap virtualenv already installed" do
         cached(:chef_run) do
-          runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
+          runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['python-version'] = python_version
           end
@@ -93,7 +93,7 @@ describe 'aws-parallelcluster-environment::cfn_bootstrap' do
 
       context "when run in China" do
         cached(:chef_run) do
-          runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
+          runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['python-version'] = python_version
             node.override['cluster']['region'] = 'cn-something'

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/isolated_install_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/isolated_install_spec.rb
@@ -4,7 +4,7 @@ describe 'aws-parallelcluster-environment::isolated_install' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       cached(:chef_run) do
-        ChefSpec::Runner.new(platform: platform, version: version).converge(described_recipe)
+        runner(platform: platform, version: version).converge(described_recipe)
       end
       cached(:node) { chef_run.node }
 

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/ephemeral_drives_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/ephemeral_drives_spec.rb
@@ -15,10 +15,7 @@ describe 'ephemeral_drives:setup' do
     context "on #{platform}#{version}" do
       cached(:network_target) { platform == 'redhat' ? 'network-online.target' : 'network.target' }
       cached(:chef_run) do
-        runner = ChefSpec::Runner.new(
-          platform: platform, version: version,
-          step_into: ['ephemeral_drives']
-        )
+        runner = runner(platform: platform, version: version, step_into: ['ephemeral_drives'])
         ConvergeEphemeralDrives.setup(runner)
       end
 

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/nfs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/nfs_spec.rb
@@ -23,10 +23,7 @@ describe 'nfs:setup' do
     context "on #{platform}#{version}" do
       cached(:disabled_service) { 'disable_service' }
       cached(:chef_run) do
-        runner = ChefSpec::Runner.new(
-          platform: platform, version: version,
-          step_into: ['nfs']
-        ) do |node|
+        runner = runner(platform: platform, version: version, step_into: ['nfs']) do |node|
           node.override['nfs']['service']['server'] = disabled_service
         end
         ConvergeNfs.setup(runner)
@@ -67,10 +64,7 @@ describe 'nfs:configure' do
       cached(:server_template) { 'server_template' }
       cached(:nfs_service) { 'nfs_service' }
       cached(:chef_run) do
-        runner = ChefSpec::Runner.new(
-          platform: platform, version: version,
-          step_into: ['nfs']
-        ) do |node|
+        runner = runner(platform: platform, version: version, step_into: ['nfs']) do |node|
           node.override['cluster']['nfs']['threads'] = threads
           node.override['nfs']['config']['server_template'] = server_template
           node.override['nfs']['service']['server'] = nfs_service

--- a/cookbooks/aws-parallelcluster-shared/spec/spec_helper.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/spec_helper.rb
@@ -41,9 +41,19 @@ def for_all_oses
     %w(centos 7.8.2003),
     %w(ubuntu 18.04),
     %w(ubuntu 20.04),
+    %w(ubuntu 22.04),
     %w(redhat 8),
   ].each do |platform, version|
     yield(platform, version)
+  end
+end
+
+def runner(platform:, version:, step_into: [])
+  path = '../aws-parallelcluster-shared/spec/ubuntu.22.json' if "#{platform}#{version}" == 'ubuntu22.04'
+  ChefSpec::SoloRunner.new(
+    platform: platform, version: version, step_into: step_into, path: path
+  ) do |node|
+    yield node if block_given?
   end
 end
 

--- a/cookbooks/aws-parallelcluster-shared/spec/ubuntu.22.json
+++ b/cookbooks/aws-parallelcluster-shared/spec/ubuntu.22.json
@@ -1,0 +1,4608 @@
+{
+  "block_device": {
+    "loop0": {
+      "logical_block_size": "512",
+      "physical_block_size": "512",
+      "removable": "0",
+      "rotational": "0",
+      "size": "51152"
+    },
+    "loop1": {
+      "logical_block_size": "512",
+      "physical_block_size": "512",
+      "removable": "0",
+      "rotational": "0",
+      "size": "113536"
+    },
+    "loop2": {
+      "logical_block_size": "512",
+      "physical_block_size": "512",
+      "removable": "0",
+      "rotational": "0",
+      "size": "126632"
+    },
+    "loop3": {
+      "logical_block_size": "512",
+      "physical_block_size": "512",
+      "removable": "0",
+      "rotational": "0",
+      "size": "137728"
+    },
+    "loop4": {
+      "logical_block_size": "512",
+      "physical_block_size": "512",
+      "removable": "0",
+      "rotational": "0",
+      "size": "66440"
+    },
+    "loop5": {
+      "logical_block_size": "512",
+      "physical_block_size": "512",
+      "removable": "0",
+      "rotational": "0",
+      "size": "0"
+    },
+    "loop6": {
+      "logical_block_size": "512",
+      "physical_block_size": "512",
+      "removable": "0",
+      "rotational": "1",
+      "size": "0"
+    },
+    "loop7": {
+      "logical_block_size": "512",
+      "physical_block_size": "512",
+      "removable": "0",
+      "rotational": "1",
+      "size": "0"
+    },
+    "xvda": {
+      "logical_block_size": "512",
+      "physical_block_size": "512",
+      "removable": "0",
+      "rotational": "0",
+      "size": "16777216",
+      "state": "Connected"
+    }
+  },
+  "chef_packages": {
+    "chef": {
+      "chef_effortless": null,
+      "chef_root": "/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.7.29/lib",
+      "version": "17.7.29"
+    },
+    "ohai": {
+      "ohai_root": "/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/ohai-17.7.8/lib/ohai",
+      "version": "17.7.8"
+    }
+  },
+  "command": {
+    "ps": "ps -ef"
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "eth0": {
+          "rx": {
+            "bytes": 0,
+            "compressed": 0,
+            "drop": 0,
+            "errors": 0,
+            "frame": 0,
+            "multicast": 0,
+            "overrun": 0,
+            "packets": 0
+          },
+          "tx": {
+            "bytes": 0,
+            "carrier": 0,
+            "collisions": 0,
+            "compressed": 0,
+            "drop": 0,
+            "errors": 0,
+            "overrun": 0,
+            "packets": 0
+          }
+        },
+        "lo": {
+          "rx": {
+            "bytes": 0,
+            "drop": 0,
+            "errors": 0,
+            "overrun": 0,
+            "packets": 0
+          },
+          "tx": {
+            "bytes": 0,
+            "carrier": 0,
+            "collisions": 0,
+            "drop": 0,
+            "errors": 0,
+            "packets": 0,
+            "queuelen": "1"
+          }
+        }
+      }
+    }
+  },
+  "cpu": {
+    "cores": 1,
+    "real": 1,
+    "total": 1
+  },
+  "current_user": "fauxhai",
+  "dmi": {
+    "bios": {
+      "address": "0xE8000",
+      "all_records": [
+        {
+          "Address": "0xE8000",
+          "BIOS Revision": "4.11",
+          "Characteristics": {
+            "Targeted content distribution is supported": null
+          },
+          "ROM Size": "64 kB",
+          "Release Date": "08/24/2006",
+          "Runtime Size": "96 kB",
+          "Vendor": "Xen",
+          "Version": "4.11.amazon",
+          "application_identifier": "BIOS Information",
+          "record_id": "0x0000",
+          "size": "0"
+        }
+      ],
+      "bios_revision": "4.11",
+      "release_date": "08/24/2006",
+      "rom_size": "64 kB",
+      "runtime_size": "96 kB",
+      "vendor": "Xen",
+      "version": "4.11.amazon"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Contained Elements": "0",
+          "Height": "Unspecified",
+          "Lock": "Not Present",
+          "Manufacturer": "Xen",
+          "Number Of Power Cords": "Unspecified",
+          "OEM Information": "0x00000000",
+          "Power Supply State": "Safe",
+          "Security Status": "Unknown",
+          "Serial Number": "Not Specified",
+          "Thermal State": "Safe",
+          "Type": "Other",
+          "Version": "Not Specified",
+          "application_identifier": "Chassis Information",
+          "record_id": "0x0300",
+          "size": "3"
+        }
+      ],
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "contained_elements": "0",
+      "height": "Unspecified",
+      "lock": "Not Present",
+      "manufacturer": "Xen",
+      "number_of_power_cords": "Unspecified",
+      "oem_information": "0x00000000",
+      "power_supply_state": "Safe",
+      "security_status": "Unknown",
+      "serial_number": "Not Specified",
+      "thermal_state": "Safe",
+      "type": "Other",
+      "version": "Not Specified"
+    },
+    "dmidecode_version": "3.2",
+    "oem_strings": {
+      "all_records": [
+        {
+          "String 1": "Xen",
+          "application_identifier": "OEM Strings",
+          "record_id": "0x0B00",
+          "size": "11"
+        }
+      ],
+      "string_1": "Xen"
+    },
+    "processor": {
+      "all_records": [
+        {
+          "Asset Tag": "Not Specified",
+          "Current Speed": "2400 MHz",
+          "External Clock": "Unknown",
+          "Family": "Other",
+          "ID": "F2 06 03 00 FF FB 8B 17",
+          "L1 Cache Handle": "Not Provided",
+          "L2 Cache Handle": "Not Provided",
+          "L3 Cache Handle": "Not Provided",
+          "Manufacturer": "Intel",
+          "Max Speed": "2400 MHz",
+          "Part Number": "Not Specified",
+          "Serial Number": "Not Specified",
+          "Socket Designation": "CPU 1",
+          "Status": "Populated, Enabled",
+          "Type": "Central Processor",
+          "Upgrade": "Other",
+          "Version": "Not Specified",
+          "Voltage": "Unknown",
+          "application_identifier": "Processor Information",
+          "record_id": "0x0401",
+          "size": "4"
+        }
+      ],
+      "asset_tag": "Not Specified",
+      "current_speed": "2400 MHz",
+      "external_clock": "Unknown",
+      "family": "Other",
+      "id": "F2 06 03 00 FF FB 8B 17",
+      "l1_cache_handle": "Not Provided",
+      "l2_cache_handle": "Not Provided",
+      "l3_cache_handle": "Not Provided",
+      "manufacturer": "Intel",
+      "max_speed": "2400 MHz",
+      "part_number": "Not Specified",
+      "serial_number": "Not Specified",
+      "socket_designation": "CPU 1",
+      "status": "Populated, Enabled",
+      "type": "Central Processor",
+      "upgrade": "Other",
+      "version": "Not Specified",
+      "voltage": "Unknown"
+    },
+    "smbios_version": "2.7",
+    "structures": {
+      "count": "11",
+      "size": "378"
+    },
+    "system": {
+      "all_records": [
+        {
+          "Family": "Not Specified",
+          "Manufacturer": "Xen",
+          "Product Name": "HVM domU",
+          "SKU Number": "Not Specified",
+          "Serial Number": "ec26d493-1dda-0d7c-e568-c1aec664825f",
+          "UUID": "ec26d493-1dda-0d7c-e568-c1aec664825f",
+          "Version": "4.11.amazon",
+          "Wake-up Type": "Power Switch",
+          "application_identifier": "System Information",
+          "record_id": "0x0100",
+          "size": "1"
+        }
+      ],
+      "family": "Not Specified",
+      "manufacturer": "Xen",
+      "product_name": "HVM domU",
+      "serial_number": "ec26d493-1dda-0d7c-e568-c1aec664825f",
+      "sku_number": "Not Specified",
+      "uuid": "ec26d493-1dda-0d7c-e568-c1aec664825f",
+      "version": "4.11.amazon",
+      "wake_up_type": "Power Switch"
+    }
+  },
+  "domain": "local",
+  "filesystem": {
+    "by_device": {
+      "/dev/loop0": {
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "16",
+        "kb_available": "0",
+        "kb_size": "25600",
+        "kb_used": "25600",
+        "mounts": [
+          "/snap/amazon-ssm-agent/4046"
+        ],
+        "percent_used": "100%",
+        "total_inodes": "16"
+      },
+      "/dev/loop1": {
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "10803",
+        "kb_available": "0",
+        "kb_size": "56832",
+        "kb_used": "56832",
+        "mounts": [
+          "/snap/core18/2128"
+        ],
+        "percent_used": "100%",
+        "total_inodes": "10803"
+      },
+      "/dev/loop2": {
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "11732",
+        "kb_available": "0",
+        "kb_size": "63360",
+        "kb_used": "63360",
+        "mounts": [
+          "/snap/core20/1169"
+        ],
+        "percent_used": "100%",
+        "total_inodes": "11732"
+      },
+      "/dev/loop3": {
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "796",
+        "kb_available": "0",
+        "kb_size": "68864",
+        "kb_used": "68864",
+        "mounts": [
+          "/snap/lxd/21545"
+        ],
+        "percent_used": "100%",
+        "total_inodes": "796"
+      },
+      "/dev/loop4": {
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "479",
+        "kb_available": "0",
+        "kb_size": "33280",
+        "kb_used": "33280",
+        "mounts": [
+          "/snap/snapd/13640"
+        ],
+        "percent_used": "100%",
+        "total_inodes": "479"
+      },
+      "/dev/root": {
+        "inodes_available": "941311",
+        "inodes_percent_used": "9%",
+        "inodes_used": "82689",
+        "kb_available": "6481764",
+        "kb_size": "8065444",
+        "kb_used": "1567296",
+        "mounts": [
+          "/"
+        ],
+        "percent_used": "20%",
+        "total_inodes": "1024000"
+      },
+      "/dev/xvda": {
+        "mounts": []
+      },
+      "/dev/xvda1": {
+        "fs_type": "ext4",
+        "label": "cloudimg-rootfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "discard"
+        ],
+        "mounts": [
+          "/"
+        ],
+        "uuid": "2a29f520-1100-4824-b5d9-d841f1267838"
+      },
+      "/var/lib/snapd/snaps/amazon-ssm-agent_4046.snap": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ],
+        "mounts": [
+          "/snap/amazon-ssm-agent/4046"
+        ]
+      },
+      "/var/lib/snapd/snaps/core18_2128.snap": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ],
+        "mounts": [
+          "/snap/core18/2128"
+        ]
+      },
+      "/var/lib/snapd/snaps/core20_1169.snap": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ],
+        "mounts": [
+          "/snap/core20/1169"
+        ]
+      },
+      "/var/lib/snapd/snaps/lxd_21545.snap": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ],
+        "mounts": [
+          "/snap/lxd/21545"
+        ]
+      },
+      "/var/lib/snapd/snaps/snapd_13640.snap": {
+        "fs_type": "squashfs",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ],
+        "mounts": [
+          "/snap/snapd/13640"
+        ]
+      },
+      "cgroup": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "net_cls",
+          "net_prio"
+        ],
+        "mounts": [
+          "/sys/fs/cgroup/systemd",
+          "/sys/fs/cgroup/pids",
+          "/sys/fs/cgroup/freezer",
+          "/sys/fs/cgroup/memory",
+          "/sys/fs/cgroup/cpuset",
+          "/sys/fs/cgroup/rdma",
+          "/sys/fs/cgroup/hugetlb",
+          "/sys/fs/cgroup/cpu,cpuacct",
+          "/sys/fs/cgroup/devices",
+          "/sys/fs/cgroup/perf_event",
+          "/sys/fs/cgroup/blkio",
+          "/sys/fs/cgroup/net_cls,net_prio"
+        ]
+      },
+      "cgroup2": {
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "nsdelegate"
+        ],
+        "mounts": [
+          "/sys/fs/cgroup/unified"
+        ]
+      },
+      "configfs": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/config"
+        ]
+      },
+      "debugfs": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/debug"
+        ]
+      },
+      "devpts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "mounts": [
+          "/dev/pts"
+        ]
+      },
+      "devtmpfs": {
+        "fs_type": "devtmpfs",
+        "inodes_available": "122820",
+        "inodes_percent_used": "1%",
+        "inodes_used": "322",
+        "kb_available": "492568",
+        "kb_size": "492568",
+        "kb_used": "0",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "size=492568k",
+          "nr_inodes=123142",
+          "mode=755",
+          "inode64"
+        ],
+        "mounts": [
+          "/dev"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "123142"
+      },
+      "fusectl": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/fuse/connections"
+        ]
+      },
+      "hugetlbfs": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "pagesize=2M"
+        ],
+        "mounts": [
+          "/dev/hugepages"
+        ]
+      },
+      "mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/dev/mqueue"
+        ]
+      },
+      "none": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "mounts": [
+          "/sys/fs/bpf"
+        ]
+      },
+      "nsfs": {
+        "fs_type": "nsfs",
+        "mount_options": [
+          "rw"
+        ],
+        "mounts": [
+          "/run/snapd/ns/lxd.mnt"
+        ]
+      },
+      "proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/proc"
+        ]
+      },
+      "pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/pstore"
+        ]
+      },
+      "securityfs": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/security"
+        ]
+      },
+      "sysfs": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys"
+        ]
+      },
+      "systemd-1": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=28",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=14339"
+        ],
+        "mounts": [
+          "/proc/sys/fs/binfmt_misc"
+        ]
+      },
+      "tmpfs": {
+        "fs_type": "tmpfs",
+        "inodes_available": "124616",
+        "inodes_percent_used": "1%",
+        "inodes_used": "22",
+        "kb_available": "99708",
+        "kb_size": "99708",
+        "kb_used": "0",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "size=99712k",
+          "mode=755",
+          "inode64"
+        ],
+        "mounts": [
+          "/dev/shm",
+          "/run",
+          "/run/lock",
+          "/sys/fs/cgroup",
+          "/run/user/1000",
+          "/run/snapd/ns"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "124638"
+      },
+      "tracefs": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/tracing"
+        ]
+      }
+    },
+    "by_mountpoint": {
+      "/": {
+        "devices": [
+          "/dev/root",
+          "/dev/xvda1"
+        ],
+        "fs_type": "ext4",
+        "inodes_available": "941311",
+        "inodes_percent_used": "9%",
+        "inodes_used": "82689",
+        "kb_available": "6481764",
+        "kb_size": "8065444",
+        "kb_used": "1567296",
+        "label": "cloudimg-rootfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "discard"
+        ],
+        "percent_used": "20%",
+        "total_inodes": "1024000",
+        "uuid": "2a29f520-1100-4824-b5d9-d841f1267838"
+      },
+      "/dev": {
+        "devices": [
+          "devtmpfs"
+        ],
+        "fs_type": "devtmpfs",
+        "inodes_available": "122820",
+        "inodes_percent_used": "1%",
+        "inodes_used": "322",
+        "kb_available": "492568",
+        "kb_size": "492568",
+        "kb_used": "0",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "size=492568k",
+          "nr_inodes=123142",
+          "mode=755",
+          "inode64"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "123142"
+      },
+      "/dev/hugepages": {
+        "devices": [
+          "hugetlbfs"
+        ],
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "pagesize=2M"
+        ]
+      },
+      "/dev/mqueue": {
+        "devices": [
+          "mqueue"
+        ],
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "/dev/pts": {
+        "devices": [
+          "devpts"
+        ],
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ]
+      },
+      "/dev/shm": {
+        "devices": [
+          "tmpfs"
+        ],
+        "fs_type": "tmpfs",
+        "inodes_available": "124636",
+        "inodes_percent_used": "1%",
+        "inodes_used": "2",
+        "kb_available": "498552",
+        "kb_size": "498552",
+        "kb_used": "0",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "inode64"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "124638"
+      },
+      "/proc": {
+        "devices": [
+          "proc"
+        ],
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "/proc/sys/fs/binfmt_misc": {
+        "devices": [
+          "systemd-1"
+        ],
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=28",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=14339"
+        ]
+      },
+      "/run": {
+        "devices": [
+          "tmpfs"
+        ],
+        "fs_type": "tmpfs",
+        "inodes_available": "124136",
+        "inodes_percent_used": "1%",
+        "inodes_used": "502",
+        "kb_available": "98892",
+        "kb_size": "99712",
+        "kb_used": "820",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "size=99712k",
+          "mode=755",
+          "inode64"
+        ],
+        "percent_used": "1%",
+        "total_inodes": "124638"
+      },
+      "/run/lock": {
+        "devices": [
+          "tmpfs"
+        ],
+        "fs_type": "tmpfs",
+        "inodes_available": "124635",
+        "inodes_percent_used": "1%",
+        "inodes_used": "3",
+        "kb_available": "5120",
+        "kb_size": "5120",
+        "kb_used": "0",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=5120k",
+          "inode64"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "124638"
+      },
+      "/run/snapd/ns": {
+        "devices": [
+          "tmpfs"
+        ],
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "size=99712k",
+          "mode=755",
+          "inode64"
+        ]
+      },
+      "/run/snapd/ns/lxd.mnt": {
+        "devices": [
+          "nsfs"
+        ],
+        "fs_type": "nsfs",
+        "mount_options": [
+          "rw"
+        ]
+      },
+      "/run/user/1000": {
+        "devices": [
+          "tmpfs"
+        ],
+        "fs_type": "tmpfs",
+        "inodes_available": "124616",
+        "inodes_percent_used": "1%",
+        "inodes_used": "22",
+        "kb_available": "99708",
+        "kb_size": "99708",
+        "kb_used": "0",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=99708k",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "124638"
+      },
+      "/snap/amazon-ssm-agent/4046": {
+        "devices": [
+          "/dev/loop0",
+          "/var/lib/snapd/snaps/amazon-ssm-agent_4046.snap"
+        ],
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "16",
+        "kb_available": "0",
+        "kb_size": "25600",
+        "kb_used": "25600",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ],
+        "percent_used": "100%",
+        "total_inodes": "16"
+      },
+      "/snap/core18/2128": {
+        "devices": [
+          "/dev/loop1",
+          "/var/lib/snapd/snaps/core18_2128.snap"
+        ],
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "10803",
+        "kb_available": "0",
+        "kb_size": "56832",
+        "kb_used": "56832",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ],
+        "percent_used": "100%",
+        "total_inodes": "10803"
+      },
+      "/snap/core20/1169": {
+        "devices": [
+          "/dev/loop2",
+          "/var/lib/snapd/snaps/core20_1169.snap"
+        ],
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "11732",
+        "kb_available": "0",
+        "kb_size": "63360",
+        "kb_used": "63360",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ],
+        "percent_used": "100%",
+        "total_inodes": "11732"
+      },
+      "/snap/lxd/21545": {
+        "devices": [
+          "/dev/loop3",
+          "/var/lib/snapd/snaps/lxd_21545.snap"
+        ],
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "796",
+        "kb_available": "0",
+        "kb_size": "68864",
+        "kb_used": "68864",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ],
+        "percent_used": "100%",
+        "total_inodes": "796"
+      },
+      "/snap/snapd/13640": {
+        "devices": [
+          "/dev/loop4",
+          "/var/lib/snapd/snaps/snapd_13640.snap"
+        ],
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "479",
+        "kb_available": "0",
+        "kb_size": "33280",
+        "kb_used": "33280",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ],
+        "percent_used": "100%",
+        "total_inodes": "479"
+      },
+      "/sys": {
+        "devices": [
+          "sysfs"
+        ],
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "/sys/fs/bpf": {
+        "devices": [
+          "none"
+        ],
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ]
+      },
+      "/sys/fs/cgroup": {
+        "devices": [
+          "tmpfs"
+        ],
+        "fs_type": "tmpfs",
+        "inodes_available": "124620",
+        "inodes_percent_used": "1%",
+        "inodes_used": "18",
+        "kb_available": "498552",
+        "kb_size": "498552",
+        "kb_used": "0",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "mode=755",
+          "inode64"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "124638"
+      },
+      "/sys/fs/cgroup/blkio": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "blkio"
+        ]
+      },
+      "/sys/fs/cgroup/cpu,cpuacct": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "cpu",
+          "cpuacct"
+        ]
+      },
+      "/sys/fs/cgroup/cpuset": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "cpuset"
+        ]
+      },
+      "/sys/fs/cgroup/devices": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "devices"
+        ]
+      },
+      "/sys/fs/cgroup/freezer": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "freezer"
+        ]
+      },
+      "/sys/fs/cgroup/hugetlb": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "hugetlb"
+        ]
+      },
+      "/sys/fs/cgroup/memory": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "memory"
+        ]
+      },
+      "/sys/fs/cgroup/net_cls,net_prio": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "net_cls",
+          "net_prio"
+        ]
+      },
+      "/sys/fs/cgroup/perf_event": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "perf_event"
+        ]
+      },
+      "/sys/fs/cgroup/pids": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "pids"
+        ]
+      },
+      "/sys/fs/cgroup/rdma": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "rdma"
+        ]
+      },
+      "/sys/fs/cgroup/systemd": {
+        "devices": [
+          "cgroup"
+        ],
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "xattr",
+          "name=systemd"
+        ]
+      },
+      "/sys/fs/cgroup/unified": {
+        "devices": [
+          "cgroup2"
+        ],
+        "fs_type": "cgroup2",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "nsdelegate"
+        ]
+      },
+      "/sys/fs/fuse/connections": {
+        "devices": [
+          "fusectl"
+        ],
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "/sys/fs/pstore": {
+        "devices": [
+          "pstore"
+        ],
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "/sys/kernel/config": {
+        "devices": [
+          "configfs"
+        ],
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "/sys/kernel/debug": {
+        "devices": [
+          "debugfs"
+        ],
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "/sys/kernel/security": {
+        "devices": [
+          "securityfs"
+        ],
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "/sys/kernel/tracing": {
+        "devices": [
+          "tracefs"
+        ],
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      }
+    },
+    "by_pair": {
+      "/dev/loop0,/snap/amazon-ssm-agent/4046": {
+        "device": "/dev/loop0",
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "16",
+        "kb_available": "0",
+        "kb_size": "25600",
+        "kb_used": "25600",
+        "mount": "/snap/amazon-ssm-agent/4046",
+        "percent_used": "100%",
+        "total_inodes": "16"
+      },
+      "/dev/loop1,/snap/core18/2128": {
+        "device": "/dev/loop1",
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "10803",
+        "kb_available": "0",
+        "kb_size": "56832",
+        "kb_used": "56832",
+        "mount": "/snap/core18/2128",
+        "percent_used": "100%",
+        "total_inodes": "10803"
+      },
+      "/dev/loop2,/snap/core20/1169": {
+        "device": "/dev/loop2",
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "11732",
+        "kb_available": "0",
+        "kb_size": "63360",
+        "kb_used": "63360",
+        "mount": "/snap/core20/1169",
+        "percent_used": "100%",
+        "total_inodes": "11732"
+      },
+      "/dev/loop3,/snap/lxd/21545": {
+        "device": "/dev/loop3",
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "796",
+        "kb_available": "0",
+        "kb_size": "68864",
+        "kb_used": "68864",
+        "mount": "/snap/lxd/21545",
+        "percent_used": "100%",
+        "total_inodes": "796"
+      },
+      "/dev/loop4,/snap/snapd/13640": {
+        "device": "/dev/loop4",
+        "fs_type": "squashfs",
+        "inodes_available": "0",
+        "inodes_percent_used": "100%",
+        "inodes_used": "479",
+        "kb_available": "0",
+        "kb_size": "33280",
+        "kb_used": "33280",
+        "mount": "/snap/snapd/13640",
+        "percent_used": "100%",
+        "total_inodes": "479"
+      },
+      "/dev/root,/": {
+        "device": "/dev/root",
+        "inodes_available": "941311",
+        "inodes_percent_used": "9%",
+        "inodes_used": "82689",
+        "kb_available": "6481764",
+        "kb_size": "8065444",
+        "kb_used": "1567296",
+        "mount": "/",
+        "percent_used": "20%",
+        "total_inodes": "1024000"
+      },
+      "/dev/xvda,": {
+        "device": "/dev/xvda"
+      },
+      "/dev/xvda1,/": {
+        "device": "/dev/xvda1",
+        "fs_type": "ext4",
+        "label": "cloudimg-rootfs",
+        "mount": "/",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "discard"
+        ],
+        "uuid": "2a29f520-1100-4824-b5d9-d841f1267838"
+      },
+      "/var/lib/snapd/snaps/amazon-ssm-agent_4046.snap,/snap/amazon-ssm-agent/4046": {
+        "device": "/var/lib/snapd/snaps/amazon-ssm-agent_4046.snap",
+        "fs_type": "squashfs",
+        "mount": "/snap/amazon-ssm-agent/4046",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ]
+      },
+      "/var/lib/snapd/snaps/core18_2128.snap,/snap/core18/2128": {
+        "device": "/var/lib/snapd/snaps/core18_2128.snap",
+        "fs_type": "squashfs",
+        "mount": "/snap/core18/2128",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ]
+      },
+      "/var/lib/snapd/snaps/core20_1169.snap,/snap/core20/1169": {
+        "device": "/var/lib/snapd/snaps/core20_1169.snap",
+        "fs_type": "squashfs",
+        "mount": "/snap/core20/1169",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ]
+      },
+      "/var/lib/snapd/snaps/lxd_21545.snap,/snap/lxd/21545": {
+        "device": "/var/lib/snapd/snaps/lxd_21545.snap",
+        "fs_type": "squashfs",
+        "mount": "/snap/lxd/21545",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ]
+      },
+      "/var/lib/snapd/snaps/snapd_13640.snap,/snap/snapd/13640": {
+        "device": "/var/lib/snapd/snaps/snapd_13640.snap",
+        "fs_type": "squashfs",
+        "mount": "/snap/snapd/13640",
+        "mount_options": [
+          "ro",
+          "nodev",
+          "relatime",
+          "x-gdu.hide"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/blkio": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/blkio",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "blkio"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/cpu,cpuacct": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/cpu,cpuacct",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "cpu",
+          "cpuacct"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/cpuset": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/cpuset",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "cpuset"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/devices": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/devices",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "devices"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/freezer": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/freezer",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "freezer"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/hugetlb": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/hugetlb",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "hugetlb"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/memory": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/memory",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "memory"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/net_cls,net_prio": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/net_cls,net_prio",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "net_cls",
+          "net_prio"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/perf_event": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/perf_event",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "perf_event"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/pids": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/pids",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "pids"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/rdma": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/rdma",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "rdma"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/systemd": {
+        "device": "cgroup",
+        "fs_type": "cgroup",
+        "mount": "/sys/fs/cgroup/systemd",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "xattr",
+          "name=systemd"
+        ]
+      },
+      "cgroup2,/sys/fs/cgroup/unified": {
+        "device": "cgroup2",
+        "fs_type": "cgroup2",
+        "mount": "/sys/fs/cgroup/unified",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "nsdelegate"
+        ]
+      },
+      "configfs,/sys/kernel/config": {
+        "device": "configfs",
+        "fs_type": "configfs",
+        "mount": "/sys/kernel/config",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "debugfs,/sys/kernel/debug": {
+        "device": "debugfs",
+        "fs_type": "debugfs",
+        "mount": "/sys/kernel/debug",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "devpts,/dev/pts": {
+        "device": "devpts",
+        "fs_type": "devpts",
+        "mount": "/dev/pts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ]
+      },
+      "devtmpfs,/dev": {
+        "device": "devtmpfs",
+        "fs_type": "devtmpfs",
+        "inodes_available": "122820",
+        "inodes_percent_used": "1%",
+        "inodes_used": "322",
+        "kb_available": "492568",
+        "kb_size": "492568",
+        "kb_used": "0",
+        "mount": "/dev",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "size=492568k",
+          "nr_inodes=123142",
+          "mode=755",
+          "inode64"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "123142"
+      },
+      "fusectl,/sys/fs/fuse/connections": {
+        "device": "fusectl",
+        "fs_type": "fusectl",
+        "mount": "/sys/fs/fuse/connections",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "hugetlbfs,/dev/hugepages": {
+        "device": "hugetlbfs",
+        "fs_type": "hugetlbfs",
+        "mount": "/dev/hugepages",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "pagesize=2M"
+        ]
+      },
+      "mqueue,/dev/mqueue": {
+        "device": "mqueue",
+        "fs_type": "mqueue",
+        "mount": "/dev/mqueue",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "none,/sys/fs/bpf": {
+        "device": "none",
+        "fs_type": "bpf",
+        "mount": "/sys/fs/bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ]
+      },
+      "nsfs,/run/snapd/ns/lxd.mnt": {
+        "device": "nsfs",
+        "fs_type": "nsfs",
+        "mount": "/run/snapd/ns/lxd.mnt",
+        "mount_options": [
+          "rw"
+        ]
+      },
+      "proc,/proc": {
+        "device": "proc",
+        "fs_type": "proc",
+        "mount": "/proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "pstore,/sys/fs/pstore": {
+        "device": "pstore",
+        "fs_type": "pstore",
+        "mount": "/sys/fs/pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "securityfs,/sys/kernel/security": {
+        "device": "securityfs",
+        "fs_type": "securityfs",
+        "mount": "/sys/kernel/security",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "sysfs,/sys": {
+        "device": "sysfs",
+        "fs_type": "sysfs",
+        "mount": "/sys",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "systemd-1,/proc/sys/fs/binfmt_misc": {
+        "device": "systemd-1",
+        "fs_type": "autofs",
+        "mount": "/proc/sys/fs/binfmt_misc",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=28",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=14339"
+        ]
+      },
+      "tmpfs,/dev/shm": {
+        "device": "tmpfs",
+        "fs_type": "tmpfs",
+        "inodes_available": "124636",
+        "inodes_percent_used": "1%",
+        "inodes_used": "2",
+        "kb_available": "498552",
+        "kb_size": "498552",
+        "kb_used": "0",
+        "mount": "/dev/shm",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "inode64"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "124638"
+      },
+      "tmpfs,/run": {
+        "device": "tmpfs",
+        "fs_type": "tmpfs",
+        "inodes_available": "124136",
+        "inodes_percent_used": "1%",
+        "inodes_used": "502",
+        "kb_available": "98892",
+        "kb_size": "99712",
+        "kb_used": "820",
+        "mount": "/run",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "size=99712k",
+          "mode=755",
+          "inode64"
+        ],
+        "percent_used": "1%",
+        "total_inodes": "124638"
+      },
+      "tmpfs,/run/lock": {
+        "device": "tmpfs",
+        "fs_type": "tmpfs",
+        "inodes_available": "124635",
+        "inodes_percent_used": "1%",
+        "inodes_used": "3",
+        "kb_available": "5120",
+        "kb_size": "5120",
+        "kb_used": "0",
+        "mount": "/run/lock",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=5120k",
+          "inode64"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "124638"
+      },
+      "tmpfs,/run/snapd/ns": {
+        "device": "tmpfs",
+        "fs_type": "tmpfs",
+        "mount": "/run/snapd/ns",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "size=99712k",
+          "mode=755",
+          "inode64"
+        ]
+      },
+      "tmpfs,/run/user/1000": {
+        "device": "tmpfs",
+        "fs_type": "tmpfs",
+        "inodes_available": "124616",
+        "inodes_percent_used": "1%",
+        "inodes_used": "22",
+        "kb_available": "99708",
+        "kb_size": "99708",
+        "kb_used": "0",
+        "mount": "/run/user/1000",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=99708k",
+          "mode=700",
+          "uid=1000",
+          "gid=1000",
+          "inode64"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "124638"
+      },
+      "tmpfs,/sys/fs/cgroup": {
+        "device": "tmpfs",
+        "fs_type": "tmpfs",
+        "inodes_available": "124620",
+        "inodes_percent_used": "1%",
+        "inodes_used": "18",
+        "kb_available": "498552",
+        "kb_size": "498552",
+        "kb_used": "0",
+        "mount": "/sys/fs/cgroup",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "mode=755",
+          "inode64"
+        ],
+        "percent_used": "0%",
+        "total_inodes": "124638"
+      },
+      "tracefs,/sys/kernel/tracing": {
+        "device": "tracefs",
+        "fs_type": "tracefs",
+        "mount": "/sys/kernel/tracing",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      }
+    }
+  },
+  "fips": {
+    "kernel": {
+      "enabled": true
+    }
+  },
+  "fqdn": "fauxhai.local",
+  "hostname": "Fauxhai",
+  "idle": "30 days 15 hours 07 minutes 30 seconds",
+  "idletime_seconds": 2646450,
+  "init_package": "systemd",
+  "ipaddress": "10.0.0.2",
+  "kernel": {
+    "machine": "x86_64",
+    "modules": {
+      "aesni_intel": {
+        "refcount": "0",
+        "size": "372736"
+      },
+      "autofs4": {
+        "refcount": "2",
+        "size": "45056"
+      },
+      "crc32_pclmul": {
+        "refcount": "0",
+        "size": "16384"
+      },
+      "crct10dif_pclmul": {
+        "refcount": "1",
+        "size": "16384"
+      },
+      "cryptd": {
+        "refcount": "2",
+        "size": "24576"
+      },
+      "crypto_simd": {
+        "refcount": "1",
+        "size": "16384"
+      },
+      "dm_multipath": {
+        "refcount": "0",
+        "size": "36864"
+      },
+      "drm": {
+        "refcount": "0",
+        "size": "548864"
+      },
+      "floppy": {
+        "refcount": "0",
+        "size": "86016"
+      },
+      "ghash_clmulni_intel": {
+        "refcount": "0",
+        "size": "16384"
+      },
+      "glue_helper": {
+        "refcount": "1",
+        "size": "16384"
+      },
+      "input_leds": {
+        "refcount": "0",
+        "size": "16384"
+      },
+      "ip_tables": {
+        "refcount": "0",
+        "size": "32768"
+      },
+      "msr": {
+        "refcount": "0",
+        "size": "16384"
+      },
+      "psmouse": {
+        "refcount": "0",
+        "size": "155648"
+      },
+      "sch_fq_codel": {
+        "refcount": "2",
+        "size": "20480"
+      },
+      "scsi_dh_alua": {
+        "refcount": "0",
+        "size": "20480",
+        "version": "2.0"
+      },
+      "scsi_dh_emc": {
+        "refcount": "0",
+        "size": "16384"
+      },
+      "scsi_dh_rdac": {
+        "refcount": "0",
+        "size": "16384",
+        "version": "01.00.0000.0000"
+      },
+      "serio_raw": {
+        "refcount": "0",
+        "size": "20480"
+      },
+      "x_tables": {
+        "refcount": "1",
+        "size": "49152"
+      }
+    },
+    "name": "Linux",
+    "os": "GNU/Linux",
+    "processor": "x86_64",
+    "release": "5.11.0-1020-aws",
+    "version": "#21~22.04.2-Ubuntu SMP Fri Oct 1 13:03:59 UTC 2021"
+  },
+  "keys": {
+    "ssh": {
+      "host_dsa_public": "ssh-dss AAAAB3NzaC1kc3MAAACBAJFo9BLAw4WKEs5hgipk5m423FzBsDXCZSMcC9ca/om/1VYzMqImixGe3uICDzNFUWxFoLJTQAOccyzo6MXZiQqwWJDLFi5qOSr6w2XcMyE+zd4wOyMoDiVM5fizmG8K3FzrqvGjwBcHcBdOQnavSijoj38DN25J9zhrid5BY4WlAAAAFQDxXrCyG52XCzn3FV4ej38wJBkomQAAAIBovGPJ4mP2P6BK8lHl0PPbktwQbWlpJ13oz6REJFDVcUi7vV26bX/BjQX+ohzZQzljdz1SpUbPc/8nuA4darYkVh91eBi307EN8IdxRHj2eBgp/ZG4yshIebG3WHrwJD/xUjjZ1MRfyDT1ermVi4LvjjPgWDxLZnPpMaR6S1nzgQAAAIEAj0Vd6DCWslvlsZ8+N53HWsqPi3gnx35JoLPz9Z2epkKIKqmEHav+93G3hdfztVa4I4t3phoPniQchYryF5+RNg8hqxKzjNtrIqUYCeuf2NJrksNsH7OZygPHZpqt4kTuwAGZxjxEGfAI0y8DhkU2ntp2LnzRnWH106BQBCmcXwo= fauxhai.local",
+      "host_rsa_public": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtLCeqtqr/HbnORckw1ukdLhpfGoOPFi5/esKEokzTqq1gsgQ2V8emmyjfq1i6XXfRtSBxkdlHv/GWdP5wBTuE2G85MzBkVSQPvmwQN8lX/JMPEEtKXkeOo0o92/PiSmvY4eRsdF0mw40Uvg7jtE3f3fxj497kzh5fKtkrHnF4x9gXCbVdr3FqXJfggR5IJwAxToerbK7x/uRS+7YuZI9Pip3tt14nv9ezwXcuGb/tvjWOZINiFl8izVIFKi7sxfTX09p4NgamxRS7TD2Yd0jT8nEoF9UZTsgXcJ1kDSx7N7NxFfNfP6rCdOGRRz4gUhXtsUjG/XkxPeCwZ7A9VnOD fauxhai.local"
+    }
+  },
+  "languages": {
+    "powershell": null,
+    "ruby": {
+      "bin_dir": "/usr/local/bin",
+      "gem_bin": "/usr/local/bin/gem",
+      "gems_dir": "/usr/local/gems",
+      "host": "x86_64-pc-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux",
+      "host_vendor": "pc",
+      "platform": "x86_64-linux",
+      "release_date": "2021-07-07",
+      "ruby_bin": "/usr/local/bin/ruby",
+      "target": "x86_64-pc-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_os": "linux",
+      "target_vendor": "pc",
+      "version": "3.0.2"
+    }
+  },
+  "lsb": {
+    "codename": "focal",
+    "description": "Ubuntu 22.04.3 LTS",
+    "id": "Ubuntu",
+    "release": "22.04"
+  },
+  "macaddress": "11:11:11:11:11:11",
+  "machinename": "Fauxhai",
+  "memory": {
+    "total": "1048576kB"
+  },
+  "network": {
+    "default_gateway": "10.0.0.1",
+    "default_interface": "eth0",
+    "interfaces": {
+      "eth0": {
+        "addresses": {
+          "10.0.0.2": {
+            "broadcast": "10.0.0.255",
+            "family": "inet",
+            "ip_scope": "RFC1918 PRIVATE",
+            "netmask": "255.255.255.0",
+            "prefixlen": "24",
+            "scope": "Global"
+          },
+          "11:11:11:11:11:11": {
+            "family": "lladdr"
+          },
+          "fe80::11:1111:1111:1111": {
+            "family": "inet6",
+            "ip_scope": "LINK LOCAL UNICAST",
+            "prefixlen": "64",
+            "scope": "Link",
+            "tags": []
+          }
+        },
+        "arp": {
+          "10.0.0.1": "fe:ff:ff:ff:ff:ff"
+        },
+        "encapsulation": "Ethernet",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "mtu": "1500",
+        "number": "0",
+        "ring_params": {},
+        "routes": [
+          {
+            "destination": "default",
+            "family": "inet",
+            "via": "10.0.0.1"
+          },
+          {
+            "destination": "10.0.0.0/24",
+            "family": "inet",
+            "proto": "kernel",
+            "scope": "link",
+            "src": "10.0.0.2"
+          },
+          {
+            "destination": "fe80::/64",
+            "family": "inet6",
+            "metric": "256",
+            "proto": "kernel"
+          }
+        ],
+        "state": "up",
+        "type": "eth"
+      },
+      "lo": {
+        "addresses": {
+          "127.0.0.1": {
+            "family": "inet",
+            "ip_scope": "LOOPBACK",
+            "netmask": "255.0.0.0",
+            "prefixlen": "8",
+            "scope": "Node"
+          },
+          "::1": {
+            "family": "inet6",
+            "ip_scope": "LINK LOCAL LOOPBACK",
+            "prefixlen": "128",
+            "scope": "Node",
+            "tags": []
+          }
+        },
+        "encapsulation": "Loopback",
+        "flags": [
+          "LOOPBACK",
+          "UP",
+          "LOWER_UP"
+        ],
+        "mtu": "65536",
+        "state": "unknown"
+      }
+    }
+  },
+  "ohai_time": 1635803518.6871707,
+  "os": "linux",
+  "os_version": "5.11.0-1020-aws",
+  "packages": {
+    "accountsservice": {
+      "arch": "amd64",
+      "version": "0.6.55-0ubuntu12~22.04.4"
+    },
+    "acpid": {
+      "arch": "amd64",
+      "version": "1:2.0.32-1ubuntu1"
+    },
+    "adduser": {
+      "arch": "all",
+      "version": "3.118ubuntu2"
+    },
+    "alsa-topology-conf": {
+      "arch": "all",
+      "version": "1.2.2-1"
+    },
+    "alsa-ucm-conf": {
+      "arch": "all",
+      "version": "1.2.2-1ubuntu0.11"
+    },
+    "amd64-microcode": {
+      "arch": "amd64",
+      "version": "3.20191218.1ubuntu1"
+    },
+    "apparmor": {
+      "arch": "amd64",
+      "version": "2.13.3-7ubuntu5.1"
+    },
+    "apport": {
+      "arch": "all",
+      "version": "2.20.11-0ubuntu27.20"
+    },
+    "apport-symptoms": {
+      "arch": "all",
+      "version": "0.23"
+    },
+    "apt": {
+      "arch": "amd64",
+      "version": "2.0.6"
+    },
+    "apt-utils": {
+      "arch": "amd64",
+      "version": "2.0.6"
+    },
+    "at": {
+      "arch": "amd64",
+      "version": "3.1.23-1ubuntu1"
+    },
+    "base-files": {
+      "arch": "amd64",
+      "version": "11ubuntu5.4"
+    },
+    "base-passwd": {
+      "arch": "amd64",
+      "version": "3.5.47"
+    },
+    "bash": {
+      "arch": "amd64",
+      "version": "5.0-6ubuntu1.1"
+    },
+    "bash-completion": {
+      "arch": "all",
+      "version": "1:2.10-1ubuntu1"
+    },
+    "bc": {
+      "arch": "amd64",
+      "version": "1.07.1-2build1"
+    },
+    "bcache-tools": {
+      "arch": "amd64",
+      "version": "1.0.8-3ubuntu0.1"
+    },
+    "bind9-dnsutils": {
+      "arch": "amd64",
+      "version": "1:9.16.1-0ubuntu2.8"
+    },
+    "bind9-host": {
+      "arch": "amd64",
+      "version": "1:9.16.1-0ubuntu2.8"
+    },
+    "bind9-libs": {
+      "arch": "amd64",
+      "version": "1:9.16.1-0ubuntu2.8"
+    },
+    "bolt": {
+      "arch": "amd64",
+      "version": "0.8-4ubuntu1"
+    },
+    "bsdmainutils": {
+      "arch": "amd64",
+      "version": "11.1.2ubuntu3"
+    },
+    "bsdutils": {
+      "arch": "amd64",
+      "version": "1:2.34-0.1ubuntu9.1"
+    },
+    "btrfs-progs": {
+      "arch": "amd64",
+      "version": "5.4.1-2"
+    },
+    "busybox-initramfs": {
+      "arch": "amd64",
+      "version": "1:1.30.1-4ubuntu6.3"
+    },
+    "busybox-static": {
+      "arch": "amd64",
+      "version": "1:1.30.1-4ubuntu6.3"
+    },
+    "byobu": {
+      "arch": "all",
+      "version": "5.133-0ubuntu1"
+    },
+    "bzip2": {
+      "arch": "amd64",
+      "version": "1.0.8-2"
+    },
+    "ca-certificates": {
+      "arch": "all",
+      "version": "20210119~22.04.2"
+    },
+    "chef": {
+      "arch": "amd64",
+      "version": "17.7.29-1"
+    },
+    "cloud-guest-utils": {
+      "arch": "all",
+      "version": "0.31-7-gd99b2d76-0ubuntu1"
+    },
+    "cloud-init": {
+      "arch": "all",
+      "version": "21.3-1-g6803368d-0ubuntu1~22.04.4"
+    },
+    "cloud-initramfs-copymods": {
+      "arch": "all",
+      "version": "0.45ubuntu1"
+    },
+    "cloud-initramfs-dyn-netconf": {
+      "arch": "all",
+      "version": "0.45ubuntu1"
+    },
+    "command-not-found": {
+      "arch": "all",
+      "version": "22.04.4"
+    },
+    "console-setup": {
+      "arch": "all",
+      "version": "1.194ubuntu3"
+    },
+    "console-setup-linux": {
+      "arch": "all",
+      "version": "1.194ubuntu3"
+    },
+    "coreutils": {
+      "arch": "amd64",
+      "version": "8.30-3ubuntu2"
+    },
+    "cpio": {
+      "arch": "amd64",
+      "version": "2.13+dfsg-2ubuntu0.3"
+    },
+    "cron": {
+      "arch": "amd64",
+      "version": "3.0pl1-136ubuntu1"
+    },
+    "cryptsetup": {
+      "arch": "amd64",
+      "version": "2:2.2.2-3ubuntu2.3"
+    },
+    "cryptsetup-bin": {
+      "arch": "amd64",
+      "version": "2:2.2.2-3ubuntu2.3"
+    },
+    "cryptsetup-initramfs": {
+      "arch": "all",
+      "version": "2:2.2.2-3ubuntu2.3"
+    },
+    "cryptsetup-run": {
+      "arch": "all",
+      "version": "2:2.2.2-3ubuntu2.3"
+    },
+    "curl": {
+      "arch": "amd64",
+      "version": "7.68.0-1ubuntu2.7"
+    },
+    "dash": {
+      "arch": "amd64",
+      "version": "0.5.10.2-6"
+    },
+    "dbus": {
+      "arch": "amd64",
+      "version": "1.12.16-2ubuntu2.1"
+    },
+    "dbus-user-session": {
+      "arch": "amd64",
+      "version": "1.12.16-2ubuntu2.1"
+    },
+    "dconf-gsettings-backend": {
+      "arch": "amd64",
+      "version": "0.36.0-1"
+    },
+    "dconf-service": {
+      "arch": "amd64",
+      "version": "0.36.0-1"
+    },
+    "debconf": {
+      "arch": "all",
+      "version": "1.5.73"
+    },
+    "debconf-i18n": {
+      "arch": "all",
+      "version": "1.5.73"
+    },
+    "debianutils": {
+      "arch": "amd64",
+      "version": "4.9.1"
+    },
+    "diffutils": {
+      "arch": "amd64",
+      "version": "1:3.7-3"
+    },
+    "dirmngr": {
+      "arch": "amd64",
+      "version": "2.2.19-3ubuntu2.1"
+    },
+    "distro-info": {
+      "arch": "amd64",
+      "version": "0.23ubuntu1"
+    },
+    "distro-info-data": {
+      "arch": "all",
+      "version": "0.43ubuntu1.9"
+    },
+    "dmeventd": {
+      "arch": "amd64",
+      "version": "2:1.02.167-1ubuntu1"
+    },
+    "dmidecode": {
+      "arch": "amd64",
+      "version": "3.2-3"
+    },
+    "dmsetup": {
+      "arch": "amd64",
+      "version": "2:1.02.167-1ubuntu1"
+    },
+    "dosfstools": {
+      "arch": "amd64",
+      "version": "4.1-2"
+    },
+    "dpkg": {
+      "arch": "amd64",
+      "version": "1.19.7ubuntu3"
+    },
+    "e2fsprogs": {
+      "arch": "amd64",
+      "version": "1.45.5-2ubuntu1"
+    },
+    "eatmydata": {
+      "arch": "all",
+      "version": "105-7"
+    },
+    "ec2-hibinit-agent": {
+      "arch": "all",
+      "version": "1.0.0-0ubuntu9.1"
+    },
+    "ec2-instance-connect": {
+      "arch": "all",
+      "version": "1.1.12+dfsg1-0ubuntu3.22.04.1"
+    },
+    "ed": {
+      "arch": "amd64",
+      "version": "1.16-1"
+    },
+    "eject": {
+      "arch": "amd64",
+      "version": "2.1.5+deb1+cvs20081104-14"
+    },
+    "ethtool": {
+      "arch": "amd64",
+      "version": "1:5.4-1"
+    },
+    "fdisk": {
+      "arch": "amd64",
+      "version": "2.34-0.1ubuntu9.1"
+    },
+    "file": {
+      "arch": "amd64",
+      "version": "1:5.38-4"
+    },
+    "finalrd": {
+      "arch": "all",
+      "version": "6~ubuntu22.04.1"
+    },
+    "findutils": {
+      "arch": "amd64",
+      "version": "4.7.0-1ubuntu1"
+    },
+    "fonts-ubuntu-console": {
+      "arch": "all",
+      "version": "0.83-4ubuntu1"
+    },
+    "friendly-recovery": {
+      "arch": "all",
+      "version": "0.2.41ubuntu0.22.04.1"
+    },
+    "ftp": {
+      "arch": "amd64",
+      "version": "0.17-34.1"
+    },
+    "fuse": {
+      "arch": "amd64",
+      "version": "2.9.9-3"
+    },
+    "fuse3": {
+      "arch": "amd64",
+      "version": "3.9.0-2"
+    },
+    "fwupd": {
+      "arch": "amd64",
+      "version": "1.5.11-0ubuntu1~22.04.2"
+    },
+    "fwupd-signed": {
+      "arch": "amd64",
+      "version": "1.27.1ubuntu5+1.5.11-0ubuntu1~22.04.2"
+    },
+    "gawk": {
+      "arch": "amd64",
+      "version": "1:5.0.1+dfsg-1"
+    },
+    "gcc-10-base": {
+      "arch": "amd64",
+      "version": "10.3.0-1ubuntu1~22.04"
+    },
+    "gdisk": {
+      "arch": "amd64",
+      "version": "1.0.5-1"
+    },
+    "gettext-base": {
+      "arch": "amd64",
+      "version": "0.19.8.1-10build1"
+    },
+    "gir1.2-glib-2.0": {
+      "arch": "amd64",
+      "version": "1.64.1-1~ubuntu22.04.1"
+    },
+    "gir1.2-packagekitglib-1.0": {
+      "arch": "amd64",
+      "version": "1.1.13-2ubuntu1.1"
+    },
+    "git": {
+      "arch": "amd64",
+      "version": "1:2.25.1-1ubuntu3.2"
+    },
+    "git-man": {
+      "arch": "all",
+      "version": "1:2.25.1-1ubuntu3.2"
+    },
+    "glib-networking": {
+      "arch": "amd64",
+      "version": "2.64.2-1ubuntu0.1"
+    },
+    "glib-networking-common": {
+      "arch": "all",
+      "version": "2.64.2-1ubuntu0.1"
+    },
+    "glib-networking-services": {
+      "arch": "amd64",
+      "version": "2.64.2-1ubuntu0.1"
+    },
+    "gnupg": {
+      "arch": "all",
+      "version": "2.2.19-3ubuntu2.1"
+    },
+    "gnupg-l10n": {
+      "arch": "all",
+      "version": "2.2.19-3ubuntu2.1"
+    },
+    "gnupg-utils": {
+      "arch": "amd64",
+      "version": "2.2.19-3ubuntu2.1"
+    },
+    "gpg": {
+      "arch": "amd64",
+      "version": "2.2.19-3ubuntu2.1"
+    },
+    "gpg-agent": {
+      "arch": "amd64",
+      "version": "2.2.19-3ubuntu2.1"
+    },
+    "gpg-wks-client": {
+      "arch": "amd64",
+      "version": "2.2.19-3ubuntu2.1"
+    },
+    "gpg-wks-server": {
+      "arch": "amd64",
+      "version": "2.2.19-3ubuntu2.1"
+    },
+    "gpgconf": {
+      "arch": "amd64",
+      "version": "2.2.19-3ubuntu2.1"
+    },
+    "gpgsm": {
+      "arch": "amd64",
+      "version": "2.2.19-3ubuntu2.1"
+    },
+    "gpgv": {
+      "arch": "amd64",
+      "version": "2.2.19-3ubuntu2.1"
+    },
+    "grep": {
+      "arch": "amd64",
+      "version": "3.4-1"
+    },
+    "groff-base": {
+      "arch": "amd64",
+      "version": "1.22.4-4build1"
+    },
+    "grub-common": {
+      "arch": "amd64",
+      "version": "2.04-1ubuntu26.13"
+    },
+    "grub-gfxpayload-lists": {
+      "arch": "amd64",
+      "version": "0.7"
+    },
+    "grub-pc": {
+      "arch": "amd64",
+      "version": "2.04-1ubuntu26.13"
+    },
+    "grub-pc-bin": {
+      "arch": "amd64",
+      "version": "2.04-1ubuntu26.13"
+    },
+    "grub2-common": {
+      "arch": "amd64",
+      "version": "2.04-1ubuntu26.13"
+    },
+    "gsettings-desktop-schemas": {
+      "arch": "all",
+      "version": "3.36.0-1ubuntu1"
+    },
+    "gzip": {
+      "arch": "amd64",
+      "version": "1.10-0ubuntu4"
+    },
+    "hdparm": {
+      "arch": "amd64",
+      "version": "9.58+ds-4"
+    },
+    "hibagent": {
+      "arch": "all",
+      "version": "1.0.1-0ubuntu1"
+    },
+    "hostname": {
+      "arch": "amd64",
+      "version": "3.23"
+    },
+    "htop": {
+      "arch": "amd64",
+      "version": "2.2.0-2build1"
+    },
+    "info": {
+      "arch": "amd64",
+      "version": "6.7.0.dfsg.2-5"
+    },
+    "init": {
+      "arch": "amd64",
+      "version": "1.57"
+    },
+    "init-system-helpers": {
+      "arch": "all",
+      "version": "1.57"
+    },
+    "initramfs-tools": {
+      "arch": "all",
+      "version": "0.136ubuntu6.6"
+    },
+    "initramfs-tools-bin": {
+      "arch": "amd64",
+      "version": "0.136ubuntu6.6"
+    },
+    "initramfs-tools-core": {
+      "arch": "all",
+      "version": "0.136ubuntu6.6"
+    },
+    "install-info": {
+      "arch": "amd64",
+      "version": "6.7.0.dfsg.2-5"
+    },
+    "intel-microcode": {
+      "arch": "amd64",
+      "version": "3.20210608.0ubuntu0.22.04.1"
+    },
+    "iproute2": {
+      "arch": "amd64",
+      "version": "5.5.0-1ubuntu1"
+    },
+    "iptables": {
+      "arch": "amd64",
+      "version": "1.8.4-3ubuntu2"
+    },
+    "iputils-ping": {
+      "arch": "amd64",
+      "version": "3:20190709-3"
+    },
+    "iputils-tracepath": {
+      "arch": "amd64",
+      "version": "3:20190709-3"
+    },
+    "irqbalance": {
+      "arch": "amd64",
+      "version": "1.6.0-3ubuntu1"
+    },
+    "isc-dhcp-client": {
+      "arch": "amd64",
+      "version": "4.4.1-2.1ubuntu5.22.04.2"
+    },
+    "isc-dhcp-common": {
+      "arch": "amd64",
+      "version": "4.4.1-2.1ubuntu5.22.04.2"
+    },
+    "iso-codes": {
+      "arch": "all",
+      "version": "4.4-1"
+    },
+    "iucode-tool": {
+      "arch": "amd64",
+      "version": "2.3.1-1"
+    },
+    "kbd": {
+      "arch": "amd64",
+      "version": "2.0.4-4ubuntu2"
+    },
+    "keyboard-configuration": {
+      "arch": "all",
+      "version": "1.194ubuntu3"
+    },
+    "klibc-utils": {
+      "arch": "amd64",
+      "version": "2.0.7-1ubuntu5"
+    },
+    "kmod": {
+      "arch": "amd64",
+      "version": "27-1ubuntu2"
+    },
+    "kpartx": {
+      "arch": "amd64",
+      "version": "0.8.3-1ubuntu2"
+    },
+    "krb5-locales": {
+      "arch": "all",
+      "version": "1.17-6ubuntu4.1"
+    },
+    "landscape-common": {
+      "arch": "amd64",
+      "version": "19.12-0ubuntu4.2"
+    },
+    "language-selector-common": {
+      "arch": "all",
+      "version": "0.204.2"
+    },
+    "less": {
+      "arch": "amd64",
+      "version": "551-1ubuntu0.1"
+    },
+    "libaccountsservice0": {
+      "arch": "amd64",
+      "version": "0.6.55-0ubuntu12~22.04.4"
+    },
+    "libacl1": {
+      "arch": "amd64",
+      "version": "2.2.53-6"
+    },
+    "libaio1": {
+      "arch": "amd64",
+      "version": "0.3.112-5"
+    },
+    "libapparmor1": {
+      "arch": "amd64",
+      "version": "2.13.3-7ubuntu5.1"
+    },
+    "libappstream4": {
+      "arch": "amd64",
+      "version": "0.12.10-2"
+    },
+    "libapt-pkg6.0": {
+      "arch": "amd64",
+      "version": "2.0.6"
+    },
+    "libarchive13": {
+      "arch": "amd64",
+      "version": "3.4.0-2ubuntu1"
+    },
+    "libargon2-1": {
+      "arch": "amd64",
+      "version": "0~20171227-0.2"
+    },
+    "libasn1-8-heimdal": {
+      "arch": "amd64",
+      "version": "7.7.0+dfsg-1ubuntu1"
+    },
+    "libasound2": {
+      "arch": "amd64",
+      "version": "1.2.2-2.1ubuntu2.4"
+    },
+    "libasound2-data": {
+      "arch": "all",
+      "version": "1.2.2-2.1ubuntu2.4"
+    },
+    "libassuan0": {
+      "arch": "amd64",
+      "version": "2.5.3-7ubuntu2"
+    },
+    "libatasmart4": {
+      "arch": "amd64",
+      "version": "0.19-5"
+    },
+    "libatm1": {
+      "arch": "amd64",
+      "version": "1:2.5.1-4"
+    },
+    "libattr1": {
+      "arch": "amd64",
+      "version": "1:2.4.48-5"
+    },
+    "libaudit-common": {
+      "arch": "all",
+      "version": "1:2.8.5-2ubuntu6"
+    },
+    "libaudit1": {
+      "arch": "amd64",
+      "version": "1:2.8.5-2ubuntu6"
+    },
+    "libblkid1": {
+      "arch": "amd64",
+      "version": "2.34-0.1ubuntu9.1"
+    },
+    "libblockdev-crypto2": {
+      "arch": "amd64",
+      "version": "2.23-2ubuntu3"
+    },
+    "libblockdev-fs2": {
+      "arch": "amd64",
+      "version": "2.23-2ubuntu3"
+    },
+    "libblockdev-loop2": {
+      "arch": "amd64",
+      "version": "2.23-2ubuntu3"
+    },
+    "libblockdev-part-err2": {
+      "arch": "amd64",
+      "version": "2.23-2ubuntu3"
+    },
+    "libblockdev-part2": {
+      "arch": "amd64",
+      "version": "2.23-2ubuntu3"
+    },
+    "libblockdev-swap2": {
+      "arch": "amd64",
+      "version": "2.23-2ubuntu3"
+    },
+    "libblockdev-utils2": {
+      "arch": "amd64",
+      "version": "2.23-2ubuntu3"
+    },
+    "libblockdev2": {
+      "arch": "amd64",
+      "version": "2.23-2ubuntu3"
+    },
+    "libbrotli1": {
+      "arch": "amd64",
+      "version": "1.0.7-6ubuntu0.1"
+    },
+    "libbsd0": {
+      "arch": "amd64",
+      "version": "0.10.0-1"
+    },
+    "libbz2-1.0": {
+      "arch": "amd64",
+      "version": "1.0.8-2"
+    },
+    "libc-bin": {
+      "arch": "amd64",
+      "version": "2.31-0ubuntu9.2"
+    },
+    "libc6": {
+      "arch": "amd64",
+      "version": "2.31-0ubuntu9.2"
+    },
+    "libcanberra0": {
+      "arch": "amd64",
+      "version": "0.30-7ubuntu1"
+    },
+    "libcap-ng0": {
+      "arch": "amd64",
+      "version": "0.7.9-2.1build1"
+    },
+    "libcap2": {
+      "arch": "amd64",
+      "version": "1:2.32-1"
+    },
+    "libcap2-bin": {
+      "arch": "amd64",
+      "version": "1:2.32-1"
+    },
+    "libcbor0.6": {
+      "arch": "amd64",
+      "version": "0.6.0-0ubuntu1"
+    },
+    "libcom-err2": {
+      "arch": "amd64",
+      "version": "1.45.5-2ubuntu1"
+    },
+    "libcrypt1": {
+      "arch": "amd64",
+      "version": "1:4.4.10-10ubuntu4"
+    },
+    "libcryptsetup12": {
+      "arch": "amd64",
+      "version": "2:2.2.2-3ubuntu2.3"
+    },
+    "libcurl3-gnutls": {
+      "arch": "amd64",
+      "version": "7.68.0-1ubuntu2.7"
+    },
+    "libcurl4": {
+      "arch": "amd64",
+      "version": "7.68.0-1ubuntu2.7"
+    },
+    "libdb5.3": {
+      "arch": "amd64",
+      "version": "5.3.28+dfsg1-0.6ubuntu2"
+    },
+    "libdbus-1-3": {
+      "arch": "amd64",
+      "version": "1.12.16-2ubuntu2.1"
+    },
+    "libdconf1": {
+      "arch": "amd64",
+      "version": "0.36.0-1"
+    },
+    "libdebconfclient0": {
+      "arch": "amd64",
+      "version": "0.251ubuntu1"
+    },
+    "libdevmapper-event1.02.1": {
+      "arch": "amd64",
+      "version": "2:1.02.167-1ubuntu1"
+    },
+    "libdevmapper1.02.1": {
+      "arch": "amd64",
+      "version": "2:1.02.167-1ubuntu1"
+    },
+    "libdns-export1109": {
+      "arch": "amd64",
+      "version": "1:9.11.16+dfsg-3~ubuntu1"
+    },
+    "libdrm-common": {
+      "arch": "all",
+      "version": "2.4.105-3~22.04.2"
+    },
+    "libdrm2": {
+      "arch": "amd64",
+      "version": "2.4.105-3~22.04.2"
+    },
+    "libeatmydata1": {
+      "arch": "amd64",
+      "version": "105-7"
+    },
+    "libedit2": {
+      "arch": "amd64",
+      "version": "3.1-20191231-1"
+    },
+    "libefiboot1": {
+      "arch": "amd64",
+      "version": "37-2ubuntu2.2"
+    },
+    "libefivar1": {
+      "arch": "amd64",
+      "version": "37-2ubuntu2.2"
+    },
+    "libelf1": {
+      "arch": "amd64",
+      "version": "0.176-1.1build1"
+    },
+    "liberror-perl": {
+      "arch": "all",
+      "version": "0.17029-1"
+    },
+    "libestr0": {
+      "arch": "amd64",
+      "version": "0.1.10-2.1"
+    },
+    "libevent-2.1-7": {
+      "arch": "amd64",
+      "version": "2.1.11-stable-1"
+    },
+    "libexpat1": {
+      "arch": "amd64",
+      "version": "2.2.9-1build1"
+    },
+    "libext2fs2": {
+      "arch": "amd64",
+      "version": "1.45.5-2ubuntu1"
+    },
+    "libfastjson4": {
+      "arch": "amd64",
+      "version": "0.99.8-2"
+    },
+    "libfdisk1": {
+      "arch": "amd64",
+      "version": "2.34-0.1ubuntu9.1"
+    },
+    "libffi7": {
+      "arch": "amd64",
+      "version": "3.3-4"
+    },
+    "libfido2-1": {
+      "arch": "amd64",
+      "version": "1.3.1-1ubuntu2"
+    },
+    "libfl2": {
+      "arch": "amd64",
+      "version": "2.6.4-6.2"
+    },
+    "libfreetype6": {
+      "arch": "amd64",
+      "version": "2.10.1-2ubuntu0.1"
+    },
+    "libfribidi0": {
+      "arch": "amd64",
+      "version": "1.0.8-2"
+    },
+    "libfuse2": {
+      "arch": "amd64",
+      "version": "2.9.9-3"
+    },
+    "libfuse3-3": {
+      "arch": "amd64",
+      "version": "3.9.0-2"
+    },
+    "libfwupd2": {
+      "arch": "amd64",
+      "version": "1.5.11-0ubuntu1~22.04.2"
+    },
+    "libfwupdplugin1": {
+      "arch": "amd64",
+      "version": "1.5.11-0ubuntu1~22.04.2"
+    },
+    "libgcab-1.0-0": {
+      "arch": "amd64",
+      "version": "1.4-1"
+    },
+    "libgcc-s1": {
+      "arch": "amd64",
+      "version": "10.3.0-1ubuntu1~22.04"
+    },
+    "libgcrypt20": {
+      "arch": "amd64",
+      "version": "1.8.5-5ubuntu1.1"
+    },
+    "libgdbm-compat4": {
+      "arch": "amd64",
+      "version": "1.18.1-5"
+    },
+    "libgdbm6": {
+      "arch": "amd64",
+      "version": "1.18.1-5"
+    },
+    "libgirepository-1.0-1": {
+      "arch": "amd64",
+      "version": "1.64.1-1~ubuntu22.04.1"
+    },
+    "libglib2.0-0": {
+      "arch": "amd64",
+      "version": "2.64.6-1~ubuntu22.04.4"
+    },
+    "libglib2.0-bin": {
+      "arch": "amd64",
+      "version": "2.64.6-1~ubuntu22.04.4"
+    },
+    "libglib2.0-data": {
+      "arch": "all",
+      "version": "2.64.6-1~ubuntu22.04.4"
+    },
+    "libgmp10": {
+      "arch": "amd64",
+      "version": "2:6.2.0+dfsg-4"
+    },
+    "libgnutls30": {
+      "arch": "amd64",
+      "version": "3.6.13-2ubuntu1.6"
+    },
+    "libgpg-error0": {
+      "arch": "amd64",
+      "version": "1.37-1"
+    },
+    "libgpgme11": {
+      "arch": "amd64",
+      "version": "1.13.1-7ubuntu2"
+    },
+    "libgpm2": {
+      "arch": "amd64",
+      "version": "1.20.7-5"
+    },
+    "libgssapi-krb5-2": {
+      "arch": "amd64",
+      "version": "1.17-6ubuntu4.1"
+    },
+    "libgssapi3-heimdal": {
+      "arch": "amd64",
+      "version": "7.7.0+dfsg-1ubuntu1"
+    },
+    "libgstreamer1.0-0": {
+      "arch": "amd64",
+      "version": "1.16.2-2"
+    },
+    "libgudev-1.0-0": {
+      "arch": "amd64",
+      "version": "1:233-1"
+    },
+    "libgusb2": {
+      "arch": "amd64",
+      "version": "0.3.4-0.1"
+    },
+    "libhcrypto4-heimdal": {
+      "arch": "amd64",
+      "version": "7.7.0+dfsg-1ubuntu1"
+    },
+    "libheimbase1-heimdal": {
+      "arch": "amd64",
+      "version": "7.7.0+dfsg-1ubuntu1"
+    },
+    "libheimntlm0-heimdal": {
+      "arch": "amd64",
+      "version": "7.7.0+dfsg-1ubuntu1"
+    },
+    "libhogweed5": {
+      "arch": "amd64",
+      "version": "3.5.1+really3.5.1-2ubuntu0.2"
+    },
+    "libhx509-5-heimdal": {
+      "arch": "amd64",
+      "version": "7.7.0+dfsg-1ubuntu1"
+    },
+    "libicu66": {
+      "arch": "amd64",
+      "version": "66.1-2ubuntu2"
+    },
+    "libidn2-0": {
+      "arch": "amd64",
+      "version": "2.2.0-2"
+    },
+    "libip4tc2": {
+      "arch": "amd64",
+      "version": "1.8.4-3ubuntu2"
+    },
+    "libip6tc2": {
+      "arch": "amd64",
+      "version": "1.8.4-3ubuntu2"
+    },
+    "libisc-export1105": {
+      "arch": "amd64",
+      "version": "1:9.11.16+dfsg-3~ubuntu1"
+    },
+    "libisns0": {
+      "arch": "amd64",
+      "version": "0.97-3"
+    },
+    "libjcat1": {
+      "arch": "amd64",
+      "version": "0.1.3-2~ubuntu22.04.1"
+    },
+    "libjson-c4": {
+      "arch": "amd64",
+      "version": "0.13.1+dfsg-7ubuntu0.3"
+    },
+    "libjson-glib-1.0-0": {
+      "arch": "amd64",
+      "version": "1.4.4-2ubuntu2"
+    },
+    "libjson-glib-1.0-common": {
+      "arch": "all",
+      "version": "1.4.4-2ubuntu2"
+    },
+    "libk5crypto3": {
+      "arch": "amd64",
+      "version": "1.17-6ubuntu4.1"
+    },
+    "libkeyutils1": {
+      "arch": "amd64",
+      "version": "1.6-6ubuntu1"
+    },
+    "libklibc": {
+      "arch": "amd64",
+      "version": "2.0.7-1ubuntu5"
+    },
+    "libkmod2": {
+      "arch": "amd64",
+      "version": "27-1ubuntu2"
+    },
+    "libkrb5-26-heimdal": {
+      "arch": "amd64",
+      "version": "7.7.0+dfsg-1ubuntu1"
+    },
+    "libkrb5-3": {
+      "arch": "amd64",
+      "version": "1.17-6ubuntu4.1"
+    },
+    "libkrb5support0": {
+      "arch": "amd64",
+      "version": "1.17-6ubuntu4.1"
+    },
+    "libksba8": {
+      "arch": "amd64",
+      "version": "1.3.5-2"
+    },
+    "libldap-2.4-2": {
+      "arch": "amd64",
+      "version": "2.4.49+dfsg-2ubuntu1.8"
+    },
+    "libldap-common": {
+      "arch": "all",
+      "version": "2.4.49+dfsg-2ubuntu1.8"
+    },
+    "liblmdb0": {
+      "arch": "amd64",
+      "version": "0.9.24-1"
+    },
+    "liblocale-gettext-perl": {
+      "arch": "amd64",
+      "version": "1.07-4"
+    },
+    "libltdl7": {
+      "arch": "amd64",
+      "version": "2.4.6-14"
+    },
+    "liblvm2cmd2.03": {
+      "arch": "amd64",
+      "version": "2.03.07-1ubuntu1"
+    },
+    "liblz4-1": {
+      "arch": "amd64",
+      "version": "1.9.2-2ubuntu0.22.04.1"
+    },
+    "liblzma5": {
+      "arch": "amd64",
+      "version": "5.2.4-1ubuntu1"
+    },
+    "liblzo2-2": {
+      "arch": "amd64",
+      "version": "2.10-2"
+    },
+    "libmagic-mgc": {
+      "arch": "amd64",
+      "version": "1:5.38-4"
+    },
+    "libmagic1": {
+      "arch": "amd64",
+      "version": "1:5.38-4"
+    },
+    "libmaxminddb0": {
+      "arch": "amd64",
+      "version": "1.4.2-0ubuntu1.22.04.1"
+    },
+    "libmnl0": {
+      "arch": "amd64",
+      "version": "1.0.4-2"
+    },
+    "libmount1": {
+      "arch": "amd64",
+      "version": "2.34-0.1ubuntu9.1"
+    },
+    "libmpdec2": {
+      "arch": "amd64",
+      "version": "2.4.2-3"
+    },
+    "libmpfr6": {
+      "arch": "amd64",
+      "version": "4.0.2-1"
+    },
+    "libmspack0": {
+      "arch": "amd64",
+      "version": "0.10.1-2"
+    },
+    "libncurses6": {
+      "arch": "amd64",
+      "version": "6.2-0ubuntu2"
+    },
+    "libncursesw6": {
+      "arch": "amd64",
+      "version": "6.2-0ubuntu2"
+    },
+    "libnetfilter-conntrack3": {
+      "arch": "amd64",
+      "version": "1.0.7-2"
+    },
+    "libnetplan0": {
+      "arch": "amd64",
+      "version": "0.103-0ubuntu5~22.04.1"
+    },
+    "libnettle7": {
+      "arch": "amd64",
+      "version": "3.5.1+really3.5.1-2ubuntu0.2"
+    },
+    "libnewt0.52": {
+      "arch": "amd64",
+      "version": "0.52.21-4ubuntu2"
+    },
+    "libnfnetlink0": {
+      "arch": "amd64",
+      "version": "1.0.1-3build1"
+    },
+    "libnftnl11": {
+      "arch": "amd64",
+      "version": "1.1.5-1"
+    },
+    "libnghttp2-14": {
+      "arch": "amd64",
+      "version": "1.40.0-1build1"
+    },
+    "libnpth0": {
+      "arch": "amd64",
+      "version": "1.6-1"
+    },
+    "libnspr4": {
+      "arch": "amd64",
+      "version": "2:4.25-1"
+    },
+    "libnss-systemd": {
+      "arch": "amd64",
+      "version": "245.4-4ubuntu3.13"
+    },
+    "libnss3": {
+      "arch": "amd64",
+      "version": "2:3.49.1-1ubuntu1.5"
+    },
+    "libntfs-3g883": {
+      "arch": "amd64",
+      "version": "1:2017.3.23AR.3-3ubuntu1.1"
+    },
+    "libnuma1": {
+      "arch": "amd64",
+      "version": "2.0.12-1"
+    },
+    "libogg0": {
+      "arch": "amd64",
+      "version": "1.3.4-0ubuntu1"
+    },
+    "libp11-kit0": {
+      "arch": "amd64",
+      "version": "0.23.20-1ubuntu0.1"
+    },
+    "libpackagekit-glib2-18": {
+      "arch": "amd64",
+      "version": "1.1.13-2ubuntu1.1"
+    },
+    "libpam-cap": {
+      "arch": "amd64",
+      "version": "1:2.32-1"
+    },
+    "libpam-modules": {
+      "arch": "amd64",
+      "version": "1.3.1-5ubuntu4.3"
+    },
+    "libpam-modules-bin": {
+      "arch": "amd64",
+      "version": "1.3.1-5ubuntu4.3"
+    },
+    "libpam-runtime": {
+      "arch": "all",
+      "version": "1.3.1-5ubuntu4.3"
+    },
+    "libpam-systemd": {
+      "arch": "amd64",
+      "version": "245.4-4ubuntu3.13"
+    },
+    "libpam0g": {
+      "arch": "amd64",
+      "version": "1.3.1-5ubuntu4.3"
+    },
+    "libparted-fs-resize0": {
+      "arch": "amd64",
+      "version": "3.3-4ubuntu0.22.04.1"
+    },
+    "libparted2": {
+      "arch": "amd64",
+      "version": "3.3-4ubuntu0.22.04.1"
+    },
+    "libpcap0.8": {
+      "arch": "amd64",
+      "version": "1.9.1-3"
+    },
+    "libpci3": {
+      "arch": "amd64",
+      "version": "1:3.6.4-1ubuntu0.22.04.1"
+    },
+    "libpcre2-8-0": {
+      "arch": "amd64",
+      "version": "10.34-7"
+    },
+    "libpcre3": {
+      "arch": "amd64",
+      "version": "2:8.39-12build1"
+    },
+    "libperl5.30": {
+      "arch": "amd64",
+      "version": "5.30.0-9ubuntu0.2"
+    },
+    "libpipeline1": {
+      "arch": "amd64",
+      "version": "1.5.2-2build1"
+    },
+    "libplymouth5": {
+      "arch": "amd64",
+      "version": "0.9.4git20200323-0ubuntu6.2"
+    },
+    "libpng16-16": {
+      "arch": "amd64",
+      "version": "1.6.37-2"
+    },
+    "libpolkit-agent-1-0": {
+      "arch": "amd64",
+      "version": "0.105-26ubuntu1.1"
+    },
+    "libpolkit-gobject-1-0": {
+      "arch": "amd64",
+      "version": "0.105-26ubuntu1.1"
+    },
+    "libpopt0": {
+      "arch": "amd64",
+      "version": "1.16-14"
+    },
+    "libprocps8": {
+      "arch": "amd64",
+      "version": "2:3.3.16-1ubuntu2.3"
+    },
+    "libproxy1v5": {
+      "arch": "amd64",
+      "version": "0.4.15-10ubuntu1.2"
+    },
+    "libpsl5": {
+      "arch": "amd64",
+      "version": "0.21.0-1ubuntu1"
+    },
+    "libpython3-stdlib": {
+      "arch": "amd64",
+      "version": "3.8.2-0ubuntu2"
+    },
+    "libpython3.8": {
+      "arch": "amd64",
+      "version": "3.8.10-0ubuntu1~22.04.1"
+    },
+    "libpython3.8-minimal": {
+      "arch": "amd64",
+      "version": "3.8.10-0ubuntu1~22.04.1"
+    },
+    "libpython3.8-stdlib": {
+      "arch": "amd64",
+      "version": "3.8.10-0ubuntu1~22.04.1"
+    },
+    "libreadline5": {
+      "arch": "amd64",
+      "version": "5.2+dfsg-3build3"
+    },
+    "libreadline8": {
+      "arch": "amd64",
+      "version": "8.0-4"
+    },
+    "libroken18-heimdal": {
+      "arch": "amd64",
+      "version": "7.7.0+dfsg-1ubuntu1"
+    },
+    "librtmp1": {
+      "arch": "amd64",
+      "version": "2.4+20151223.gitfa8646d.1-2build1"
+    },
+    "libsasl2-2": {
+      "arch": "amd64",
+      "version": "2.1.27+dfsg-2"
+    },
+    "libsasl2-modules": {
+      "arch": "amd64",
+      "version": "2.1.27+dfsg-2"
+    },
+    "libsasl2-modules-db": {
+      "arch": "amd64",
+      "version": "2.1.27+dfsg-2"
+    },
+    "libseccomp2": {
+      "arch": "amd64",
+      "version": "2.5.1-1ubuntu1~22.04.1"
+    },
+    "libselinux1": {
+      "arch": "amd64",
+      "version": "3.0-1build2"
+    },
+    "libsemanage-common": {
+      "arch": "all",
+      "version": "3.0-1build2"
+    },
+    "libsemanage1": {
+      "arch": "amd64",
+      "version": "3.0-1build2"
+    },
+    "libsepol1": {
+      "arch": "amd64",
+      "version": "3.0-1"
+    },
+    "libsgutils2-2": {
+      "arch": "amd64",
+      "version": "1.44-1ubuntu2"
+    },
+    "libsigsegv2": {
+      "arch": "amd64",
+      "version": "2.12-2"
+    },
+    "libslang2": {
+      "arch": "amd64",
+      "version": "2.3.2-4"
+    },
+    "libsmartcols1": {
+      "arch": "amd64",
+      "version": "2.34-0.1ubuntu9.1"
+    },
+    "libsmbios-c2": {
+      "arch": "amd64",
+      "version": "2.4.3-1"
+    },
+    "libsodium23": {
+      "arch": "amd64",
+      "version": "1.0.18-1"
+    },
+    "libsoup2.4-1": {
+      "arch": "amd64",
+      "version": "2.70.0-1"
+    },
+    "libsqlite3-0": {
+      "arch": "amd64",
+      "version": "3.31.1-4ubuntu0.2"
+    },
+    "libss2": {
+      "arch": "amd64",
+      "version": "1.45.5-2ubuntu1"
+    },
+    "libssh-4": {
+      "arch": "amd64",
+      "version": "0.9.3-2ubuntu2.2"
+    },
+    "libssl1.1": {
+      "arch": "amd64",
+      "version": "1.1.1f-1ubuntu2.8"
+    },
+    "libstdc++6": {
+      "arch": "amd64",
+      "version": "10.3.0-1ubuntu1~22.04"
+    },
+    "libstemmer0d": {
+      "arch": "amd64",
+      "version": "0+svn585-2"
+    },
+    "libsystemd0": {
+      "arch": "amd64",
+      "version": "245.4-4ubuntu3.13"
+    },
+    "libtasn1-6": {
+      "arch": "amd64",
+      "version": "4.16.0-2"
+    },
+    "libtdb1": {
+      "arch": "amd64",
+      "version": "1.4.2-3build1"
+    },
+    "libtext-charwidth-perl": {
+      "arch": "amd64",
+      "version": "0.04-10"
+    },
+    "libtext-iconv-perl": {
+      "arch": "amd64",
+      "version": "1.7-7"
+    },
+    "libtext-wrapi18n-perl": {
+      "arch": "all",
+      "version": "0.06-9"
+    },
+    "libtinfo6": {
+      "arch": "amd64",
+      "version": "6.2-0ubuntu2"
+    },
+    "libtss2-esys0": {
+      "arch": "amd64",
+      "version": "2.3.2-1"
+    },
+    "libuchardet0": {
+      "arch": "amd64",
+      "version": "0.0.6-3build1"
+    },
+    "libudev1": {
+      "arch": "amd64",
+      "version": "245.4-4ubuntu3.13"
+    },
+    "libudisks2-0": {
+      "arch": "amd64",
+      "version": "2.8.4-1ubuntu2"
+    },
+    "libunistring2": {
+      "arch": "amd64",
+      "version": "0.9.10-2"
+    },
+    "libunwind8": {
+      "arch": "amd64",
+      "version": "1.2.1-9build1"
+    },
+    "liburcu6": {
+      "arch": "amd64",
+      "version": "0.11.1-2"
+    },
+    "libusb-1.0-0": {
+      "arch": "amd64",
+      "version": "2:1.0.23-2build1"
+    },
+    "libutempter0": {
+      "arch": "amd64",
+      "version": "1.1.6-4"
+    },
+    "libuuid1": {
+      "arch": "amd64",
+      "version": "2.34-0.1ubuntu9.1"
+    },
+    "libuv1": {
+      "arch": "amd64",
+      "version": "1.34.2-1ubuntu1.3"
+    },
+    "libvolume-key1": {
+      "arch": "amd64",
+      "version": "0.3.12-3.1"
+    },
+    "libvorbis0a": {
+      "arch": "amd64",
+      "version": "1.3.6-2ubuntu1"
+    },
+    "libvorbisfile3": {
+      "arch": "amd64",
+      "version": "1.3.6-2ubuntu1"
+    },
+    "libwind0-heimdal": {
+      "arch": "amd64",
+      "version": "7.7.0+dfsg-1ubuntu1"
+    },
+    "libwrap0": {
+      "arch": "amd64",
+      "version": "7.6.q-30"
+    },
+    "libx11-6": {
+      "arch": "amd64",
+      "version": "2:1.6.9-2ubuntu1.2"
+    },
+    "libx11-data": {
+      "arch": "all",
+      "version": "2:1.6.9-2ubuntu1.2"
+    },
+    "libxau6": {
+      "arch": "amd64",
+      "version": "1:1.0.9-0ubuntu1"
+    },
+    "libxcb1": {
+      "arch": "amd64",
+      "version": "1.14-2"
+    },
+    "libxdmcp6": {
+      "arch": "amd64",
+      "version": "1:1.1.3-0ubuntu1"
+    },
+    "libxext6": {
+      "arch": "amd64",
+      "version": "2:1.3.4-0ubuntu1"
+    },
+    "libxml2": {
+      "arch": "amd64",
+      "version": "2.9.10+dfsg-5ubuntu0.22.04.1"
+    },
+    "libxmlb1": {
+      "arch": "amd64",
+      "version": "0.1.15-2ubuntu1~22.04.1"
+    },
+    "libxmlsec1": {
+      "arch": "amd64",
+      "version": "1.2.28-2"
+    },
+    "libxmlsec1-openssl": {
+      "arch": "amd64",
+      "version": "1.2.28-2"
+    },
+    "libxmuu1": {
+      "arch": "amd64",
+      "version": "2:1.1.3-0ubuntu1"
+    },
+    "libxslt1.1": {
+      "arch": "amd64",
+      "version": "1.1.34-4"
+    },
+    "libxtables12": {
+      "arch": "amd64",
+      "version": "1.8.4-3ubuntu2"
+    },
+    "libyaml-0-2": {
+      "arch": "amd64",
+      "version": "0.2.2-1"
+    },
+    "libzstd1": {
+      "arch": "amd64",
+      "version": "1.4.4+dfsg-3ubuntu0.1"
+    },
+    "linux-aws": {
+      "arch": "amd64",
+      "version": "5.11.0.1020.21~22.04.19"
+    },
+    "linux-aws-5.11-headers-5.11.0-1020": {
+      "arch": "all",
+      "version": "5.11.0-1020.21~22.04.2"
+    },
+    "linux-base": {
+      "arch": "all",
+      "version": "4.5ubuntu3.6"
+    },
+    "linux-headers-5.11.0-1020-aws": {
+      "arch": "amd64",
+      "version": "5.11.0-1020.21~22.04.2"
+    },
+    "linux-headers-aws": {
+      "arch": "amd64",
+      "version": "5.11.0.1020.21~22.04.19"
+    },
+    "linux-image-5.11.0-1020-aws": {
+      "arch": "amd64",
+      "version": "5.11.0-1020.21~22.04.2"
+    },
+    "linux-image-aws": {
+      "arch": "amd64",
+      "version": "5.11.0.1020.21~22.04.19"
+    },
+    "linux-modules-5.11.0-1020-aws": {
+      "arch": "amd64",
+      "version": "5.11.0-1020.21~22.04.2"
+    },
+    "locales": {
+      "arch": "all",
+      "version": "2.31-0ubuntu9.2"
+    },
+    "login": {
+      "arch": "amd64",
+      "version": "1:4.8.1-1ubuntu5.22.04.1"
+    },
+    "logrotate": {
+      "arch": "amd64",
+      "version": "3.14.0-4ubuntu3"
+    },
+    "logsave": {
+      "arch": "amd64",
+      "version": "1.45.5-2ubuntu1"
+    },
+    "lsb-base": {
+      "arch": "all",
+      "version": "11.1.0ubuntu2"
+    },
+    "lsb-release": {
+      "arch": "all",
+      "version": "11.1.0ubuntu2"
+    },
+    "lshw": {
+      "arch": "amd64",
+      "version": "02.18.85-0.3ubuntu2.22.04.1"
+    },
+    "lsof": {
+      "arch": "amd64",
+      "version": "4.93.2+dfsg-1ubuntu0.22.04.1"
+    },
+    "ltrace": {
+      "arch": "amd64",
+      "version": "0.7.3-6.1ubuntu1"
+    },
+    "lvm2": {
+      "arch": "amd64",
+      "version": "2.03.07-1ubuntu1"
+    },
+    "lxd-agent-loader": {
+      "arch": "all",
+      "version": "0.4"
+    },
+    "lz4": {
+      "arch": "amd64",
+      "version": "1.9.2-2ubuntu0.22.04.1"
+    },
+    "man-db": {
+      "arch": "amd64",
+      "version": "2.9.1-1"
+    },
+    "manpages": {
+      "arch": "all",
+      "version": "5.05-1"
+    },
+    "mawk": {
+      "arch": "amd64",
+      "version": "1.3.4.20200120-2"
+    },
+    "mdadm": {
+      "arch": "amd64",
+      "version": "4.1-5ubuntu1.2"
+    },
+    "microcode-initrd": {
+      "arch": "amd64",
+      "version": "2~22.04.0"
+    },
+    "mime-support": {
+      "arch": "all",
+      "version": "3.64ubuntu1"
+    },
+    "motd-news-config": {
+      "arch": "all",
+      "version": "11ubuntu5.4"
+    },
+    "mount": {
+      "arch": "amd64",
+      "version": "2.34-0.1ubuntu9.1"
+    },
+    "mtr-tiny": {
+      "arch": "amd64",
+      "version": "0.93-1"
+    },
+    "multipath-tools": {
+      "arch": "amd64",
+      "version": "0.8.3-1ubuntu2"
+    },
+    "nano": {
+      "arch": "amd64",
+      "version": "4.8-1ubuntu1"
+    },
+    "ncurses-base": {
+      "arch": "all",
+      "version": "6.2-0ubuntu2"
+    },
+    "ncurses-bin": {
+      "arch": "amd64",
+      "version": "6.2-0ubuntu2"
+    },
+    "ncurses-term": {
+      "arch": "all",
+      "version": "6.2-0ubuntu2"
+    },
+    "netbase": {
+      "arch": "all",
+      "version": "6.1"
+    },
+    "netcat-openbsd": {
+      "arch": "amd64",
+      "version": "1.206-1ubuntu1"
+    },
+    "netplan.io": {
+      "arch": "amd64",
+      "version": "0.103-0ubuntu5~22.04.1"
+    },
+    "networkd-dispatcher": {
+      "arch": "all",
+      "version": "2.1-2~ubuntu22.04.1"
+    },
+    "ntfs-3g": {
+      "arch": "amd64",
+      "version": "1:2017.3.23AR.3-3ubuntu1.1"
+    },
+    "open-iscsi": {
+      "arch": "amd64",
+      "version": "2.0.874-7.1ubuntu6.2"
+    },
+    "open-vm-tools": {
+      "arch": "amd64",
+      "version": "2:11.0.5-4"
+    },
+    "openssh-client": {
+      "arch": "amd64",
+      "version": "1:8.2p1-4ubuntu0.3"
+    },
+    "openssh-server": {
+      "arch": "amd64",
+      "version": "1:8.2p1-4ubuntu0.3"
+    },
+    "openssh-sftp-server": {
+      "arch": "amd64",
+      "version": "1:8.2p1-4ubuntu0.3"
+    },
+    "openssl": {
+      "arch": "amd64",
+      "version": "1.1.1f-1ubuntu2.8"
+    },
+    "os-prober": {
+      "arch": "amd64",
+      "version": "1.74ubuntu2"
+    },
+    "overlayroot": {
+      "arch": "all",
+      "version": "0.45ubuntu1"
+    },
+    "packagekit": {
+      "arch": "amd64",
+      "version": "1.1.13-2ubuntu1.1"
+    },
+    "packagekit-tools": {
+      "arch": "amd64",
+      "version": "1.1.13-2ubuntu1.1"
+    },
+    "parted": {
+      "arch": "amd64",
+      "version": "3.3-4ubuntu0.22.04.1"
+    },
+    "passwd": {
+      "arch": "amd64",
+      "version": "1:4.8.1-1ubuntu5.22.04.1"
+    },
+    "pastebinit": {
+      "arch": "all",
+      "version": "1.5.1-1"
+    },
+    "patch": {
+      "arch": "amd64",
+      "version": "2.7.6-6"
+    },
+    "pci.ids": {
+      "arch": "all",
+      "version": "0.0~2020.03.20-1"
+    },
+    "pciutils": {
+      "arch": "amd64",
+      "version": "1:3.6.4-1ubuntu0.22.04.1"
+    },
+    "perl": {
+      "arch": "amd64",
+      "version": "5.30.0-9ubuntu0.2"
+    },
+    "perl-base": {
+      "arch": "amd64",
+      "version": "5.30.0-9ubuntu0.2"
+    },
+    "perl-modules-5.30": {
+      "arch": "all",
+      "version": "5.30.0-9ubuntu0.2"
+    },
+    "pinentry-curses": {
+      "arch": "amd64",
+      "version": "1.1.0-3build1"
+    },
+    "plymouth": {
+      "arch": "amd64",
+      "version": "0.9.4git20200323-0ubuntu6.2"
+    },
+    "plymouth-theme-ubuntu-text": {
+      "arch": "amd64",
+      "version": "0.9.4git20200323-0ubuntu6.2"
+    },
+    "policykit-1": {
+      "arch": "amd64",
+      "version": "0.105-26ubuntu1.1"
+    },
+    "pollinate": {
+      "arch": "all",
+      "version": "4.33-3ubuntu1.22.04.1"
+    },
+    "popularity-contest": {
+      "arch": "all",
+      "version": "1.69ubuntu1"
+    },
+    "powermgmt-base": {
+      "arch": "all",
+      "version": "1.36"
+    },
+    "procps": {
+      "arch": "amd64",
+      "version": "2:3.3.16-1ubuntu2.3"
+    },
+    "psmisc": {
+      "arch": "amd64",
+      "version": "23.3-1"
+    },
+    "publicsuffix": {
+      "arch": "all",
+      "version": "20200303.0012-1"
+    },
+    "python-apt-common": {
+      "arch": "all",
+      "version": "2.0.0ubuntu0.22.04.6"
+    },
+    "python3": {
+      "arch": "amd64",
+      "version": "3.8.2-0ubuntu2"
+    },
+    "python3-apport": {
+      "arch": "all",
+      "version": "2.20.11-0ubuntu27.20"
+    },
+    "python3-apt": {
+      "arch": "amd64",
+      "version": "2.0.0ubuntu0.22.04.6"
+    },
+    "python3-attr": {
+      "arch": "all",
+      "version": "19.3.0-2"
+    },
+    "python3-automat": {
+      "arch": "all",
+      "version": "0.8.0-1ubuntu1"
+    },
+    "python3-blinker": {
+      "arch": "all",
+      "version": "1.4+dfsg1-0.3ubuntu1"
+    },
+    "python3-certifi": {
+      "arch": "all",
+      "version": "2019.11.28-1"
+    },
+    "python3-cffi-backend": {
+      "arch": "amd64",
+      "version": "1.14.0-1build1"
+    },
+    "python3-chardet": {
+      "arch": "all",
+      "version": "3.0.4-4build1"
+    },
+    "python3-click": {
+      "arch": "all",
+      "version": "7.0-3"
+    },
+    "python3-colorama": {
+      "arch": "all",
+      "version": "0.4.3-1build1"
+    },
+    "python3-commandnotfound": {
+      "arch": "all",
+      "version": "22.04.4"
+    },
+    "python3-configobj": {
+      "arch": "all",
+      "version": "5.0.6-4"
+    },
+    "python3-constantly": {
+      "arch": "all",
+      "version": "15.1.0-1build1"
+    },
+    "python3-cryptography": {
+      "arch": "amd64",
+      "version": "2.8-3ubuntu0.1"
+    },
+    "python3-dbus": {
+      "arch": "amd64",
+      "version": "1.2.16-1build1"
+    },
+    "python3-debconf": {
+      "arch": "all",
+      "version": "1.5.73"
+    },
+    "python3-debian": {
+      "arch": "all",
+      "version": "0.1.36ubuntu1"
+    },
+    "python3-distro": {
+      "arch": "all",
+      "version": "1.4.0-1"
+    },
+    "python3-distro-info": {
+      "arch": "all",
+      "version": "0.23ubuntu1"
+    },
+    "python3-distupgrade": {
+      "arch": "all",
+      "version": "1:22.04.36"
+    },
+    "python3-distutils": {
+      "arch": "all",
+      "version": "3.8.10-0ubuntu1~22.04"
+    },
+    "python3-entrypoints": {
+      "arch": "all",
+      "version": "0.3-2ubuntu1"
+    },
+    "python3-gdbm": {
+      "arch": "amd64",
+      "version": "3.8.10-0ubuntu1~22.04"
+    },
+    "python3-gi": {
+      "arch": "amd64",
+      "version": "3.36.0-1"
+    },
+    "python3-hamcrest": {
+      "arch": "all",
+      "version": "1.9.0-3"
+    },
+    "python3-httplib2": {
+      "arch": "all",
+      "version": "0.14.0-1ubuntu1"
+    },
+    "python3-hyperlink": {
+      "arch": "all",
+      "version": "19.0.0-1"
+    },
+    "python3-idna": {
+      "arch": "all",
+      "version": "2.8-1"
+    },
+    "python3-importlib-metadata": {
+      "arch": "all",
+      "version": "1.5.0-1"
+    },
+    "python3-incremental": {
+      "arch": "all",
+      "version": "16.10.1-3.2"
+    },
+    "python3-jinja2": {
+      "arch": "all",
+      "version": "2.10.1-2"
+    },
+    "python3-json-pointer": {
+      "arch": "all",
+      "version": "2.0-0ubuntu1"
+    },
+    "python3-jsonpatch": {
+      "arch": "all",
+      "version": "1.23-3"
+    },
+    "python3-jsonschema": {
+      "arch": "all",
+      "version": "3.2.0-0ubuntu2"
+    },
+    "python3-jwt": {
+      "arch": "all",
+      "version": "1.7.1-2ubuntu2"
+    },
+    "python3-keyring": {
+      "arch": "all",
+      "version": "18.0.1-2ubuntu1"
+    },
+    "python3-launchpadlib": {
+      "arch": "all",
+      "version": "1.10.13-1"
+    },
+    "python3-lazr.restfulclient": {
+      "arch": "all",
+      "version": "0.14.2-2build1"
+    },
+    "python3-lazr.uri": {
+      "arch": "all",
+      "version": "1.0.3-4build1"
+    },
+    "python3-lib2to3": {
+      "arch": "all",
+      "version": "3.8.10-0ubuntu1~22.04"
+    },
+    "python3-markupsafe": {
+      "arch": "amd64",
+      "version": "1.1.0-1build2"
+    },
+    "python3-minimal": {
+      "arch": "amd64",
+      "version": "3.8.2-0ubuntu2"
+    },
+    "python3-more-itertools": {
+      "arch": "all",
+      "version": "4.2.0-1build1"
+    },
+    "python3-nacl": {
+      "arch": "amd64",
+      "version": "1.3.0-5"
+    },
+    "python3-netifaces": {
+      "arch": "amd64",
+      "version": "0.10.4-1ubuntu4"
+    },
+    "python3-newt": {
+      "arch": "amd64",
+      "version": "0.52.21-4ubuntu2"
+    },
+    "python3-oauthlib": {
+      "arch": "all",
+      "version": "3.1.0-1ubuntu2"
+    },
+    "python3-openssl": {
+      "arch": "all",
+      "version": "19.0.0-1build1"
+    },
+    "python3-pexpect": {
+      "arch": "all",
+      "version": "4.6.0-1build1"
+    },
+    "python3-pkg-resources": {
+      "arch": "all",
+      "version": "45.2.0-1"
+    },
+    "python3-problem-report": {
+      "arch": "all",
+      "version": "2.20.11-0ubuntu27.20"
+    },
+    "python3-ptyprocess": {
+      "arch": "all",
+      "version": "0.6.0-1ubuntu1"
+    },
+    "python3-pyasn1": {
+      "arch": "all",
+      "version": "0.4.2-3build1"
+    },
+    "python3-pyasn1-modules": {
+      "arch": "all",
+      "version": "0.2.1-0.2build1"
+    },
+    "python3-pymacaroons": {
+      "arch": "all",
+      "version": "0.13.0-3"
+    },
+    "python3-pyrsistent": {
+      "arch": "amd64",
+      "version": "0.15.5-1build1"
+    },
+    "python3-requests": {
+      "arch": "all",
+      "version": "2.22.0-2ubuntu1"
+    },
+    "python3-requests-unixsocket": {
+      "arch": "all",
+      "version": "0.2.0-2"
+    },
+    "python3-secretstorage": {
+      "arch": "all",
+      "version": "2.3.1-2ubuntu1"
+    },
+    "python3-serial": {
+      "arch": "all",
+      "version": "3.4-5.1"
+    },
+    "python3-service-identity": {
+      "arch": "all",
+      "version": "18.1.0-5build1"
+    },
+    "python3-setuptools": {
+      "arch": "all",
+      "version": "45.2.0-1"
+    },
+    "python3-simplejson": {
+      "arch": "amd64",
+      "version": "3.16.0-2ubuntu2"
+    },
+    "python3-six": {
+      "arch": "all",
+      "version": "1.14.0-2"
+    },
+    "python3-software-properties": {
+      "arch": "all",
+      "version": "0.98.9.5"
+    },
+    "python3-systemd": {
+      "arch": "amd64",
+      "version": "234-3build2"
+    },
+    "python3-twisted": {
+      "arch": "all",
+      "version": "18.9.0-11ubuntu0.22.04.1"
+    },
+    "python3-twisted-bin": {
+      "arch": "amd64",
+      "version": "18.9.0-11ubuntu0.22.04.1"
+    },
+    "python3-update-manager": {
+      "arch": "all",
+      "version": "1:22.04.10.9"
+    },
+    "python3-urllib3": {
+      "arch": "all",
+      "version": "1.25.8-2ubuntu0.1"
+    },
+    "python3-wadllib": {
+      "arch": "all",
+      "version": "1.3.3-3build1"
+    },
+    "python3-yaml": {
+      "arch": "amd64",
+      "version": "5.3.1-1ubuntu0.1"
+    },
+    "python3-zipp": {
+      "arch": "all",
+      "version": "1.0.0-1"
+    },
+    "python3-zope.interface": {
+      "arch": "amd64",
+      "version": "4.7.1-1"
+    },
+    "python3.8": {
+      "arch": "amd64",
+      "version": "3.8.10-0ubuntu1~22.04.1"
+    },
+    "python3.8-minimal": {
+      "arch": "amd64",
+      "version": "3.8.10-0ubuntu1~22.04.1"
+    },
+    "readline-common": {
+      "arch": "all",
+      "version": "8.0-4"
+    },
+    "rsync": {
+      "arch": "amd64",
+      "version": "3.1.3-8"
+    },
+    "rsyslog": {
+      "arch": "amd64",
+      "version": "8.2001.0-1ubuntu1.1"
+    },
+    "run-one": {
+      "arch": "all",
+      "version": "1.17-0ubuntu1"
+    },
+    "sbsigntool": {
+      "arch": "amd64",
+      "version": "0.9.2-2ubuntu1"
+    },
+    "screen": {
+      "arch": "amd64",
+      "version": "4.8.0-1ubuntu0.1"
+    },
+    "secureboot-db": {
+      "arch": "amd64",
+      "version": "1.5"
+    },
+    "sed": {
+      "arch": "amd64",
+      "version": "4.7-1"
+    },
+    "sensible-utils": {
+      "arch": "all",
+      "version": "0.0.12+nmu1"
+    },
+    "sg3-utils": {
+      "arch": "amd64",
+      "version": "1.44-1ubuntu2"
+    },
+    "sg3-utils-udev": {
+      "arch": "all",
+      "version": "1.44-1ubuntu2"
+    },
+    "shared-mime-info": {
+      "arch": "amd64",
+      "version": "1.15-1"
+    },
+    "snapd": {
+      "arch": "amd64",
+      "version": "2.51.1+22.04ubuntu2"
+    },
+    "software-properties-common": {
+      "arch": "all",
+      "version": "0.98.9.5"
+    },
+    "sosreport": {
+      "arch": "amd64",
+      "version": "4.1-1ubuntu0.22.04.3"
+    },
+    "sound-theme-freedesktop": {
+      "arch": "all",
+      "version": "0.8-2ubuntu1"
+    },
+    "squashfs-tools": {
+      "arch": "amd64",
+      "version": "1:4.4-1ubuntu0.3"
+    },
+    "ssh-import-id": {
+      "arch": "all",
+      "version": "5.10-0ubuntu1"
+    },
+    "strace": {
+      "arch": "amd64",
+      "version": "5.5-3ubuntu1"
+    },
+    "sudo": {
+      "arch": "amd64",
+      "version": "1.8.31-1ubuntu1.2"
+    },
+    "systemd": {
+      "arch": "amd64",
+      "version": "245.4-4ubuntu3.13"
+    },
+    "systemd-sysv": {
+      "arch": "amd64",
+      "version": "245.4-4ubuntu3.13"
+    },
+    "systemd-timesyncd": {
+      "arch": "amd64",
+      "version": "245.4-4ubuntu3.13"
+    },
+    "sysvinit-utils": {
+      "arch": "amd64",
+      "version": "2.96-2.1ubuntu1"
+    },
+    "tar": {
+      "arch": "amd64",
+      "version": "1.30+dfsg-7ubuntu0.22.04.1"
+    },
+    "tcpdump": {
+      "arch": "amd64",
+      "version": "4.9.3-4"
+    },
+    "telnet": {
+      "arch": "amd64",
+      "version": "0.17-41.2build1"
+    },
+    "thin-provisioning-tools": {
+      "arch": "amd64",
+      "version": "0.8.5-4build1"
+    },
+    "time": {
+      "arch": "amd64",
+      "version": "1.7-25.1build1"
+    },
+    "tmux": {
+      "arch": "amd64",
+      "version": "3.0a-2ubuntu0.3"
+    },
+    "tpm-udev": {
+      "arch": "all",
+      "version": "0.4"
+    },
+    "tzdata": {
+      "arch": "all",
+      "version": "2021a-2ubuntu0.22.04"
+    },
+    "ubuntu-advantage-tools": {
+      "arch": "amd64",
+      "version": "27.2.2~22.04.1"
+    },
+    "ubuntu-keyring": {
+      "arch": "all",
+      "version": "2020.02.11.4"
+    },
+    "ubuntu-minimal": {
+      "arch": "amd64",
+      "version": "1.450.2"
+    },
+    "ubuntu-release-upgrader-core": {
+      "arch": "all",
+      "version": "1:22.04.36"
+    },
+    "ubuntu-server": {
+      "arch": "amd64",
+      "version": "1.450.2"
+    },
+    "ubuntu-standard": {
+      "arch": "amd64",
+      "version": "1.450.2"
+    },
+    "ucf": {
+      "arch": "all",
+      "version": "3.0038+nmu1"
+    },
+    "udev": {
+      "arch": "amd64",
+      "version": "245.4-4ubuntu3.13"
+    },
+    "udisks2": {
+      "arch": "amd64",
+      "version": "2.8.4-1ubuntu2"
+    },
+    "ufw": {
+      "arch": "all",
+      "version": "0.36-6"
+    },
+    "unattended-upgrades": {
+      "arch": "all",
+      "version": "2.3ubuntu0.1"
+    },
+    "update-manager-core": {
+      "arch": "all",
+      "version": "1:22.04.10.9"
+    },
+    "update-notifier-common": {
+      "arch": "all",
+      "version": "3.192.30.9"
+    },
+    "usb.ids": {
+      "arch": "all",
+      "version": "2020.03.19-1"
+    },
+    "usbutils": {
+      "arch": "amd64",
+      "version": "1:012-2"
+    },
+    "util-linux": {
+      "arch": "amd64",
+      "version": "2.34-0.1ubuntu9.1"
+    },
+    "uuid-runtime": {
+      "arch": "amd64",
+      "version": "2.34-0.1ubuntu9.1"
+    },
+    "vim": {
+      "arch": "amd64",
+      "version": "2:8.1.2269-1ubuntu5.3"
+    },
+    "vim-common": {
+      "arch": "all",
+      "version": "2:8.1.2269-1ubuntu5.3"
+    },
+    "vim-runtime": {
+      "arch": "all",
+      "version": "2:8.1.2269-1ubuntu5.3"
+    },
+    "vim-tiny": {
+      "arch": "amd64",
+      "version": "2:8.1.2269-1ubuntu5.3"
+    },
+    "wget": {
+      "arch": "amd64",
+      "version": "1.20.3-1ubuntu1"
+    },
+    "whiptail": {
+      "arch": "amd64",
+      "version": "0.52.21-4ubuntu2"
+    },
+    "xauth": {
+      "arch": "amd64",
+      "version": "1:1.1-0ubuntu1"
+    },
+    "xdg-user-dirs": {
+      "arch": "amd64",
+      "version": "0.17-2ubuntu1"
+    },
+    "xfsprogs": {
+      "arch": "amd64",
+      "version": "5.3.0-1ubuntu2"
+    },
+    "xkb-data": {
+      "arch": "all",
+      "version": "2.29-2"
+    },
+    "xxd": {
+      "arch": "amd64",
+      "version": "2:8.1.2269-1ubuntu5.3"
+    },
+    "xz-utils": {
+      "arch": "amd64",
+      "version": "5.2.4-1ubuntu1"
+    },
+    "zerofree": {
+      "arch": "amd64",
+      "version": "1.1.1-1"
+    },
+    "zlib1g": {
+      "arch": "amd64",
+      "version": "1:1.2.11.dfsg-2ubuntu1.2"
+    }
+  },
+  "platform": "ubuntu",
+  "platform_family": "debian",
+  "platform_version": "22.04",
+  "root_group": "root",
+  "shard_seed": 174433164,
+  "shells": [
+    "/bin/sh",
+    "/bin/bash",
+    "/usr/bin/bash",
+    "/bin/rbash",
+    "/usr/bin/rbash",
+    "/bin/dash",
+    "/usr/bin/dash",
+    "/usr/bin/tmux",
+    "/usr/bin/screen"
+  ],
+  "time": {
+    "timezone": "GMT"
+  },
+  "uptime": "30 days 15 hours 07 minutes 30 seconds",
+  "uptime_seconds": 2646450,
+  "virtualization": {
+    "systems": {}
+  }
+}

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/resources/activate_virtual_env_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/resources/activate_virtual_env_spec.rb
@@ -26,10 +26,7 @@ describe 'activate_virtual_env:run' do
 
       context "with requirements" do
         cached(:chef_run) do
-          runner = ChefSpec::Runner.new(
-            platform: platform, version: version,
-            step_into: ['activate_virtual_env']
-          )
+          runner = runner(platform: platform, version: version, step_into: ['activate_virtual_env'])
           ConvergeActivateVirtualEnv.run(runner, pyenv_name: pyenv_name, pyenv_path: pyenv_path, python_version: python_version, user: user, requirements: requirements_path)
         end
         cached(:node) { chef_run.node }
@@ -70,10 +67,7 @@ describe 'activate_virtual_env:run' do
 
       context "without requirements" do
         cached(:chef_run) do
-          runner = ChefSpec::Runner.new(
-            platform: platform, version: version,
-            step_into: ['activate_virtual_env']
-          )
+          runner = runner(platform: platform, version: version, step_into: ['activate_virtual_env'])
           ConvergeActivateVirtualEnv.run(runner, pyenv_name: pyenv_name, pyenv_path: pyenv_path, python_version: python_version, user: user)
         end
         cached(:node) { chef_run.node }

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/resources/package_repos_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/resources/package_repos_spec.rb
@@ -14,10 +14,7 @@ describe 'package_repos:setup' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       cached(:chef_run) do
-        runner = ChefSpec::Runner.new(
-          platform: platform, version: version,
-          step_into: ['package_repos']
-        )
+        runner = runner(platform: platform, version: version, step_into: ['package_repos'])
         ConvergePackageRepos.setup(runner)
       end
 


### PR DESCRIPTION
### Description of changes
Add Ubuntu22.04 capability to ChefSpec tests

### Tests
ChefSpec tests on shared and environment cookbooks

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.