### PR TITLE
[POC] Add support for Rocky Linux 8

### DIFF
--- a/.github/workflows/dokken-system-tests.yml
+++ b/.github/workflows/dokken-system-tests.yml
@@ -34,6 +34,7 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - rhel8
+          - rocky8
       fail-fast: false
     steps:
       - uses: actions/checkout@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **ENHANCEMENTS**
+- Add support for Rocky Linux 8.
 - Allow configuration of static and dynamic node priorities in compute resources via the ParallelCluster configuration YAML file.
 - Forward SLURM_RESUME_FILE to ParallelCluster resume program.
 - Allow to override aws-parallelcluster-node package at cluster creation and update time (only on the head node during update).

--- a/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_config_spec.rb
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 control 'tag:config_awsbatch_cli_commands_available' do
-  only_if { node['cluster']['scheduler'] == 'awsbatch' && !os_properties.redhat8? }
+  only_if { node['cluster']['scheduler'] == 'awsbatch' && !os_properties.redhat8? && !os_properties.rocky8? }
 
   # Test that batch commands can be accessed without absolute path
   %w(awsbkill awsbqueues awsbsub awsbhosts awsbout awsbstat).each do |cli_commmand|

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
@@ -18,7 +18,8 @@
       "platforms": [
         "amazon",
         "centos",
-        "redhat"
+        "redhat",
+        "rocky"
       ],
       "node_roles": [
         "ComputeFleet",
@@ -55,6 +56,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -74,6 +76,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -92,6 +95,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -111,6 +115,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -131,6 +136,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -151,6 +157,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -171,6 +178,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -189,6 +197,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -207,6 +216,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -225,6 +235,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -243,6 +254,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -261,6 +273,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -279,6 +292,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -297,6 +311,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -315,6 +330,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -333,6 +349,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -351,6 +368,7 @@
         "amazon",
         "centos",
         "redhat",
+        "rocky",
         "ubuntu"
       ],
       "node_roles": [
@@ -369,6 +387,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -392,6 +411,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -418,6 +438,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -444,6 +465,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -472,6 +494,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -496,6 +519,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -520,6 +544,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -544,6 +569,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -568,6 +594,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -592,6 +619,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -615,6 +643,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -633,6 +662,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],
@@ -651,6 +681,7 @@
       "platforms": [
         "centos",
         "redhat",
+        "rocky",
         "ubuntu",
         "amazon"
       ],

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config_schema.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config_schema.json
@@ -16,7 +16,7 @@
           },
           "platforms": {
             "type": "array",
-            "items": {"type": "string", "enum": ["amazon", "centos", "ubuntu", "redhat"]}
+            "items": {"type": "string", "enum": ["amazon", "centos", "ubuntu", "redhat", "rocky"]}
           },
           "node_roles": {
             "type": "array",

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/write_cloudwatch_agent_json.py
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/write_cloudwatch_agent_json.py
@@ -20,14 +20,17 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Create the cloudwatch agent config file")
     parser.add_argument("--config", help="Path to JSON file describing logs that should be monitored", required=True)
     parser.add_argument(
-        "--platform", help="OS family of this instance", choices=["amazon", "centos", "ubuntu", "redhat"], required=True
+        "--platform",
+        help="OS family of this instance",
+        choices=["amazon", "centos", "ubuntu", "redhat", "rocky"],
+        required=True,
     )
     parser.add_argument("--log-group", help="Name of the log group", required=True)
     parser.add_argument(
         "--node-role",
         required=True,
         choices=["HeadNode", "ComputeFleet", "LoginNode"],
-        help="Role this node plays in the cluster " "(i.e., is it a compute node or the head node?)",
+        help="Role this node plays in the cluster (i.e., is it a compute node or the head node?)",
     )
     parser.add_argument("--scheduler", required=True, choices=["slurm", "awsbatch"], help="Scheduler")
     return parser.parse_args()

--- a/cookbooks/aws-parallelcluster-environment/files/rocky/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/rocky/network_interfaces/configure_nw_interface.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Configure a specific Network Interface according to the OS
+# The configuration involves 3 aspects:
+# - Main configuration (IP address, protocol and gateway)
+# - A specific routing table, so that all traffic coming to a network interface leaves the instance using the same
+#   interface
+# - A routing rule to make the OS use the specific routing table for this network interface
+
+# RedHat 8 official documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/configuring-policy-based-routing-to-define-alternative-routes_configuring-and-managing-networking
+
+set -e
+
+if
+  [ -z "${DEVICE_NAME}" ] ||          # name of the device
+  [ -z "${DEVICE_NUMBER}" ] ||        # number of the device
+  [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
+  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
+  [ -z "${CIDR_PREFIX_LENGTH}" ]      # the prefix length of the device IP cidr block
+then
+  echo 'One or more environment variables missing'
+  exit 1
+fi
+
+con_name="System ${DEVICE_NAME}"
+route_table="100${DEVICE_NUMBER}"
+priority="100${DEVICE_NUMBER}"
+metric="100${DEVICE_NUMBER}"
+
+# Rename connection
+original_con_name=`nmcli -t -f GENERAL.CONNECTION device show ${DEVICE_NAME} | cut -f2 -d':'`
+sudo nmcli connection modify "${original_con_name}" con-name "${con_name}" ifname ${DEVICE_NAME}
+
+configured_ip=`nmcli -t -f IP4.ADDRESS device show ${DEVICE_NAME} | cut -f2 -d':'`
+if [ -z "${configured_ip}" ]; then
+  # Setup connection method to "manual", configure ip address and gateway, only if not already configured.
+  sudo nmcli connection modify "${con_name}" ipv4.method manual ipv4.addresses ${DEVICE_IP_ADDRESS}/${CIDR_PREFIX_LENGTH} ipv4.gateway ${GW_IP_ADDRESS}
+fi
+
+# Setup routes
+# This command uses the ipv4.routes parameter to add a static route to the routing table with ID ${route_table}.
+# This static route for 0.0.0.0/0 uses the IP of the gateway as next hop.
+sudo nmcli connection modify "${con_name}" ipv4.routes "0.0.0.0/0 ${GW_IP_ADDRESS} ${metric} table=${route_table}"
+
+# Setup routing rules
+# The command uses the ipv4.routing-rules parameter to add a routing rule with priority ${priority} that routes
+# traffic from ${DEVICE_IP_ADDRESS} to table ${route_table}. Low values have a high priority.
+# The syntax in the ipv4.routing-rules parameter is the same as in an "ip rule add" command,
+# except that ipv4.routing-rules always requires specifying a priority.
+sudo nmcli connection modify "${con_name}" ipv4.routing-rules "priority ${priority} from ${DEVICE_IP_ADDRESS} table ${route_table}"
+
+# Reapply previous connection modification.
+sudo nmcli device reapply ${DEVICE_NAME}

--- a/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/cloudwatch_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/cloudwatch_rocky8.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :cloudwatch, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_cloudwatch_common'
+use 'partial/_cloudwatch_install_package_rhel'
+
+action_class do
+  def platform_url_component
+    node['platform']
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/cloudwatch_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/cloudwatch_rocky8.rb
@@ -21,6 +21,6 @@ use 'partial/_cloudwatch_install_package_rhel'
 
 action_class do
   def platform_url_component
-    node['platform']
+    "redhat"
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/ec2_udev_rules/ec2_udev_rules_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/ec2_udev_rules/ec2_udev_rules_rocky8.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+provides :ec2_udev_rules, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+unified_mode true
+use 'partial/_common_udev_configuration'
+
+default_action :setup
+
+action :setup do
+  action_create_common_udev_files
+  action_start_ec2blk
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/efa/efa_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efa/efa_rocky8.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :efa, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+unified_mode true
+default_action :setup
+
+use 'partial/_common'
+
+action_class do
+  def efa_supported?
+    if node['platform_version'].to_f < 8.4
+      log "EFA is not supported in this Rocky Linux version #{node['platform_version']}, supported versions are >= 8.4" do
+        level :warn
+      end
+      false
+    else
+      true
+    end
+  end
+
+  def conflicting_packages
+    %w(openmpi-devel openmpi)
+  end
+
+  def prerequisites
+    %w(environment-modules libibverbs-utils librdmacm-utils rdma-core-devel)
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/efs/efs_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/efs_rocky8.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :efs, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_get_package_version_rpm'
+use 'partial/_common'
+use 'partial/_redhat_based'
+use 'partial/_install_from_tar'
+use 'partial/_mount_umount'
+
+def prerequisites
+  %w(rpm-build make)
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/ephemeral_drives/ephemeral_drives_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/ephemeral_drives/ephemeral_drives_rocky8.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :ephemeral_drives, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_ephemeral_drives_common.rb'
+
+action_class do
+  def network_target
+    'network-online.target'
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_rocky8.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :lustre, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+unified_mode true
+
+use 'partial/_install_lustre_centos_redhat'
+use 'partial/_mount_unmount'
+
+default_action :setup
+
+action :setup do
+  version = node['platform_version']
+  if version.to_f < 8.2
+    log "FSx for Lustre is not supported in this Rocky Linux version #{version}, supported versions are >= 8.2" do
+      level :warn
+    end
+    # rhel8 kernel 4.18.0-425.3.1.el8 has broken kABI compat https://github.com/openzfs/zfs/issues/14724
+  elsif node['cluster']['kernel_release'].include? "4.18.0-425.3.1.el8"
+    log "FSx for Lustre is not supported in kernel version 4.18.0-425.3.1.el8 of Rocky Linux, please update the kernel version" do
+      level :warn
+    end
+  else
+    action_install_lustre
+  end
+end
+
+def find_os_minor_version
+  os_minor_version = ''
+  kernel_patch_version = find_kernel_patch_version
+
+  # kernel patch versions under 193 are prior to RHEL 8.2
+  # kernel patch version number can be retrieved from https://access.redhat.com/articles/3078#RHEL8
+  os_minor_version = '2' if kernel_patch_version >= '193'
+  os_minor_version = '3' if kernel_patch_version >= '240'
+  os_minor_version = '4' if kernel_patch_version >= '305'
+  os_minor_version = '5' if kernel_patch_version >= '348'
+  os_minor_version = '6' if kernel_patch_version >= '372'
+  os_minor_version = '7' if kernel_patch_version >= '425'
+  os_minor_version = '8' if kernel_patch_version >= '477'
+
+  os_minor_version
+end
+
+action_class do
+  def base_url
+    # https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html#lustre-client-rhel
+    "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8.#{find_os_minor_version}/$basearch"
+  end
+
+  def public_key
+    "https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc"
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_install_lustre_centos_redhat.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_install_lustre_centos_redhat.rb
@@ -33,7 +33,7 @@ action :install_lustre do
     retry_delay 5
   end
 
-  kernel_module 'lnet' unless redhat_on_docker?
+  kernel_module 'lnet' unless redhat_on_docker? || rocky_on_docker?
 end
 
 def find_kernel_patch_version

--- a/cookbooks/aws-parallelcluster-environment/resources/network_service/network_service_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/network_service/network_service_rocky8.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :network_service, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_network_service'
+use 'partial/_network_service_redhat_based'
+
+def network_service_name
+  'NetworkManager'
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_rocky8.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nfs, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+unified_mode true
+
+use 'partial/_install_nfs4_and_disable'
+use 'partial/_configure'
+
+default_action :setup
+
+action :setup do
+  action_install_nfs4
+  action_disable_start_at_boot
+end
+
+action_class do
+  def override_server_template
+    edit_resource(:template, node['nfs']['config']['server_template']) do
+      cookbook 'nfs'
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/raid/raid_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/raid/raid_rocky8.rb
@@ -1,0 +1,11 @@
+provides :raid, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_raid_common'
+
+action_class do
+  def raid_superblock_version
+    '1.2'
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/spack/spack_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/spack/spack_rocky8.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :spack, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_spack_common.rb'
+
+def dependencies
+  %w(autoconf automake bison byacc cscope ctags diffstat doxygen elfutils flex gcc gcc-c++ gcc-gfortran git
+     indent intltool libtool patch patchutils rcs rpm-build rpm-sign subversion swig system-rpm-config systemtap
+     curl findutils hostname iproute redhat-lsb-core python3 python3-setuptools unzip python3-boto3)
+end
+
+def libfabric_path
+  '/opt/amazon/efa/lib64/pkgconfig/libfabric.pc'
+end
+
+action :setup do
+  action_install_spack
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_rocky8.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :system_authentication, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_system_authentication_common'
+
+action :configure do
+  # oddjobd service is required for creating homedir
+  service "oddjobd" do
+    action %i(start enable)
+  end unless on_docker?
+
+  execute 'Configure Directory Service' do
+    user 'root'
+    # Tell NSS, PAM to use SSSD for system authentication and identity information
+    # authconfig is a compatibility tool, replaced by authselect
+    command "authselect select sssd with-mkhomedir"
+    sensitive true
+  end
+end
+
+action_class do
+  def required_packages
+    %w(sssd sssd-tools sssd-ldap authselect oddjob-mkhomedir)
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
@@ -40,7 +40,7 @@ control 'tag:config_cloudwatch_configured' do
 
   describe file('/usr/local/bin/write_cloudwatch_agent_json.py') do
     it { should exist }
-    its('sha256sum') { should eq 'cf304d5c8fa3dd6b5866b28d4a866d5190d7282adeda3adbb39b8bed116ab30c' }
+    its('sha256sum') { should eq 'b2bc3a9de8aa6c8afd2f2978ac33b96e0c76daf6e8a144a1656a45683f751302' }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0755' }
@@ -56,7 +56,7 @@ control 'tag:config_cloudwatch_configured' do
 
   describe file('/usr/local/etc/cloudwatch_agent_config_schema.json') do
     it { should exist }
-    its('sha256sum') { should eq '9019c9235fe54091db4c225fe6be552b229c958ab8a87fa94b5a875545bbfd87' }
+    its('sha256sum') { should eq '902aab6974f296b6da757159edf4210b3e4674ba4aea96c9cd1662bcbc987cb4' }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0644' }

--- a/cookbooks/aws-parallelcluster-environment/test/controls/ephemeral_drives_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/ephemeral_drives_spec.rb
@@ -43,7 +43,7 @@ end
 
 control 'tag:install_ephemeral_service_after_network_config' do
   title 'Check setup-ephemeral service to have the correct After statement'
-  network_target = os_properties.redhat? ? /^After=network-online.target/ : /^After=network.target$/
+  network_target = os_properties.redhat? || os_properties.rocky? ? /^After=network-online.target/ : /^After=network.target$/
   describe file('/etc/systemd/system/setup-ephemeral.service') do
     it { should exist }
     its('content') { should match network_target }

--- a/cookbooks/aws-parallelcluster-platform/files/dcv/pcluster_dcv_connect.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/dcv/pcluster_dcv_connect.sh
@@ -112,7 +112,7 @@ main() {
     os=$(< /etc/chef/dna.json jq -r .cluster.base_os)
     _log "Input parameters: user: ${user}, OS: ${os}, shared_folder_path: ${shared_folder_path}."
 
-    if ! [[ "${os}" =~ ^(alinux2|ubuntu2004|ubuntu2204|centos[7-8]|rhel8)$ ]]; then
+    if ! [[ "${os}" =~ ^(alinux2|ubuntu2004|ubuntu2204|centos[7-8]|rhel8|rocky8)$ ]]; then
         _fail "OS not supported."
     fi
 

--- a/cookbooks/aws-parallelcluster-platform/resources/arm_pl/arm_pl_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/arm_pl/arm_pl_rocky8.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :arm_pl, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_arm_pl_common.rb'
+
+action_class do
+  def armpl_platform
+    'RHEL-8'
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/build_tools/build_tools_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/build_tools/build_tools_rocky8.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :build_tools, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_build_tools_yum.rb'
+
+action_class do
+  def packages
+    %w(gcc gcc-c++ make)
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/c_states/c_states_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/c_states/c_states_rocky8.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :c_states, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_c_states_common'
+use 'partial/_c_states_redhat_based'

--- a/cookbooks/aws-parallelcluster-platform/resources/chrony/chrony_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/chrony/chrony_rocky8.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :chrony, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_chrony_common.rb'
+
+action_class do
+  def chrony_conf_path
+    '/etc/chrony.conf'
+  end
+
+  def chrony_service
+    'chronyd'
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/dcv_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/dcv_rocky8.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :dcv, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_dcv_common'
+use 'partial/_rhel_common'

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_rocky8.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :fabric_manager, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_fabric_manager_common.rb'
+use 'partial/_fabric_manager_install_rhel.rb'
+
+def fabric_manager_package
+  'nvidia-fabric-manager'
+end
+
+def fabric_manager_version
+  _nvidia_driver_version
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_rocky8.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :gdrcopy, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_gdrcopy_common.rb'
+use 'partial/_gdrcopy_common_rhel.rb'
+
+def gdrcopy_enabled?
+  nvidia_enabled?
+end
+
+def gdrcopy_platform
+  '.el8'
+end
+
+def gdrcopy_arch
+  arm_instance? ? 'aarch64' : 'x86_64'
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
@@ -22,12 +22,14 @@ use 'partial/_install_packages_rhel_amazon.rb'
 def default_packages
   # environment-modules required by EFA, Intel MPI and ARM PL
   # iptables needed for IMDS setup
-  %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
+  packages = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
      libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
      httpd boost-devel redhat-lsb mlocate R atlas-devel
      blas-devel libffi-devel dkms libedit-devel jq
      libical-devel sendmail libxml2-devel libglvnd-devel
      python2 python2-pip libgcrypt-devel libevent-devel glibc-static bind-utils
      iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
-     coreutils moreutils curl environment-modules gcc gcc-c++ bzip2)
+     moreutils curl environment-modules gcc gcc-c++ bzip2)
+  packages.append("coreutils") unless on_docker?  # on docker image coreutils conflict with coreutils-single, already installed on it
+  packages
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :install_packages, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_install_packages_common.rb'
+use 'partial/_install_packages_rhel_amazon.rb'
+
+def default_packages
+  # environment-modules required by EFA, Intel MPI and ARM PL
+  # iptables needed for IMDS setup
+  %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
+     libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
+     httpd boost-devel redhat-lsb mlocate R atlas-devel
+     blas-devel libffi-devel dkms libedit-devel jq
+     libical-devel sendmail libxml2-devel libglvnd-devel
+     python2 python2-pip libgcrypt-devel libevent-devel glibc-static bind-utils
+     iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
+     coreutils moreutils curl environment-modules gcc gcc-c++ bzip2)
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/modules/modules_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/modules/modules_rocky8.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :modules, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_modules_common.rb'
+use 'partial/_modules_yum.rb'
+
+action_class do
+  def packages
+    %w(environment-modules)
+  end
+
+  def modulepath_config_file
+    '/etc/environment-modules/modulespath'
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/nvidia_dcgm_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/nvidia_dcgm_rocky8.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nvidia_dcgm, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_nvidia_dcgm_common.rb'
+
+def _nvidia_dcgm_enabled
+  _nvidia_enabled
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/nvidia_driver_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/nvidia_driver_rocky8.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nvidia_driver, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_nvidia_driver_common.rb'

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_repo/nvidia_repo_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_repo/nvidia_repo_rocky8.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nvidia_repo, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_nvidia_repo_common.rb'
+
+def platform
+  'rhel8'
+end
+
+def repository_key
+  'D42D0685.pub'
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_rocky8.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :stunnel, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_common'
+use 'partial/_setup'
+
+action_class do
+  def dependencies
+    # tcp_wrappers-devel has been deprecated in RHEL7 and deleted in RHEL8, however it is
+    # an optional requirement not strictly necessary for either stunnel or efs-utils
+    %w(openssl-devel)
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/disable_selinux_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/disable_selinux_spec.rb
@@ -14,7 +14,7 @@ control 'tag:install_selinux_disabled' do
   describe selinux do
     it { should be_disabled }
     it { should_not be_enforcing }
-  end unless os_properties.redhat? || os_properties.centos? # Because it requires reboot of the instance
+  end unless os_properties.redhat? || os_properties.rocky? || os_properties.centos? # Because it requires reboot of the instance
 end
 
 control 'tag:testami_selinux_disabled' do

--- a/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
@@ -5,7 +5,7 @@ control 'tag:install_install_packages' do
   only_if { !os_properties.redhat_on_docker? }
 
   # verify package with a common name is installed
-  describe package('coreutils') do
+  describe package('moreutils') do
     it { should be_installed }
   end
 

--- a/cookbooks/aws-parallelcluster-platform/test/controls/stunnel_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/stunnel_spec.rb
@@ -13,8 +13,8 @@ control 'tag:install_stunnel_installed' do
   title "Check that the correct version of stunnel has been installed"
 
   # In AL2 stunnel comes as part of the aws-efs-utils package.
-  # In RHEL8 on Docker we disable the installation of base packages, so stunnel cannot be built.
-  only_if { !os_properties.alinux2? && !os_properties.redhat_on_docker? }
+  # In RHEL8 and Rocky8 on Docker we disable the installation of base packages, so stunnel cannot be built.
+  only_if { !os_properties.alinux2? && !os_properties.redhat_on_docker? && !os_properties.rocky_on_docker? }
 
   stunnel_version = node['cluster']['stunnel']['version']
 

--- a/cookbooks/aws-parallelcluster-shared/attributes/users_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/users_rocky8.rb
@@ -1,0 +1,3 @@
+return unless platform?('rocky') && node['platform_version'].to_i == 8
+
+default['cluster']['cluster_user'] = 'rocky'

--- a/cookbooks/aws-parallelcluster-shared/libraries/test.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/test.rb
@@ -6,3 +6,7 @@ end
 def redhat_on_docker?
   on_docker? && platform?('redhat')
 end
+
+def rocky_on_docker?
+  on_docker? && platform?('rocky')
+end

--- a/cookbooks/aws-parallelcluster-shared/resources/os_type/os_type_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/os_type/os_type_rocky8.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :os_type, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_os_type_common.rb'
+
+def current_os
+  "rocky#{node['platform_version'].to_i}"
+end

--- a/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_rocky8.rb
@@ -32,8 +32,8 @@ action :setup do
 
   execute 'yum-config-manager-rhel' do
     # Needed by hwloc-devel blas-devel libedit-devel and glibc-static packages
-    command "yum-config-manager --enable codeready-builder-for-rhel-8-rhui-rpms"
-  end unless on_docker?
+    command "yum-config-manager --enable powertools"
+  end
 
   execute 'yum-config-manager_skip_if_unavail' do
     command "yum-config-manager --setopt=\*.skip_if_unavailable=1 --save"

--- a/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_rocky8.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :package_repos, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+unified_mode true
+
+use 'partial/_package_repos_rpm.rb'
+
+default_action :setup
+
+action :setup do
+  include_recipe 'yum'
+  include_recipe "yum-epel"
+
+  package 'yum-utils' do
+    retries 3
+    retry_delay 5
+  end
+
+  execute 'yum-config-manager-rhel' do
+    # Needed by hwloc-devel blas-devel libedit-devel and glibc-static packages
+    command "yum-config-manager --enable codeready-builder-for-rhel-8-rhui-rpms"
+  end unless on_docker?
+
+  execute 'yum-config-manager_skip_if_unavail' do
+    command "yum-config-manager --setopt=\*.skip_if_unavailable=1 --save"
+  end
+end
+
+action :update do
+  # Do nothing
+end

--- a/cookbooks/aws-parallelcluster-shared/test/libraries/os_properties.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/libraries/os_properties.rb
@@ -20,6 +20,14 @@ class OsProperties < Inspec.resource(1)
     inspec.os.name == 'redhat'
   end
 
+  def rocky?
+    inspec.os.name == 'rocky'
+  end
+
+  def rocky_on_docker?
+    on_docker? && rocky?
+  end
+
   def centos?
     inspec.os.name == 'centos'
   end
@@ -30,6 +38,10 @@ class OsProperties < Inspec.resource(1)
 
   def redhat8?
     redhat? && inspec.os.release.to_i == 8
+  end
+
+  def rocky8?
+    rocky? && inspec.os.release.to_i == 8
   end
 
   def centos7?

--- a/cookbooks/aws-parallelcluster-slurm/files/rocky/dns_domain/NetworkManager.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/rocky/dns_domain/NetworkManager.conf
@@ -1,0 +1,52 @@
+# Configuration file for NetworkManager.
+#
+# See "man 5 NetworkManager.conf" for details.
+#
+# The directories /usr/lib/NetworkManager/conf.d/ and /run/NetworkManager/conf.d/
+# can contain additional .conf snippets installed by packages. These files are
+# read before NetworkManager.conf and have thus lowest priority.
+# The directory /etc/NetworkManager/conf.d/ can contain additional .conf
+# snippets. Those snippets are merged last and overwrite the settings from this main
+# file.
+#
+# The files within one conf.d/ directory are read in asciibetical order.
+#
+# You can prevent loading a file /usr/lib/NetworkManager/conf.d/NAME.conf
+# by having a file NAME.conf in either /run/NetworkManager/conf.d/ or /etc/NetworkManager/conf.d/.
+# Likewise, snippets from /run can be prevented from loading by placing
+# a file with the same name in /etc/NetworkManager/conf.d/.
+#
+# If two files define the same key, the one that is read afterwards will overwrite
+# the previous one.
+
+[main]
+plugins = ifcfg-rh,
+dhcp = dhclient
+
+[logging]
+# When debugging NetworkManager, enabling debug logging is of great help.
+#
+# Logfiles contain no passwords and little sensitive information. But please
+# check before posting the file online. You can also personally hand over the
+# logfile to a NM developer to treat it confidential. Meet us on #nm on Libera.Chat.
+#
+# You can also change the log-level at runtime via
+#   $ nmcli general logging level TRACE domains ALL
+# However, usually it's cleaner to enable debug logging
+# in the configuration and restart NetworkManager so that
+# debug logging is enabled from the start.
+#
+# You will find the logfiles in syslog, for example via
+#   $ journalctl -u NetworkManager
+#
+# Please post full logfiles for bug reports without pre-filtering or truncation.
+# Also, for debugging the entire `journalctl` output can be interesting. Don't
+# limit unnecessarily with `journalctl -u`. Exceptions are if you are worried
+# about private data. Check before posting logfiles!
+#
+# Note that debug logging of NetworkManager can be quite verbose. Some messages
+# might be rate-limited by the logging daemon (see RateLimitIntervalSec, RateLimitBurst
+# in man journald.conf). Please disable rate-limiting before collecting debug logs!
+#
+#level=TRACE
+#domains=ALL

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_rocky8.rb
@@ -1,0 +1,38 @@
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :dns_domain, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_dns_domain_common'
+use 'partial/_dns_domain_redhat'
+
+# Configure custom dns domain (only if defined) by appending the Route53 domain created within the cluster
+# ($CLUSTER_NAME.pcluster) and be listed as a "search" domain in the resolv.conf file.
+action :configure do
+  return if on_docker?
+
+  # On RHEL8 dhclient is not enabled by default
+  # Put pcluster version of NetworkManager.conf in place
+  # dhcp = dhclient needs to be added under [main] section to enable dhclient
+  # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/networking_considerations-in-adopting-rhel-8#dhcp_plugin_networking
+  cookbook_file 'NetworkManager.conf' do
+    path '/etc/NetworkManager/NetworkManager.conf'
+    source 'dns_domain/NetworkManager.conf'
+    cookbook 'aws-parallelcluster-slurm'
+    user 'root'
+    group 'root'
+    mode '0644'
+  end
+
+  action_update_search_domain
+  network_service 'Restart network service'
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/jwt_dependencies/jwt_dependencies_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/jwt_dependencies/jwt_dependencies_rocky8.rb
@@ -1,0 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :jwt_dependencies, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_jwt_dependencies_common'

--- a/cookbooks/aws-parallelcluster-slurm/resources/munge/munge_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/munge/munge_rocky8.rb
@@ -1,0 +1,20 @@
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :munge, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_munge_actions'
+use 'partial/_munge_rhel'
+
+def munge_libdir
+  '/usr/lib64'
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/mysql_client_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/mysql_client_rocky8.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :mysql_client, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_common'
+use 'partial/_setup_rhel_based'

--- a/cookbooks/aws-parallelcluster-slurm/resources/slurm_dependencies/slurm_dependencies_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/slurm_dependencies/slurm_dependencies_rocky8.rb
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :slurm_dependencies, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_slurm_dependencies_common'
+
+def dependencies
+  %w(json-c-devel http-parser-devel perl-Switch lua-devel)
+end

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -69,3 +69,10 @@ platforms:
       cluster:
         base_os: rhel8
         kernel_release: '4.18.0-477.13.1.el8_7.fake-value' # Use 477 version to match 8.8 kernel version available on docker
+  - name: rocky8
+    driver:
+      image: <% if ENV['KITCHEN_ROCKY8_IMAGE'] %> <%= ENV['KITCHEN_ROCKY8_IMAGE'] %> <% else %> dokken/rockylinux-8 <% end %>
+    attributes:
+      cluster:
+        base_os: rocky8
+        kernel_release: '4.18.0-477.10.1.el8_8.x86_64'

--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -38,6 +38,7 @@ lifecycle:
 
       case $KITCHEN_PLATFORM_NAME in
       alinux*|redhat* ) export KITCHEN_EC2_USER='ec2-user';;
+      rocky*          ) export KITCHEN_EC2_USER='rocky';;
       centos*         ) export KITCHEN_EC2_USER='centos';;
       ubuntu*         ) export KITCHEN_EC2_USER='ubuntu';;
       esac
@@ -127,6 +128,32 @@ platforms:
     attributes:
       cluster:
         base_os: rhel8
+  - name: rocky8
+    driver_plugin: ec2
+    driver:
+      <% if ENV['KITCHEN_ROCKY8_AMI'] %>
+      # Use the Rocky Linux 8 AMI most similar to the base AMI used to build the ParallelCluster image
+      image_id: <%= ENV['KITCHEN_ROCKY8_AMI'] %>
+      <% else %>
+      image_search:
+        name: <% if ENV['KITCHEN_PHASE']=='install' %>Rocky-8-EC2-Base-8*<% else %><%= pcluster_prefix %>-rocky8-hvm-*<% end %>
+        architecture: <%= ENV['KITCHEN_ARCHITECTURE'] %>
+      <% end %>
+      block_device_mappings:
+        - device_name: /dev/sda1
+          ebs:
+            volume_size: <% if (ENV['KITCHEN_VOLUME_SIZE'] || '') == '' %> 35 <% else %> <%= ENV['KITCHEN_VOLUME_SIZE'] %> <% end %>
+            volume_type: gp2
+            delete_on_termination: true
+      <% %w(a b c d e f g h i j k l m n o p q r s t u v w x).each_with_index do | c, i | %>
+        - device_name: /dev/xvdb<%= c %>
+          virtual_name: ephemeral<%= i %>
+      <% end %>
+    transport:
+      username: rocky
+    attributes:
+      cluster:
+        base_os: rocky8
   - name: centos7
     driver_plugin: ec2
     driver:

--- a/kitchen/kitchen.run-hook.sh
+++ b/kitchen/kitchen.run-hook.sh
@@ -26,6 +26,7 @@ if [ -e "${SCRIPT}" ]; then
     if [ -n "${KITCHEN_INSTANCE_HOSTNAME}" ]; then
       case ${KITCHEN_PLATFORM_NAME} in
         alinux*|redhat* ) export KITCHEN_EC2_USER='ec2-user';;
+        rocky*          ) export KITCHEN_EC2_USER='rocky';;
         centos*         ) export KITCHEN_EC2_USER='centos';;
         ubuntu*         ) export KITCHEN_EC2_USER='ubuntu';;
       esac


### PR DESCRIPTION
### Description of changes

Used new utility `os-resources.py` introduced as part of https://github.com/aws/aws-parallelcluster-cookbook/pull/2328 to create new resources for rocky linux, starting from redhat8 resources.

Manually modified:
* efa -> Replaced RHEL with Rocky Linux in log messages
* lustre -> Replaced RHEL with Rocky Linux in log messages
* users --> Replaced ec2-user with rocky
* os_type --> Replaced rhel with rocky
* install_packages --> Removed postgresql packages

Removed redhat_on_docker condition from:
* stunnel
* system_authentication
* efa

Relevant fixes to the code:
* Fix CloudWatch agent setup for Rocky Linux: `platform_url_component` should point to the same of rhel
* Copied network setup templates from redhat folders
* Enabled PowerTools repository. Needed by hwloc-devel blas-devel libedit-devel and glibc-static packages
* Added rocky8 to pcluster_dcv_connect.sh script


### Tests

* Add Rocky Linux to kitchen configuration files. Copied from rhel8 with minor changes:
    * AMI name prefix took from EC2 Rocky Linux official AMI
    * `kernel_release` version took from an EC2 Rocky Linux instance
    * username `rocky` found in kitchen-ec2 driver documentation.
* Add Rocky Linux to GitHub actions
* Remove coreutils package on docker. 
    * This package conflicts by design with `coreutils-single`. 
    * `coreutils-single` cannot be removed because related to `sudo`.
    * This change permits the install_package test to be executed on docker.
* Fix Inspec tests conditions

### References
* https://hub.docker.com/r/dokken/rockylinux-8
* https://github.com/test-kitchen/kitchen-ec2/tree/main/lib/kitchen/driver/aws/standard_platform
* Related to https://github.com/aws/aws-parallelcluster/pull/5423