### PR TITLE
Export default ENV when PATH is required for command execution

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_alinux_centos.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_alinux_centos.rb
@@ -17,6 +17,7 @@ action :configure do
     user 'root'
     # Tell NSS, PAM to use SSSD for system authentication and identity information
     command "authconfig --enablemkhomedir --enablesssdauth --enablesssd --updateall"
+    default_env true
     sensitive true
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_debian.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_debian.rb
@@ -17,6 +17,7 @@ action :configure do
     user 'root'
     # Enable PAM mkhomedir module
     command "pam-auth-update --enable mkhomedir"
+    default_env true
     sensitive true
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_redhat8.rb
@@ -30,6 +30,7 @@ action :configure do
     # authconfig is a compatibility tool, replaced by authselect
     command "authselect select sssd with-mkhomedir"
     sensitive true
+    default_env true
   end unless redhat_on_docker?
 end
 

--- a/cookbooks/aws-parallelcluster-environment/resources/volume.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/volume.rb
@@ -128,5 +128,6 @@ action :unexport do
 
   execute "unexport volume" do
     command "exportfs -ra"
+    default_env true
   end
 end


### PR DESCRIPTION
`exportfs` and `authconfig` execution was failing with: `No such file or directory - exportfs/authconfig` during update phase. This is happening after the refactoring/reordering of the cookbook recipes.

### References
* `default_env true` documentation: https://docs.chef.io/resources/execute/#properties
* Related issue: https://github.com/sous-chefs/nfs/issues/106

