### PR TITLE
Fix kitchen tests conditions

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -14,7 +14,7 @@ default['cluster']['log_group_name'] = "NONE"
 # IMDS
 default['cluster']['head_node_imds_secured'] = 'true'
 default['cluster']['head_node_imds_allowed_users'] = ['root', node['cluster']['cluster_admin_user'], node['cluster']['cluster_user'] ]
-default['cluster']['head_node_imds_allowed_users'].append('dcv') if node['cluster']['dcv_enabled'] == 'head_node'
+default['cluster']['head_node_imds_allowed_users'].append('dcv') if node['cluster']['dcv_enabled'] == 'head_node' && dcv_installed?
 
 # ParallelCluster internal variables to configure active directory service
 default['cluster']["directory_service"]["domain_name"] = nil

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -15,7 +15,6 @@ default['cluster']['log_group_name'] = "NONE"
 default['cluster']['head_node_imds_secured'] = 'true'
 default['cluster']['head_node_imds_allowed_users'] = ['root', node['cluster']['cluster_admin_user'], node['cluster']['cluster_user'] ]
 default['cluster']['head_node_imds_allowed_users'].append('dcv') if node['cluster']['dcv_enabled'] == 'head_node'
-default['cluster']['head_node_imds_allowed_users'].append(lazy { node['cluster']['scheduler_plugin']['user'] }) if node['cluster']['scheduler'] == 'plugin'
 
 # ParallelCluster internal variables to configure active directory service
 default['cluster']["directory_service"]["domain_name"] = nil

--- a/cookbooks/aws-parallelcluster-environment/test/controls/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/efa_spec.rb
@@ -72,13 +72,14 @@ control 'tag:config_efa_debian_system_settings_configured' do
 
   only_if { os.debian? && !os_properties.on_docker? }
 
+  ptrace_scope = instance.head_node? ? 1 : 0
   describe 'Verify ptrace config file is present' do
     subject { file('/etc/sysctl.d/99-chef-kernel.yama.ptrace_scope.conf') }
     it { should exist }
-    its('content') { should match /kernel.yama.ptrace_scope = 0/ }
+    its('content') { should match /kernel.yama.ptrace_scope = #{ptrace_scope}/ }
   end
 
   describe kernel_parameter('kernel.yama.ptrace_scope') do
-    its('value') { should eq 0 }
+    its('value') { should eq ptrace_scope }
   end
 end

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/config_slurmd_systemd_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/config_slurmd_systemd_service_spec.rb
@@ -37,6 +37,7 @@ end
 control 'tag:config_systemd_slurmd_service_nvidia_gpu_nodes' do
   title 'Check the systemd slurmd service dependencies on NVIDIA GPU compute nodes'
   only_if { !os_properties.on_docker? && instance.compute_node? && node['cluster']['scheduler'] == 'slurm' }
+  only_if { instance.graphic? && instance.nvidia_installed? }
 
   describe 'Check slurmd systemd "after" dependencies'
   describe command('systemctl list-dependencies --after --plain slurmd.service') do


### PR DESCRIPTION
* Remove scheduler plugin leftover
* Do not add dcv user if DCV is not installed
  * This cannot work on Ubuntu 20 ARM, on which DCV is not installed
because `imds-access.sh` script is unable to find the `dcv` user.
* Differentiate ptrace check according to the node type
  * ptrace_scope is configured to 0 in compute nodes and should be 1 in the head node.
* Check slurmd dependencies on graphic instances only