### PR TITLE
Fix system test config for efa, remove duplicate test in intel_mpi, tag ptrace control with 'config'

### DIFF
--- a/kitchen.resources-config.yml
+++ b/kitchen.resources-config.yml
@@ -30,7 +30,7 @@ suites:
       - recipe[aws-parallelcluster-common::test_resource]
     verifier:
       controls:
-        - efa_debian_system_settings_configured
+        - tag:config_efa_debian_system_settings_configured
     attributes:
       resource: efa:configure
       cluster:
@@ -44,7 +44,7 @@ suites:
       - recipe[aws-parallelcluster-common::test_resource]
     verifier:
       controls:
-        - efa_debian_system_settings_configured
+        - tag:config_efa_debian_system_settings_configured
     attributes:
       resource: efa:configure
       cluster:

--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -17,7 +17,7 @@ _common_cluster_attributes: &_common_cluster_attributes
   custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
   dcv_enabled: 'head_node'
   dcv_port: '8443'
-  enable_efa: 'compute'
+  enable_efa: 'efa'
   nvidia:
     enabled: <%= ENV['NVIDIA_ENABLED'] %>
 

--- a/test/recipes/controls/aws_parallelcluster_install/intel_mpi_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_install/intel_mpi_spec.rb
@@ -21,13 +21,3 @@ control 'tag:config_intel_mpi_installed' do
     its('stdout') { should match(/Version #{node['cluster']['intelmpi']['version'].split('.')[0..1].join(".")}/) }
   end
 end
-
-control 'tag:config_intel_mpi_ptrace_protection_configured_on_ubuntu1804' do
-  only_if { node['conditions']['intel_mpi_supported'] && os_properties.ubuntu1804? }
-
-  ptrace_scope = instance.head_node? ? 1 : 0
-  describe 'check ptrace protection enabled' do
-    subject { bash("sudo -u #{node['cluster']['cluster_user']} sysctl kernel.yama.ptrace_scope") }
-    its('stdout') { should match /kernel.yama.ptrace_scope = #{ptrace_scope}/ }
-  end
-end

--- a/test/resources/controls/aws_parallelcluster_config/efa_spec.rb
+++ b/test/resources/controls/aws_parallelcluster_config/efa_spec.rb
@@ -1,4 +1,4 @@
-control 'efa_debian_system_settings_configured' do
+control 'tag:config_efa_debian_system_settings_configured' do
   title 'Check debian system is correctly configured for EFA'
 
   only_if { os.debian? && !os_properties.virtualized? }


### PR DESCRIPTION
### Tests
* Tested the `tag:config_efa_debian_system_settings_configured` control locally for ubuntu18 and ubuntu20
* Tested the `efa_configure_headnode` and `efa_configure_compute` suites locally for ubuntu18 and ubuntu20

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.