### PR TITLE
Remove provisioner name

### DIFF
--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -60,7 +60,6 @@ transport:
   name: speedy_ssh
 
 provisioner:
-  name: cinc
   product_name: cinc
   product_version: 17.2.29
   install_strategy: once


### PR DESCRIPTION
This is no longer required and causing issues:

```
>>>>>> Message: Could not load the 'cinc' provisioner from the load path. Did you mean: chef_apply, chef_base, chef_infra, chef_solo, chef_zero, chef_zero_capture, dokken, dummy, policyfile_zero, shell ? Please ensure that your provisioner is installed as a gem or included in your Gemfile if using Bundler.
```

### Tests
* Tested running local kitchen test.

### References
* Issue introduced with: https://github.com/aws/aws-parallelcluster-cookbook/pull/2334 on which I added the name just before pushing the patch, after the tests.

