### PR TITLE
Fix the kitchen test condition for ptrace_scope to switch on node type and add an efa kitchen test suite for the head node

### DIFF
--- a/kitchen.resources-config.yml
+++ b/kitchen.resources-config.yml
@@ -26,6 +26,7 @@ suites:
       resource: sticky_bits
   - name: efa_configure_compute
     run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
       - recipe[aws-parallelcluster-common::test_resource]
     verifier:
       controls:
@@ -33,8 +34,24 @@ suites:
     attributes:
       resource: efa:configure
       cluster:
-        enable_efa: compute
+        enable_efa: efa
         node_type: ComputeFleet
+      dependencies:
+        - recipe:aws-parallelcluster-common::node_attributes
+  - name: efa_configure_headnode
+    run_list:
+      - recipe[aws-parallelcluster::add_dependencies]
+      - recipe[aws-parallelcluster-common::test_resource]
+    verifier:
+      controls:
+        - efa_debian_system_settings_configured
+    attributes:
+      resource: efa:configure
+      cluster:
+        enable_efa: efa
+        node_type: HeadNode
+      dependencies:
+        - recipe:aws-parallelcluster-common::node_attributes
   - name: efs_configure
     run_list:
       - recipe[aws-parallelcluster::add_dependencies]

--- a/test/resources/controls/aws_parallelcluster_config/efa_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_config/efa_spec.rb
@@ -3,7 +3,21 @@ control 'efa_debian_system_settings_configured' do
 
   only_if { os.debian? && !os_properties.virtualized? }
 
+  ptrace_scope = instance.head_node? ? 1 : 0
+  if ptrace_scope == 1
+    describe 'Verify ptrace config file is not present' do
+      subject { file('/etc/sysctl.d/99-chef-kernel.yama.ptrace_scope.conf') }
+      it { should_not exist }
+    end
+  else
+    describe 'Verify ptrace config file is present' do
+      subject { file('/etc/sysctl.d/99-chef-kernel.yama.ptrace_scope.conf') }
+      it { should exist }
+      its('content') { should match /kernel.yama.ptrace_scope = #{ptrace_scope}/ }
+    end
+  end
+
   describe kernel_parameter('kernel.yama.ptrace_scope') do
-    its('value') { should eq 0 }
+    its('value') { should eq ptrace_scope }
   end
 end


### PR DESCRIPTION
### Description of changes
* The ptrace_scope parameter is different for head nodes versus compute nodes.
* This change addresses that difference in kitchen tests

###
* Tested `efa_debian_system_settings_configured` control locally with ubuntu20 and ubuntu18
* Tested `efa_configure_compute` and `efa_configure_headnode` suites with ubuntu20 and ubuntu18

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2291/files
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2314/files

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.