### PR TITLE
[develop] Avoid to start NFS server on compute nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Forward SLURM_RESUME_FILE to ParallelCluster resume program.
 - Allow to override aws-parallelcluster-node package at cluster creation and update time (only on the head node during update).
   Useful for development purposes only.
+- Avoid to start NFS server on compute nodes.
 
 **CHANGES**
 - Assign Slurm dynamic nodes a priority (weight) of 1000 by default. This allows Slurm to prioritize idle static nodes over idle dynamic ones.

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -185,7 +185,7 @@ suites:
         - network_service_running
     attributes:
       resource: network_service:reload
-  - name: nfs
+  - name: nfs_headnode
     run_list:
       - recipe[aws-parallelcluster-tests::setup]
       - recipe[aws-parallelcluster-tests::test_resource]
@@ -196,6 +196,21 @@ suites:
       resource: nfs:configure
       dependencies:
         - resource:nfs
+      cluster:
+        node_type: HeadNode
+  - name: nfs_computefleet
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-tests::test_resource]
+    verifier:
+      controls:
+        - /tag:config_nfs/
+    attributes:
+      resource: nfs:configure
+      dependencies:
+        - resource:nfs
+      cluster:
+        node_type: ComputeFleet
   - name: raid_mount
     run_list:
       - recipe[aws-parallelcluster-tests::setup]

--- a/cookbooks/aws-parallelcluster-environment/recipes/test/mock_compute_shared_storages.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/test/mock_compute_shared_storages.rb
@@ -10,6 +10,6 @@ dirs_to_export.each do |dir|
   nfs_export dir do
     network '127.0.0.1/32'
     writeable true
-    options node['cluster']['nfs']['hard_mount_options'].split(",")
+    options ['no_root_squash']
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/partial/_configure.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/partial/_configure.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 action :configure do
+  return if node['cluster']['node_type'] != "HeadNode"
   node.force_override['nfs']['threads'] = node['cluster']['nfs']['threads']
 
   override_server_template

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/nfs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/nfs_spec.rb
@@ -59,7 +59,7 @@ end
 
 describe 'nfs:configure' do
   for_all_oses do |platform, version|
-    context "on #{platform}#{version}" do
+    context "on #{platform}#{version} on node type HeadNode" do
       cached(:threads) { 10 }
       cached(:server_template) { 'server_template' }
       cached(:nfs_service) { 'nfs_service' }
@@ -68,6 +68,7 @@ describe 'nfs:configure' do
           node.override['cluster']['nfs']['threads'] = threads
           node.override['nfs']['config']['server_template'] = server_template
           node.override['nfs']['service']['server'] = nfs_service
+          node.override['cluster']['node_type'] = "HeadNode"
         end
         ConvergeNfs.configure(runner)
       end
@@ -111,6 +112,29 @@ describe 'nfs:configure' do
         is_expected.to restart_service(nfs_service)
           .with(action: %i(restart enable))
           .with(supports: { restart: true })
+      end
+    end
+
+    context "on #{platform}#{version} on node type ComputeFleet" do
+      cached(:server_template) { 'server_template' }
+      cached(:nfs_service) { 'nfs_service' }
+      cached(:chef_run) do
+        runner = runner(platform: platform, version: version, step_into: ['nfs']) do |node|
+          node.override['cluster']['node_type'] = "ComputeFleet"
+        end
+        ConvergeNfs.configure(runner)
+      end
+
+      it 'configures nfs' do
+        is_expected.to configure_nfs('configure')
+      end
+
+      it 'not overrides nfs config with custom template' do
+        is_expected.to_not create_template(server_template)
+      end
+
+      it 'not enables and restarts service' do
+        is_expected.to_not restart_service(nfs_service)
       end
     end
   end


### PR DESCRIPTION
### Description of changes
Avoid to start NFS server on compute nodes

### Tests
* `chef exec rspec ./spec/unit/resources/nfs_spec.rb`
* `bash kitchen.ec2.sh environment-config test nfs-headnode-alinux2`
* `bash kitchen.ec2.sh environment-config test nfs-computefleet-alinux2`

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.