### PR TITLE
Fix bug in disable_ptrace action to allow sysctl to disable ptrace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Remove security updates step executed on cluster nodes bootstrap in US isolated regions
   in order to reduce bootstrap time and avoid a potential point of failure.
 
+**BUG FIXES**
+- Fix an issue that was preventing ptrace protection from being disabled on Ubuntu and allowing Cross Memory Attach (CMA) in libfabric.
+
 3.6.0
 ------
 

--- a/cookbooks/aws-parallelcluster-common/resources/efa/partial/_disable_ptrace_debian.rb
+++ b/cookbooks/aws-parallelcluster-common/resources/efa/partial/_disable_ptrace_debian.rb
@@ -15,7 +15,7 @@
 
 action :disable_ptrace do
   # Disabling ptrace protection is needed for EFA in order to use SHA transfer for intra-node communication.
-  if node['cluster']['enable_efa'] == 'compute' && node['cluster']['node_type'] == 'ComputeFleet'
+  if node['cluster']['enable_efa'] == 'efa' && node['cluster']['node_type'] == 'ComputeFleet'
     sysctl 'kernel.yama.ptrace_scope' do
       value 0
     end

--- a/cookbooks/aws-parallelcluster-common/spec/unit/resources/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-common/spec/unit/resources/efa_spec.rb
@@ -190,7 +190,7 @@ describe 'efa:configure' do
       elsif platform == 'ubuntu'
         context 'when efa enabled on compute node' do
           before do
-            chef_run.node.override['cluster']['enable_efa'] = 'compute'
+            chef_run.node.override['cluster']['enable_efa'] = 'efa'
             chef_run.node.override['cluster']['node_type'] = 'ComputeFleet'
             ConvergeEfa.configure(chef_run)
           end
@@ -214,7 +214,7 @@ describe 'efa:configure' do
 
         context 'when it is not a compute node' do
           before do
-            chef_run.node.override['cluster']['enable_efa'] = 'compute'
+            chef_run.node.override['cluster']['enable_efa'] = 'efa'
             chef_run.node.override['cluster']['node_type'] = 'other'
             ConvergeEfa.configure(chef_run)
           end


### PR DESCRIPTION
Previously the setting for Ubuntu systems was not getting used due to a misalignment between the cookbook and cli. On the cli, node['cluster']['enable_efa'] was set to 'efa' in the dna.json file, but the cookbook assumed the parameter was set to 'compute'.  This causes the disable_ptrace action if clause to be skipped. This page describes the use of sysctl https://manpages.ubuntu.com/manpages/bionic/man5/sysctl.conf.5.html This page describes the function of the ptrace_scope parameter https://www.kernel.org/doc/Documentation/security/Yama.txt Chef actually generates a config file in /etc/sysctl.d/ for the parameter that is changed so it should persist. https://docs.chef.io/resources/sysctl/

### Tests
* Manual kitchen tests in develop

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.