### PR TITLE
Introduce a new approach to share info from lifecycle hooks to kitchen environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,32 @@ __Example.__
 - `test/hooks/config/network_interfaces/post_create.sh`: creates ENI and attaches it to the instance
 - `test/hooks/config/network_interfaces/pre_destroy.sh`: detaches and deletes ENI.
 
+### Use variables from lifecycle hooks as resource properties
+
+In the `kitchen.global.yaml` we're configuring an [environment](https://docs.chef.io/environments/).
+
+In the environment file (i.e. `test/environments/kitchen.rb`), for every value to pass and for every OS, 
+you have to define a line like: `'<suite_name>-<variable_name>/<platform>' => 'placeholder'`. For instance:
+```
+default_attributes 'kitchen_hooks' => {
+  'ebs_mount-vol_array/alinux2' => 'placeholder',
+  ...
+}
+```
+
+These environment variables will be available to the kitchen tests as node attributes:
+`node['kitchen_hooks']['ebs_mount-vol_array/alinux2']`. 
+
+To permit to use these environment variables as parameters attributes you have to use th `FROM-HOOK`
+keyword in the test suite definition.
+e.g. `resource: 'manage_ebs:mount {"shared_dir_array" : ["shared_dir"], "vol_array" : "FROM_HOOK-<suite_name>-<variable_name>"}'`
+
+This value will be automatically replaced, searching for the `<suite_name>-<variable_name>/<platform>` in the environment.
+You can find all the details of this mechanism in the `test_resource.rb`.
+
+Note: the value of the property to be replaced must be a string even if it's an array.
+It's up to the post_create script to define an array in the environment.
+
 ### Known issues with docker
 
 #### Running kitchen tests on non `amd64` architectures

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-install.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-install.yml
@@ -130,9 +130,7 @@ suites:
       controls:
         - /ebs_mounted/
     attributes:
-      # manually create a volume (default values with 1G size are OK) and paste Volume ID below
-      # manually delete the volume after the test is concluded
-      resource: 'manage_ebs:mount {"shared_dir_array" : ["shared_dir"], "vol_array" : ["vol-00ec1f3bbcef44f6d"]}'
+      resource: 'manage_ebs:mount {"shared_dir_array" : ["shared_dir"], "vol_array" : "FROM_HOOK-ebs_mount-vol_array"}'
       dependencies:
         - recipe:aws-parallelcluster-platform::cookbook_virtualenv
         - resource:ec2_udev_rules

--- a/cookbooks/aws-parallelcluster-environment/test/hooks/install/ebs_mount/post_create.sh
+++ b/cookbooks/aws-parallelcluster-environment/test/hooks/install/ebs_mount/post_create.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "**** post_create"
+
+[[ "${KITCHEN_DRIVER}" = "ec2" ]] || exit 0
+
+RESOURCE_NAME=ebs_mount-vol_array
+
+echo "** Creating EBS volume..."
+
+KITCHEN_EBS_VOLUME_ID=$(aws ec2 create-volume \
+        --region "${KITCHEN_AWS_REGION}" \
+        --availability-zone "${KITCHEN_AWS_REGION}${KITCHEN_AVAILABILITY_ZONE}" \
+        --size 1 \
+        --tag-specifications "ResourceType=volume,Tags=[{Key=Kitchen, Value=true},{Key=Platform, Value=${KITCHEN_PLATFORM_NAME}},{Key=ResourceName, Value=${RESOURCE_NAME}}]" \
+        --query "VolumeId" --output text)
+
+echo "** EBS volume created: ${KITCHEN_EBS_VOLUME_ID}"
+
+sed -i.bak "s#'${RESOURCE_NAME}/${KITCHEN_PLATFORM_NAME}' => .*,#'${RESOURCE_NAME}/${KITCHEN_PLATFORM_NAME}' => %w(${KITCHEN_EBS_VOLUME_ID}),#" "${KITCHEN_ROOT_DIR}/test/environments/kitchen.rb"

--- a/cookbooks/aws-parallelcluster-environment/test/hooks/install/ebs_mount/pre_destroy.sh
+++ b/cookbooks/aws-parallelcluster-environment/test/hooks/install/ebs_mount/pre_destroy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "**** pre_destroy"
+
+[[ "${KITCHEN_DRIVER}" = "ec2" ]] || exit 0
+[ -n "${KITCHEN_INSTANCE_HOSTNAME}" ] || exit 0
+
+RESOURCE_NAME=ebs_mount-vol_array
+
+KITCHEN_EBS_VOLUME_ID=$(cat "${KITCHEN_ROOT_DIR}/test/environments/kitchen.rb" | sed -n -e "s/.*'${RESOURCE_NAME}\/${KITCHEN_PLATFORM_NAME}' => %w(\(.*\)),/\1/p")
+
+echo "** Deleting EBS volume ${KITCHEN_EBS_VOLUME_ID}"
+
+aws ec2 detach-volume --volume-id "${KITCHEN_EBS_VOLUME_ID}"
+
+echo "** EBS volume ${KITCHEN_EBS_VOLUME_ID} detached"
+
+aws ec2 delete-volume --volume-id "${KITCHEN_EBS_VOLUME_ID}"
+
+echo "** EBS volumes ${KITCHEN_EBS_VOLUME_ID} deleted"

--- a/cookbooks/aws-parallelcluster-tests/resources/test_resource.rb
+++ b/cookbooks/aws-parallelcluster-tests/resources/test_resource.rb
@@ -24,7 +24,30 @@ end
 
 def its_properties
   if descriptor.include? "{"
-    Chef::JSONCompat.from_json("{#{descriptor.sub(/.*?{/, '')}")
+    if descriptor.include? "FROM_HOOK"
+      # Replace FROM_HOOK keyword with values from the environment
+      # Note the value of the property to be replaced must be "FROM_HOOK" even if it's an array.
+      # It's up to the post_create script to define an array in the environment.
+      # e.g. resource: 'manage_ebs:mount {"shared_dir_array" : ["shared_dir"], "vol_array" : "FROM_HOOK-ebs_mount-vol_array"}'
+      Chef::Log.info("FROM_HOOK found in resource properties. Original descriptor is: #{descriptor}")
+      properties = Chef::JSONCompat.from_json("{#{descriptor.sub(/.*?{/, '')}")
+      properties.each do |key, value|
+        Chef::Log.debug("property: #{key}, value: #{value}")
+        next unless value.include? "FROM_HOOK"
+
+        env_property = value.sub(/FROM_HOOK-/, '')
+        # Retrieve properties from environment file (e.g. values from lifecycle hooks)
+        hook_key = "#{env_property}/#{node['cluster']['base_os']}"
+        hook_value = node['kitchen_hooks'][hook_key]
+
+        Chef::Log.info("Hook key #{hook_key} found in the environment. Replacing FROM_HOOK value with: #{hook_value}")
+        properties[key] = hook_value
+        Chef::Log.debug("Modified properties are now: #{properties}")
+      end
+      properties
+    else
+      Chef::JSONCompat.from_json("{#{descriptor.sub(/.*?{/, '')}")
+    end
   else
     {}
   end

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -9,6 +9,9 @@ verifier:
 
 provisioner:
   data_path: test/data
+  environments_path: test/environments
+  client_rb:
+    environment: kitchen
   attributes:
     kitchen: true
     cluster:

--- a/test/environments/kitchen.rb
+++ b/test/environments/kitchen.rb
@@ -1,0 +1,13 @@
+# In order to share values with kitchen recipes running remotely, attribute values must be set in this file.
+# For every value to pass and for every OS, add a line to this file:
+#   '<suite_name>-<variable_name>/<platform>' => 'placeholder'
+# For instance: 'ebs_mount-vol_array/alinux2' => 'placeholder'.
+name 'kitchen'
+default_attributes 'kitchen_hooks' => {
+  'ebs_mount-vol_array/alinux2' => '',
+  'ebs_mount-vol_array/rhel8' => '',
+  'ebs_mount-vol_array/centos7' => '',
+  'ebs_mount-vol_array/ubuntu1804' => '',
+  'ebs_mount-vol_array/ubuntu2004' => '',
+  'ebs_mount-vol_array/ubuntu2204' => '',
+}


### PR DESCRIPTION
`kitchen.global.yml` configures lifecycle hooks to run potentially pre and post every operation. `kitchen.run-hook.sh` verifies if the hook script exists under `<cookbook>/test/hooks/<install|config>/<suite>`. If the script exists, it is called.

`kitchen.global.yml` uses kitchen environment, which is configured in `test/environments/kitchen.rb`.

In order to share values with kitchen recipes running remotely, attribute values must be set in this file.

For every value to pass and for every OS, you need add a line to this file:
```
'<suite_name>-<variable_name>/<platform>' => 'placeholder'
```

For instance: `'ebs_mount-vol_array_id/alinux2' => 'placeholder'`.

In your hook scripts, use sed to replace the placeholder with the actual value to share with the remote host. Also, read the value from the same file to retrieve it locally, for instance to be able to delete a resource during the destroy phase.

It creates an EBS volume using post_create hook,
shares it with hooks recipe which logs the value, and destroys it in pre_destroy hook.

If you use the "FROM_HOOK" keyword in the suite definition, the `test_resource.rb` will automatically replace the placeholder for you in the environment file. 

Note the value of the property to be replaced must be "FROM_HOOK" even if it's an array.
It's up to the post_create script to define an array in the environment. e.g.:
```
resource: 'manage_ebs:mount {"shared_dir_array" : ["shared_dir"], "vol_array" : "FROM_HOOK-<suite_name>-<variable_name>"}'
```


### Tests

* `./kitchen.ec2.sh environment-install test ebs-mount` -c 6 --> tests are failing because expecting `xvdb` rather than `nvme1n1` but the hooks work as expected.

```
[2023-06-09T08:09:49+00:00] INFO: FROM_HOOK found in resource properties. Original descriptor is: manage_ebs:mount {"shared_dir_array" : ["shared_dir"], "vol_array" : "FROM_HOOK-ebs_mount-vol_array"}
[2023-06-09T08:09:49+00:00] DEBUG: property: shared_dir_array, value: ["shared_dir"]
[2023-06-09T08:09:49+00:00] DEBUG: property: vol_array, value: FROM_HOOK-ebs_mount-vol_array
[2023-06-09T08:09:49+00:00] INFO: Hook key ebs_mount-vol_array/centos7 found in the environment. Replacing FROM_HOOK value with: ["vol-0ac6a0534c431319f"]
[2023-06-09T08:09:49+00:00] DEBUG: Modified properties are now: {"shared_dir_array"=>["shared_dir"], "vol_array"=>["vol-0ac6a0534c431319f"]}

```

### References
* Part of the patch leverages the work done in https://github.com/aws/aws-parallelcluster-cookbook/pull/2245
