### PR TITLE
Add Ubuntu22.04 capability to ChefSpec tests for platform and computefleet cookbook

### DIFF
--- a/cookbooks/aws-parallelcluster-computefleet/spec/spec_helper.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/spec/spec_helper.rb
@@ -1,4 +1,4 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-require_relative '../../aws-parallelcluster-common/spec/spec_helper'
+require_relative '../../aws-parallelcluster-shared/spec/spec_helper'

--- a/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/node_spec.rb
@@ -10,7 +10,7 @@ describe 'aws-parallelcluster-computefleet::node' do
 
       context "when node virtualenv not installed yet and custom node package is not set" do
         cached(:chef_run) do
-          runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
+          runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['python-version'] = python_version
             node.override['cluster']['parallelcluster-node-version'] = node_version
@@ -45,7 +45,7 @@ describe 'aws-parallelcluster-computefleet::node' do
 
       context "when node virtualenv already installed" do
         cached(:chef_run) do
-          runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
+          runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['python-version'] = python_version
           end
@@ -61,7 +61,7 @@ describe 'aws-parallelcluster-computefleet::node' do
       context "when custom node package is specified" do
         cached(:custom_node_package) { 'custom_node_package' }
         cached(:chef_run) do
-          runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
+          runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['python-version'] = python_version
             node.override['cluster']['custom_node_package'] = custom_node_package

--- a/cookbooks/aws-parallelcluster-platform/spec/spec_helper.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/spec_helper.rb
@@ -1,4 +1,4 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-require_relative '../../aws-parallelcluster-common/spec/spec_helper'
+require_relative '../../aws-parallelcluster-shared/spec/spec_helper'

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/awscli_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/awscli_spec.rb
@@ -8,7 +8,7 @@ describe 'aws-parallelcluster-platform::awscli' do
       context "when awscli is not installed" do
         cached(:chef_run) do
           allow(File).to receive(:exist?).with('/usr/local/bin/aws').and_return(false)
-          ChefSpec::Runner.new(platform: platform, version: version).converge(described_recipe)
+          runner(platform: platform, version: version).converge(described_recipe)
         end
         cached(:node) { chef_run.node }
 
@@ -38,7 +38,7 @@ describe 'aws-parallelcluster-platform::awscli' do
       context "when awscli is not installed" do
         cached(:chef_run) do
           allow(File).to receive(:exist?).with('/usr/local/bin/aws').and_return(true)
-          ChefSpec::Runner.new(platform: platform, version: version).converge(described_recipe)
+          runner(platform: platform, version: version).converge(described_recipe)
         end
         cached(:node) { chef_run.node }
 

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cookbook_virtualenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cookbook_virtualenv_spec.rb
@@ -9,7 +9,7 @@ describe 'aws-parallelcluster-platform::cookbook_virtualenv' do
 
       context "when cookbook virtualenv not installed yet" do
         cached(:chef_run) do
-          runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
+          runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['python-version'] = python_version
           end
@@ -37,7 +37,7 @@ describe 'aws-parallelcluster-platform::cookbook_virtualenv' do
 
       context "when cookbook virtualenv already installed" do
         cached(:chef_run) do
-          runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
+          runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['python-version'] = python_version
           end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/directories_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/directories_spec.rb
@@ -4,7 +4,7 @@ describe 'aws-parallelcluster-platform::directories' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       cached(:chef_run) do
-        ChefSpec::Runner.new(platform: platform, version: version).converge(described_recipe)
+        runner(platform: platform, version: version).converge(described_recipe)
       end
       cached(:node) { chef_run.node }
 

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
@@ -4,7 +4,7 @@ describe 'aws-parallelcluster-platform::disable_services' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       cached(:chef_run) do
-        ChefSpec::Runner.new(platform: platform, version: version).converge(described_recipe)
+        runner(platform: platform, version: version).converge(described_recipe)
       end
 
       it 'disables DLAMI multi eni helper' do

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/sudo_install_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/sudo_install_spec.rb
@@ -4,7 +4,7 @@ describe 'aws-parallelcluster-platform::sudo_install' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       cached(:chef_run) do
-        ChefSpec::Runner.new(platform: platform, version: version).converge(described_recipe)
+        runner(platform: platform, version: version).converge(described_recipe)
       end
 
       it 'installs sudo package' do

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/supervisord_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/supervisord_spec.rb
@@ -6,7 +6,7 @@ describe 'aws-parallelcluster-platform::supervisord' do
       cached(:cookbook_venv_path) { 'cookbook_virtualenv_test_path' }
       cached(:chef_run) do
         allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
-        ChefSpec::Runner.new(platform: platform, version: version).converge(described_recipe)
+        runner(platform: platform, version: version).converge(described_recipe)
       end
       cached(:node) { chef_run.node }
 

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/users_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/users_spec.rb
@@ -4,7 +4,7 @@ describe 'aws-parallelcluster-platform::users' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       cached(:chef_run) do
-        ChefSpec::Runner.new(platform: platform, version: version).converge(described_recipe)
+        runner(platform: platform, version: version).converge(described_recipe)
       end
       cached(:node) { chef_run.node }
 

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/c_states_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/c_states_spec.rb
@@ -20,10 +20,7 @@ describe 'c_states:setup' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version} x86" do
       cached(:chef_run) do
-        runner = ChefSpec::Runner.new(
-          platform: platform, version: version,
-          step_into: ['c_states']
-        ) do |node|
+        runner = runner(platform: platform, version: version, step_into: ['c_states']) do |node|
           node.automatic['kernel']['machine'] = 'x86_64'
         end
         ConvergeCStates.setup(runner)
@@ -58,10 +55,7 @@ describe 'c_states:setup' do
 
     context "on #{platform}#{version} arm" do
       cached(:chef_run) do
-        runner = ChefSpec::Runner.new(
-          platform: platform, version: version,
-          step_into: ['c_states']
-        ) do |node|
+        runner = runner(platform: platform, version: version, step_into: ['c_states']) do |node|
           node.automatic['kernel']['machine'] = 'aarch64'
         end
         ConvergeCStates.setup(runner)

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/chrony_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/chrony_spec.rb
@@ -8,9 +8,7 @@ for_all_oses do |platform, version|
 
     describe 'aws-parallelcluster-platform::chrony setup' do
       cached(:chef_run) do
-        ChefSpec::Runner.new(
-          platform: platform, version: version, step_into: ['chrony']
-        ).converge_dsl('aws-parallelcluster-platform') do
+        runner(platform: platform, version: version, step_into: ['chrony']).converge_dsl('aws-parallelcluster-platform') do
           chrony 'setup' do
             action :setup
           end
@@ -49,9 +47,7 @@ for_all_oses do |platform, version|
 
     describe 'aws-parallelcluster-platform::chrony enable' do
       cached(:chef_run) do
-        ChefSpec::Runner.new(
-          platform: platform, version: version, step_into: ['chrony']
-        ).converge_dsl('aws-parallelcluster-platform') do
+        runner(platform: platform, version: version, step_into: ['chrony']).converge_dsl('aws-parallelcluster-platform') do
           chrony 'enable' do
             action :enable
           end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/modules_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/modules_spec.rb
@@ -4,9 +4,7 @@ for_all_oses do |platform, version|
   context "on #{platform}#{version}" do
     describe 'aws-parallelcluster-platform::modules setup' do
       cached(:chef_run) do
-        ChefSpec::Runner.new(
-          platform: platform, version: version, step_into: ['modules']
-        ).converge_dsl('aws-parallelcluster-platform') do
+        runner(platform: platform, version: version, step_into: ['modules']).converge_dsl('aws-parallelcluster-platform') do
           modules 'setup' do
             action :setup
           end
@@ -47,9 +45,7 @@ for_all_oses do |platform, version|
 
       cached(:chef_run) do
         the_line = line
-        ChefSpec::Runner.new(
-          platform: platform, version: version, step_into: ['modules']
-        ).converge_dsl('aws-parallelcluster-platform') do
+        runner(platform: platform, version: version, step_into: ['modules']).converge_dsl('aws-parallelcluster-platform') do
           modules 'append_to_config' do
             line the_line
             action :append_to_config


### PR DESCRIPTION
### Description of changes
Add Ubuntu22.04 capability to ChefSpec tests for platform and computefleet cookbook

### Tests
ChefSpec tests

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.