### PR TITLE
Move log_rotation recipe from init to config phase

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/config.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/config.rb
@@ -24,3 +24,6 @@ fetch_config 'Fetch and load cluster configs'
 include_recipe 'aws-parallelcluster-slurm::config' if node['cluster']['scheduler'] == 'slurm'
 include_recipe 'aws-parallelcluster-scheduler-plugin::config' if node['cluster']['scheduler'] == 'plugin'
 include_recipe 'aws-parallelcluster-awsbatch::config' if node['cluster']['scheduler'] == 'awsbatch'
+
+# ParallelCluster log rotation configuration
+include_recipe "aws-parallelcluster-config::log_rotation"

--- a/cookbooks/aws-parallelcluster-config/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/init.rb
@@ -34,9 +34,6 @@ cloudwatch "Configure CloudWatch" do
   action :configure
 end
 
-# ParallelCluster log rotation configuration
-include_recipe "aws-parallelcluster-config::log_rotation"
-
 include_recipe "aws-parallelcluster-config::custom_actions_setup" unless on_docker?
 
 # Configure additional Networking Interfaces (if present)


### PR DESCRIPTION
### Description of changes
Move log_rotation recipe from init to config phase, so that it can rely on dcv configuration.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.