### PR TITLE
Use volume resource for ebs recipe and cleanup of all common libraries

### DIFF
--- a/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
@@ -3,16 +3,6 @@ def virtualized?
   node.include?('virtualized') and node['virtualized']
 end
 
-#
-# Check if the instance has a GPU
-#
-def graphic_instance?
-  has_gpu = Mixlib::ShellOut.new("lspci | grep -i -o 'NVIDIA'")
-  has_gpu.run_command
-
-  !has_gpu.stdout.strip.empty?
-end
-
 def format_directory(dir)
   format_dir = dir.strip
   format_dir = "/#{format_dir}" unless format_dir.start_with?('/')

--- a/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
@@ -1,8 +1,3 @@
-def virtualized?
-  # Check if we are running in a Docker System Tests
-  node.include?('virtualized') and node['virtualized']
-end
-
 def format_directory(dir)
   format_dir = dir.strip
   format_dir = "/#{format_dir}" unless format_dir.start_with?('/')

--- a/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-common/libraries/helpers.rb
@@ -1,5 +1,0 @@
-def format_directory(dir)
-  format_dir = dir.strip
-  format_dir = "/#{format_dir}" unless format_dir.start_with?('/')
-  format_dir
-end

--- a/cookbooks/aws-parallelcluster-common/test/common/libraries/os_properties.rb
+++ b/cookbooks/aws-parallelcluster-common/test/common/libraries/os_properties.rb
@@ -8,13 +8,6 @@ class OsProperties < Inspec.resource(1)
     os_properties.redhat_ubi?
   '
 
-  #
-  # Check if we are running in a virtualized environment
-  #
-  def virtualized?
-    inspec.virtualization.system == 'docker'
-  end
-
   def on_docker?
     inspec.virtualization.system == 'docker'
   end

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/config/head_node_fleet_status.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/config/head_node_fleet_status.rb
@@ -43,7 +43,7 @@ template "#{node['cluster']['etc_dir']}/clusterstatusmgtd.conf" do
   mode '0644'
 end
 
-unless virtualized? || kitchen_test? && !node['interact_with_ddb']
+unless on_docker? || kitchen_test? && !node['interact_with_ddb']
   execute 'initialize compute fleet status in DynamoDB' do
     # Initialize the status of the compute fleet in the DynamoDB table. Set it to RUNNING.
     command "#{cookbook_virtualenv_path}/bin/aws dynamodb put-item --table-name #{node['cluster']['ddb_table']}"\

--- a/cookbooks/aws-parallelcluster-environment/libraries/volume.rb
+++ b/cookbooks/aws-parallelcluster-environment/libraries/volume.rb
@@ -18,3 +18,12 @@ end
 def rescan_pci
   shell_out("echo 1 > /sys/bus/pci/rescan")
 end
+
+#
+# Ensure directory has the right format (i.e. starts with `/`).
+#
+def format_directory(dir)
+  format_dir = dir.strip
+  format_dir = "/#{format_dir}" unless format_dir.start_with?('/')
+  format_dir
+end

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/ebs.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/ebs.rb
@@ -27,24 +27,12 @@ when 'ComputeFleet'
 
   # Mount each volume with NFS
   shared_dir_array.each do |dir|
-    dirname = format_directory(dir)
-    exported_dirname = format_directory(dir)
-
-    # Created shared mount point
-    directory dirname do
-      mode '1777'
-      owner 'root'
-      group 'root'
-      recursive true
-      action :create
-    end
-
-    # Mount shared volume over NFS
-    mount dirname do
-      device(lazy { "#{node['cluster']['head_node_private_ip']}:#{exported_dirname}" })
+    volume "mount volume #{index}" do
+      action :mount
+      shared_dir dir
+      device(lazy { "#{node['cluster']['head_node_private_ip']}:#{format_directory(dir)}" })
       fstype 'nfs'
       options node['cluster']['nfs']['hard_mount_options']
-      action %i(mount enable)
       retries 10
       retry_delay 6
     end

--- a/cookbooks/aws-parallelcluster-environment/resources/volume.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/volume.rb
@@ -130,9 +130,3 @@ action :unexport do
     command "exportfs -ra"
   end
 end
-
-def format_directory(dir)
-  format_dir = dir.strip
-  format_dir = "/#{format_dir}" unless format_dir.start_with?('/')
-  format_dir
-end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/libraries/volume_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/libraries/volume_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-environment:libraries:format_directory' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new.converge_dsl do
+      volume 'nothing' do
+        action :nothing
+      end
+    end
+  end
+
+  it 'adds / at the beginning if not starting with /' do
+    expect(format_directory('any')).to eq('/any')
+  end
+
+  it 'does not add / at the beginning if already starting with /' do
+    expect(format_directory('/any')).to eq('/any')
+  end
+
+  it 'strips whitespaces from directory' do
+    expect(format_directory('  any ')).to eq('/any')
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/volume_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/volume_spec.rb
@@ -1,33 +1,5 @@
 require 'spec_helper'
 
-describe 'volume:format_directory' do
-  cached(:chef_run) do
-    ChefSpec::SoloRunner.new.converge_dsl do
-      volume 'nothing' do
-        action :nothing
-      end
-    end
-  end
-
-  cached(:resource) { chef_run.find_resource('volume', 'nothing') }
-
-  it 'calls volume:nothing' do
-    is_expected.to nothing_volume('nothing')
-  end
-
-  it 'adds / at the beginning if not starting with /' do
-    expect(resource.format_directory('any')).to eq('/any')
-  end
-
-  it 'does not add / at the beginning if already starting with /' do
-    expect(resource.format_directory('/any')).to eq('/any')
-  end
-
-  it 'strips whitespaces from directory' do
-    expect(resource.format_directory('  any ')).to eq('/any')
-  end
-end
-
 describe 'volume:mount' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do

--- a/cookbooks/aws-parallelcluster-environment/test/controls/network_interfaces_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/network_interfaces_spec.rb
@@ -22,7 +22,7 @@ control 'network_interfaces_configuration_script_created' do
 end
 
 control 'multiple_network_interfaces_can_ping_gateway' do
-  only_if { !os_properties.virtualized? }
+  only_if { !os_properties.on_docker? }
 
   describe bash("ip -o link | grep -v lo | wc -l") do
     its('stdout.strip') { should cmp >= 2 }
@@ -46,7 +46,7 @@ end
 control 'network_interfaces_configured' do
   title 'Check that network interfaces have been configured'
 
-  only_if { !os_properties.virtualized? }
+  only_if { !os_properties.on_docker? }
 
   device_names = bash("ip -o link | awk '{print substr($2, 1, length($2) -1)}' | grep -v lo").stdout.split(/\n+/)
   device_names.each do |device_name|

--- a/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
@@ -22,7 +22,7 @@ control 'tag:install_install_packages' do
 
     describe package('kernel-devel') do
       it { should be_installed }
-    end unless os_properties.virtualized?
+    end unless os_properties.on_docker?
 
     # Check amazon linux2 extra
     if os_properties.alinux2?
@@ -39,7 +39,7 @@ control 'tag:install_install_packages' do
 
     describe bash('dpkg -l | grep linux-headers') do
       its('exit_status') { should eq 0 }
-    end unless os_properties.virtualized?
+    end unless os_properties.on_docker?
 
   else
     describe "unsupported OS" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_head_node.rb
@@ -265,7 +265,7 @@ ruby_block "Configure Slurm Accounting" do
     run_context.include_recipe "aws-parallelcluster-slurm::config_slurm_accounting"
   end
   not_if { node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
-end unless virtualized?
+end unless on_docker?
 
 service "slurmctld" do
   supports restart: false

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update_head_node.rb
@@ -199,7 +199,7 @@ ruby_block "Update Slurm Accounting" do
     end
   end
   only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_slurm_database_updated? }
-end unless virtualized?
+end unless on_docker?
 
 # The previous execute "generate_pcluster_slurm_configs" block resource may have overridden the slurmdbd password in
 # slurm_parallelcluster_slurmdbd.conf with a default value, so if it has run and Slurm accounting

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
@@ -18,7 +18,7 @@ use 'partial/_dns_domain_redhat'
 # Configure custom dns domain (only if defined) by appending the Route53 domain created within the cluster
 # ($CLUSTER_NAME.pcluster) and be listed as a "search" domain in the resolv.conf file.
 action :configure do
-  return if virtualized?
+  return if on_docker?
 
   # On RHEL8 dhclient is not enabled by default
   # Put pcluster version of NetworkManager.conf in place

--- a/cookbooks/aws-parallelcluster-test/recipes/docker_mock.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/docker_mock.rb
@@ -1,4 +1,4 @@
-return unless virtualized?
+return unless on_docker?
 
 file '/bin/systemctl' do
   content %{

--- a/cookbooks/aws-parallelcluster-test/recipes/export_directories_mock.rb
+++ b/cookbooks/aws-parallelcluster-test/recipes/export_directories_mock.rb
@@ -1,4 +1,4 @@
-return if virtualized?
+return if on_docker?
 
 directory '/fake_headnode_home'
 directory '/fake_headnode_shared'

--- a/system_tests/README.md
+++ b/system_tests/README.md
@@ -53,8 +53,8 @@ configuration recipes as would be done during node boot time.
 The `system_tests/test.sh` script runs the full process described above.
 
 ### Skipping tests
-A few of the tests are not setup to run in the virtual enviroment and thus can be
-skipped by checking the `is_virtualized?` condition from within the recipe.
+A few of the tests are not setup to run in Docker environment and thus can be
+skipped by checking the `on_docker?` condition from within the recipe.
 
 
 ### Testing the installation

--- a/test/recipes/controls/aws_parallelcluster_slurm/config_slurmd_systemd_service_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/config_slurmd_systemd_service_spec.rb
@@ -11,7 +11,7 @@
 
 control 'systemd_slurmd_service' do
   title 'Check the basic configuration of the systemd slurmd service'
-  only_if { !os_properties.virtualized? }
+  only_if { !os_properties.on_docker? }
 
   describe 'Check that slurmd service is defined'
   describe service('slurmd') do
@@ -35,7 +35,7 @@ end
 
 control 'systemd_slurmd_service_nvidia_gpu_nodes' do
   title 'Check the systemd slurmd service dependencies on NVIDIA GPU compute nodes'
-  only_if { !os_properties.virtualized? }
+  only_if { !os_properties.on_docker? }
 
   describe 'Check slurmd systemd "after" dependencies'
   describe command('systemctl list-dependencies --after --plain slurmd.service') do


### PR DESCRIPTION
### Description of changes
* Use volume resource for ebs recipe
  * I had to move format_directory to environment libraries because explicitly used by the ebs recipe.
* Replace all usage of virtualized with on_docker
* Delete unused graphic_instance function
  * This is defined in platform libraries too and used by nvidia, dcv, slurm recipes.

### Tests
* Moved tests for format_directory method.