### PR TITLE
[develop] Save cuda_samples_version into node_attributes

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/recipes/install/cuda.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/cuda.rb
@@ -29,7 +29,8 @@ cuda_samples_version = '11.8'
 cuda_samples_url = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v#{cuda_samples_version}.tar.gz"
 
 node.default['cluster']['nvidia']['cuda']['version'] = cuda_version
-node_attributes 'Save cuda version for InSpec tests'
+node.default['cluster']['nvidia']['cuda_samples_version'] = cuda_samples_version
+node_attributes 'Save cuda and cuda samples versions for InSpec tests'
 
 # Get CUDA run file
 remote_file "/tmp/cuda.run" do

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cuda_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cuda_spec.rb
@@ -32,9 +32,10 @@ describe 'aws-parallelcluster-platform::cuda' do
     end
     cached(:node) { chef_run.node }
 
-    it 'saves cuda version' do
+    it 'saves cuda and cuda samples version' do
       expect(node['cluster']['nvidia']['cuda']['version']).to eq(cuda_version)
-      is_expected.to write_node_attributes('Save cuda version for InSpec tests')
+      expect(node['cluster']['nvidia']['cuda_samples_version']).to eq(cuda_samples_version)
+      is_expected.to write_node_attributes('Save cuda and cuda samples versions for InSpec tests')
     end
 
     it 'downloads CUDA run file' do


### PR DESCRIPTION
### Description of changes
* This attribute is used by "Testing CUDA with deviceQuery" executed as part of the build ami validation.

### References
* Change introduced with: https://github.com/aws/aws-parallelcluster-cookbook/pull/2203

