### PR TITLE
[develop] Do not use DCV file exist to verify if DCV is configured or not

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/log_rotation.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/log_rotation.rb
@@ -20,5 +20,5 @@ template node['cluster']['pcluster_log_rotation_path'] do
   source 'log_rotation/parallelcluster_log_rotation.erb'
   mode '0644'
   only_if { node['cluster']['log_rotation_enabled'] == 'true' }
-  variables(dcv_configured: ::File.exist?("/etc/dcv/dcv.conf"))
+  variables(dcv_configured: node['cluster']['dcv_enabled'] == "head_node" && node['conditions']['dcv_supported'])
 end

--- a/cookbooks/aws-parallelcluster-config/recipes/sudo.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/sudo.rb
@@ -33,6 +33,6 @@ template '/etc/parallelcluster/parallelcluster_supervisord.conf' do
   variables(
     region: region,
     aws_ca_bundle: region.start_with?('us-iso') ? "/etc/pki/#{region}/certs/ca-bundle.pem" : '',
-    dcv_configured: ::File.exist?("/etc/dcv/dcv.conf")
+    dcv_configured: node['cluster']['dcv_enabled'] == "head_node" && node['conditions']['dcv_supported']
   )
 end

--- a/cookbooks/aws-parallelcluster-config/spec/unit/recipes/sudo_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-config/spec/unit/recipes/sudo_config_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-config::sudo' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        ChefSpec::Runner.new(platform: platform, version: version).converge(described_recipe)
+      end
+
+      it 'creates the sudoers template with the correct attributes' do
+        is_expected.to create_template('/etc/sudoers.d/99-parallelcluster-user-tty').with(
+          owner: 'root',
+          group: 'root',
+          mode:  '0600'
+        )
+      end
+
+      it 'creates the supervisord template with the correct attributes' do
+        is_expected.to create_template('/etc/parallelcluster/parallelcluster_supervisord.conf').with(
+          owner: 'root',
+          group: 'root',
+          mode:  '0644'
+        )
+      end
+
+      context "when head node and dcv configured" do
+        cached(:chef_run) do
+          runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
+            node.override['cluster']['node_type'] = 'HeadNode'
+            node.override['cluster']['dcv_enabled'] = 'head_node'
+            node.override['conditions']['dcv_supported'] = true
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'has the correct content' do
+          is_expected.to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
+            .with_content("[program:clusterstatusmgtd]")
+            .with_content("[program:pcluster_dcv_authenticator]")
+            .with_content("--port 8444")
+        end
+
+        context "when head node and dcv not configured" do
+          cached(:chef_run) do
+            runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
+              node.override['cluster']['node_type'] = 'HeadNode'
+              node.override['cluster']['dcv_enabled'] = 'NONE'
+              node.override['conditions']['dcv_supported'] = true
+            end
+            runner.converge(described_recipe)
+          end
+          cached(:node) { chef_run.node }
+
+          it 'has the correct content' do
+            is_expected.to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
+              .with_content("[program:clusterstatusmgtd]")
+
+            is_expected.not_to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
+              .with_content("[program:pcluster_dcv_authenticator]")
+          end
+        end
+      end
+
+      context "when compute fleet" do
+        cached(:chef_run) do
+          runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
+            node.override['cluster']['node_type'] = 'ComputeFleet'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'has the correct content' do
+          is_expected.to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
+            .with_content("[program:computemgtd]")
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
@@ -103,7 +103,7 @@ action :setup do
   return if ::File.exist?("/etc/dcv/dcv.conf")
   return if redhat_ubi?
 
-  # share values with InSpec tests
+  # share values with InSpec tests and configuration recipes
   node.default['conditions']['dcv_supported'] = dcv_supported?
   node.default['cluster']['dcv']['authenticator']['virtualenv_path'] = dcvauth_virtualenv_path
   node_attributes 'dump node attributes'
@@ -188,7 +188,7 @@ action :setup do
 end
 
 action :configure do
-  # share values with InSpec tests
+  # share values with InSpec tests and configuration recipes
   node.default['conditions']['dcv_supported'] = dcv_supported?
   node.default['cluster']['dcv']['authenticator']['virtualenv_path'] = dcvauth_virtualenv_path
   node_attributes 'dump node attributes'


### PR DESCRIPTION
ParallelCluster recipes are creating the DCV configuration file from a template file at instance bootstrap time if DCV is enabled, but the file is created at DCV setup.

Check if the file exists is not enough, we need to verify if DCV is currently enabled.

This issue was causing the addition of dcv authenticator daemon in the supervisord template even if DCV was not enabled and this was causing failures in the recipe execution because dcv_port was set to NONE by CDK generation so it was not possible to convert it to Integer.

I verified in the code and there is only a remaining `File.exist?("/etc/dcv/dcv.conf")` in the `setup` action of the `dcv` resource and this is correct.

### Tests

Created a unit test to verify supervisord template creation.

### References

Issue introduced with: 9467c928784703d94ca9010c08215192adaeab65

