### PR TITLE
Use test_resource resource in test_resource recipe

### DIFF
--- a/cookbooks/aws-parallelcluster-tests/recipes/test_resource.rb
+++ b/cookbooks/aws-parallelcluster-tests/recipes/test_resource.rb
@@ -4,10 +4,7 @@
 #     run_list:
 #       - recipe[aws-parallelcluster-tests::test_resource]
 #     attributes:
-#       resource: <resource_name>[:<resource_action>]
-#       [resource_properties:
-#         <resource_property_1_name>: <resource_property_1_value>
-#         <resource_property_2_name>: <resource_property_2_value>]
+#       resource: '<resource_name>[:<resource_action>] [{"resource_property_1_name" : "<resource_property_1_value>", "<resource_property_2_name>": "<resource_property_2_value>"}]'
 #
 # Examples
 #
@@ -27,18 +24,9 @@
 #     run_list:
 #       - recipe[aws-parallelcluster-tests::test_resource]
 #     attributes:
-#       resource: resource_name
-#       resource_properties:
-#         property1: x
-#         property2: y
+#       resource: 'resource_name {"property1": "x", "property2": "y"}'
 #
 
-resource_item = node['resource'].split(/:/)
-resource_properties = node['resource_properties'] || {}
-
-declare_resource(resource_item[0], 'test') do
-  resource_properties.each_key do |key|
-    send("#{key}=", resource_properties[key])
-  end
-  action resource_item[1]
+test_resource 'resource' do
+  descriptor node['resource']
 end


### PR DESCRIPTION
### Description of changes
`test_resource` resource was already used in `aws-parallelcluster-tests::setup` recipe.

This PR removes duplicate code and makes resource descriptor consistent both when the resource is a dependency and when it is the code unit to test.

### Tests
* `./kitchen.ec2.sh platform-install test chrony-a -c 5` : OK

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.