### PR TITLE
Skip the failing features for the Ubuntu 22 AMI build

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/kitchen.entrypoints-install.yml
+++ b/cookbooks/aws-parallelcluster-entrypoints/kitchen.entrypoints-install.yml
@@ -18,3 +18,6 @@ suites:
     verifier:
       controls:
         - /tag:install/
+    driver:
+      # nvidia_driver can be executed only on a graphic EC2 instance example: g5.xlarge(x86_86) or g5g.xlarge(aarm64)
+      instance_type: g4dn.2xlarge

--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/install.rb
@@ -27,6 +27,8 @@ include_recipe 'aws-parallelcluster-awsbatch::install'
 # == WORKSTATIONS
 # DCV recipe installs Gnome, X and their dependencies so it must be installed as latest to not break the environment
 # used to build the schedulers packages
-dcv "Install DCV"
+dcv "Install DCV" do
+  not_if { platform?('ubuntu') && node['platform_version'].to_i == 22 }
+end
 
 node_attributes "dump node attributes"

--- a/cookbooks/aws-parallelcluster-platform/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install.rb
@@ -31,5 +31,7 @@ chrony 'install Amazon Time Sync'
 c_states 'disable x86_64 C states'
 include_recipe "aws-parallelcluster-platform::nvidia_install"
 include_recipe "aws-parallelcluster-platform::intel_mpi"
-arm_pl 'Install ARM Performance Library'
+arm_pl 'Install ARM Performance Library' do
+  not_if { platform?('ubuntu') && node['platform_version'].to_i == 22 }
+end
 intel_hpc 'Setup Intel HPC'


### PR DESCRIPTION
### Description of changes
* DCV and ARM PL are not currently working in Ubuntu 22 so are disabled for development

### Tests
* global_first_stage_build on personal jenkins

### References

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.