### PR TITLE
Remove mariadb-libs from Intel HPC deps

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/intel_hpc/intel_hpc_centos7.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/intel_hpc/intel_hpc_centos7.rb
@@ -27,7 +27,7 @@ property :dependencies, default: %w(compat-libstdc++-33 nscd nss-pam-ldapd opens
                                     libXcursor libXdamage libXext libXfixes libXft libXi libXinerama libXmu libXp
                                     libXrandr libXrender libXt libXtst libXxf86vm libdrm libglvnd libglvnd-glx
                                     libjpeg-turbo libpciaccess libpipeline libpng libpng12 libunistring libxcb
-                                    libxshmfence m4 mailx man-db mariadb-libs mesa-libGL
+                                    libxshmfence m4 mailx man-db mesa-libGL
                                     mesa-libGLU mesa-libglapi patch pax perl perl-Carp perl-Data-Dumper perl-Encode
                                     perl-Exporter perl-File-Path perl-File-Temp perl-Filter perl-Getopt-Long perl-HTTP-Tiny
                                     perl-PathTools perl-Pod-Escapes perl-Pod-Perldoc perl-Pod-Simple perl-Pod-Usage

--- a/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
@@ -25,6 +25,7 @@ end
 control 'tag:config_intel_hpc_configured' do
   title 'Checks Intel HPC packages have been installed'
 
+  only_if { !os_properties.on_docker? }
   only_if { os_properties.centos7? && !os_properties.arm? && node['cluster']['enable_intel_hpc_platform'] == 'true' }
 
   # Verify non-intel dependencies are installed


### PR DESCRIPTION
This is required only when running on docker.

### Tests
*  `bash kitchen.ec2.sh platform-install test intel-hpc-centos`
*  `bash kitchen.ec2.sh platform-config test intel-hpc-centos`
