### PR TITLE
Restore previous condition on systemd checks

### DIFF
--- a/test/recipes/controls/other_spec.rb
+++ b/test/recipes/controls/other_spec.rb
@@ -39,7 +39,11 @@ end
 
 control 'tag:config_check_non_graphical_systemd_settings' do
   only_if do
-    !::File.exist?("/etc/dcv/dcv.conf") && node['conditions']['ami_bootstrapped']
+    (
+      !instance.head_node? ||
+      !node['conditions']['dcv_supported'] ||
+      node['cluster']['dcv_enabled'] != "head_node"
+    ) && node['conditions']['ami_bootstrapped']
   end
   describe 'check systemd default runlevel' do
     subject { bash("systemctl get-default | grep -i multi-user.target") }


### PR DESCRIPTION
File::Exist condition was not enough to skip this test in the head node

In this way we're sure we're checking it in the opposite condition of `tag:config_check_non_graphical_systemd_settings`
```
  only_if do
    instance.head_node? && node['conditions']['dcv_supported'] && node['cluster']['dcv_enabled'] == "head_node" &&
      !os_properties.on_docker?
  end
```
### References

This issue was introduced with: https://github.com/aws/aws-parallelcluster-cookbook/pull/2216
