### PR TITLE
Replace deprecated `require_chef_omnibus` setting that is going to be deprecated

### DIFF
--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -60,8 +60,10 @@ transport:
   name: speedy_ssh
 
 provisioner:
-  name: chef_zero
-  require_chef_omnibus: 17.2.29
+  name: cinc
+  product_name: cinc
+  product_version: 17.2.29
+  install_strategy: once
   chef_omnibus_url: https://omnitruck.cinc.sh/install.sh
   chef_omnibus_root: /opt/cinc
   retry_on_exit_code:


### PR DESCRIPTION
By using these new settings is possible in future to override some parameters, for example we can specify a direct `download_url` if cinc package is not available for a given product platform or version.

`product_name` is required when specifying `product_version`.

### Tests
Tested locally running some inspec tests.

### References
* https://docs.chef.io/workstation/config_yml_kitchen/#new-provisioner-settings

