### PR TITLE
Fix raid_vol_array initialization

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/templates/shared_storages/shared_storages_data.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/shared_storages/shared_storages_data.erb
@@ -12,7 +12,7 @@ raid:
 <% unless raid_shared_dir.empty? -%>
   - raid_shared_dir: <%= node['cluster']['raid_shared_dir'] %>
     raid_type: <%= node['cluster']['raid_type'] %>
-    raid_vol_array: <%= node['cluster']['raid_vol_ids'] %>
+    raid_vol_array: <%= node['cluster']['raid_vol_ids'].split(',') %>
 <% end -%>
 <%# EFS %>
 <% efs_fs_ids_array = node['cluster']['efs_fs_ids'].split(',') -%>


### PR DESCRIPTION
This must be an Array and not a string.

Code was failing with:
```
Chef::Exceptions::ValidationFailed: raid[add raid] (aws-parallelcluster-environment::update_shared_storages line 171) had an error: Chef::Exceptions::ValidationFailed: Property raid_vol_array must be one of: Array!  You passed "vol-0c79cc89dbb45d9cc,vol-00a87f00044e7df7f,vol-0431c0fbcd4d1bd33,vol-08662461b6a62b4ce,vol-01aab50f03443244f".
```

