### PR TITLE
Fix DCV InSpec test for ARM case

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
@@ -137,7 +137,7 @@ control 'tag:install_dcv_alinux2_specific_setup' do
   prereq_packages = %w(gdm gnome-session gnome-classic-session gnome-session-xsession
                        xorg-x11-server-Xorg xorg-x11-fonts-Type1 xorg-x11-drivers
                        gnu-free-fonts-common gnu-free-mono-fonts gnu-free-sans-fonts
-                       gnu-free-serif-fonts glx-utils gnome-terminal)
+                       gnu-free-serif-fonts glx-utils) + (os_properties.arm? ? %w(mate-terminal) : %w(gnome-terminal))
 
   prereq_packages.each do |pkg|
     describe package(pkg) do

--- a/kitchen.ec2.sh
+++ b/kitchen.ec2.sh
@@ -8,6 +8,9 @@
 # KITCHEN_ARCHITECTURE:       [x86_64|arm64];
 #                             default x86_64
 #
+# KITCHEN_INSTANCE_TYPE:      instance type to use
+#                             default t2.micro
+#
 # KITCHEN_KEY_NAME:           KeyPair to use with EC2 instances
 #                             default kitchen
 #
@@ -125,6 +128,7 @@ export KITCHEN_KEY_NAME
 export KITCHEN_SSH_KEY_PATH
 export KITCHEN_AVAILABILITY_ZONE
 export KITCHEN_ARCHITECTURE
+export KITCHEN_INSTANCE_TYPE
 export KITCHEN_SUBNET_ID
 export KITCHEN_VPC_ID
 export KITCHEN_SECURITY_GROUP_ID
@@ -134,6 +138,7 @@ echo "** KITCHEN_KEY_NAME: ${KITCHEN_KEY_NAME}"
 echo "** KITCHEN_SSH_KEY_PATH: ${KITCHEN_SSH_KEY_PATH}"
 echo "** KITCHEN_AVAILABILITY_ZONE: ${KITCHEN_AVAILABILITY_ZONE}"
 echo "** KITCHEN_ARCHITECTURE: ${KITCHEN_ARCHITECTURE}"
+echo "** KITCHEN_INSTANCE_TYPE: ${KITCHEN_INSTANCE_TYPE}"
 echo "** KITCHEN_SUBNET_ID: ${KITCHEN_SUBNET_ID}"
 echo "** KITCHEN_VPC_ID: ${KITCHEN_VPC_ID}"
 echo "** KITCHEN_SECURITY_GROUP_ID: ${KITCHEN_SECURITY_GROUP_ID}"


### PR DESCRIPTION
### Tests:

* `bash kitchen.ec2.sh platform-install test dcv-alinux2` passing on x86
* the same test is not passing on arm because we are missing to enable the amazon-linux-extras epel topic as dependency of the test (TODO).
