### PR TITLE
Allow aws-parallelcluster-tests::test_resource to accept  properties

### DIFF
--- a/cookbooks/aws-parallelcluster-tests/recipes/test_resource.rb
+++ b/cookbooks/aws-parallelcluster-tests/recipes/test_resource.rb
@@ -1,13 +1,44 @@
 # This is a helper recipe executing an action of the resource
-# which type was set as `resource` attribute during the test execution.
-# Expected syntax for the resource attribute is resource-name:optional-action
+# Usage:
+#   - name: <suite_name>
+#     run_list:
+#       - recipe[aws-parallelcluster-tests::test_resource]
+#     attributes:
+#       resource: <resource_name>[:<resource_action>]
+#       [resource_properties:
+#         <resource_property_1_name>: <resource_property_1_value>
+#         <resource_property_2_name>: <resource_property_2_value>]
+#
+# Examples
+#
+#   - name: resource_with_defaults
+#     run_list:
+#       - recipe[aws-parallelcluster-tests::test_resource]
+#     attributes:
+#       resource: resource_name
+#
+#   - name: resource_with_action
+#     run_list:
+#       - recipe[aws-parallelcluster-tests::test_resource]
+#     attributes:
+#       resource: resource_name:action
+#
+#   - name: resource_with_properties
+#     run_list:
+#       - recipe[aws-parallelcluster-tests::test_resource]
+#     attributes:
+#       resource: resource_name
+#       resource_properties:
+#         property1: x
+#         property2: y
+#
 
 resource_item = node['resource'].split(/:/)
-if resource_item[1].nil?
-  # default action
-  declare_resource(resource_item[0], 'test')
-else
-  declare_resource(resource_item[0], 'test') do
-    action resource_item[1]
+resource_properties = node['resource_properties'] || {}
+
+declare_resource(resource_item[0], 'test') do
+  resource_properties.each_key do |key|
+    send("#{key}=", resource_properties[key])
   end
+  action resource_item[1]
 end


### PR DESCRIPTION
### Description of changes
Allow aws-parallelcluster-tests::test_resource to accept  properties

### Tests
#### Resource
```
provides :trs
unified_mode true

property :message, String
property :index, Integer
property :flag, [true, false]

default_action :write

action :write do
  log "message #{new_resource.message} && #{new_resource.index} && #{new_resource.flag}"
end
```

#### Test config
```
  - name: trs
    run_list:
      - recipe[aws-parallelcluster-tests::setup]
      - recipe[aws-parallelcluster-tests::test_resource]
    verifier:
      controls:
        - /none/
    attributes:
      resource: trs
      resource_properties:
        message: Hello!
        index: 1
        flag: true
```

#### Result:
```
 Recipe: aws-parallelcluster-tests::test_resource
   * trs[test] action write
     * log[message Hello! && 1 && true] action write
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.