### PR TITLE
[develop] Rename group used to read SLURM_RESUME_FILE

### DIFF
--- a/cookbooks/aws-parallelcluster-shared/attributes/users.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/users.rb
@@ -4,14 +4,14 @@ default['cluster']['cluster_admin_user'] = 'pcluster-admin'
 default['cluster']['cluster_admin_user_id'] = node['cluster']['reserved_base_uid']
 default['cluster']['cluster_admin_group'] = node['cluster']['cluster_admin_user']
 default['cluster']['cluster_admin_group_id'] = node['cluster']['cluster_admin_user_id']
+default['cluster']['cluster_admin_slurm_share_group'] = 'pcluster-slurm-share'
+default['cluster']['cluster_admin_slurm_share_group_id'] = node['cluster']['reserved_base_uid'] + 5
 
 # Slurm
 default['cluster']['slurm']['user'] = 'slurm'
 default['cluster']['slurm']['user_id'] = node['cluster']['reserved_base_uid'] + 1
 default['cluster']['slurm']['group'] = node['cluster']['slurm']['user']
 default['cluster']['slurm']['group_id'] = node['cluster']['slurm']['user_id']
-default['cluster']['slurm']['resume_group'] = 'pcluster-slurm-resume'
-default['cluster']['slurm']['resume_group_id'] = node['cluster']['reserved_base_uid'] + 5
 
 # Munge
 default['cluster']['munge']['user'] = 'munge'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install_slurm.rb
@@ -21,8 +21,8 @@ slurm_user = node['cluster']['slurm']['user']
 slurm_user_id = node['cluster']['slurm']['user_id']
 slurm_group = node['cluster']['slurm']['group']
 slurm_group_id = node['cluster']['slurm']['group_id']
-slurm_resume_program_group = node['cluster']['slurm']['resume_group']
-slurm_resume_program_group_id = node['cluster']['slurm']['resume_group_id']
+cluster_admin_slurm_share_group = node['cluster']['cluster_admin_slurm_share_group']
+cluster_admin_slurm_share_group_id = node['cluster']['cluster_admin_slurm_share_group_id']
 slurm_install_dir = node['cluster']['slurm']['install_dir']
 
 slurm_version = node['cluster']['slurm']['version']
@@ -55,15 +55,15 @@ user slurm_user do
   shell '/bin/bash'
 end
 
-# Setup slurm resume program group
-group slurm_resume_program_group do
+# Setup cluster admin slurm share group
+group cluster_admin_slurm_share_group do
   comment 'slurm resume program group'
-  gid slurm_resume_program_group_id
+  gid cluster_admin_slurm_share_group_id
   system true
 end
 
-# add slurm user and pcluster-admin to slurm resume program group
-group slurm_resume_program_group do
+# add slurm user and pcluster-admin to share group
+group cluster_admin_slurm_share_group do
   action :modify
   members [ slurm_user, node['cluster']['cluster_admin_user'] ]
   append true

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/resume_program.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/resume_program.erb
@@ -7,7 +7,7 @@ trap "rm -f ${SLURM_RESUME_FILE_TMP}" EXIT
 SLURM_RESUME_FILE_TMP=$(mktemp)
 cp ${SLURM_RESUME_FILE} ${SLURM_RESUME_FILE_TMP}
 
-chgrp <%= node['cluster']['slurm']['resume_group'] %> ${SLURM_RESUME_FILE_TMP}
+chgrp <%= node['cluster']['cluster_admin_slurm_share_group'] %> ${SLURM_RESUME_FILE_TMP}
 chmod g+r ${SLURM_RESUME_FILE_TMP}
 
 sudo -u <%= node['cluster']['cluster_admin_user'] %> SLURM_RESUME_FILE=${SLURM_RESUME_FILE_TMP} <%= node_virtualenv_path %>/bin/slurm_resume  "$@"


### PR DESCRIPTION
### Description of changes
Rename group used to read SLURM_RESUME_FILE. Name is now more generic

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.