### PR TITLE
Multiple fixes and improvements after recipes movement

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_virtualenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_virtualenv_spec.rb
@@ -15,7 +15,7 @@ pyenv_dir = "#{base_dir}/pyenv"
 
 control 'tag:install_awsbatch_virtualenv_created' do
   title "awsbatch virtualenv should be created on #{python_version}"
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat? }
 
   describe directory("#{pyenv_dir}/versions/#{python_version}/envs/awsbatch_virtualenv") do
     it { should exist }

--- a/cookbooks/aws-parallelcluster-common/attributes/common.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common.rb
@@ -15,8 +15,5 @@ default['cluster']['head_node_imds_allowed_users'] = ['root', node['cluster']['c
 default['cluster']['head_node_imds_allowed_users'].append('dcv') if node['cluster']['dcv_enabled'] == 'head_node'
 default['cluster']['head_node_imds_allowed_users'].append(lazy { node['cluster']['scheduler_plugin']['user'] }) if node['cluster']['scheduler'] == 'plugin'
 
-# Default NFS mount options
-default['cluster']['nfs']['hard_mount_options'] = 'hard,_netdev,noatime'
-
 default['cluster']['computefleet_status_path'] = "#{node['cluster']['shared_dir']}/computefleet-status.json"
 default['cluster']['head_node_private_ip'] = nil

--- a/cookbooks/aws-parallelcluster-common/attributes/common.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common.rb
@@ -1,7 +1,5 @@
 # Common attributes shared between multiple cookbooks
 
-default['cluster']['kernel_release'] = node['kernel']['release'] unless default['cluster'].key?('kernel_release')
-
 # Base dir
 
 default['cluster']['head_node_home_path'] = '/home'

--- a/cookbooks/aws-parallelcluster-common/attributes/common.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common.rb
@@ -6,9 +6,6 @@ default['cluster']['head_node_home_path'] = '/home'
 default['cluster']['shared_dir_compute'] = node['cluster']['shared_dir']
 default['cluster']['shared_dir_head'] = node['cluster']['shared_dir']
 
-default['cluster']['ebs_shared_dirs'] = '/shared'
-default['cluster']['exported_ebs_shared_dirs'] = node['cluster']['ebs_shared_dirs']
-
 # IMDS
 default['cluster']['head_node_imds_secured'] = 'true'
 default['cluster']['head_node_imds_allowed_users'] = ['root', node['cluster']['cluster_admin_user'], node['cluster']['cluster_user'] ]

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -1,6 +1,9 @@
 # For performance, set NFS threads to min(256, max(8, num_cores * 4))
 default['cluster']['nfs']['threads'] = [[node['cpu']['cores'].to_i * 4, 8].max, 256].min
 
+# Kernel release version used to select Lustre version
+default['cluster']['kernel_release'] = node['kernel']['release'] unless default['cluster'].key?('kernel_release')
+
 # CloudWatch
 default['cluster']['log_group_name'] = "NONE"
 

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -21,7 +21,8 @@ default['cluster']['directory_service']['disabled_on_compute_nodes'] = nil
 
 # Other ParallelCluster internal variables
 default['cluster']['volume_fs_type'] = 'ext4'
-default['cluster']['efs_shared_dirs'] = ''
+default['cluster']['efs_shared_dirs'] = '/shared'
+default['cluster']['exported_ebs_shared_dirs'] = node['cluster']['ebs_shared_dirs']
 default['cluster']['efs_fs_ids'] = ''
 default['cluster']['efs_encryption_in_transits'] = ''
 default['cluster']['efs_iam_authorizations'] = ''

--- a/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
@@ -14,7 +14,8 @@ control 'tag:install_intel_hpc_dependencies_downloaded' do
 
   only_if { os_properties.centos7? && !os_properties.arm? }
 
-  node['cluster']['intelhpc']['dependencies'].each do |package|
+  dependencies = %w(compat-libstdc++-33 nscd nss-pam-ldapd openssl098e)
+  dependencies.each do |package|
     # The rpm can be in the sources_dir folder or already installed as dependency of other packages
     describe command("ls #{node['cluster']['sources_dir']}/#{package}*.rpm || rpm -qa #{package}* | grep #{package}") do
       its('exit_status') { should eq 0 }
@@ -29,7 +30,8 @@ control 'tag:config_intel_hpc_configured' do
   only_if { os_properties.centos7? && !os_properties.arm? && node['cluster']['enable_intel_hpc_platform'] == 'true' }
 
   # Verify non-intel dependencies are installed
-  node['cluster']['intelhpc']['dependencies'].each do |package|
+  dependencies = %w(compat-libstdc++-33 nscd nss-pam-ldapd openssl098e)
+  dependencies.each do |package|
     describe package(package) do
       it { should be_installed }
     end

--- a/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
@@ -19,3 +19,6 @@ default['cluster']['scheduler'] = 'slurm'
 default['cluster']['node_type'] = nil
 
 default['cluster']["directory_service"]["enabled"] = 'false'
+
+# Default NFS mount options
+default['cluster']['nfs']['hard_mount_options'] = 'hard,_netdev,noatime'


### PR DESCRIPTION
* Move kernel release attribute to environment
  * This is used by Lustre resource and was causing installation failures
* Do not execute AWS Batch inspec tests on RHEL8
* Avoid to test all the Intel HPC dependencies
  * This was causing sporadic issues with some of the packages
* Move ebs_shared_dirs attribute to environment cookbook
  * This is used by both ephemeral_dir recipe and config recipes.
* Move default nfs options to shared cookbook
  * They are used by both slurm and config recipes 