### PR TITLE
Supporting ubuntu22 for cloudwatch

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
@@ -14,9 +14,9 @@ control 'tag:install_cloudwatch_installation_files' do
   end
 
   describe 'Check the presence of the cloudwatch package gpg key'
-  # In Ubuntu 20.04 due to environment variable the keyring is placed under home of the user ubuntu with the permission of root
+  # In Ubuntu >20.04 due to environment variable the keyring is placed under home of the user ubuntu with the permission of root
   ubuntu2004 = os_properties.ubuntu2004?
-  keyring = os_properties.ubuntu2004? && !os_properties.on_docker? ? '--keyring /home/ubuntu/.gnupg/pubring.kbx' : ''
+  keyring = (os_properties.ubuntu2004? || os_properties.ubuntu2204?) && !os_properties.on_docker? ? '--keyring /home/ubuntu/.gnupg/pubring.kbx' : ''
   sudo = os_properties.redhat_ubi? ? '' : 'sudo'
   describe bash("#{sudo} gpg --list-keys #{keyring}") do
     # Don't check exit status for Ubuntu20 because it returns 2 when executed in the validate phase of a created AMI


### PR DESCRIPTION
### Description of changes
* Supporting ubuntu22 for cloudwatch

### Tests
* ` ./kitchen.ec2.sh environment-install verify cloudwatch-ubuntu`
* ` ./kitchen.ec2.sh environment-install verify cloudwatch-ubuntu`



### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.