### PR TITLE
Fix dcv_configured condition usage 

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/log_rotation.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/log_rotation.rb
@@ -20,5 +20,5 @@ template node['cluster']['pcluster_log_rotation_path'] do
   source 'log_rotation/parallelcluster_log_rotation.erb'
   mode '0644'
   only_if { node['cluster']['log_rotation_enabled'] == 'true' }
-  variables(dcv_configured: node['cluster']['dcv_enabled'] == "head_node" && ::File.exist?("/etc/dcv/dcv.conf"))
+  variables(dcv_configured: node['cluster']['dcv_enabled'] == "head_node" && dcv_installed?)
 end

--- a/cookbooks/aws-parallelcluster-config/recipes/log_rotation.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/log_rotation.rb
@@ -20,5 +20,5 @@ template node['cluster']['pcluster_log_rotation_path'] do
   source 'log_rotation/parallelcluster_log_rotation.erb'
   mode '0644'
   only_if { node['cluster']['log_rotation_enabled'] == 'true' }
-  variables(dcv_configured: node['cluster']['dcv_enabled'] == "head_node" && node['conditions']['dcv_supported'])
+  variables(dcv_configured: node['cluster']['dcv_enabled'] == "head_node" && ::File.exist?("/etc/dcv/dcv.conf"))
 end

--- a/cookbooks/aws-parallelcluster-config/recipes/sudo.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/sudo.rb
@@ -33,6 +33,6 @@ template "#{node['cluster']['etc_dir']}/parallelcluster_supervisord.conf" do
   variables(
     region: region,
     aws_ca_bundle: region.start_with?('us-iso') ? "/etc/pki/#{region}/certs/ca-bundle.pem" : '',
-    dcv_configured: node['cluster']['dcv_enabled'] == "head_node" && ::File.exist?("/etc/dcv/dcv.conf")
+    dcv_configured: node['cluster']['dcv_enabled'] == "head_node" && dcv_installed?
   )
 end

--- a/cookbooks/aws-parallelcluster-config/recipes/sudo.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/sudo.rb
@@ -33,6 +33,6 @@ template "#{node['cluster']['etc_dir']}/parallelcluster_supervisord.conf" do
   variables(
     region: region,
     aws_ca_bundle: region.start_with?('us-iso') ? "/etc/pki/#{region}/certs/ca-bundle.pem" : '',
-    dcv_configured: node['cluster']['dcv_enabled'] == "head_node" && node['conditions']['dcv_supported']
+    dcv_configured: node['cluster']['dcv_enabled'] == "head_node" && ::File.exist?("/etc/dcv/dcv.conf")
   )
 end

--- a/cookbooks/aws-parallelcluster-config/spec/unit/recipes/sudo_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-config/spec/unit/recipes/sudo_config_spec.rb
@@ -28,7 +28,7 @@ describe 'aws-parallelcluster-config::sudo' do
           runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
             node.override['cluster']['node_type'] = 'HeadNode'
             node.override['cluster']['dcv_enabled'] = 'head_node'
-            allow(File).to receive(:exist?).with('/etc/dcv/dcv.conf').and_return(true)
+            allow_any_instance_of(Object).to receive(:dcv_installed?).and_return(true)
           end
           runner.converge(described_recipe)
         end
@@ -46,7 +46,7 @@ describe 'aws-parallelcluster-config::sudo' do
             runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
               node.override['cluster']['node_type'] = 'HeadNode'
               node.override['cluster']['dcv_enabled'] = 'NONE'
-              allow(File).to receive(:exist?).with('/etc/dcv/dcv.conf').and_return(true)
+              allow_any_instance_of(Object).to receive(:dcv_installed?).and_return(true)
             end
             runner.converge(described_recipe)
           end
@@ -67,7 +67,7 @@ describe 'aws-parallelcluster-config::sudo' do
           runner = ChefSpec::Runner.new(platform: platform, version: version) do |node|
             node.override['cluster']['node_type'] = 'ComputeFleet'
             node.override['cluster']['dcv_enabled'] = 'head_node'
-            allow(File).to receive(:exist?).with('/etc/dcv/dcv.conf').and_return(false)
+            allow_any_instance_of(Object).to receive(:dcv_installed?).and_return(false)
           end
           runner.converge(described_recipe)
         end

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
@@ -100,11 +100,10 @@ action_class do
 end
 
 action :setup do
-  return if ::File.exist?("/etc/dcv/dcv.conf")
+  return if dcv_installed?
   return if redhat_ubi?
 
   # share values with InSpec tests and configuration recipes
-  node.default['conditions']['dcv_supported'] = dcv_supported?
   node.default['cluster']['dcv']['authenticator']['virtualenv_path'] = dcvauth_virtualenv_path
   node_attributes 'dump node attributes'
 
@@ -189,7 +188,6 @@ end
 
 action :configure do
   # share values with InSpec tests and configuration recipes
-  node.default['conditions']['dcv_supported'] = dcv_supported?
   node.default['cluster']['dcv']['authenticator']['virtualenv_path'] = dcvauth_virtualenv_path
   node_attributes 'dump node attributes'
 

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -439,7 +439,6 @@ describe 'dcv:setup' do
         end
 
         it 'shares dcv_supported with InSpec tests' do
-          expect(node['conditions']['dcv_supported']).to eq(true)
           expect(node['cluster']['dcv']['authenticator']['virtualenv_path']).to eq(dcvauth_virtualenv_path)
           is_expected.to write_node_attributes('dump node attributes')
         end
@@ -814,7 +813,6 @@ describe 'dcv:configure' do
         end
 
         it 'shares dcv_supported with InSpec tests' do
-          expect(node['conditions']['dcv_supported']).to eq(true)
           expect(node['cluster']['dcv']['authenticator']['virtualenv_path']).to eq(dcvauth_virtualenv_path)
           is_expected.to write_node_attributes('dump node attributes')
         end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
@@ -166,7 +166,7 @@ control 'tag:install_dcv_switch_runlevel_to_multiuser_target' do
 end
 
 control 'tag:config_dcv_external_authenticator_user_and_group_correctly_defined' do
-  only_if { node['conditions']['dcv_supported'] && !os_properties.redhat_ubi? }
+  only_if { dcv_installed? && !os_properties.redhat_ubi? }
 
   describe user(node['cluster']['dcv']['authenticator']['user']) do
     it { should exist }
@@ -183,7 +183,7 @@ end
 
 control 'tag:config_expected_versions_of_nice-dcv-gl_installed' do
   only_if do
-    instance.head_node? && node['conditions']['dcv_supported'] && node['cluster']['dcv_enabled'] == "head_node" &&
+    instance.head_node? && dcv_installed? && node['cluster']['dcv_enabled'] == "head_node" &&
       instance.graphic? && instance.nvidia_installed? && instance.dcv_gpu_accel_supported?
   end
 
@@ -195,7 +195,7 @@ end
 
 control 'tag:config_dcv_correctly_installed' do
   only_if do
-    instance.head_node? && node['conditions']['dcv_supported'] &&
+    instance.head_node? && dcv_installed? &&
       ['yes', true].include?(node['cluster']['dcv']['installed']) && !os_properties.redhat_ubi?
   end
 
@@ -220,7 +220,7 @@ end
 
 control 'tag:config_dcv_services_correctly_configured' do
   only_if do
-    instance.head_node? && node['conditions']['dcv_supported'] && node['cluster']['dcv_enabled'] == "head_node" &&
+    instance.head_node? && dcv_installed? && node['cluster']['dcv_enabled'] == "head_node" &&
       !os_properties.on_docker?
   end
 

--- a/cookbooks/aws-parallelcluster-shared/libraries/environment.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/environment.rb
@@ -63,3 +63,10 @@ end
 def x86_instance?
   node['kernel']['machine'] == 'x86_64'
 end
+
+#
+# Check if DCV is installed
+#
+def dcv_installed?
+  ::File.exist?("/etc/dcv/dcv.conf")
+end


### PR DESCRIPTION
The `node['conditions']['dcv_supported']` is set in the dcv resource, so it's not always available in the environment.
By using the DCV file existence we're sure that DCV is installed and it can happen only on supported OSes.


Within this patch we're replacing `dcv_supported` node attribute with a helper function.
`dcv_supported` condition was only used on the kitchen tests and it's equivalent to use File.exist condition: `dcv.conf` file is present on supported AMIs only.

Note: the `node['cluster']['dcv_enabled'] == "head_node"` is required, we added it as part of: https://github.com/aws/aws-parallelcluster-cookbook/pull/2246

### Tests

Updated and extended dcv_spec tests