### PR TITLE
[Isolated Regions] Remove security updates from script used to configure ISO instances

### DIFF
--- a/cookbooks/aws-parallelcluster-install/templates/default/base/patch-iso-instance.sh.erb
+++ b/cookbooks/aws-parallelcluster-install/templates/default/base/patch-iso-instance.sh.erb
@@ -41,7 +41,6 @@ REPO_DEFINITION
 
 yum --disablerepo="*" --enablerepo="amzn2-iso" install -y "*-${REGION}"
 rm -f ${REPOSITORY_DEFINITION_FILE}
-yum --disablerepo="*" --enablerepo="amzn2-*" --security -y update
 
 echo "[INFO] Complete: installation of packages from amazon Linux 2 repository for US isolated region"
 


### PR DESCRIPTION
### Description of changes
Remove security updates from script used to configure cluster instances in isolated regions.
This update step should be removed because:
1. it should not be required to make the ISO instance work (we must verify that experimentally)
1. it’s risky to execute package updates within user data because transient yum/networking failures may cause node bootstrap failures
1. we want to provide consistency between ADC and Commercial as much as possible and in Commercial we do not execute any package updates at node bootstrap.

### Tests
1. [PENDING] Validation in ADC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.