### PR TITLE
[release-3.6] Replace nvidia-persistenced service with parallelcluster_nvidia service to avoid conflicts with DLAMI

### DIFF
--- a/cookbooks/aws-parallelcluster-config/recipes/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-config/recipes/nvidia.rb
@@ -35,14 +35,23 @@ if graphic_instance? && nvidia_installed?
     group 'root'
     mode '0644'
   end
-  # Install nvidia_persistenced. See https://download.nvidia.com/XFree86/Linux-x86_64/396.51/README/nvidia-persistenced.html
-  bash 'Install nvidia_persistenced' do
-    cwd '/usr/share/doc/NVIDIA_GLX-1.0/samples'
-    user 'root'
+
+  # Install ParallelCluster nvidia service.
+  # The service ensures the creation of the block devices /dev/nvidia0 after reboot and it is needed by the slurmd service
+  # cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurmd_nvidia_persistenced.conf.erb
+  #
+  # The service starts the nvidia-persistenced or run nvidia-smi to avoid race condition with other services
+  template '/etc/systemd/system/parallelcluster_nvidia.service' do
+    source 'nvidia/parallelcluster_nvidia_service.erb'
+    owner 'root'
     group 'root'
-    code <<-NVIDIA
-      tar -xf nvidia-persistenced-init.tar.bz2
-      ./nvidia-persistenced-init/install.sh
-    NVIDIA
+    mode '0644'
+    action :create
+    variables(is_nvidia_persistenced_running: is_process_running('nvidia-persistenced'))
+  end
+
+  service "parallelcluster_nvidia" do
+    supports restart: false
+    action %i(enable start)
   end
 end

--- a/cookbooks/aws-parallelcluster-config/templates/default/nvidia/parallelcluster_nvidia_service.erb
+++ b/cookbooks/aws-parallelcluster-config/templates/default/nvidia/parallelcluster_nvidia_service.erb
@@ -1,0 +1,20 @@
+# This systemd service file, designed to trigger the creation device block file /dev/nvidia0
+# The service start nvidia-persistenced if it is not already started or execute the command nvidia-smi.
+
+[Unit]
+Description=ParallelCluster NVIDIA Daemon
+Wants=syslog.target
+
+[Service]
+<% if @is_nvidia_persistenced_running -%>
+Type=simple
+ExecStart=/usr/bin/nvidia-smi
+RemainAfterExit=yes
+<% else %>
+Type=forking
+ExecStart=/usr/bin/nvidia-persistenced --user root
+ExecStopPost=/bin/rm -rf /var/run/nvidia-persistenced
+<% end %>
+
+[Install]
+WantedBy=multi-user.target

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config_slurmd_systemd_service.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config_slurmd_systemd_service.rb
@@ -24,7 +24,7 @@ template '/etc/systemd/system/slurmd.service' do
   action :create
 end
 
-# Add systemd dependency between slurmd and nvidia-persistenced for NVIDIA GPU nodes
+# Add systemd dependency between slurmd and parallelcluster_nvidia for NVIDIA GPU nodes
 if graphic_instance? && nvidia_installed?
   directory '/etc/systemd/system/slurmd.service.d' do
     user 'root'

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurmd_nvidia_persistenced.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurmd_nvidia_persistenced.conf.erb
@@ -1,3 +1,3 @@
 [Unit]
-After=nvidia-persistenced.service
-Wants=nvidia-persistenced.service
+After=parallelcluster_nvidia.service
+Wants=parallelcluster_nvidia.service

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -130,6 +130,16 @@ def ignore_failure(lookup)
 end
 
 #
+# Check if a process is running
+#
+def is_process_running(process_name)
+  ps = Mixlib::ShellOut.new("ps aux | grep '#{process_name}' | egrep -v \"grep .*#{process_name}\"")
+  ps.run_command
+
+  !ps.stdout.strip.empty?
+end
+
+#
 # Check if the instance has a GPU
 #
 def graphic_instance?

--- a/test/recipes/controls/aws_parallelcluster_config/nvidia_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_config/nvidia_spec.rb
@@ -55,7 +55,7 @@ control 'tag:config_nvidia_uvm_and_persistenced_on_graphic_instances' do
     its('content') { should include("uvm") }
   end
 
-  describe service('nvidia-persistenced') do
+  describe service('parallelcluster_nvidia') do
     it { should be_enabled }
     it { should be_running }
   end

--- a/test/recipes/controls/aws_parallelcluster_slurm/config_slurmd_systemd_service_spec.rb
+++ b/test/recipes/controls/aws_parallelcluster_slurm/config_slurmd_systemd_service_spec.rb
@@ -28,10 +28,10 @@ control 'systemd_slurmd_service_nvidia_gpu_nodes' do
 
   describe 'Check slurmd systemd "after" dependencies'
   describe command('systemctl list-dependencies --after --plain slurmd.service') do
-    its('stdout') { should include "nvidia-persistenced.service" }
+    its('stdout') { should include "parallelcluster_nvidia.service" }
   end
   describe 'Check slurmd systemd requirement dependencies'
   describe command('systemctl list-dependencies --plain slurmd.service') do
-    its('stdout') { should include "nvidia-persistenced.service" }
+    its('stdout') { should include "parallelcluster_nvidia.service" }
   end
 end


### PR DESCRIPTION
### Description of changes
* Replace the installation of the service `nvidia-persistenced.service` with `parallelcluster_nvidia` service which can:
1. Execute `/usr/bin/nvidia-persistenced` if no other `/usr/bin/nvidia-persistenced` are already running.
2. Execute `/usr/bin/nvidia-smi` which triggers the `/dev/nvidia0` creation but does not conflict with other services

This allow ParallelCluster to have a service which `slurmd` can depends on. However the service will not have race conditions with other possible customer nvidia daemon.

### Tests
* Kitchen tested on EC2.
* Created a cluster with in `us-east-1` with `ami-0901c773cf8fa8cb6`and
```
 DevSettings:
  AmiSearchFilters:
    Owner: '447714826191'
  Cookbook:
    ChefCookbook: https://github.com/francesco-giordano/aws-parallelcluster-cookbook/tarball/b25d096b2d32da5ee67bcb70af37eeabe940270e
```


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.