### PR TITLE
Fix mock_compute shared storage recipes

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -47,8 +47,6 @@ suites:
       cluster:
         node_type: ComputeFleet
         ebs_shared_dirs: ebs1,ebs2
-        nfs:
-          hard_mount_options: hard,_netdev,noatime
         head_node_private_ip: '127.0.0.1'
   - name: raid_compute
     run_list:
@@ -64,8 +62,6 @@ suites:
       cluster:
         node_type: ComputeFleet
         raid_shared_dir: raid1
-        nfs:
-          hard_mount_options: hard,_netdev,noatime
         head_node_private_ip: '127.0.0.1'
   - name: shared_storages_compute
     run_list:
@@ -80,8 +76,6 @@ suites:
         - recipe:aws-parallelcluster-environment::mock_compute_shared_storages
       cluster:
         node_type: ComputeFleet
-        nfs:
-          hard_mount_options: hard,_netdev,noatime
         head_node_private_ip: '127.0.0.1'
   - name: directory_service
     # FIXME: breaks on Docker

--- a/cookbooks/aws-parallelcluster-environment/recipes/test/mock_compute_ebs.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/test/mock_compute_ebs.rb
@@ -12,6 +12,6 @@ dirs_to_export.each do |dir|
   nfs_export dir do
     network '127.0.0.1/32'
     writeable true
-    options node['cluster']['nfs']['hard_mount_options'].split(",")
+    options ['no_root_squash']
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/recipes/test/mock_compute_raid.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/test/mock_compute_raid.rb
@@ -12,6 +12,6 @@ dirs_to_export.each do |dir|
   nfs_export dir do
     network '127.0.0.1/32'
     writeable true
-    options node['cluster']['nfs']['hard_mount_options'].split(",")
+    options ['no_root_squash']
   end
 end


### PR DESCRIPTION
During the export the only accepted value is "no_root_squash".

Removed useless node attribute parameters from the test.
Issue introduced with: https://github.com/aws/aws-parallelcluster-cookbook/pull/2336 - I merged the patch that was missing a local fix.

### Tests

* Verified with: `bash kitchen.ec2.sh environment-config test ebs-compute-rhel8`