### PR TITLE
Move networking recipe to platform cookbook

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -26,7 +26,7 @@ end
 
 include_recipe 'aws-parallelcluster-config::ephemeral_drives'
 
-include_recipe 'aws-parallelcluster-config::networking'
+include_recipe 'aws-parallelcluster-platform::networking'
 
 # Amazon Time Sync
 chrony 'enable chrony' do

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
@@ -144,3 +144,9 @@ suites:
       cluster:
         enable_intel_hpc_platform: 'true'
         node_type: HeadNode
+  - name: networking
+    run_list:
+      - recipe[aws-parallelcluster-platform::networking]
+    verifier:
+      controls:
+        - /tag:config_networking/

--- a/cookbooks/aws-parallelcluster-platform/recipes/config/networking.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/networking.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
-# Recipe:: networking
-#
 # Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
@@ -15,7 +12,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-return if virtualized?
+return if on_docker?
 
 # Increase somaxconn and tcp_max_syn_backlog for large scale setting
 sysctl 'net.core.somaxconn' do

--- a/cookbooks/aws-parallelcluster-platform/test/controls/networking_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/networking_spec.rb
@@ -9,10 +9,10 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'networking_configured' do
+control 'tag:config_networking' do
   title 'Check that networking has been configured'
 
-  only_if { !os_properties.virtualized? }
+  only_if { !os_properties.on_docker? }
 
   describe kernel_parameter('net.core.somaxconn') do
     its('value') { should eq 65_535 }

--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -69,12 +69,6 @@ suites:
         efs_shared_dirs: ''
         fsx_shared_dirs: ''
         raid_shared_dir: ''
-  - name: networking_configured
-    run_list:
-      - recipe[aws-parallelcluster-config::networking]
-    verifier:
-      controls:
-        - networking_configured
   - name: ephemeral_drives_mounted
     driver:
       instance_type: d3.xlarge  # instance type with ephemeral drives


### PR DESCRIPTION
Add tag:config to execute related inspec tests as part of CI/CD kitchen tests.

### Tests

* `bash kitchen.ec2.sh platform-config test networking-configured-centos` OK

