### PR TITLE
Move stunnel resource to platform cookbook

### DIFF
--- a/.github/workflows/dokken-unit-tests.yml
+++ b/.github/workflows/dokken-unit-tests.yml
@@ -155,7 +155,7 @@ jobs:
           - jwt-dependencies
           - efa-setup
           - munge
-          - stunnel-installed
+          - /stunnel-installed/
       fail-fast: false
     steps:
       - name: Check out code

--- a/cookbooks/aws-parallelcluster-install/attributes/default.rb
+++ b/cookbooks/aws-parallelcluster-install/attributes/default.rb
@@ -1,7 +1,0 @@
-# aws-parallelcluster-install attributes
-
-# stunnel
-default['cluster']['stunnel']['version'] = '5.67'
-default['cluster']['stunnel']['url'] = lazy { "#{node['cluster']['artifacts_s3_url']}/stunnel/stunnel-#{node['cluster']['stunnel']['version']}.tar.gz" }
-default['cluster']['stunnel']['sha256'] = '3086939ee6407516c59b0ba3fbf555338f9d52f459bcab6337c0f00e91ea8456'
-default['cluster']['stunnel']['tarball_path'] = "#{node['cluster']['sources_dir']}/stunnel-#{node['cluster']['stunnel']['version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
@@ -156,3 +156,12 @@ suites:
       resource: arm_pl
       dependencies:
         - resource:package_repos
+  - name: stunnel
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-install::test_resource]
+    verifier:
+      controls:
+        - /tag:install_stunnel/
+    attributes:
+      resource: stunnel:setup

--- a/cookbooks/aws-parallelcluster-platform/resources/stunnel/partial/_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/stunnel/partial/_common.rb
@@ -1,0 +1,5 @@
+property :stunnel_version, String, default: '5.67'
+property :stunnel_checksum, String, default: '3086939ee6407516c59b0ba3fbf555338f9d52f459bcab6337c0f00e91ea8456'
+
+unified_mode true
+default_action :setup

--- a/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_amazon2.rb
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 provides :stunnel, platform: 'amazon', platform_version: '2'
-unified_mode true
-default_action :setup
+
+use 'partial/_common'
 
 action :setup do
   # do nothing - in AL2 stunnel comes as part of the aws-efs-utils package

--- a/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_centos7.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_centos7.rb
@@ -12,14 +12,15 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License
 
-provides :stunnel, platform: 'ubuntu'
-unified_mode true
-default_action :setup
+provides :stunnel, platform: 'centos' do |node|
+  node['platform_version'].to_i == 7
+end
 
+use 'partial/_common'
 use 'partial/_setup'
 
 action_class do
   def dependencies
-    %w(libwrap0-dev)
+    %w(openssl-devel tcp_wrappers-devel)
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_redhat8.rb
@@ -15,9 +15,8 @@
 provides :stunnel, platform: 'redhat' do |node|
   node['platform_version'].to_i == 8
 end
-unified_mode true
-default_action :setup
 
+use 'partial/_common'
 use 'partial/_setup' unless redhat_ubi?
 
 action :setup do
@@ -28,6 +27,6 @@ action_class do
   def dependencies
     # tcp_wrappers-devel has been deprecated in RHEL7 and deleted in RHEL8, however it is
     # an optional requirement not strictly necessary for either stunnel or efs-utils
-    %w()
+    %w(openssl-devel)
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_ubuntu.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_ubuntu.rb
@@ -12,16 +12,13 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License
 
-provides :stunnel, platform: 'centos' do |node|
-  node['platform_version'].to_i == 7
-end
-unified_mode true
-default_action :setup
+provides :stunnel, platform: 'ubuntu'
 
+use 'partial/_common'
 use 'partial/_setup'
 
 action_class do
   def dependencies
-    %w(tcp_wrappers-devel)
+    %w(libssl-dev libwrap0-dev)
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/stunnel_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/stunnel_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+class ConvergeStunnel
+  def self.setup(chef_run, stunnel_version:, stunnel_checksum:)
+    chef_run.converge_dsl('aws-parallelcluster-platform') do
+      stunnel 'setup' do
+        stunnel_version stunnel_version
+        stunnel_checksum stunnel_checksum
+        action :setup
+      end
+    end
+  end
+end
+
+describe 'stunnel:setup' do
+  cached(:sources_dir) { 'sources_dir' }
+  cached(:artifacts_s3_url) { 's3://artifacts_s3_url' }
+  cached(:stunnel_version) { 'stunnel_version' }
+  cached(:stunnel_checksum) { 'stunnel_checksum' }
+  cached(:stunnel_url) { "#{artifacts_s3_url}/stunnel/stunnel-#{stunnel_version}.tar.gz" }
+  cached(:stunnel_tarball) { "#{sources_dir}/stunnel-#{stunnel_version}.tar.gz" }
+
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:dependencies) do
+        case platform
+        when 'centos'
+          %w(openssl-devel tcp_wrappers-devel)
+        when 'ubuntu'
+          %w(libssl-dev libwrap0-dev)
+        else
+          %w(openssl-devel)
+        end
+      end
+      cached(:chef_run) do
+        runner = runner(platform: platform, version: version, step_into: ['stunnel']) do |node|
+          node.override['cluster']['sources_dir'] = sources_dir
+          node.override['cluster']['artifacts_s3_url'] = artifacts_s3_url
+        end
+
+        ConvergeStunnel.setup(runner, stunnel_version: stunnel_version, stunnel_checksum: stunnel_checksum)
+      end
+
+      it 'sets up stunnel' do
+        is_expected.to setup_stunnel('setup')
+      end
+
+      if platform == 'amazon'
+        it "doesn't install stunnel" do
+          is_expected.not_to run_bash('install stunnel')
+        end
+      else
+        it 'creates sources directory' do
+          is_expected.to create_directory(sources_dir).with_recursive(true)
+        end
+
+        it 'updates package repositories' do
+          is_expected.to update_package_repos('update package repositories')
+        end
+
+        it 'installs dependencies' do
+          is_expected.to install_package(dependencies)
+        end
+
+        it 'downloads tarball' do
+          is_expected.to create_if_missing_remote_file(stunnel_tarball).with(
+            source: stunnel_url,
+            mode: '0644',
+            retries: 3,
+            retry_delay: 5,
+            checksum: stunnel_checksum
+          )
+        end
+
+        it 'installs stunnel' do
+          is_expected.to run_bash('install stunnel')
+            .with_cwd(sources_dir)
+            .with_code(/tar xvfz #{stunnel_tarball}/)
+            .with_code(/cd stunnel-#{stunnel_version}/)
+            .with_code(%r{./configure})
+            .with_code(%r{rm /bin/stunnel})
+            .with_code(/make install/)
+            .with_code(%r{ln -s /usr/local/bin/stunnel /bin/stunnel})
+        end
+
+        it 'writes node attributes' do
+          is_expected.to write_node_attributes('dump node attributes')
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/arm_pl_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/arm_pl_spec.rb
@@ -12,7 +12,7 @@
 control 'tag:install_arm_pl_installed' do
   title "Check ARM Performance libraries installation"
 
-  only_if { os_properties.arm? && !os_properties.virtualized? }
+  only_if { os_properties.arm? && !os_properties.on_docker? }
 
   armpl_major_minor_version = node['cluster']['armpl']['major_minor_version']
   armpl_version = node['cluster']['armpl']['version']
@@ -64,7 +64,7 @@ end
 control 'tag:install_arm_pl_gcc_installed' do
   title "Check ARM Performance libraries installation"
 
-  only_if { os_properties.arm? && !os_properties.virtualized? }
+  only_if { os_properties.arm? && !os_properties.on_docker? }
 
   gcc_major_minor_version = node['cluster']['armpl']['gcc']['major_minor_version']
   gcc_patch_version = node['cluster']['armpl']['gcc']['patch_version']

--- a/cookbooks/aws-parallelcluster-platform/test/controls/c_states_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/c_states_spec.rb
@@ -1,7 +1,7 @@
 
 control 'tag:install_c_states_kernel_configured' do
   title 'Check the configuration to disable c states'
-  only_if { !os_properties.virtualized? && os_properties.x86? }
+  only_if { !os_properties.on_docker? && os_properties.x86? }
 
   describe file('/etc/default/grub') do
     it { should exist }

--- a/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
@@ -12,7 +12,7 @@
 control 'tag:testami_tag:config_services_disabled_on_debian_family' do
   title 'Test that DLAMI multi eni helper is disabled and masked on debian family'
 
-  only_if { os_properties.debian_family? && !os_properties.virtualized? }
+  only_if { os_properties.debian_family? && !os_properties.on_docker? }
 
   describe service('aws-ubuntu-eni-helper') do
     it { should_not be_enabled }
@@ -28,7 +28,7 @@ end
 control 'tag:testami_tag:config_services_disabled_on_amazon_family' do
   title 'Test that log4j-cve-2021-44228-hotpatch is disabled and masked on amazon family'
 
-  only_if { os_properties.amazon_family? && !os_properties.virtualized? }
+  only_if { os_properties.amazon_family? && !os_properties.on_docker? }
 
   describe service('log4j-cve-2021-44228-hotpatch') do
     it { should_not be_enabled }

--- a/cookbooks/aws-parallelcluster-platform/test/controls/stunnel_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/stunnel_spec.rb
@@ -9,14 +9,14 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'stunnel_installed' do
+control 'tag:install_stunnel_installed' do
   title "Check that the correct version of stunnel has been installed"
 
   # In AL2 stunnel comes as part of the aws-efs-utils package.
   # In RHEL8 on Docker we disable the installation of base packages, so stunnel cannot be built.
   only_if { !os_properties.alinux2? && !os_properties.redhat_ubi? }
 
-  stunnel_version = '5.67'
+  stunnel_version = node['cluster']['stunnel']['version']
 
   describe bash("/bin/stunnel -version 2>&1 | awk '/^stunnel / { printf $2 }'") do
     its('exit_status') { should eq 0 }

--- a/kitchen.resources-install.yml
+++ b/kitchen.resources-install.yml
@@ -104,19 +104,6 @@ suites:
         - recipe:aws-parallelcluster-platform::directories
         - resource:package_repos
         - resource:install_packages
-  - name: stunnel
-    run_list:
-      - recipe[aws-parallelcluster-tests::setup]
-      - recipe[aws-parallelcluster-install::test_resource]
-    verifier:
-      controls:
-        - stunnel_installed
-    attributes:
-      resource: stunnel:setup
-      dependencies:
-        - recipe:aws-parallelcluster-platform::directories
-        - resource:package_repos
-        - resource:install_packages
   - name: dns_domain_setup
     run_list:
       - recipe[aws-parallelcluster-slurm::test_resource]

--- a/kitchen.validate-install.yml
+++ b/kitchen.validate-install.yml
@@ -37,7 +37,6 @@ suites:
         - node_attributes_created
         - /services_disabled_on_amazon_family/
         - /services_disabled_on_debian_family/
-        - stunnel_installed
         - system_authentication_packages_installed
         - /nvidia_driver/
         - /fabric_manager/


### PR DESCRIPTION
### Description of changes
Move stunnel resource to platform cookbook

### Tests
* `bash kitchen.ec2.sh platform-install verify stunnel -c 6`: OK
* `bash kitchen.docker.sh platform-install verify stunnel -c 6`: didn't work locally because of the issue with colima not being able to download from s3
  * we don't want to disable tests on docker because they should work once we solve the issue with colima

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.