### PR TITLE
[Ubuntu 22] Add kitchen test support for EFS mount and unmount actions for all OSes, including Ubuntu 22.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-install.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-install.yml
@@ -75,7 +75,7 @@ suites:
         - /tag:install_efa/
     attributes:
       resource: efa:setup
-  - name: efs
+  - name: efs_install_utils
     run_list:
       - recipe[aws-parallelcluster-tests::setup]
       - recipe[aws-parallelcluster-tests::test_resource]
@@ -84,6 +84,35 @@ suites:
         - /tag:install_efs/
     attributes:
       resource: efs:install_utils
+      dependencies:
+        - resource:node_attributes
+  - name: efs_mount
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-tests::test_resource]
+    verifier:
+      controls:
+        - /efs_mounted/
+    attributes:
+      # manually create a volume (default values with 1G size are OK) and paste Volume ID below
+      # manually delete the volume after the test is concluded
+      resource: 'efs:mount {"shared_dir_array" : ["shared_dir"], "efs_fs_id_array" : ["fs-03ad31942a4205839"]}'
+      dependencies:
+        - resource:efs
+  - name: efs_unmount
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-tests::test_resource]
+    verifier:
+      controls:
+        - /efs_unmounted/
+    attributes:
+      # manually create a volume (default values with 1G size are OK) and paste Volume ID below (2 rows)
+      # manually delete the volume after the test is concluded
+      resource: 'efs:unmount {"shared_dir_array" : ["shared_dir"], "efs_fs_id_array" : ["fs-03ad31942a4205839"]}'
+      dependencies:
+        - resource:efs
+        - 'resource:efs:mount {"shared_dir_array" : ["shared_dir"], "efs_fs_id_array" : ["fs-03ad31942a4205839"]}'
   - name: system_authentication
     run_list:
       - recipe[aws-parallelcluster-tests::setup]

--- a/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_mount_umount.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_mount_umount.rb
@@ -19,6 +19,7 @@ property :efs_encryption_in_transit_array, Array, required: false
 property :efs_iam_authorization_array, Array, required: false
 
 action :mount do
+  return if on_docker?
   efs_shared_dir_array = new_resource.shared_dir_array.dup
   efs_fs_id_array = new_resource.efs_fs_id_array.dup
   efs_encryption_in_transit_array = new_resource.efs_encryption_in_transit_array.dup
@@ -26,8 +27,8 @@ action :mount do
 
   efs_fs_id_array.each_with_index do |efs_fs_id, index|
     efs_shared_dir = efs_shared_dir_array[index]
-    efs_encryption_in_transit = efs_encryption_in_transit_array[index]
-    efs_iam_authorization = efs_iam_authorization_array[index]
+    efs_encryption_in_transit = efs_encryption_in_transit_array[index] unless efs_encryption_in_transit_array.nil?
+    efs_iam_authorization = efs_iam_authorization_array[index] unless efs_iam_authorization_array.nil?
 
     # Path needs to be fully qualified, for example "shared/temp" becomes "/shared/temp"
     efs_shared_dir = "/#{efs_shared_dir}" unless efs_shared_dir.start_with?('/')
@@ -87,6 +88,7 @@ action :mount do
 end
 
 action :unmount do
+  return if on_docker?
   efs_shared_dir_array = new_resource.shared_dir_array.dup
   efs_shared_dir_array.each do |efs_shared_dir|
     # Path needs to be fully qualified, for example "shared/temp" becomes "/shared/temp"


### PR DESCRIPTION
EBS kitchen tests existed for the install utils action, but not yet for mount and unmount. Updated the mount and unmount actions to check for a nil array on optional properties. Similar to EBS, the tests are executed with manually created EFS filesystems, so not CI/CD.

The following controls were added:
- efs_mounted
- efs_unmounted

The following controls were tested manually:
- efs_install_utils on ec2 and docker (only rhel8 no-op)
- efs_mount on ec2 and docker (all no-op)
- efs_unmount on ec2 and docker (all no-op)

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.