### PR TITLE
Add job info daemon to supervisord conf, add configs and log files

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/templates/log_rotation/parallelcluster_log_rotation.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/log_rotation/parallelcluster_log_rotation.erb
@@ -70,6 +70,32 @@
   nodateext
 }
 <% end -%>
+<% if node['cluster']['scheduler'] == 'slurm' && node['cluster']['cluster_job_info_enabled'] -%>
+<%# job info log %>
+/var/log/parallelcluster/clusterjobinfomgtd {
+  missingok
+  notifempty
+  nodateext
+  size 50M
+  rotate 1
+  su root root
+  postrotate
+    pkill --signal=SIGUSR2 supervisord
+    echo 0
+  endscript
+  create 0644 root root
+}
+<%# jobinfo events log %>
+/var/log/parallelcluster/clusterjobinfomgtd.events {
+  rotate 1
+  size 10M
+  missingok
+  notifempty
+  copytruncate
+  su pcluster-admin pcluster-admin
+  nodateext
+}
+<% end -%>
 <% if node['cluster']["directory_service"]["generate_ssh_keys_for_users"] == 'true' -%>
 <%# pam_ssh_key_generator log %>
 /var/log/parallelcluster/pam_ssh_key_generator.log {

--- a/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
@@ -39,7 +39,15 @@ command = <%= @dcv_auth_virtualenv_path %>/bin/python <%= @dcv_auth_user_home %>
 user = <%= @dcv_auth_user %>
 environment = HOME="<%= @dcv_auth_user_home %>",USER="<%= @dcv_auth_user %>"<% if @region.start_with?('us-iso') -%>,AWS_CA_BUNDLE="<%= @aws_ca_bundle %>"<% end -%>
 <% end -%>
-
+<% if node['cluster']['scheduler'] == 'slurm' && node['cluster']['cluster_job_info_enabled'] -%>
+[program:clusterjobinfomgtd]
+command = <%= node_virtualenv_path %>/bin/clusterjobinfomgtd
+user = <%= node['cluster']['cluster_admin_user'] %>
+environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"<% if @region.start_with?('us-iso') -%>,AWS_CA_BUNDLE="<%= @aws_ca_bundle %>"<% end -%>
+redirect_stderr = true
+stdout_logfile = /var/log/parallelcluster/clusterjobinfomgtd
+stdout_logfile_maxbytes = 0
+<% end -%>
 <%# ComputeFleet -%>
 <% when 'ComputeFleet' -%>
 <% if node['cluster']['scheduler'] == 'slurm' -%>

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -16,3 +16,6 @@ default['cluster']['slurm_plugin_console_logging']['sample_size'] = 1
 default["cluster"]["scheduler_compute_resource_name"] = nil
 
 default['cluster']['enable_nss_slurm'] = node['cluster']['directory_service']['enabled']
+
+# Default job information collection option
+default['cluster']['cluster_job_info_enabled'] = true

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
@@ -281,3 +281,5 @@ execute "check slurmctld status" do
   retries 5
   retry_delay 2
 end unless redhat_on_docker?
+
+include_recipe 'aws-parallelcluster-slurm::config_clusterjobinfomgtd'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_clusterjobinfomgtd.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_clusterjobinfomgtd.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Job Info Management Demon
+return unless node['cluster']['node_type'] == 'HeadNode' && node['cluster']['cluster_job_info_enabled']
+
+# create log file for clusterjobinfomgtd
+file "/var/log/parallelcluster/clusterjobinfomgtd" do
+  owner 'root'
+  group 'root'
+  mode '0640'
+end
+
+template "/etc/parallelcluster/parallelcluster_jobinfomgtd.conf" do
+  source 'jobinfomgtd/parallelcluster_jobinfomgtd.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  variables(
+    cluster_name: node['cluster']['stack_name'],
+    instance_id: on_docker? ? 'instance_id' : node['ec2']['instance_id']
+  )
+end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/jobinfomgtd/parallelcluster_jobinfomgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/jobinfomgtd/parallelcluster_jobinfomgtd.conf.erb
@@ -1,0 +1,7 @@
+[clusterjobinfomgtd]
+cluster_name = <%= @cluster_name %>
+region = <%= node['cluster']['region'] %>
+proxy = <%= node['cluster']['proxy'] %>
+instance_id = <%= @instance_id %>
+cpu_gpu_cost_ratio = 1
+custom_discount_rate = 0


### PR DESCRIPTION
### Description of changes
* Add job info daemon to supervisord conf when job info collection is enabled, 
* Set the loop time to be 180 seconds
* Add job info daemon config

### Tests
* Manually test with job info collection is enabled:
```
[ec2-user@ip-192-168-14-181 log]$ sudo cat /var/log/parallelcluster/jobinfomgtd
2023-05-25 03:08:36,544 - [jobinfomgtd:main] - INFO - Jobinfomgtd Startup
2023-05-25 03:08:36,544 - [jobinfomgtd:_get_config] - INFO - Reading /etc/parallelcluster/parallelcluster_jobinfomgtd.conf
2023-05-25 03:08:36,544 - [jobinfomgtd:set_config] - INFO - Applying new jobinfomgtd config: JobinfomgtdConfig(_config=<configparser.ConfigParser object at 0x7f3e69614400>, region='us-west-1', cluster_name='gpu-cluster11', logging_config='/opt/parallelcluster/scripts/jobinfomgtd_logging.conf', loop_time=180, cpu_gpu_cost_ratio=1, custom_discount_rate=0, _boto3_retry=5, _boto3_config={'retries': {'max_attempts': 5, 'mode': 'standard'}}, boto3_config=<botocore.config.Config object at 0x7f3e69620640>)
2023-05-25 03:08:36,544 - [jobinfomgtd:_get_config] - INFO - Reading /etc/parallelcluster/parallelcluster_jobinfomgtd.conf

```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.