### PR TITLE
Move Mount_shared recipe to environment cookbook

### DIFF
--- a/cookbooks/aws-parallelcluster-common/attributes/common.rb
+++ b/cookbooks/aws-parallelcluster-common/attributes/common.rb
@@ -1,9 +1,0 @@
-# Common attributes shared between multiple cookbooks
-
-# Base dir
-
-default['cluster']['head_node_home_path'] = '/home'
-default['cluster']['shared_dir_compute'] = node['cluster']['shared_dir']
-default['cluster']['shared_dir_head'] = node['cluster']['shared_dir']
-
-default['cluster']['head_node_private_ip'] = nil

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -42,3 +42,9 @@ default['cluster']['raid_vol_ids'] = ''
 default['cluster']['raid_shared_dir'] = ''
 default['cluster']['ephemeral_dir'] = '/scratch'
 default['cluster']['scheduler_slots'] = 'vcpus'
+
+default['cluster']['head_node_home_path'] = '/home'
+default['cluster']['shared_dir_compute'] = node['cluster']['shared_dir']
+default['cluster']['shared_dir_head'] = node['cluster']['shared_dir']
+
+default['cluster']['head_node_private_ip'] = nil

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -412,3 +412,19 @@ suites:
                                   "fsx_dns_name_array": "FROM_HOOK-lustre_mount-fsx_dns_name_array",
                                   "fsx_mount_name_array": "FROM_HOOK-lustre_mount-fsx_mount_name_array",
                                   "fsx_volume_junction_path_array": [""]}'
+  - name: mount_shared
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-environment::mount_shared]
+    verifier:
+      controls:
+        - /tag:config_mount_shared/
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-platform::directories
+        - resource:nfs
+        - recipe:aws-parallelcluster-test::export_directories_mock
+      cluster:
+        head_node_private_ip: '127.0.0.1'
+        head_node_home_path: '/fake_headnode_home'
+        shared_dir_head: '/fake_headnode_shared'

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/mount_shared.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/mount_shared.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-#
-# Cookbook:: aws-parallelcluster
-# Recipe:: mount_shared
-#
 # Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
@@ -15,7 +11,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-return if virtualized?
+return if on_docker?
 
 # Mount /home over NFS
 mount '/home' do

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/mount_shared_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/mount_shared_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-environment::mount_shared' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner = runner(platform: platform, version: version) do |node|
+          node.override['cluster']['head_node_private_ip'] = '0.0.0.0'
+        end
+        runner.converge(described_recipe)
+      end
+      cached(:node) { chef_run.node }
+
+      it 'mounts /home' do
+        is_expected.to mount_mount('/home')
+          .with(device: "0.0.0.0:/home")
+          .with(fstype: 'nfs')
+          .with(options: %W(hard _netdev noatime))
+          .with(retries: 10)
+          .with(retry_delay: 6)
+
+        is_expected.to enable_mount('/home')
+      end
+
+      it 'mounts /opt/parallelcluster/shared' do
+        is_expected.to mount_mount('/opt/parallelcluster/shared')
+          .with(device: "0.0.0.0:/opt/parallelcluster/shared")
+          .with(fstype: 'nfs')
+          .with(options: %W(hard _netdev noatime))
+          .with(retries: 10)
+          .with(retry_delay: 6)
+
+        is_expected.to enable_mount('/opt/parallelcluster/shared')
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/test/controls/mount_shared_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/mount_shared_spec.rb
@@ -9,10 +9,10 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'mount_shared_configured' do
+control 'tag:config_mount_shared_configured' do
   title 'Check if the home and the shared directories are mounted'
 
-  only_if { !os_properties.virtualized? }
+  only_if { !os_properties.on_docker? }
 
   describe mount('/home') do
     it { should be_mounted }

--- a/kitchen.recipes-config.yml
+++ b/kitchen.recipes-config.yml
@@ -20,22 +20,6 @@ verifier:
 # You can find an example in the add_depdendencies.rb file.
 
 suites:
-  - name: mount_shared
-    run_list:
-      - recipe[aws-parallelcluster::add_dependencies]
-      - recipe[aws-parallelcluster-config::mount_shared]
-    verifier:
-      controls:
-        - mount_shared_configured
-    attributes:
-      dependencies:
-        - recipe:aws-parallelcluster-platform::directories
-        - resource:nfs
-        - recipe:aws-parallelcluster-test::export_directories_mock
-      cluster:
-        head_node_private_ip: '127.0.0.1'
-        head_node_home_path: '/fake_headnode_home'
-        shared_dir_head: '/fake_headnode_shared'
   - name: head_node_base
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]


### PR DESCRIPTION
### Description of changes
* Move mount_shared recipe to environment cookbook

### Tests
* Unit tests ` chef exec rspec ./spec/unit/recipes/mount_shared_spec.rb`
* `./kitchen.docker.sh environment-config test mount-shared -c 5`
* `./kitchen.ec2.sh environment-config test mount-shared -c 5`


### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.