### PR TITLE
POC for kitchen lifecycle hooks.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
@@ -324,3 +324,10 @@ suites:
         is_official_ami_build: true
     driver:
       instance_type: t3.medium
+  - name: hooks
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-platform::hooks]
+    verifier:
+      controls:
+        - /nothing/

--- a/cookbooks/aws-parallelcluster-platform/recipes/hooks.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/hooks.rb
@@ -1,0 +1,7 @@
+log "Environment #{node.environment}"
+
+resource_name = 'ebs_volume_id_ebs_mount'
+platform_name = node['cluster']['base_os']
+key = "#{resource_name}/#{platform_name}"
+
+log "volume #{node['kitchen_hooks'][key]}"

--- a/cookbooks/aws-parallelcluster-platform/test/hooks/install/hooks/post_create.sh
+++ b/cookbooks/aws-parallelcluster-platform/test/hooks/install/hooks/post_create.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "**** hooks POC pre-pre_converge"
+
+[[ "${KITCHEN_DRIVER}" = "ec2" ]] || return
+
+RESOURCE_NAME=ebs_volume_id_ebs_mount
+
+echo "** Creating EBS volume..."
+
+KITCHEN_EBS_VOLUME_ID=$(aws ec2 create-volume \
+        --region "${KITCHEN_AWS_REGION}" \
+        --availability-zone "${KITCHEN_AWS_REGION}${KITCHEN_AVAILABILITY_ZONE}" \
+        --size 1 \
+        --tag-specifications "ResourceType=volume,Tags=[{Key=Kitchen, Value=true},{Key=Platform, Value=${KITCHEN_PLATFORM_NAME}},{Key=ResourceName, Value=${RESOURCE_NAME}}]" \
+        --query "VolumeId" --output text)
+
+echo "** EBS volume created: ${KITCHEN_EBS_VOLUME_ID}"
+
+sed -i.bak "s#'${RESOURCE_NAME}/${KITCHEN_PLATFORM_NAME}' => '.*',#'${RESOURCE_NAME}/${KITCHEN_PLATFORM_NAME}' => '${KITCHEN_EBS_VOLUME_ID}',#" "${KITCHEN_ROOT_DIR}/test/environments/kitchen.rb"

--- a/cookbooks/aws-parallelcluster-platform/test/hooks/install/hooks/pre_destroy.sh
+++ b/cookbooks/aws-parallelcluster-platform/test/hooks/install/hooks/pre_destroy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "**** hooks POC pre-pre_converge"
+
+[[ "${KITCHEN_DRIVER}" = "ec2" ]] || return
+[ -n "${KITCHEN_INSTANCE_HOSTNAME}" ] || return
+
+RESOURCE_NAME=ebs_volume_id_ebs_mount
+
+KITCHEN_EBS_VOLUME_ID=$(cat "${KITCHEN_ROOT_DIR}/test/environments/kitchen.rb"  | sed -n -e "s/.*'${RESOURCE_NAME}\/${KITCHEN_PLATFORM_NAME}' => '\(.*\)',/\1/p")
+
+echo "** Deleting EBS volume ${KITCHEN_EBS_VOLUME_ID}"
+
+aws ec2 detach-volume --volume-id "${KITCHEN_EBS_VOLUME_ID}"
+
+echo "** EBS volume ${KITCHEN_EBS_VOLUME_ID} detached"
+
+aws ec2 delete-volume --volume-id "${KITCHEN_EBS_VOLUME_ID}"
+
+echo "** EBS volume ${KITCHEN_EBS_VOLUME_ID} deleted"
+

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -9,9 +9,21 @@ verifier:
 
 provisioner:
   data_path: test/data
+  environments_path: test/environments
+  client_rb:
+    environment: kitchen
   attributes:
     kitchen: true
     cluster:
       # right now tests depend on this parameter: we will try to remove the dependency later
       region: us-east-1
       parallelcluster-node-version: '3.4.1'
+
+lifecycle:
+  <% %w(pre post).each do |prefix| %>
+  <% %w(create converge verify destroy).each do |phase| %>
+  <%   op = "#{prefix}_#{phase}" %>
+  <%= op %>:
+      - local: bash ./kitchen.run-hook.sh <%= op %> $(dirname "$0")
+  <% end %>
+  <% end %>

--- a/kitchen.run-hook.sh
+++ b/kitchen.run-hook.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+export KITCHEN_HOOK=$1
+KITCHEN_ROOT_DIR=$(readlink -f $2)
+export KITCHEN_ROOT_DIR
+
+echo "*** Run ${KITCHEN_HOOK} for cookbook ${KITCHEN_COOKBOOK_PATH} suite ${KITCHEN_SUITE_NAME} on host ${KITCHEN_INSTANCE_HOSTNAME}"
+
+THIS_DIR=$(dirname "$0")
+SCRIPT="${THIS_DIR}/${KITCHEN_COOKBOOK_PATH}/test/hooks/${KITCHEN_PHASE}/${KITCHEN_SUITE_NAME}/${KITCHEN_HOOK}.sh"
+
+echo "${SCRIPT}"
+
+if [ -e "${SCRIPT}" ]; then
+
+  echo "**** Script: ${SCRIPT}"
+
+  if [ "${KITCHEN_DRIVER}" = "ec2" ]; then
+
+    if [ -n "${KITCHEN_INSTANCE_HOSTNAME}" ]; then
+      echo "*** Retrieve EC2 instance id using key ${KITCHEN_SSH_KEY_PATH}"
+
+      case $KITCHEN_PLATFORM_NAME in
+        alinux*|redhat* ) export KITCHEN_EC2_USER='ec2-user';;
+        centos*         ) export KITCHEN_EC2_USER='centos';;
+        ubuntu*         ) export KITCHEN_EC2_USER='ubuntu';;
+      esac
+
+      KITCHEN_EC2_INSTANCE_ID=$(ssh -o StrictHostKeyChecking=no -i "${KITCHEN_SSH_KEY_PATH}" \
+        "${KITCHEN_EC2_USER}@${KITCHEN_INSTANCE_HOSTNAME}" '
+        TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600") \
+        && curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/instance-id
+      ')
+
+      echo "EC2 instance id: ${KITCHEN_EC2_INSTANCE_ID}"
+
+      export KITCHEN_EC2_INSTANCE_ID
+    fi
+  fi
+
+  # shellcheck disable=SC1090
+  source "${SCRIPT}"
+
+else
+  echo "*** Hook ${KITCHEN_HOOK} undefined for ${KITCHEN_SUITE_NAME}"
+fi

--- a/test/environments/kitchen.rb
+++ b/test/environments/kitchen.rb
@@ -1,0 +1,11 @@
+# sed -i.bak "s#'ebs_volume_id/alinux2' => '<put your id here>',#" test/environments/kitchen.rb
+
+name 'newenv'
+default_attributes 'kitchen_hooks' => {
+  'ebs_volume_id_ebs_mount/alinux2' => 'vol-0275f6b70934850af',
+  'ebs_volume_id_ebs_mount/rhel8' => 'vol-05bd421bfd23c1c8d',
+  'ebs_volume_id_ebs_mount/centos7' => 'vol-03cdd20a7b89eccf0',
+  'ebs_volume_id_ebs_mount/ubuntu1804' => 'vol-0d51f9fca3d80b4fb',
+  'ebs_volume_id_ebs_mount/ubuntu2004' => 'vol-06835966c9152c876',
+  'ebs_volume_id_ebs_mount/ubuntu2204' => 'vol-0ce05a2e6b48bfdf4',
+}


### PR DESCRIPTION
### Description of changes

`kitchen.global.yml` configures lifecycle hooks to run potentially pre and post every operation. 
`kitchen.run-hook.sh` verifies if the hook script exists under `<cookbook>>/test/hooks/<install|config>/<suite>`. 
If the script exists, it is called.

`kitchen.global.yml` uses kitchen environment, which is configured in `test/environments/kitchen.rb`.

In order to share values with kitchen recipes running remotely, attribute values must be set in this file.

For every value to pass and for every OS, add a line to this file:

```
'<variable>/<platform>' => 'placeholder'
```

For instance: `'ebs_volume_id_ebs_mount/alinux2' => 'placeholder'`.

In your hook scripts, use sed to replace the placeholder with the actual value to share with the remote host. Also, read the value from the same file to retrieve it locally, for instance to be able to delete a resource during the destroy phase.

The example in this POC uses platform-install hooks recipe and test (created ad-hoc for the POC). It creates an EBS volume using post_create hook, shares it with hooks recipe which logs the value, and destroys it in pre_destroy hook.

### Tests
* `./kitchen.ec2.sh platform-install verify hooks -c 5`
* `./kitchen.ec2.sh platform-install destroy hooks -c 5`

One volume has been created for each platform, logged by hooks recipe and then deleted.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.