### PR TITLE
Update the ptrace_scope if clause to check the correct string and add a check in the kitchen test for the config file chef generates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Remove security updates step executed on cluster nodes bootstrap in US isolated regions
   in order to reduce bootstrap time and avoid a potential point of failure.
 
+**BUG FIXES**
+- Fix an issue that was preventing ptrace protection from being disabled on Ubuntu and allowing Cross Memory Attach (CMA) in libfabric
+
 3.6.0
 ------
 

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -162,11 +162,11 @@ suites:
       - recipe[aws-parallelcluster-tests::test_resource]
     verifier:
       controls:
-        - efa_debian_system_settings_configured
+        - tag:config_efa_debian_system_settings_configured
     attributes:
       resource: efa:configure
       cluster:
-        enable_efa: compute
+        enable_efa: efa
         node_type: ComputeFleet
   - name: network_service_restart
     run_list:

--- a/cookbooks/aws-parallelcluster-environment/resources/efa/partial/_disable_ptrace_debian.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efa/partial/_disable_ptrace_debian.rb
@@ -15,7 +15,8 @@
 
 action :disable_ptrace do
   # Disabling ptrace protection is needed for EFA in order to use SHA transfer for intra-node communication.
-  if node['cluster']['enable_efa'] == 'compute' && node['cluster']['node_type'] == 'ComputeFleet'
+
+  if node['cluster']['enable_efa'] == 'efa' && node['cluster']['node_type'] == 'ComputeFleet'
     sysctl 'kernel.yama.ptrace_scope' do
       value 0
     end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
@@ -173,11 +173,10 @@ describe 'efa:configure' do
       elsif platform == 'ubuntu'
         context 'when efa enabled on compute node' do
           before do
-            chef_run.node.override['cluster']['enable_efa'] = 'compute'
+            chef_run.node.override['cluster']['enable_efa'] = 'efa'
             chef_run.node.override['cluster']['node_type'] = 'ComputeFleet'
             ConvergeEfa.configure(chef_run)
           end
-
           it 'disables ptrace protection on compute nodes' do
             is_expected.to apply_sysctl('kernel.yama.ptrace_scope').with(value: "0")
           end
@@ -197,7 +196,7 @@ describe 'efa:configure' do
 
         context 'when it is not a compute node' do
           before do
-            chef_run.node.override['cluster']['enable_efa'] = 'compute'
+            chef_run.node.override['cluster']['enable_efa'] = 'efa'
             chef_run.node.override['cluster']['node_type'] = 'other'
             ConvergeEfa.configure(chef_run)
           end

--- a/cookbooks/aws-parallelcluster-environment/test/controls/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/efa_spec.rb
@@ -67,10 +67,16 @@ control 'tag:config_efa_installed' do
   end
 end
 
-control 'efa_debian_system_settings_configured' do
+control 'tag:config_efa_debian_system_settings_configured' do
   title 'Check debian system is correctly configured for EFA'
 
   only_if { os.debian? && !os_properties.on_docker? }
+
+  describe 'Verify ptrace config file is present' do
+    subject { file('/etc/sysctl.d/99-chef-kernel.yama.ptrace_scope.conf') }
+    it { should exist }
+    its('content') { should match /kernel.yama.ptrace_scope = 0/ }
+  end
 
   describe kernel_parameter('kernel.yama.ptrace_scope') do
     its('value') { should eq 0 }


### PR DESCRIPTION
Fix bug in disable_ptrace action to allow sysctl to disable ptrace.

Previously the setting for Ubuntu systems was not getting used due to a misalignment between the cookbook and cli.
On the cli, node['cluster']['enable_efa'] was set to 'efa' in the dna.json file, but the cookbook assumed the parameter was set to 'compute'.  This causes the disable_ptrace action if clause to be skipped.

This page describes the use of sysctl https://manpages.ubuntu.com/manpages/bionic/man5/sysctl.conf.5.html
This page describes the function of the ptrace_scope parameter https://www.kernel.org/doc/Documentation/security/Yama.txt
Chef actually generates a config file in /etc/sysctl.d/ for the parameter that is changed so it should persist. https://docs.chef.io/resources/sysctl/

Extended the efa_debian_system_settings_configured kitchen test to include the file addition but spec tests remain the same.

### Tests
* `efa_debian_system_settings_configured` executed manually and added to `tag:config*`
* Confirmed that changing the parameter `enable_efa` in the dna.json results in the resource running
```
Recipe: aws-parallelcluster-config::base
  * efa[Configure system for EFA] action configure[2023-06-15T15:05:05+00:00] INFO: Processing efa[Configure system for EFA] action configure (aws-parallelcluster-config::base line 38)

    * sysctl[kernel.yama.ptrace_scope] action apply[2023-06-15T15:05:05+00:00] INFO: Processing sysctl[kernel.yama.ptrace_scope] action apply ((eval) line 19)

      * directory[/etc/sysctl.d] action create[2023-06-15T15:05:05+00:00] INFO: Processing directory[/etc/sysctl.d] action create (/opt/cinc/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/resource/sysctl.rb line 139)
 (up to date)
      * file[/etc/sysctl.d/99-chef-kernel.yama.ptrace_scope.conf] action create[2023-06-15T15:05:05+00:00] INFO: Processing file[/etc/sysctl.d/99-chef-kernel.yama.ptrace_scope.conf] action create (/opt/cinc/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib/chef/resource/sysctl.rb line 141)
```

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.