### PR TITLE
Create new mechanism to execute OS specific hooks

### DIFF
--- a/kitchen/kitchen.run-hook.sh
+++ b/kitchen/kitchen.run-hook.sh
@@ -3,27 +3,21 @@
 export KITCHEN_HOOK=$1
 KITCHEN_ROOT_DIR=$(readlink -f $2)
 export KITCHEN_ROOT_DIR
-
-echo "*** Run ${KITCHEN_HOOK} for cookbook ${KITCHEN_COOKBOOK_PATH} suite ${KITCHEN_SUITE_NAME} on host ${KITCHEN_INSTANCE_HOSTNAME}"
-
 THIS_DIR=$(dirname "$0")
 SCRIPT="${THIS_DIR}/../${KITCHEN_COOKBOOK_PATH}/test/hooks/${KITCHEN_PHASE}/${KITCHEN_SUITE_NAME}/${KITCHEN_HOOK}.sh"
-echo "${SCRIPT}"
-
 if [ -e "${SCRIPT}" ]; then
-
+  echo "*** Run ${KITCHEN_HOOK} for cookbook ${KITCHEN_COOKBOOK_PATH} suite ${KITCHEN_SUITE_NAME} on host ${KITCHEN_INSTANCE_HOSTNAME}"
   echo "**** Script: ${SCRIPT}"
 
   if [ "${KITCHEN_DRIVER}" = "ec2" ]; then
 
     if [ -n "${KITCHEN_INSTANCE_HOSTNAME}" ]; then
-      echo "Retrieve EC2 instance id using key ${KITCHEN_SSH_KEY_PATH}"
-
-      case $KITCHEN_PLATFORM_NAME in
+      case ${KITCHEN_PLATFORM_NAME} in
         alinux*|redhat* ) export KITCHEN_EC2_USER='ec2-user';;
         centos*         ) export KITCHEN_EC2_USER='centos';;
         ubuntu*         ) export KITCHEN_EC2_USER='ubuntu';;
       esac
+      echo "Retrieve EC2 instance id using key ${KITCHEN_SSH_KEY_PATH}"
 
       KITCHEN_EC2_INSTANCE_ID=$(ssh -o StrictHostKeyChecking=no -i "${KITCHEN_SSH_KEY_PATH}" \
         "${KITCHEN_EC2_USER}@${KITCHEN_INSTANCE_HOSTNAME}" '

--- a/kitchen/kitchen.run-hook.sh
+++ b/kitchen/kitchen.run-hook.sh
@@ -4,6 +4,18 @@ export KITCHEN_HOOK=$1
 KITCHEN_ROOT_DIR=$(readlink -f $2)
 export KITCHEN_ROOT_DIR
 THIS_DIR=$(dirname "$0")
+
+# Run OS specific hooks from kitchen/hooks folder
+SCRIPT="${THIS_DIR}/hooks/${KITCHEN_PLATFORM_NAME}/${KITCHEN_HOOK}.sh"
+if [ -e "${SCRIPT}" ]; then
+
+  echo "*** Run ${KITCHEN_HOOK} on host ${KITCHEN_INSTANCE_HOSTNAME}"
+  echo "**** Script: ${SCRIPT}"
+  # shellcheck disable=SC1090
+  source "${SCRIPT}"
+fi
+
+# Run test specific hooks from cookbooks/aws-parallelcluster-*/test/hooks folder
 SCRIPT="${THIS_DIR}/../${KITCHEN_COOKBOOK_PATH}/test/hooks/${KITCHEN_PHASE}/${KITCHEN_SUITE_NAME}/${KITCHEN_HOOK}.sh"
 if [ -e "${SCRIPT}" ]; then
   echo "*** Run ${KITCHEN_HOOK} for cookbook ${KITCHEN_COOKBOOK_PATH} suite ${KITCHEN_SUITE_NAME} on host ${KITCHEN_INSTANCE_HOSTNAME}"


### PR DESCRIPTION
### Description of changes

The kitchen tests will automatically execute hooks from `kitchen/hooks` folder before executing the hooks for the specific test.

For example we can have a `kitchen/hooks/alinux2/pre_converge.sh` with the following content,
to automatically install some packages in the instance right after the startup, before Chef installation:

```
#!/bin/bash

if [ -n "${KITCHEN_INSTANCE_HOSTNAME}" ]; then
    export KITCHEN_EC2_USER='ec2-user'
    echo "Install some-package package by using SSH key: ${KITCHEN_SSH_KEY_PATH}"

    KITCHEN_EC2_INSTANCE_ID=$(ssh -o StrictHostKeyChecking=no -i "${KITCHEN_SSH_KEY_PATH}" \
      "${KITCHEN_EC2_USER}@${KITCHEN_INSTANCE_HOSTNAME}" 'sudo yum install -y some-package')
fi
```

This is useful for example when Chef cannot be installed in the AMI because due to a missing or
conflicting packages.

### Tests
* Tested it with an hook for Amazon Linux 2023, on which I wasn't able to install Chef.

### References
* TODO add ALinux2023 patch.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.