### PR TITLE
Fix nfs test to pass on every instance type

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -14,9 +14,6 @@ suites:
         - /tag:config_nfs/
     attributes:
       resource: nfs:configure
-      cluster:
-        nfs:
-          threads: 10
       dependencies:
         - resource:nfs
   - name: cloudwatch

--- a/cookbooks/aws-parallelcluster-environment/test/controls/nfs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/nfs_spec.rb
@@ -33,7 +33,7 @@ control 'tag:config_nfs_configured' do
   describe 'Check that the number of nfs threads is correct'
   describe bash("grep th /proc/net/rpc/nfsd | awk '{print $2}'") do
     its('exit_status') { should eq 0 }
-    its('stdout') { should cmp 10 }
+    its('stdout') { should cmp [[node['cpu']['cores'].to_i * 4, 8].max, 256].min }
   end
 end
 


### PR DESCRIPTION
### Description of changes
* We were comparing the number of threads with 10, but the value of threads depends by the number of cores.

### Tests
* Tested for alinux on ec2 and docker
* It was failing with:
``` 
[2023-05-25T02:18:21.811Z]      ×  Bash command grep th /proc/net/rpc/nfsd | awk '{print $2}' stdout is expected to cmp == 10
[2023-05-25T02:18:21.811Z]      
[2023-05-25T02:18:21.811Z]      expected: 10
[2023-05-25T02:18:21.811Z]           got: 16
```

Now passing:
``` 
  ✔  tag:config_nfs_has_correct_number_of_threads: Bash command cat /proc/net/rpc/nfsd | grep th | awk '{print$2}'
     ✔  Bash command cat /proc/net/rpc/nfsd | grep th | awk '{print$2}' stdout is expected to cmp == 8
```

### References
* Failing after adding `tag:config` to the test that will run the test with multiple instance types on CICD: https://github.com/aws/aws-parallelcluster-cookbook/commit/c55537f4934602d95c996e8c1f537706947717f4

