### PR TITLE
Rename redhat_ubi to redhat_on_docker

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/recipes/awsbatch_virtualenv.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/recipes/awsbatch_virtualenv.rb
@@ -11,8 +11,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: find a way to make this code work on ubi8
-return if redhat_ubi?
+# TODO: find a way to make this code work on RedHat UBI8 on Docker
+return if redhat_on_docker?
 
 install_pyenv 'pyenv for default python version'
 

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/parallelcluster_node.rb
@@ -23,7 +23,7 @@ node.default['cluster']['node_virtualenv_path'] = virtualenv_path
 node_attributes "dump node attributes"
 
 # TODO: find a way to make this code work on ubi8
-return if redhat_ubi?
+return if redhat_on_docker?
 
 install_pyenv 'pyenv for default python version'
 

--- a/cookbooks/aws-parallelcluster-computefleet/test/controls/custom_parallelcluster_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/test/controls/custom_parallelcluster_node_spec.rb
@@ -13,7 +13,7 @@ control 'custom_parallelcluster_node_installed' do
   file_cache_path = "/tmp/kitchen/cache"
 
   title "custom aws-parallelcluster-node should have been installed in the node virtualenv"
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   # Unless we fix the version of aws-parallelcluster-node to be installed, we cannot really say from pip if a custom
   # node package was installed. The only thing we can test is that the custom node recipe was triggered, which can

--- a/cookbooks/aws-parallelcluster-computefleet/test/controls/node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/test/controls/node_spec.rb
@@ -15,7 +15,7 @@ control 'tag:install_tag:testami_node_virtualenv_created' do
   min_pip_version = '19.3'
 
   title "node virtualenv should be created on #{python_version}"
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe directory(virtualenv_path) do
     it { should exist }

--- a/cookbooks/aws-parallelcluster-environment/recipes/install/cfn_bootstrap.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/install/cfn_bootstrap.rb
@@ -21,7 +21,7 @@ virtualenv_path = "#{pyenv_root}/versions/#{python_version}/envs/#{virtualenv_na
 node.default['cluster']['cfn_bootstrap_virtualenv_path'] = virtualenv_path
 node_attributes "dump node attributes"
 
-return if redhat_ubi?
+return if redhat_on_docker?
 
 install_pyenv 'pyenv for cfn_bootstrap' do
   python_version python_version

--- a/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/partial/_cloudwatch_common.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/partial/_cloudwatch_common.rb
@@ -137,7 +137,7 @@ action :configure do
       'CW_LOGS_CONFIGS_PATH' => config_data_path
     )
     command "#{cookbook_virtualenv_path}/bin/python #{validator_script_path}"
-  end unless redhat_ubi?
+  end unless redhat_on_docker?
 
   execute "cloudwatch-config-creation" do
     user 'root'
@@ -153,7 +153,7 @@ action :configure do
     command "#{cookbook_virtualenv_path}/bin/python #{config_script_path} "\
         "--platform #{node['platform']} --config $CONFIG_DATA_PATH --log-group $LOG_GROUP_NAME "\
         "--scheduler $SCHEDULER --node-role $NODE_ROLE"
-  end unless redhat_ubi?
+  end unless redhat_on_docker?
 
   execute "cloudwatch-agent-start" do
     user 'root'

--- a/cookbooks/aws-parallelcluster-environment/resources/efa/efa_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efa/efa_redhat8.rb
@@ -37,7 +37,7 @@ action_class do
   end
 
   def prerequisites
-    if redhat_ubi?
+    if redhat_on_docker?
       %w(environment-modules)
     else
       %w(environment-modules libibverbs-utils librdmacm-utils rdma-core-devel)

--- a/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_install_from_tar.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_install_from_tar.rb
@@ -27,7 +27,7 @@ action :install_utils do
     recursive true
   end
 
-  return if redhat_ubi?
+  return if redhat_on_docker?
 
   package_name = "amazon-efs-utils"
   package_version = new_resource.efs_utils_version

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_install_lustre_centos_redhat.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_install_lustre_centos_redhat.rb
@@ -33,7 +33,7 @@ action :install_lustre do
     retry_delay 5
   end
 
-  kernel_module 'lnet' unless redhat_ubi?
+  kernel_module 'lnet' unless redhat_on_docker?
 end
 
 def find_kernel_patch_version

--- a/cookbooks/aws-parallelcluster-environment/resources/raid/partial/_raid_common.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/raid/partial/_raid_common.rb
@@ -20,7 +20,7 @@ action :setup do
   package 'mdadm' do
     retries 3
     retry_delay 5
-  end unless redhat_ubi?
+  end unless redhat_on_docker?
 end
 
 action :mount do

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_common.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_common.rb
@@ -23,5 +23,5 @@ action :setup do
   package required_packages do
     retries 3
     retry_delay 5
-  end unless redhat_ubi?
+  end unless redhat_on_docker?
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_redhat8.rb
@@ -30,7 +30,7 @@ action :configure do
     # authconfig is a compatibility tool, replaced by authselect
     command "authselect select sssd with-mkhomedir"
     sensitive true
-  end unless redhat_ubi?
+  end unless redhat_on_docker?
 end
 
 action_class do

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cfn_bootstrap_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cfn_bootstrap_spec.rb
@@ -15,7 +15,7 @@ pyenv_dir = "#{base_dir}/pyenv"
 
 control 'tag:install_cfnbootstrap_virtualenv_created' do
   title "cfnbootstrap virtualenv should be created on #{cfn_python_version}"
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe directory("#{pyenv_dir}/versions/#{cfn_python_version}/envs/cfn_bootstrap_virtualenv") do
     it { should exist }

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
@@ -17,7 +17,7 @@ control 'tag:install_cloudwatch_installation_files' do
   # In Ubuntu >20.04 due to environment variable the keyring is placed under home of the user ubuntu with the permission of root
   ubuntu2004 = os_properties.ubuntu2004?
   keyring = (os_properties.ubuntu2004? || os_properties.ubuntu2204?) && !os_properties.on_docker? ? '--keyring /home/ubuntu/.gnupg/pubring.kbx' : ''
-  sudo = os_properties.redhat_ubi? ? '' : 'sudo'
+  sudo = os_properties.redhat_on_docker? ? '' : 'sudo'
   describe bash("#{sudo} gpg --list-keys #{keyring}") do
     # Don't check exit status for Ubuntu20 because it returns 2 when executed in the validate phase of a created AMI
     its('exit_status') { should eq 0 } unless ubuntu2004

--- a/cookbooks/aws-parallelcluster-environment/test/controls/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/efa_spec.rb
@@ -32,7 +32,7 @@ end
 control 'tag:install_efa_prereq_packages_installed' do
   title "EFA prereq packages are installed"
 
-  efa_prereq_packages = if os_properties.redhat8? && !os_properties.redhat_ubi?
+  efa_prereq_packages = if os_properties.redhat8? && !os_properties.redhat_on_docker?
                           %w(environment-modules libibverbs-utils librdmacm-utils rdma-core-devel)
                         elsif os_properties.alinux2?
                           %w(environment-modules libibverbs-utils librdmacm-utils)

--- a/cookbooks/aws-parallelcluster-environment/test/controls/efs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/efs_spec.rb
@@ -2,7 +2,7 @@
 control 'tag:install_efs_utils_installed' do
   title 'Verify that efs_utils is installed'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe file("#{node['cluster']['sources_dir']}/efs-utils-1.34.1.tar.gz") do
     it { should exist }

--- a/cookbooks/aws-parallelcluster-environment/test/controls/raid_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/raid_spec.rb
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 control 'tag:install_raid' do
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
   describe package('mdadm') do
     it { should be_installed }
   end

--- a/cookbooks/aws-parallelcluster-environment/test/controls/system_authentication_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/system_authentication_spec.rb
@@ -23,7 +23,7 @@ control 'tag:install_system_authentication_packages_installed' do
     describe package(pkg) do
       it { should be_installed }
     end
-  end unless os_properties.redhat_ubi?
+  end unless os_properties.redhat_on_docker?
 end
 
 control 'tag:config_system_authentication_services_enabled' do
@@ -61,7 +61,7 @@ control 'tag:config_system_authentication_configured' do
       its('exit_status') { should eq 0 }
       its('stdout') { should match /Profile ID: sssd/ }
       its('stdout') { should match /with-mkhomedir/ }
-    end unless os_properties.redhat_ubi?
+    end unless os_properties.redhat_on_docker?
 
   elsif os_properties.centos7? || os_properties.alinux2?
 

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/awscli.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/awscli.rb
@@ -16,7 +16,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-return if ::File.exist?("/usr/local/bin/aws") || redhat_ubi?
+return if ::File.exist?("/usr/local/bin/aws") || redhat_on_docker?
 
 file_cache_path = Chef::Config[:file_cache_path]
 

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/cookbook_virtualenv.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/cookbook_virtualenv.rb
@@ -17,7 +17,7 @@ node.default['cluster']['cookbook_virtualenv_path'] = virtualenv_path
 node_attributes "dump node attributes"
 
 # TODO: find a way to make this code work on ubi8
-return if redhat_ubi?
+return if redhat_on_docker?
 
 install_pyenv 'pyenv for default python version'
 

--- a/cookbooks/aws-parallelcluster-platform/resources/chrony/partial/_chrony_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/chrony/partial/_chrony_common.rb
@@ -4,7 +4,7 @@ provides :chrony
 unified_mode true
 
 action :setup do
-  return if redhat_ubi?
+  return if redhat_on_docker?
 
   package_repos 'update package repositories' do
     action :update
@@ -39,7 +39,7 @@ action :enable do
     supports restart: false
     reload_command chrony_reload_command
     action %i(enable start)
-  end unless redhat_ubi?
+  end unless redhat_on_docker?
 end
 
 action_class do

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
@@ -101,7 +101,7 @@ end
 
 action :setup do
   return if dcv_installed?
-  return if redhat_ubi?
+  return if redhat_on_docker?
 
   directory node['cluster']['scripts_dir'] do
     recursive true

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/partial/_install_packages_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/partial/_install_packages_common.rb
@@ -22,7 +22,7 @@ property :packages, [String, Array],
 action :install_base_packages do
   install_packages 'default' do
     action :install
-  end unless redhat_ubi?
+  end unless redhat_on_docker?
 end
 
 action :install_kernel_source do

--- a/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_redhat8.rb
@@ -17,11 +17,11 @@ provides :stunnel, platform: 'redhat' do |node|
 end
 
 use 'partial/_common'
-use 'partial/_setup' unless redhat_ubi?
+use 'partial/_setup' unless redhat_on_docker?
 
 action :setup do
   # If on RHEL8 Docker, we don't install the base packages, so stunnel cannot be built.
-end if redhat_ubi?
+end if redhat_on_docker?
 
 action_class do
   def dependencies

--- a/cookbooks/aws-parallelcluster-platform/test/controls/awscli_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/awscli_spec.rb
@@ -12,7 +12,7 @@
 control 'tag:install_awscli_installed' do
   title 'awscli package should be installed in cookbook virtualenv'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe bash("#{node['cluster']['cookbook_virtualenv_path']}/bin/pip list") do
     its('exit_status') { should eq(0) }
@@ -25,7 +25,7 @@ control 'tag:install_awscli_installed' do
 end
 
 control 'tag:testami_awscli_can_run_as_cluster_user_and_as_root' do
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
   virtualenv_path = node['cluster']['cookbook_virtualenv_path']
 
   describe "aws cli can run as cluster default user #{node['cluster']['cluster_user']}" do

--- a/cookbooks/aws-parallelcluster-platform/test/controls/chrony_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/chrony_spec.rb
@@ -12,7 +12,7 @@
 control 'tag:install_chrony' do
   title 'Test chrony installation and configuration'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe package('chrony') do
     it { should be_installed }

--- a/cookbooks/aws-parallelcluster-platform/test/controls/cluster_user_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/cluster_user_spec.rb
@@ -17,5 +17,5 @@ control 'tag:config_cluster_user' do
   # The command checks all the homes with globbing since the user can be different for each OS
   describe command("sudo su -c 'ls /home/*/.ssh/authorized_keys_cluster'") do
     its('exit_status') { should eq 0 }
-  end unless os_properties.redhat_ubi?
+  end unless os_properties.redhat_on_docker?
 end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/cookbook_virtualenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/cookbook_virtualenv_spec.rb
@@ -4,7 +4,7 @@ control 'tag:install_tag:testami_cookbook_virtualenv_created' do
   min_pip_version = '19.3'
 
   title "cookbook virtualenv should be created on #{python_version}"
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe directory(virtualenv_path) do
     it { should exist }

--- a/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
@@ -12,7 +12,7 @@
 control 'tag:install_dcv_connect_script_installed' do
   title 'Check pcluster dcv connect script is installed'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe file("#{node['cluster']['scripts_dir']}/pcluster_dcv_connect.sh") do
     it { should be_file }
@@ -25,7 +25,7 @@ end
 control 'tag:install_dcv_authenticator_user_and_group_set_up' do
   title 'Check that dcv authenticator user and group have been set up'
 
-  only_if { !os_properties.redhat_ubi? && !(os_properties.ubuntu2004? && os_properties.arm?) }
+  only_if { !os_properties.redhat_on_docker? && !(os_properties.ubuntu2004? && os_properties.arm?) }
 
   describe group(node['cluster']['dcv']['authenticator']['group']) do
     it { should exist }
@@ -42,7 +42,7 @@ end
 control 'tag:install_dcv_disabled_lock_screen' do
   title 'Check that the lock screen has been disabled'
 
-  only_if { !os_properties.redhat_ubi? && !(os_properties.ubuntu2004? && os_properties.arm?) }
+  only_if { !os_properties.redhat_on_docker? && !(os_properties.ubuntu2004? && os_properties.arm?) }
 
   describe bash('gsettings get org.gnome.desktop.lockdown disable-lock-screen') do
     its('exit_status') { should eq 0 }
@@ -58,7 +58,7 @@ end
 control 'tag:install_dcv_installed' do
   title 'Check dcv is installed'
 
-  only_if { !os_properties.redhat_ubi? && !(os_properties.ubuntu2004? && os_properties.arm?) }
+  only_if { !os_properties.redhat_on_docker? && !(os_properties.ubuntu2004? && os_properties.arm?) }
 
   pkgs = %W(nice-dcv-server nice-xdcv nice-dcv-web-viewer)
   pkgs.each do |pkg|
@@ -71,7 +71,7 @@ end
 control 'tag:install_dcv_external_authenticator_virtualenv_created' do
   title 'Check dcv external authenticator virtual environment is created'
 
-  only_if { !os_properties.redhat_ubi? && !(os_properties.ubuntu2004? && os_properties.arm?) }
+  only_if { !os_properties.redhat_on_docker? && !(os_properties.ubuntu2004? && os_properties.arm?) }
 
   describe file("#{node['cluster']['dcv']['authenticator']['virtualenv_path']}/bin/activate") do
     it { should be_file }
@@ -176,7 +176,7 @@ control 'tag:install_dcv_switch_runlevel_to_multiuser_target' do
 end
 
 control 'tag:config_dcv_external_authenticator_user_and_group_correctly_defined' do
-  only_if { instance.dcv_installed? && !os_properties.redhat_ubi? }
+  only_if { instance.dcv_installed? && !os_properties.redhat_on_docker? }
 
   describe user(node['cluster']['dcv']['authenticator']['user']) do
     it { should exist }
@@ -194,7 +194,7 @@ end
 control 'tag:config_expected_versions_of_nice-dcv-gl_installed' do
   only_if do
     instance.head_node? && instance.dcv_installed? && node['cluster']['dcv_enabled'] == "head_node" &&
-      instance.graphic? && instance.nvidia_installed? && instance.dcv_gpu_accel_supported? && !os_properties.redhat_ubi?
+      instance.graphic? && instance.nvidia_installed? && instance.dcv_gpu_accel_supported? && !os_properties.redhat_on_docker?
   end
 
   describe package('nice-dcv-gl') do
@@ -205,7 +205,7 @@ end
 
 control 'tag:config_dcv_correctly_installed' do
   only_if do
-    instance.head_node? && instance.dcv_installed? && !os_properties.redhat_ubi?
+    instance.head_node? && instance.dcv_installed? && !os_properties.redhat_on_docker?
   end
 
   describe bash("sudo -u #{node['cluster']['cluster_user']} dcv version") do
@@ -276,7 +276,7 @@ control 'tag:config_dcv_correctly_configured' do
 end
 
 control 'tag:config_dcv_services_correctly_configured' do
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
   if instance.head_node? && instance.dcv_installed? && node['cluster']['dcv_enabled'] == "head_node"
     describe service('dcvserver') do
       it { should be_installed }

--- a/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
@@ -2,7 +2,7 @@
 control 'tag:install_install_packages' do
   title 'Test installation of packages'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   # verify package with a common name is installed
   describe package('coreutils') do

--- a/cookbooks/aws-parallelcluster-platform/test/controls/stunnel_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/stunnel_spec.rb
@@ -14,7 +14,7 @@ control 'tag:install_stunnel_installed' do
 
   # In AL2 stunnel comes as part of the aws-efs-utils package.
   # In RHEL8 on Docker we disable the installation of base packages, so stunnel cannot be built.
-  only_if { !os_properties.alinux2? && !os_properties.redhat_ubi? }
+  only_if { !os_properties.alinux2? && !os_properties.redhat_on_docker? }
 
   stunnel_version = node['cluster']['stunnel']['version']
 

--- a/cookbooks/aws-parallelcluster-shared/libraries/test.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/test.rb
@@ -3,6 +3,6 @@ def on_docker?
   node.include?('virtualized') and node['virtualized']
 end
 
-def redhat_ubi?
+def redhat_on_docker?
   on_docker? && platform?('redhat')
 end

--- a/cookbooks/aws-parallelcluster-shared/test/controls/install_pyenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/controls/install_pyenv_spec.rb
@@ -12,7 +12,7 @@
 control 'default_pyenv_installed' do
   title 'pyenv should be installed'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe command("#{node['cluster']['system_pyenv_root']}/bin/pyenv") do
     it { should exist }

--- a/cookbooks/aws-parallelcluster-shared/test/libraries/os_properties.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/libraries/os_properties.rb
@@ -5,14 +5,14 @@ class OsProperties < Inspec.resource(1)
     Properties of an OS
   '
   example '
-    os_properties.redhat_ubi?
+    os_properties.redhat_on_docker?
   '
 
   def on_docker?
     inspec.virtualization.system == 'docker'
   end
 
-  def redhat_ubi?
+  def redhat_on_docker?
     on_docker? && inspec.os.name == 'redhat'
   end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-setup_munge_head_node unless redhat_ubi?
+setup_munge_head_node unless redhat_on_docker?
 
 # Export /opt/slurm
 nfs_export "#{node['cluster']['slurm']['install_dir']}" do
@@ -29,7 +29,7 @@ directory "#{node['cluster']['slurm']['install_dir']}" do
   user 'root'
   group 'root'
   mode '0755'
-end if redhat_ubi? # we skip slurm setup on Docker UBI because we don't install python
+end if redhat_on_docker? # we skip slurm setup on Docker UBI because we don't install python
 
 # Ensure config directory is in place
 directory "#{node['cluster']['slurm']['install_dir']}/etc" do
@@ -280,4 +280,4 @@ execute "check slurmctld status" do
   command "systemctl is-active --quiet slurmctld.service"
   retries 5
   retry_delay 2
-end unless redhat_ubi?
+end unless redhat_on_docker?

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_jwt.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_jwt.rb
@@ -45,4 +45,4 @@ bash 'libjwt' do
     make -j $CORES
     sudo make install
   LIBJWT
-end unless redhat_ubi?
+end unless redhat_on_docker?

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pmix.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pmix.rb
@@ -44,7 +44,7 @@ bash 'Install PMIx' do
     make -j $CORES
     make install
   PMIX
-end unless redhat_ubi?
+end unless redhat_on_docker?
 
 # Ensure directory containing PMIx shared library is part of the runtime
 # loader's search path.

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
@@ -89,7 +89,7 @@ end
 
 # Install Slurm
 bash 'make install' do
-  not_if { redhat_ubi? }
+  not_if { redhat_on_docker? }
   user 'root'
   group 'root'
   cwd Chef::Config[:file_cache_path]
@@ -130,7 +130,7 @@ end
 directory "#{node['cluster']['license_dir']}/slurm"
 
 bash 'copy license stuff' do
-  not_if { redhat_ubi? }
+  not_if { redhat_on_docker? }
   user 'root'
   group 'root'
   cwd Chef::Config[:file_cache_path]
@@ -147,7 +147,7 @@ bash 'copy license stuff' do
 end
 
 file '/etc/ld.so.conf.d/slurm.conf' do
-  not_if { redhat_ubi? }
+  not_if { redhat_on_docker? }
   content "#{slurm_install_dir}/lib/"
   mode '0744'
 end

--- a/cookbooks/aws-parallelcluster-slurm/resources/jwt_dependencies/partial/_jwt_dependencies_common.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/jwt_dependencies/partial/_jwt_dependencies_common.rb
@@ -19,7 +19,7 @@ action :setup do
   install_packages 'jwt dependencies' do
     packages dependencies
     action :install
-  end unless redhat_ubi?
+  end unless redhat_on_docker?
 end
 
 def dependencies

--- a/cookbooks/aws-parallelcluster-slurm/resources/munge/partial/_munge_actions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/munge/partial/_munge_actions.rb
@@ -51,7 +51,7 @@ action :setup do
     action_set_user_and_group
     action_create_required_directories
   }
-  actions.call unless redhat_ubi?
+  actions.call unless redhat_on_docker?
 end
 
 action :purge_packages do

--- a/cookbooks/aws-parallelcluster-slurm/resources/slurm_dependencies/partial/_slurm_dependencies_common.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/slurm_dependencies/partial/_slurm_dependencies_common.rb
@@ -17,5 +17,5 @@ action :setup do
   install_packages 'install' do
     packages dependencies
     action :install
-  end unless redhat_ubi?
+  end unless redhat_on_docker?
 end

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/jwt_dependencies_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/jwt_dependencies_spec.rb
@@ -15,7 +15,7 @@ control 'tag:install_jwt_dependencies_installed' do
   packages = []
   if os.redhat?
     # Skipping redhat on docker since ubi-appstream repo is not aligned with the main repo
-    packages.concat %w(jansson-devel) unless os_properties.redhat_ubi?
+    packages.concat %w(jansson-devel) unless os_properties.redhat_on_docker?
   elsif os.debian?
     packages.concat %w(libjansson-dev)
   else

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/jwt_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/jwt_spec.rb
@@ -18,5 +18,5 @@ control 'tag:install_jwt_installed' do
     its('mode') { should cmp '0755' }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
-  end unless os_properties.redhat_ubi?
+  end unless os_properties.redhat_on_docker?
 end

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/munge_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/munge_spec.rb
@@ -20,7 +20,7 @@ control 'tag:install_munge_installed' do
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
   end
-end unless os_properties.redhat_ubi?
+end unless os_properties.redhat_on_docker?
 
 control 'tag:install_munge_user_and_group_created' do
   title 'Check munge user and group exist and are properly configured'
@@ -33,7 +33,7 @@ control 'tag:install_munge_user_and_group_created' do
     it { should exist }
     its('group') { should eq munge_group }
   end
-end unless os_properties.redhat_ubi?
+end unless os_properties.redhat_on_docker?
 
 control 'tag:install_munge_init_script_configured' do
   title 'Check munge init script is configured with the proper user and group'
@@ -47,7 +47,7 @@ control 'tag:install_munge_init_script_configured' do
       should match("USER=#{munge_user}")
       should match("GROUP=#{munge_group}")
     end
-  end unless os_properties.redhat_ubi?
+  end unless os_properties.redhat_on_docker?
 end
 
 control 'tag:install_munge_folders_created' do
@@ -67,10 +67,10 @@ control 'tag:install_munge_folders_created' do
     it { should exist }
     it { should be_directory }
   end
-end unless os_properties.redhat_ubi?
+end unless os_properties.redhat_on_docker?
 
 control 'tag:config_munge_service_enabled' do
-  only_if { node['cluster']['scheduler'] == 'slurm' && !os_properties.redhat_ubi? }
+  only_if { node['cluster']['scheduler'] == 'slurm' && !os_properties.redhat_on_docker? }
 
   describe service('munge') do
     it { should be_installed }

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/pmix_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/pmix_spec.rb
@@ -18,7 +18,7 @@ control 'tag:install_pmix_installed' do
     its('mode') { should cmp '0755' }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
-  end unless os_properties.redhat_ubi?
+  end unless os_properties.redhat_on_docker?
 end
 
 control 'tag:install_pmix_library_shared' do
@@ -32,5 +32,5 @@ control 'tag:install_pmix_library_shared' do
     its('content') do
       should match('/opt/pmix/lib')
     end
-  end unless os_properties.redhat_ubi?
+  end unless os_properties.redhat_on_docker?
 end

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_dependencies_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_dependencies_spec.rb
@@ -25,7 +25,7 @@ control 'tag:install_slurm_dependencies_installed' do
   packages = []
   if os.redhat?
     # Skipping redhat on docker since ubi-appstream repo is not aligned with the main repo
-    packages.concat %w(json-c-devel http-parser-devel perl-Switch) unless os_properties.redhat_ubi?
+    packages.concat %w(json-c-devel http-parser-devel perl-Switch) unless os_properties.redhat_on_docker?
   elsif os.debian?
     packages.concat %w(libjson-c-dev libhttp-parser-dev libswitch-perl)
   else
@@ -34,7 +34,7 @@ control 'tag:install_slurm_dependencies_installed' do
     end
   end
 
-  packages.append(lua_devel_package()) unless os_properties.redhat_ubi?
+  packages.append(lua_devel_package()) unless os_properties.redhat_on_docker?
   packages.each do |pkg|
     describe package(pkg) do
       it { should be_installed }

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_spec.rb
@@ -20,7 +20,7 @@ pcluster_admin_group = pcluster_admin
 control 'tag:install_slurm_installed' do
   title 'Checks slurm has been installed'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe file("/opt/slurm") do
     it { should exist }
@@ -56,7 +56,7 @@ end
 control 'tag:install_slurm_licence_configured' do
   title 'Checks slurm licences folder has the required files'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe file(slurm_license_path) do
     it { should exist }
@@ -98,7 +98,7 @@ end
 control 'tag:install_slurm_shared_libraries_compiled' do
   title 'Checks that all required slurm shared libraries were compiled'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe file("#{slurm_library_folder}/accounting_storage_mysql.so") do
     it { should exist }
@@ -132,7 +132,7 @@ end
 control 'tag:install_slurm_library_shared' do
   title 'Checks slurm shared library is part of the runtime search path'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe file("/etc/ld.so.conf.d/slurm.conf") do
     it { should exist }
@@ -147,7 +147,7 @@ end
 
 control 'tag:install_slurm_pam_slurm_adopt_module_installed' do
   title "Check that pam_slurm_adopt has been built and installed"
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   lib_security_folder = '/lib/security'
   if os.redhat?
@@ -179,7 +179,7 @@ end
 control 'tag:install_slurm_lua_support_libraries_compiled' do
   title 'Checks that all slurm libraries required for lua were compiled'
 
-  only_if { !os_properties.redhat_ubi? }
+  only_if { !os_properties.redhat_on_docker? }
 
   describe file("#{slurm_library_folder}/burst_buffer_lua.so") do
     it { should exist }

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_users_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_users_spec.rb
@@ -58,7 +58,7 @@ control 'tag:config_slurm_sudoers_correctly_defined' do
 
   install_dir = node['cluster']['slurm']['install_dir']
   venv_bin = "#{node['cluster']['node_virtualenv_path']}/bin"
-  redhat_ubi = os_properties.redhat_ubi?
+  redhat_on_docker = os_properties.redhat_on_docker?
 
   describe file("/etc/sudoers.d/99-parallelcluster-slurm") do
     it { should exist }
@@ -70,6 +70,6 @@ control 'tag:config_slurm_sudoers_correctly_defined' do
     its('content') { should match /#{node['cluster']['cluster_admin_user']} ALL = \(root\) NOPASSWD: SHUTDOWN/ }
     its('content') { should match %r{Cmnd_Alias SHUTDOWN = /usr/sbin/shutdown} }
     its('content') { should match /#{node['cluster']['slurm']['user']} ALL = \(#{node['cluster']['cluster_admin_user']}\) NOPASSWD:SETENV: SLURM_HOOKS_COMMANDS/ }
-    its('content') { should match %r{Cmnd_Alias SLURM_HOOKS_COMMANDS = #{venv_bin}/slurm_suspend, #{venv_bin}/slurm_resume, #{venv_bin}/slurm_fleet_status_manager} } unless redhat_ubi
+    its('content') { should match %r{Cmnd_Alias SLURM_HOOKS_COMMANDS = #{venv_bin}/slurm_suspend, #{venv_bin}/slurm_resume, #{venv_bin}/slurm_fleet_status_manager} } unless redhat_on_docker
   end
 end

--- a/cookbooks/aws-parallelcluster-tests/recipes/docker_mock.rb
+++ b/cookbooks/aws-parallelcluster-tests/recipes/docker_mock.rb
@@ -56,12 +56,12 @@ if platform_family?('debian')
   %w(nfs-common nfs-kernel-server).each do |nfspkg|
     package nfspkg
   end
-elsif !redhat_ubi?
+elsif !redhat_on_docker?
   #  Rhel family except redhat
   package 'nfs-utils'
 end
 
-if redhat_ubi?
+if redhat_on_docker?
   package 'openssh-clients'
 
   # Mock python environment


### PR DESCRIPTION
UBI stands for Universal Base Image.
This is the Docker image created and maintained by Red Hat and updated regularly.

Rename internal variable to redhat_on_docker to avoid confusion.

https://hub.docker.com/r/redhat/ubi8

