### PR TITLE
Execute awsbatch cookbook Chefspec as GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,11 @@ jobs:
       fail-fast: false
       matrix:
         cookbook:
-          - cookbooks/aws-parallelcluster-shared
-          - cookbooks/aws-parallelcluster-platform
-          - cookbooks/aws-parallelcluster-environment
+          - cookbooks/aws-parallelcluster-awsbatch
           - cookbooks/aws-parallelcluster-computefleet
+          - cookbooks/aws-parallelcluster-environment
+          - cookbooks/aws-parallelcluster-platform
+          - cookbooks/aws-parallelcluster-shared
           - cookbooks/aws-parallelcluster-slurm
     steps:
       - uses: actions/checkout@main


### PR DESCRIPTION
Now the ChefSpecs for all the cookbooks are executed as part of GitHub actions.