### PR TITLE
Fix typo in slurm_node_spec.json

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurm_node_spec.json.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurm_node_spec.json.erb
@@ -1,9 +1,9 @@
 {
   "region": "<%= @region %>",
-  "cluster_name": "<%= @cluster_name %>",
+  "cluster-name": "<%= @cluster_name %>",
   "scheduler": "<%= @scheduler %>",
-  "node_role": "<%= @node_role %>",
-  "instance_id": "<%= @instance_id %>",
+  "node-role": "<%= @node_role %>",
+  "instance-id": "<%= @instance_id %>",
   "compute": {
     "queue-name": "<%= @queue_name %>",
     "compute-resource": "<%= @compute_resource %>",


### PR DESCRIPTION
### Description of changes
* Some top level  property names used `_` instead of `-`
* Fixed property names

### Tests
* Ran unit tests.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.