### PR TITLE
Minor improvements to Inspec Tests

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -56,3 +56,7 @@ suites:
       resource: system_authentication:configure
       dependencies:
         - resource:system_authentication:setup
+      cluster:
+        directory_service:
+          enabled: "true"
+        node_type: HeadNode

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-install.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-install.yml
@@ -63,8 +63,7 @@ suites:
       - recipe[aws-parallelcluster-tests::test_resource]
     verifier:
       controls:
-        - lustre_client_installed
-        - lnet_kernel_module_enabled
+        - /tag:install_lustre/
     attributes:
       resource: lustre
   - name: efa_setup

--- a/cookbooks/aws-parallelcluster-environment/test/controls/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/efa_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'tag:install_efa_conflicting_packages_removed' do
+control 'efa_conflicting_packages_removed' do
   title 'Check packages conflicting with EFA are not installed'
 
   if os.redhat?

--- a/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
@@ -1,4 +1,4 @@
-control 'lustre_client_installed' do
+control 'tag:install_lustre_client_installed' do
   title "Verify that lustre client is installed"
   minimal_lustre_client_version = '2.12'
   if (os_properties.centos? && inspec.os.release.to_f >= 7.5) || os_properties.redhat?
@@ -58,7 +58,7 @@ control 'lustre_client_installed' do
   end
 end
 
-control 'lnet_kernel_module_enabled' do
+control 'tag:install_lustre_lnet_kernel_module_enabled' do
   title "Verify that lnet kernel module is enabled"
   only_if { !os_properties.on_docker? && !os_properties.alinux2? }
   describe kernel_module("lnet") do

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
@@ -317,7 +317,7 @@ suites:
       - recipe[aws-parallelcluster-tests::test_resource]
     verifier:
       controls:
-        - /^dcv/
+        - /tag:install_dcv/
     attributes:
       resource: dcv
       cluster:

--- a/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'dcv_connect_script_installed' do
+control 'tag:install_dcv_connect_script_installed' do
   title 'Check pcluster dcv connect script is installed'
 
   only_if { !os_properties.redhat_ubi? }
@@ -22,7 +22,7 @@ control 'dcv_connect_script_installed' do
   end
 end
 
-control 'dcv_authenticator_user_and_group_set_up' do
+control 'tag:install_dcv_authenticator_user_and_group_set_up' do
   title 'Check that dcv authenticator user and group have been set up'
 
   only_if { !os_properties.redhat_ubi? }
@@ -39,7 +39,7 @@ control 'dcv_authenticator_user_and_group_set_up' do
   end
 end
 
-control 'dcv_disabled_lock_screen' do
+control 'tag:install_dcv_disabled_lock_screen' do
   title 'Check that the lock screen has been disabled'
 
   only_if { !os_properties.redhat_ubi? }
@@ -55,7 +55,7 @@ control 'dcv_disabled_lock_screen' do
   end
 end
 
-control 'dcv_installed' do
+control 'tag:install_dcv_installed' do
   title 'Check dcv is installed'
 
   only_if { !os_properties.redhat_ubi? }
@@ -68,7 +68,7 @@ control 'dcv_installed' do
   end
 end
 
-control 'dcv_external_authenticator_virtualenv_created' do
+control 'tag:install_dcv_external_authenticator_virtualenv_created' do
   title 'Check dcv external authenticator virtual environment is created'
 
   only_if { !os_properties.redhat_ubi? }
@@ -79,7 +79,7 @@ control 'dcv_external_authenticator_virtualenv_created' do
   end
 end
 
-control 'dcv_debian_specific_setup' do
+control 'tag:install_dcv_debian_specific_setup' do
   title 'Check debian specific setup'
 
   only_if { os_properties.debian_family? }
@@ -101,9 +101,10 @@ control 'dcv_debian_specific_setup' do
   end
 end
 
-control 'dcv_rhel_and_centos_specific_setup' do
+control 'tag:install_dcv_rhel_and_centos_specific_setup' do
   title 'Check rhel and centos specific setup'
 
+  only_if { !os_properties.on_docker? }
   only_if { os_properties.centos? || os_properties.redhat? }
 
   describe command('gnome-shell --version') do
@@ -124,11 +125,11 @@ control 'dcv_rhel_and_centos_specific_setup' do
   end
 
   # As in the disable_selinux_spec we would need to skip testing that selinux is disabled
-  # in centos and redhat beacuse there we would need a reboot. As these are the two OSs that
+  # in centos and redhat because there we would need a reboot. As these are the two OSs that
   # we test in this control, we simply omit that check.
 end
 
-control 'dcv_alinux2_specific_setup' do
+control 'tag:install_dcv_alinux2_specific_setup' do
   title 'Check alinux2 specific setup'
 
   only_if { os_properties.alinux2? }
@@ -153,10 +154,10 @@ control 'dcv_alinux2_specific_setup' do
   end
 end
 
-control 'dcv_switch_runlevel_to_multiuser_target' do
+control 'tag:install_dcv_switch_runlevel_to_multiuser_target' do
   title 'Check that runlevel is switched to multi-user.target'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.on_docker? }
 
   describe bash('systemctl get-default') do
     its('exit_status') { should eq 0 }

--- a/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
@@ -12,7 +12,7 @@
 control 'tag:install_intel_hpc_dependencies_downloaded' do
   title 'Checks Intel HPC dependencies have been downloaded'
 
-  only_if { os_properties.centos7? }
+  only_if { os_properties.centos7? && !os_properties.arm? }
 
   node['cluster']['intelhpc']['dependencies'].each do |package|
     # The rpm can be in the sources_dir folder or already installed as dependency of other packages

--- a/test/recipes/controls/other_spec.rb
+++ b/test/recipes/controls/other_spec.rb
@@ -39,7 +39,7 @@ end
 
 control 'tag:config_check_non_graphical_systemd_settings' do
   only_if do
-    !File.exist?("/etc/dcv/dcv.conf") && node['conditions']['ami_bootstrapped']
+    !::File.exist?("/etc/dcv/dcv.conf") && node['conditions']['ami_bootstrapped']
   end
   describe 'check systemd default runlevel' do
     subject { bash("systemctl get-default | grep -i multi-user.target") }


### PR DESCRIPTION
- Add missing attributes to permit system_authentication to run locally
- Add tag:install to dcv tests
- Add tag:install to lustre tests
- Skip Intel HPC deps download test for CentOS7 ARM
- Remove tag:install from EFA conflicting packages check - They can be re-installed by other dependencies after EFA installation or they exist in the custom AMI case.
- Fix syntax of File.exist check