### PR TITLE
Forward SLURM_RESUME_FILE to PCluster resume program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Load kernel module [nvidia-uvm](https://developer.nvidia.com/blog/unified-memory-cuda-beginners/) by default to provide Unified Virtual Memory (UVM) functionality to the CUDA driver.
 - Install [NVIDIA Persistence Daemon](https://docs.nvidia.com/deploy/driver-persistence/index.html) as a system service.
 - Install [NVIDIA Data Center GPU Manager (DCGM)](https://developer.nvidia.com/dcgm) package on all supported OSes except for aarch64 `centos7` and `alinux2`.
+- Forward SLURM_RESUME_FILE to ParallelCluster resume program.
 
 **CHANGES**
 - Upgrade Slurm to version 23.02.2.

--- a/cookbooks/aws-parallelcluster-shared/attributes/users.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/users.rb
@@ -10,6 +10,8 @@ default['cluster']['slurm']['user'] = 'slurm'
 default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1
 default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']
 default['cluster']['slurm']['group_id'] = node['cluster']['slurm']['user_id']
+default['cluster']['slurm']['resume_group'] = 'slurm-resume'
+default['cluster']['slurm']['resume_group_id'] = node['cluster']['reserved_base_uid'] + 5
 
 # Munge
 default['cluster']['munge']['user'] = 'munge'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -21,6 +21,8 @@ slurm_user = node['cluster']['slurm']['user']
 slurm_user_id = node['cluster']['slurm']['user_id']
 slurm_group = node['cluster']['slurm']['group']
 slurm_group_id = node['cluster']['slurm']['group_id']
+slurm_resume_program_group = node['cluster']['slurm']['resume_group']
+slurm_resume_program_group_id = node['cluster']['slurm']['resume_group_id']
 slurm_install_dir = node['cluster']['slurm']['install_dir']
 
 slurm_version = node['cluster']['slurm']['version']
@@ -51,6 +53,20 @@ user slurm_user do
   home "/home/#{slurm_user}"
   system true
   shell '/bin/bash'
+end
+
+# Setup slurm resume program group
+group slurm_resume_program_group do
+  comment 'slurm resume program group'
+  gid slurm_resume_program_group_id
+  system true
+end
+
+# add slurm user and pcluster-admin to slurm resume program group
+group slurm_resume_program_group do
+  action :modify
+  members [ slurm_user, node['cluster']['cluster_admin_user'] ]
+  append true
 end
 
 # Get slurm tarball

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/99-parallelcluster-slurm.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/99-parallelcluster-slurm.erb
@@ -5,4 +5,4 @@ Cmnd_Alias SHUTDOWN = /usr/sbin/shutdown
 <%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SLURM_COMMANDS
 <%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SHUTDOWN
 
-<%= node['cluster']['slurm']['user'] %> ALL = (<%= node['cluster']['cluster_admin_user'] %>) NOPASSWD: SLURM_HOOKS_COMMANDS
+<%= node['cluster']['slurm']['user'] %> ALL = (<%= node['cluster']['cluster_admin_user'] %>) NOPASSWD:SETENV: SLURM_HOOKS_COMMANDS

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/resume_program.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/resume_program.erb
@@ -1,2 +1,13 @@
 #!/bin/bash
-sudo -u <%= node['cluster']['cluster_admin_user'] %> <%= node_virtualenv_path %>/bin/slurm_resume "$@"
+# ResumeProgram should read SLURM_RESUME_FILE within ten seconds of starting to guarantee that it still exists.
+# ref https://slurm.schedmd.com/power_save.html#tolerance
+
+trap "rm -f ${SLURM_RESUME_FILE_TMP}" EXIT
+
+SLURM_RESUME_FILE_TMP=$(mktemp)
+cp ${SLURM_RESUME_FILE} ${SLURM_RESUME_FILE_TMP}
+
+chgrp <%= node['cluster']['slurm']['resume_group'] %> ${SLURM_RESUME_FILE_TMP}
+chmod g+r ${SLURM_RESUME_FILE_TMP}
+
+sudo -u <%= node['cluster']['cluster_admin_user'] %> SLURM_RESUME_FILE=${SLURM_RESUME_FILE_TMP} <%= node_virtualenv_path %>/bin/slurm_resume  "$@"

--- a/kitchen.recipes-install.yml
+++ b/kitchen.recipes-install.yml
@@ -113,6 +113,7 @@ suites:
         - slurm_lua_support_libraries_compiled
     attributes:
       dependencies:
+        - recipe:aws-parallelcluster-platform::users
         - recipe:aws-parallelcluster-platform::directories
         - resource:package_repos
         - resource:install_packages

--- a/test/recipes/controls/aws_parallelcluster_slurm/install_slurm_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/install_slurm_spec.rb
@@ -11,8 +11,11 @@
 
 slurm_user = 'slurm'
 slurm_group = slurm_user
+slurm_resume_group = 'slurm-resume'
 slurm_license_path = '/opt/parallelcluster/licenses/slurm'
 slurm_library_folder = '/opt/slurm/lib/slurm'
+pcluster_admin = 'pcluster-admin'
+pcluster_admin_group = pcluster_admin
 
 control 'slurm_installed' do
   title 'Checks slurm has been installed'
@@ -35,9 +38,18 @@ control 'slurm_user_and_group_created' do
     it { should exist }
   end
 
+  describe group(slurm_resume_group) do
+    it { should exist }
+  end
+
   describe user(slurm_user) do
     it { should exist }
-    its('group') { should eq slurm_group }
+    its('groups') { should eq [slurm_group, slurm_resume_group] }
+  end
+
+  describe user(pcluster_admin) do
+    it { should exist }
+    its('groups') { should eq [pcluster_admin_group, slurm_resume_group] }
   end
 end
 

--- a/test/recipes/controls/aws_parallelcluster_slurm/slurm_users_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/slurm_users_spec.rb
@@ -69,7 +69,7 @@ control 'tag:config_slurm_sudoers_correctly_defined' do
     its('content') { should match %r{Cmnd_Alias SLURM_COMMANDS = #{install_dir}/bin/scontrol, #{install_dir}/bin/sinfo} }
     its('content') { should match /#{node['cluster']['cluster_admin_user']} ALL = \(root\) NOPASSWD: SHUTDOWN/ }
     its('content') { should match %r{Cmnd_Alias SHUTDOWN = /usr/sbin/shutdown} }
-    its('content') { should match /#{node['cluster']['slurm']['user']} ALL = \(#{node['cluster']['cluster_admin_user']}\) NOPASSWD: SLURM_HOOKS_COMMANDS/ }
+    its('content') { should match /#{node['cluster']['slurm']['user']} ALL = \(#{node['cluster']['cluster_admin_user']}\) NOPASSWD:SETENV: SLURM_HOOKS_COMMANDS/ }
     its('content') { should match %r{Cmnd_Alias SLURM_HOOKS_COMMANDS = #{venv_bin}/slurm_suspend, #{venv_bin}/slurm_resume, #{venv_bin}/slurm_fleet_status_manager} } unless redhat_ubi
   end
 end


### PR DESCRIPTION
### Description of changes
`SLURM_RESUME_FILE` is owned by the same user running the Slurm resume program (`slurm`) while PCluster resume program is executed by `pcluster-admin` user.

Ownership or permission of the `SLURM_RESUME_FILE` cannot be changed, so the file is copied into a temporary one and the group-ship of this is changed to a group that is in common between the two users

The copy is then passed to the PCluster resume program through sudo exported env

### Tests
* added inspec test

### References
n/a

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.