### PR TITLE
Skip mount_shared recipe tests on head node

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -418,13 +418,14 @@ suites:
       - recipe[aws-parallelcluster-environment::mount_shared]
     verifier:
       controls:
-        - /tag:config_mount_shared/
+        - mount_shared
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-platform::directories
         - resource:nfs
         - recipe:aws-parallelcluster-environment::mock_export_directories
       cluster:
+        node_type: 'ComputeFleet'
         head_node_private_ip: '127.0.0.1'
         head_node_home_path: '/fake_headnode_home'
         shared_dir_head: '/fake_headnode_shared'

--- a/cookbooks/aws-parallelcluster-environment/test/controls/mount_shared_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/mount_shared_spec.rb
@@ -9,10 +9,10 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'tag:config_mount_shared_configured' do
+control 'mount_shared' do
   title 'Check if the home and the shared directories are mounted'
 
-  only_if { !os_properties.on_docker? }
+  only_if { !os_properties.on_docker? && instance.compute_node? }
 
   describe mount('/home') do
     it { should be_mounted }


### PR DESCRIPTION
These steps are executed in the compute nodes only.

Remove `tag:config` since this test requires some folders to be exported from the head node.
