### PR TITLE
[develop] Move compute_base recipe to environment cookbook

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/base.rb
@@ -45,7 +45,7 @@ case node['cluster']['node_type']
 when 'HeadNode'
   include_recipe 'aws-parallelcluster-config::head_node_base'
 when 'ComputeFleet'
-  include_recipe 'aws-parallelcluster-config::compute_base'
+  include_recipe 'aws-parallelcluster-environment::compute_base'
 else
   raise "node_type must be HeadNode or ComputeFleet"
 end

--- a/cookbooks/aws-parallelcluster-config/recipes/compute_base.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/compute_base.rb
@@ -42,12 +42,11 @@ end
 
 # Parse shared directory info and turn into an array
 shared_dir_array = node['cluster']['ebs_shared_dirs'].split(',')
-exported_shared_dir_array = node['cluster']['exported_ebs_shared_dirs'].split(',')
 
 # Mount each volume with NFS
-shared_dir_array.zip(exported_shared_dir_array).each do |dir, exported_dir|
+shared_dir_array.each do |dir|
   dirname = format_directory(dir)
-  exported_dirname = format_directory(exported_dir)
+  exported_dirname = format_directory(dir)
 
   # Created shared mount point
   directory dirname do

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -28,7 +28,6 @@ default['cluster']['directory_service']['disabled_on_compute_nodes'] = nil
 # Other ParallelCluster internal variables
 default['cluster']['volume_fs_type'] = 'ext4'
 default['cluster']['efs_shared_dirs'] = '/shared'
-default['cluster']['exported_ebs_shared_dirs'] = node['cluster']['ebs_shared_dirs']
 default['cluster']['efs_fs_ids'] = ''
 default['cluster']['efs_encryption_in_transits'] = ''
 default['cluster']['efs_iam_authorizations'] = ''

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -33,6 +33,25 @@ suites:
         scheduler: slurm
         cw_logging_enabled: "true"
         log_group_name: test
+  - name: compute_base
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-environment::compute_base]
+    verifier:
+      controls:
+        - compute_base_configured
+    attributes:
+      dependencies:
+        - resource:nfs
+        - recipe:aws-parallelcluster-environment::mock_compute_base
+      cluster:
+        node_type: ComputeFleet
+        cluster_user: test_user
+        raid_shared_dir: raid1
+        ebs_shared_dirs: ebs1,ebs2
+        nfs:
+          hard_mount_options: hard,_netdev,noatime
+        head_node_private_ip: '127.0.0.1'
   - name: directory_service
     # FIXME: breaks on Docker
     run_list:

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/compute_base.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/compute_base.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
-# Recipe:: compute_base
-#
 # Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the

--- a/cookbooks/aws-parallelcluster-environment/recipes/test/mock_compute_base.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/test/mock_compute_base.rb
@@ -1,6 +1,6 @@
-return if virtualized?
+return if on_docker?
 
-raid_and_ebs_dirs = %w(/exported_raid1 /exported_ebs1 /exported_ebs2)
+raid_and_ebs_dirs = %w(/raid1 /ebs1 /ebs2)
 raid_and_ebs_dirs.each do |dir|
   directory dir do
     mode '1777'
@@ -11,9 +11,8 @@ end
 # only need the folder to be present, and this way we can speed
 # things up by avoiding the installation of Intel MPI
 directory '/opt/intel'
-directory '/exported_intel'
 
-dirs_to_export = %w(/exported_raid1 /exported_ebs1 /exported_ebs2 /exported_intel)
+dirs_to_export = %w(/raid1 /ebs1 /ebs2 /opt/intel)
 dirs_to_export.each do |dir|
   nfs_export dir do
     network '127.0.0.1/32'

--- a/cookbooks/aws-parallelcluster-environment/test/controls/compute_base_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/compute_base_spec.rb
@@ -12,7 +12,7 @@
 control 'compute_base_configured' do
   title 'Check the basic configuration for compute node'
 
-  only_if { !os_properties.virtualized? }
+  only_if { !os_properties.on_docker? }
 
   describe 'Check that cluster user exist'
   describe user('test_user') do
@@ -34,7 +34,7 @@ control 'compute_base_configured' do
 
     describe mount("/#{directory}") do
       it { should be_mounted }
-      its('device') { should eq "127.0.0.1:/exported_#{directory}" }
+      its('device') { should eq "127.0.0.1:/#{directory}" }
       its('type') { should eq 'nfs4' }
       its('options') { should include 'hard' }
       its('options') { should include '_netdev' }
@@ -45,7 +45,7 @@ control 'compute_base_configured' do
   describe 'Check that /opt/intel dir has been mounted'
   describe mount("/opt/intel") do
     it { should be_mounted }
-    its('device') { should eq "127.0.0.1:/exported_intel" }
+    its('device') { should eq "127.0.0.1:/opt/intel" }
     its('type') { should eq 'nfs4' }
     its('options') { should include 'hard' }
     its('options') { should include '_netdev' }

--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -137,28 +137,6 @@ suites:
         local_hostname: dokken
         local_ipv4: 172.17.1.15
       ipaddress: 172.17.1.15
-  - name: compute_base
-    run_list:
-      - recipe[aws-parallelcluster::add_dependencies]
-      - recipe[aws-parallelcluster-config::compute_base]
-    verifier:
-      controls:
-        - compute_base_configured
-    attributes:
-      dependencies:
-        #- resource:nfs
-        - recipe:aws-parallelcluster-test::compute_base_mock
-      cluster:
-        node_type: ComputeFleet
-        cluster_user: test_user
-        exported_intel_dir: exported_intel
-        raid_shared_dir: raid1
-        exported_raid_shared_dir: exported_raid1
-        ebs_shared_dirs: ebs1,ebs2
-        exported_ebs_shared_dirs: exported_ebs1,exported_ebs2
-        nfs:
-          hard_mount_options: hard,_netdev,noatime
-        head_node_private_ip: '127.0.0.1'
   - name: compute_slurmd_systemd
     run_list:
       - recipe[aws-parallelcluster-slurm::config_slurmd_systemd_service]


### PR DESCRIPTION
* Remove useless `exported_ebs_shared_dirs` attribute
  * Other than the tests, this is always assigned to `ebs_shared_dirs`

### Tests

* Renamed `compute_base_mock.rb` to `mock_compute_base` and moved to environment/test recipes
* Moved Inspec tests
* Replaced `virtualized` with `on_docker` check
* Added explicit dependency of nfs resource
* Removed `exported_intel_dir`, `exported_raid_shared_dir` and `exported_ebs_shared_dirs` to align it with the actual code
* `bash kitchen.docker.sh environment-config test compute-base -c 6`
* `bash kitchen.ec2.sh environment-config test compute-base -c 6`

### References
* Within this patch we're fixing the tests to be aligned with https://github.com/aws/aws-parallelcluster-cookbook/pull/2253

