### PR TITLE
Correcting the source path of cfnconfig.erb from config to environment cookbook

### DIFF
--- a/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-scheduler-plugin/recipes/update_head_node.rb
@@ -29,6 +29,6 @@ end
 # The updated cfnconfig will be used by post update custom scripts
 template "#{node['cluster']['etc_dir']}/cfnconfig" do
   source 'init/cfnconfig.erb'
-  cookbook 'aws-parallelcluster-config'
+  cookbook 'aws-parallelcluster-environment'
   mode '0644'
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -245,6 +245,6 @@ end
 # The updated cfnconfig will be used by post update custom scripts
 template "#{node['cluster']['etc_dir']}/cfnconfig" do
   source 'init/cfnconfig.erb'
-  cookbook 'aws-parallelcluster-config'
+  cookbook 'aws-parallelcluster-environment'
   mode '0644'
 end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::update_head_node' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner = runner(platform: platform, version: version) do
+          allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+          allow_any_instance_of(Object).to receive(:dig).and_return(true)
+          RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+        end
+        runner.converge(described_recipe)
+      end
+
+      it 'creates the template cfnconfig' do
+        is_expected.to create_template('/etc/parallelcluster/cfnconfig').with(
+          source: 'init/cfnconfig.erb',
+          cookbook: 'aws-parallelcluster-environment',
+          mode:  '0644'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
* Correcting the source path of cfnconfig.erb from config to environment cookbook 
* PR where we moved the File -> https://github.com/aws/aws-parallelcluster-cookbook/pull/2198/files

### Tests
Unit test from  aws-parallelcluster-slurm
* ` chef exec rspec ./spec/unit/recipes/update_head_node_spec.rb`



### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.