### PR TITLE
Move fabric_manager resource to platform cookbook

### DIFF
--- a/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_amazon2.rb
@@ -12,11 +12,5 @@ default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrc
 default['cluster']['nvidia']['gdrcopy']['sha256'] = 'b85d15901889aa42de6c4a9233792af40dd94543e82abe0439e544c87fd79475'
 default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 
-# NVIDIA fabric-manager
-# The package name of Fabric Manager for alinux2 is nvidia-fabric-manager-version
-default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
-default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
-default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']
-
 # Nvidia Repository for fabricmanager and datacenter-gpu-manager
 default['cluster']['nvidia']['cuda']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_centos7.rb
@@ -12,11 +12,5 @@ default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrc
 default['cluster']['nvidia']['gdrcopy']['sha256'] = 'b85d15901889aa42de6c4a9233792af40dd94543e82abe0439e544c87fd79475'
 default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 
-# NVIDIA fabric-manager
-# The package name of Fabric Manager for centos7 is nvidia-fabric-manager-version
-default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
-default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
-default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']
-
 # Nvidia Repository for fabricmanager and datacenter-gpu-manager
 default['cluster']['nvidia']['cuda']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel7/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_redhat8.rb
@@ -12,11 +12,5 @@ default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrc
 default['cluster']['nvidia']['gdrcopy']['sha256'] = 'b85d15901889aa42de6c4a9233792af40dd94543e82abe0439e544c87fd79475'
 default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrcopy'
 
-# NVIDIA fabric-manager
-# The package name of Fabric Manager for rhel8 is nvidia-fabric-manager-version
-default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabric-manager"
-default['cluster']['nvidia']['fabricmanager']['repository_key'] = "D42D0685.pub"
-default['cluster']['nvidia']['fabricmanager']['version'] = node['cluster']['nvidia']['driver_version']
-
 # Nvidia Repository for fabricmanager and datacenter-gpu-manager
 default['cluster']['nvidia']['cuda']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/rhel8/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common_ubuntu.rb
@@ -12,12 +12,5 @@ default['cluster']['nvidia']['gdrcopy']['url'] = "https://github.com/NVIDIA/gdrc
 default['cluster']['nvidia']['gdrcopy']['sha256'] = 'b85d15901889aa42de6c4a9233792af40dd94543e82abe0439e544c87fd79475'
 default['cluster']['nvidia']['gdrcopy']['service'] = 'gdrdrv'
 
-# NVIDIA fabric-manager
-# The package name of Fabric Manager for ubuntu is nvidia-fabricmanager-470_version
-# with apt a star is needed to match the package version
-default['cluster']['nvidia']['fabricmanager']['package'] = "nvidia-fabricmanager-470"
-default['cluster']['nvidia']['fabricmanager']['repository_key'] = "3bf863cc.pub"
-default['cluster']['nvidia']['fabricmanager']['version'] = "#{node['cluster']['nvidia']['driver_version']}*"
-
 # Nvidia Repository for fabricmanager and datacenter-gpu-manager
 default['cluster']['nvidia']['cuda']['repository_uri'] = "https://developer.download.nvidia._domain_/compute/cuda/repos/#{node['cluster']['base_os']}/#{arm_instance? ? 'sbsa' : 'x86_64'}"

--- a/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
@@ -80,11 +80,3 @@ end
 def platform_supports_dcv?
   node['cluster']['dcv']['supported_os'].include?("#{node['platform']}#{node['platform_version'].to_i}")
 end
-
-# Get number of nv switches
-def get_nvswitches
-  # NVSwitch device id is 10de:1af1
-  nvswitch_check = Mixlib::ShellOut.new("lspci -d 10de:1af1 | wc -l")
-  nvswitch_check.run_command
-  nvswitch_check.stdout.strip.to_i
-end

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
@@ -30,3 +30,19 @@ suites:
             vpc_ipv4_cidr_blocks: |
               cidr1
               cidr2
+  - name: fabric_manager
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-tests::test_resource]
+    verifier:
+      controls:
+        - /tag:config_.*fabric_manager/
+    attributes:
+      resource: fabric_manager:configure
+      cluster:
+        nvidia:
+          enabled: true
+      dependencies:
+        - resource:fabric_manager:setup
+    driver:
+      instance_type: g4dn.2xlarge

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
@@ -185,4 +185,16 @@ suites:
       resource: nvidia_repo:remove
       dependencies:
         - resource:nvidia_repo:add
+  - name: fabric_manager
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-tests::test_resource]
+    verifier:
+      controls:
+        - /tag:install_.*fabric_manager/
+    attributes:
+      resource: fabric_manager
+      cluster:
+        nvidia:
+          enabled: yes
 

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_amazon2.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-#
-# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
@@ -12,12 +12,15 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-action :install_package do
-  # For ubuntu, CINC17 apt-package resources need full versions for `version`
-  execute "install_fabricmanager_for_ubuntu" do
-    command "apt -y install #{node['cluster']['nvidia']['fabricmanager']['package']}=#{node['cluster']['nvidia']['fabricmanager']['version']} "\
-            "&& apt-mark hold #{node['cluster']['nvidia']['fabricmanager']['package']}"
-    retries 3
-    retry_delay 5
-  end
+provides :fabric_manager, platform: 'amazon', platform_version: '2'
+
+use 'partial/_fabric_manager_common.rb'
+use 'partial/_fabric_manager_install_rhel.rb'
+
+def fabric_manager_package
+  'nvidia-fabric-manager'
+end
+
+def fabric_manager_version
+  _nvidia_driver_version
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_centos7.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_centos7.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-#
-# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
@@ -12,11 +12,17 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-action :install_package do
-  package 'yum-plugin-versionlock'
+provides :fabric_manager, platform: 'centos' do |node|
+  node['platform_version'].to_i == 7
+end
 
-  package node['cluster']['nvidia']['fabricmanager']['package'] do
-    version node['cluster']['nvidia']['fabricmanager']['version']
-    action %i(install lock)
-  end
+use 'partial/_fabric_manager_common.rb'
+use 'partial/_fabric_manager_install_rhel.rb'
+
+def fabric_manager_package
+  'nvidia-fabric-manager'
+end
+
+def fabric_manager_version
+  _nvidia_driver_version
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_redhat8.rb
@@ -18,3 +18,11 @@ end
 
 use 'partial/_fabric_manager_common.rb'
 use 'partial/_fabric_manager_install_rhel.rb'
+
+def fabric_manager_package
+  'nvidia-fabric-manager'
+end
+
+def fabric_manager_version
+  _nvidia_driver_version
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_ubuntu.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_ubuntu.rb
@@ -16,3 +16,11 @@ provides :fabric_manager, platform: 'ubuntu'
 
 use 'partial/_fabric_manager_common.rb'
 use 'partial/_fabric_manager_install_debian.rb'
+
+def fabric_manager_package
+  'nvidia-fabricmanager-470'
+end
+
+def fabric_manager_version
+  "#{_nvidia_driver_version}*"
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_debian.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-
-# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
@@ -12,7 +12,12 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-provides :fabric_manager, platform: 'amazon', platform_version: '2'
-
-use 'partial/_fabric_manager_common.rb'
-use 'partial/_fabric_manager_install_rhel.rb'
+action :install_package do
+  # For ubuntu, CINC17 apt-package resources need full versions for `version`
+  execute "install_fabricmanager_for_ubuntu" do
+    command "apt -y install #{fabric_manager_package}=#{fabric_manager_version} "\
+            "&& apt-mark hold #{fabric_manager_package}"
+    retries 3
+    retry_delay 5
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_rhel.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-
-# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-provides :fabric_manager, platform: 'centos' do |node|
-  node['platform_version'].to_i == 7
-end
+action :install_package do
+  package 'yum-plugin-versionlock'
 
-use 'partial/_fabric_manager_common.rb'
-use 'partial/_fabric_manager_install_rhel.rb'
+  package fabric_manager_package do
+    version fabric_manager_version
+    action %i(install lock)
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
@@ -1,0 +1,259 @@
+require 'spec_helper'
+
+class ConvergeFabricManager
+  def self.setup(chef_run, nvidia_driver_version: nil, nvidia_enabled: nil)
+    chef_run.converge_dsl('aws-parallelcluster-platform') do
+      fabric_manager 'setup' do
+        nvidia_enabled nvidia_enabled
+        nvidia_driver_version nvidia_driver_version
+        action :setup
+      end
+    end
+  end
+
+  def self.configure(chef_run)
+    chef_run.converge_dsl('aws-parallelcluster-platform') do
+      fabric_manager 'configure' do
+        action :configure
+      end
+    end
+  end
+end
+
+describe 'fabric_manager:_nvidia_driver_version' do
+  cached(:nvidia_driver_attribute) { 'nvidia_driver_attribute' }
+  cached(:nvidia_driver_property) { 'nvidia_driver_property' }
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: ['fabric_manager']) do |node|
+      node.override['cluster']['nvidia']['driver_version'] = nvidia_driver_attribute
+    end
+  end
+
+  context 'when nvidia driver property is set' do
+    cached(:resource) do
+      ConvergeFabricManager.setup(chef_run, nvidia_driver_version: nvidia_driver_property)
+      chef_run.find_resource('fabric_manager', 'setup')
+    end
+
+    it 'takes the value from nvidia driver property' do
+      expect(resource._nvidia_driver_version).to eq(nvidia_driver_property)
+    end
+  end
+
+  context 'when nvidia driver property is not set' do
+    cached(:resource) do
+      ConvergeFabricManager.setup(chef_run)
+      chef_run.find_resource('fabric_manager', 'setup')
+    end
+
+    it 'takes the value from nvidia driver attribute' do
+      expect(resource._nvidia_driver_version).to eq(nvidia_driver_attribute)
+    end
+  end
+end
+
+describe 'fabric_manager:_nvidia_enabled' do
+  context 'when nvidia enabled property is set' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(step_into: ['fabric_manager']) do |node|
+        node.override['cluster']['nvidia']['enabled'] = false
+      end
+    end
+    cached(:resource) do
+      ConvergeFabricManager.setup(chef_run, nvidia_enabled: true)
+      chef_run.find_resource('fabric_manager', 'setup')
+    end
+
+    it "takes precedence over node['cluster']['nvidia']['enabled'] attribute" do
+      expect(resource._nvidia_enabled).to eq(true)
+    end
+  end
+
+  context 'when nvidia enabled property is not set' do
+    context "and node['cluster']['nvidia']['enabled'] is true" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(step_into: ['fabric_manager']) do |node|
+          node.override['cluster']['nvidia']['enabled'] = true
+        end
+      end
+      cached(:resource) do
+        ConvergeFabricManager.setup(chef_run)
+        chef_run.find_resource('fabric_manager', 'setup')
+      end
+      it "is true" do
+        expect(resource._nvidia_enabled).to eq(true)
+      end
+    end
+
+    context "and node['cluster']['nvidia']['enabled'] is yes" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(step_into: ['fabric_manager']) do |node|
+          node.override['cluster']['nvidia']['enabled'] = 'yes'
+        end
+      end
+      cached(:resource) do
+        ConvergeFabricManager.setup(chef_run)
+        chef_run.find_resource('fabric_manager', 'setup')
+      end
+      it "is true" do
+        expect(resource._nvidia_enabled).to eq(true)
+      end
+    end
+
+    context "and node['cluster']['nvidia']['enabled'] is not yes or true" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(step_into: ['fabric_manager']) do |node|
+          node.override['cluster']['nvidia']['enabled'] = 'any'
+        end
+      end
+      cached(:resource) do
+        ConvergeFabricManager.setup(chef_run)
+        chef_run.find_resource('fabric_manager', 'setup')
+      end
+      it "is false" do
+        expect(resource._nvidia_enabled).to eq(false)
+      end
+    end
+  end
+end
+
+describe 'fabric_manager:_fabric_manager_enabled' do
+  context 'when on arm' do
+    cached(:chef_run) do
+      allow_any_instance_of(Object).to receive(:arm_instance?).and_return(true)
+      ChefSpec::SoloRunner.new(step_into: ['fabric_manager'])
+    end
+    cached(:resource) do
+      ConvergeFabricManager.setup(chef_run, nvidia_enabled: true)
+      chef_run.find_resource('fabric_manager', 'setup')
+    end
+    it "is not enabled" do
+      expect(resource._fabric_manager_enabled).to eq(false)
+    end
+  end
+
+  context 'when not on arm' do
+    cached(:chef_run) do
+      allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+      ChefSpec::SoloRunner.new(step_into: ['fabric_manager'])
+    end
+
+    context 'when nvidia enabled' do
+      cached(:resource) do
+        ConvergeFabricManager.setup(chef_run, nvidia_enabled: true)
+        chef_run.find_resource('fabric_manager', 'setup')
+      end
+
+      it "is enabled" do
+        expect(resource._fabric_manager_enabled).to eq(true)
+      end
+    end
+
+    context 'when nvidia not enabled' do
+      cached(:resource) do
+        ConvergeFabricManager.setup(chef_run, nvidia_enabled: false)
+        chef_run.find_resource('fabric_manager', 'setup')
+      end
+
+      it "is not enabled" do
+        expect(resource._fabric_manager_enabled).to eq(false)
+      end
+    end
+  end
+end
+
+describe 'fabric_manager:setup' do
+  cached(:nvidia_driver_version) { 'nvidia_driver_version' }
+
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:fabric_manager_package) { platform == 'ubuntu' ? 'nvidia-fabricmanager-470' : 'nvidia-fabric-manager' }
+      cached(:fabric_manager_version) { platform == 'ubuntu' ? "#{nvidia_driver_version}*" : nvidia_driver_version }
+
+      context 'when fabric manager is to install' do
+        cached(:chef_run) do
+          stubs_for_resource('fabric_manager') do |res|
+            allow(res).to receive(:_fabric_manager_enabled).and_return(true)
+          end
+          runner = runner(platform: platform, version: version, step_into: ['fabric_manager'])
+          ConvergeFabricManager.setup(runner, nvidia_driver_version: nvidia_driver_version)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'sets up fabric manager' do
+          is_expected.to setup_fabric_manager('setup')
+        end
+
+        it 'dumps node attributes' do
+          expect(node['cluster']['nvidia']['fabricmanager']['package']).to eq(fabric_manager_package)
+          expect(node['cluster']['nvidia']['fabricmanager']['version']).to eq(fabric_manager_version)
+          is_expected.to write_node_attributes('dump node attributes')
+        end
+
+        if platform == 'ubuntu'
+          it 'installs fabric manager for ubuntu' do
+            is_expected.to run_execute('install_fabricmanager_for_ubuntu')
+              .with_retries(3)
+              .with_retry_delay(5)
+              .with_command("apt -y install #{fabric_manager_package}=#{fabric_manager_version} && apt-mark hold #{fabric_manager_package}")
+          end
+        else
+          it 'installs yum-plugin-versionlock' do
+            is_expected.to install_package('yum-plugin-versionlock')
+          end
+
+          it 'installs fabric manager' do
+            is_expected.to install_package(fabric_manager_package)
+              .with_version(fabric_manager_version)
+              .with_action(%i(install lock))
+          end
+        end
+      end
+    end
+  end
+end
+
+describe 'fabric_manager:configure' do
+  cached(:nvidia_driver_version) { 'nvidia_driver_version' }
+
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:fabric_manager_package) { platform == 'ubuntu' ? 'nvidia-fabricmanager-470' : 'nvidia-fabric-manager' }
+      cached(:fabric_manager_version) { platform == 'ubuntu' ? "#{nvidia_driver_version}*" : nvidia_driver_version }
+
+      context('when nvswithes are > 1') do
+        cached(:chef_run) do
+          stubs_for_resource('fabric_manager') do |res|
+            allow(res).to receive(:get_nvswitches).and_return(2)
+          end
+          runner = runner(platform: platform, version: version, step_into: ['fabric_manager'])
+          ConvergeFabricManager.configure(runner)
+        end
+
+        it 'configures fabric manager' do
+          is_expected.to configure_fabric_manager('configure')
+        end
+
+        it 'starts nvidia-fabricmanager service' do
+          is_expected.to start_service('nvidia-fabricmanager')
+            .with_action(%i(start enable))
+            .with_supports({ status: true })
+        end
+      end
+
+      context('when nvswithes are not > 1') do
+        cached(:chef_run) do
+          stubs_for_resource('fabric_manager') do |res|
+            allow(res).to receive(:get_nvswitches).and_return(1)
+          end
+          runner = runner(platform: platform, version: version, step_into: ['fabric_manager'])
+          ConvergeFabricManager.configure(runner)
+        end
+
+        it "doesn't start nvidia-fabricmanager service" do
+          is_expected.not_to start_service('nvidia-fabricmanager')
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-shared/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/environment.rb
@@ -6,3 +6,8 @@ default['cluster']['aws_domain'] = aws_domain
 # URL for ParallelCluster Artifacts stored in public S3 buckets
 # ['cluster']['region'] will need to be defined by image_dna.json during AMI build.
 default['cluster']['artifacts_s3_url'] = "https://#{node['cluster']['region']}-aws-parallelcluster.s3.#{node['cluster']['region']}.#{node['cluster']['aws_domain']}/archives"
+
+# Adding temporarily while working on nvidia setup
+# TODO: move to platform cookbook
+default['cluster']['nvidia']['enabled'] = 'no'
+default['cluster']['nvidia']['driver_version'] = '470.182.03'

--- a/kitchen.resources-config.yml
+++ b/kitchen.resources-config.yml
@@ -63,20 +63,6 @@ suites:
           enabled: true
     driver:
       instance_type: g4dn.2xlarge
-  - name: nvidia_fabricmanager_config
-    run_list:
-      - recipe[aws-parallelcluster-tests::setup]
-      - recipe[aws-parallelcluster-config::test_resource]
-    verifier:
-      controls:
-        - /tag:config_.*fabricmanager/
-    attributes:
-      resource: fabric_manager:configure
-      cluster:
-        nvidia:
-          enabled: true
-    driver:
-      instance_type: g4dn.2xlarge
   - name: nvidia_gdrcopy_config
     run_list:
       - recipe[aws-parallelcluster-tests::setup]

--- a/kitchen.resources-install.yml
+++ b/kitchen.resources-install.yml
@@ -208,24 +208,6 @@ suites:
       cluster:
         nvidia:
           enabled: true
-  - name: nvidia_fabric_manager
-    run_list:
-      - recipe[aws-parallelcluster-tests::setup]
-      - recipe[aws-parallelcluster-install::test_resource]
-    verifier:
-      controls:
-        - /tag:install_.*fabric_manager/
-    driver:
-      # nvidia_driver can be executed only on a graphic EC2 instance example: g5.xlarge(x86_86) or g5g.xlarge(aarm64)
-      instance_type: g4dn.2xlarge
-    attributes:
-      resource: fabric_manager
-      dependencies:
-        - recipe:aws-parallelcluster-platform::directories
-        - resource:package_repos
-      cluster:
-        nvidia:
-          enabled: true
   - name: nvidia_dcgm
     run_list:
       - recipe[aws-parallelcluster-tests::setup]

--- a/kitchen.validate-install.yml
+++ b/kitchen.validate-install.yml
@@ -38,5 +38,4 @@ suites:
         - /services_disabled_on_amazon_family/
         - /services_disabled_on_debian_family/
         - /nvidia_driver/
-        - /fabric_manager/
         - /tag:install/

--- a/test/resources/controls/aws_parallelcluster_config/nvidia_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_config/nvidia_spec.rb
@@ -9,17 +9,6 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'tag:config_nvidia-fabricmanager_enabled' do
-  only_if do
-    instance.nvs_switch_enabled?
-  end
-
-  describe service('nvidia-fabricmanager') do
-    it { should be_enabled }
-    it { should be_running }
-  end
-end
-
 control 'tag:config_gdrcopy_enabled_on_graphic_instances' do
   only_if do
     !(os_properties.centos7? && os_properties.arm?) &&


### PR DESCRIPTION
### Description of changes
Move fabric_manager resource to platform cookbook

### Tests
* `bash kitchen.ec2.sh platform-install verify fabric-manager -c 6`: OK
* `bash kitchen.docker.sh platform-install verify nvidia-repo-add -c 6`: OK
* `bash kitchen.ec2.sh platform-config verify fabric-manager -c 6`: OK but no tests run
* `bash kitchen.docker.sh platform-config verify fabric-manager -c 6`: OK but no tests run

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.