### PR TITLE
[POC] Add support for Amazon Linux 2023

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/files/alinux2023/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/alinux2023/network_interfaces/configure_nw_interface.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Configure a specific Network Interface according to the OS
+# The configuration involves 3 aspects:
+# - Main configuration (IP address, protocol and gateway)
+# - A specific routing table, so that all traffic coming to a network interface leaves the instance using the same
+#   interface
+# - A routing rule to make the OS use the specific routing table for this network interface
+
+# RedHat 8 official documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/configuring-policy-based-routing-to-define-alternative-routes_configuring-and-managing-networking
+
+set -e
+
+if
+  [ -z "${DEVICE_NAME}" ] ||          # name of the device
+  [ -z "${DEVICE_NUMBER}" ] ||        # number of the device
+  [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
+  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
+  [ -z "${CIDR_PREFIX_LENGTH}" ]      # the prefix length of the device IP cidr block
+then
+  echo 'One or more environment variables missing'
+  exit 1
+fi
+
+con_name="System ${DEVICE_NAME}"
+route_table="100${DEVICE_NUMBER}"
+priority="100${DEVICE_NUMBER}"
+metric="100${DEVICE_NUMBER}"
+
+# Rename connection
+original_con_name=`nmcli -t -f GENERAL.CONNECTION device show ${DEVICE_NAME} | cut -f2 -d':'`
+sudo nmcli connection modify "${original_con_name}" con-name "${con_name}" ifname ${DEVICE_NAME}
+
+configured_ip=`nmcli -t -f IP4.ADDRESS device show ${DEVICE_NAME} | cut -f2 -d':'`
+if [ -z "${configured_ip}" ]; then
+  # Setup connection method to "manual", configure ip address and gateway, only if not already configured.
+  sudo nmcli connection modify "${con_name}" ipv4.method manual ipv4.addresses ${DEVICE_IP_ADDRESS}/${CIDR_PREFIX_LENGTH} ipv4.gateway ${GW_IP_ADDRESS}
+fi
+
+# Setup routes
+# This command uses the ipv4.routes parameter to add a static route to the routing table with ID ${route_table}.
+# This static route for 0.0.0.0/0 uses the IP of the gateway as next hop.
+sudo nmcli connection modify "${con_name}" ipv4.routes "0.0.0.0/0 ${GW_IP_ADDRESS} ${metric} table=${route_table}"
+
+# Setup routing rules
+# The command uses the ipv4.routing-rules parameter to add a routing rule with priority ${priority} that routes
+# traffic from ${DEVICE_IP_ADDRESS} to table ${route_table}. Low values have a high priority.
+# The syntax in the ipv4.routing-rules parameter is the same as in an "ip rule add" command,
+# except that ipv4.routing-rules always requires specifying a priority.
+sudo nmcli connection modify "${con_name}" ipv4.routing-rules "priority ${priority} from ${DEVICE_IP_ADDRESS} table ${route_table}"
+
+# Reapply previous connection modification.
+sudo nmcli device reapply ${DEVICE_NAME}

--- a/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/cloudwatch_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/cloudwatch_alinux2023.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :cloudwatch, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_cloudwatch_common'
+use 'partial/_cloudwatch_install_package_rhel'
+
+action_class do
+  def platform_url_component
+    'redhat'
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/ec2_udev_rules/ec2_udev_rules_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/ec2_udev_rules/ec2_udev_rules_alinux2023.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+provides :ec2_udev_rules, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+unified_mode true
+use 'partial/_common_udev_configuration'
+
+default_action :setup
+
+action :setup do
+  action_create_common_udev_files
+  action_start_ec2blk
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/efa/efa_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efa/efa_alinux2023.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :efa, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+unified_mode true
+default_action :setup
+
+use 'partial/_common'
+
+action_class do
+  def efa_supported?
+    if node['platform_version'].to_f < 8.4
+      log "EFA is not supported in this Amazon Linux version #{node['platform_version']}, supported versions are >= 8.4" do
+        level :warn
+      end
+      false
+    else
+      true
+    end
+  end
+
+  def conflicting_packages
+    %w(openmpi-devel openmpi)
+  end
+
+  def prerequisites
+    %w(environment-modules libibverbs-utils librdmacm-utils rdma-core-devel)
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/efs/efs_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/efs_alinux2023.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :efs, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_get_package_version_rpm'
+use 'partial/_common'
+use 'partial/_redhat_based'
+use 'partial/_install_from_tar'
+use 'partial/_mount_umount'
+
+def prerequisites
+  %w(rpm-build make)
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/ephemeral_drives/ephemeral_drives_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/ephemeral_drives/ephemeral_drives_alinux2023.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :ephemeral_drives, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_ephemeral_drives_common.rb'
+
+action_class do
+  def network_target
+    'network-online.target'
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_alinux2023.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :lustre, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+unified_mode true
+
+use 'partial/_install_lustre_centos_redhat'
+use 'partial/_mount_unmount'
+
+default_action :setup
+
+action :setup do
+  version = node['platform_version']
+  if version.to_f < 8.2
+    log "FSx for Lustre is not supported in this RHEL version #{version}, supported versions are >= 8.2" do
+      level :warn
+    end
+    # rhel8 kernel 4.18.0-425.3.1.el8 has broken kABI compat https://github.com/openzfs/zfs/issues/14724
+  elsif node['cluster']['kernel_release'].include? "4.18.0-425.3.1.el8"
+    log "FSx for Lustre is not supported in kernel version 4.18.0-425.3.1.el8 of RHEL, please update the kernel version" do
+      level :warn
+    end
+  else
+    action_install_lustre
+  end
+end
+
+def find_os_minor_version
+  os_minor_version = ''
+  kernel_patch_version = find_kernel_patch_version
+
+  # kernel patch versions under 193 are prior to RHEL 8.2
+  # kernel patch version number can be retrieved from https://access.redhat.com/articles/3078#RHEL8
+  os_minor_version = '2' if kernel_patch_version >= '193'
+  os_minor_version = '3' if kernel_patch_version >= '240'
+  os_minor_version = '4' if kernel_patch_version >= '305'
+  os_minor_version = '5' if kernel_patch_version >= '348'
+  os_minor_version = '6' if kernel_patch_version >= '372'
+  os_minor_version = '7' if kernel_patch_version >= '425'
+  os_minor_version = '8' if kernel_patch_version >= '477'
+
+  os_minor_version
+end
+
+action_class do
+  def base_url
+    # https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html#lustre-client-rhel
+    "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8.#{find_os_minor_version}/$basearch"
+  end
+
+  def public_key
+    "https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc"
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/network_service/network_service_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/network_service/network_service_alinux2023.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :network_service, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_network_service'
+use 'partial/_network_service_redhat_based'
+
+def network_service_name
+  'NetworkManager'
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_alinux2023.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nfs, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+unified_mode true
+
+use 'partial/_install_nfs4_and_disable'
+use 'partial/_configure'
+
+default_action :setup
+
+action :setup do
+  action_install_nfs4
+  action_disable_start_at_boot
+end
+
+action_class do
+  def override_server_template
+    edit_resource(:template, node['nfs']['config']['server_template']) do
+      cookbook 'nfs'
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/raid/raid_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/raid/raid_alinux2023.rb
@@ -1,0 +1,11 @@
+provides :raid, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_raid_common'
+
+action_class do
+  def raid_superblock_version
+    '1.2'
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_alinux2023.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :system_authentication, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_system_authentication_common'
+
+action :configure do
+  # oddjobd service is required for creating homedir
+  service "oddjobd" do
+    action %i(start enable)
+  end unless on_docker?
+
+  execute 'Configure Directory Service' do
+    user 'root'
+    # Tell NSS, PAM to use SSSD for system authentication and identity information
+    # authconfig is a compatibility tool, replaced by authselect
+    command "authselect select sssd with-mkhomedir"
+    sensitive true
+    default_env true
+  end
+end
+
+action_class do
+  def required_packages
+    %w(sssd sssd-tools sssd-ldap authselect oddjob-mkhomedir)
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/files/dcv/pcluster_dcv_connect.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/dcv/pcluster_dcv_connect.sh
@@ -112,7 +112,7 @@ main() {
     os=$(< /etc/chef/dna.json jq -r .cluster.base_os)
     _log "Input parameters: user: ${user}, OS: ${os}, shared_folder_path: ${shared_folder_path}."
 
-    if ! [[ "${os}" =~ ^(alinux2|ubuntu2004|centos[7-8]|rhel8)$ ]]; then
+    if ! [[ "${os}" =~ ^(alinux2|alinux2023|ubuntu1804|ubuntu2004|centos[7-8]|rhel8)$ ]]; then
         _fail "OS not supported."
     fi
 

--- a/cookbooks/aws-parallelcluster-platform/resources/arm_pl/arm_pl_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/arm_pl/arm_pl_alinux2023.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :arm_pl, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_arm_pl_common.rb'
+
+action_class do
+  def armpl_platform
+    'RHEL-8'
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/build_tools/build_tools_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/build_tools/build_tools_alinux2023.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :build_tools, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_build_tools_yum.rb'
+
+action_class do
+  def packages
+    %w(gcc gcc-c++ make)
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/c_states/c_states_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/c_states/c_states_alinux2023.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :c_states, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_c_states_common'
+use 'partial/_c_states_redhat_based'

--- a/cookbooks/aws-parallelcluster-platform/resources/chrony/chrony_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/chrony/chrony_alinux2023.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :chrony, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_chrony_common.rb'
+
+action_class do
+  def chrony_conf_path
+    '/etc/chrony.conf'
+  end
+
+  def chrony_service
+    'chronyd'
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/dcv_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/dcv_alinux2023.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :dcv, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_dcv_common'
+use 'partial/_rhel_common'

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/fabric_manager_alinux2023.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :fabric_manager, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_fabric_manager_common.rb'
+use 'partial/_fabric_manager_install_rhel.rb'
+
+def fabric_manager_package
+  'nvidia-fabric-manager'
+end
+
+def fabric_manager_version
+  _nvidia_driver_version
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_alinux2023.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :gdrcopy, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_gdrcopy_common.rb'
+use 'partial/_gdrcopy_common_rhel.rb'
+
+def gdrcopy_enabled?
+  nvidia_enabled?
+end
+
+def gdrcopy_platform
+  '.el8'
+end
+
+def gdrcopy_arch
+  arm_instance? ? 'aarch64' : 'x86_64'
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_alinux2023.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :install_packages, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_install_packages_common.rb'
+use 'partial/_install_packages_rhel_amazon.rb'
+
+def default_packages
+  # environment-modules required by EFA, Intel MPI and ARM PL
+  # Removed libssh2-devel from base_packages since is not shipped by RedHat 8 and in conflict with package libssh-0.9.6-3.el8.x86_64
+  # iptables needed for IMDS setup
+  %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
+     libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
+     httpd boost-devel redhat-lsb mlocate R atlas-devel
+     blas-devel libffi-devel dkms libedit-devel jq
+     libical-devel sendmail libxml2-devel libglvnd-devel
+     python2 python2-pip libgcrypt-devel libevent-devel glibc-static bind-utils
+     iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
+     coreutils moreutils curl environment-modules gcc gcc-c++ bzip2)
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/modules/modules_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/modules/modules_alinux2023.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :modules, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_modules_common.rb'
+use 'partial/_modules_yum.rb'
+
+action_class do
+  def packages
+    %w(environment-modules)
+  end
+
+  def modulepath_config_file
+    '/etc/environment-modules/modulespath'
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/nvidia_dcgm_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/nvidia_dcgm_alinux2023.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nvidia_dcgm, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_nvidia_dcgm_common.rb'
+
+def _nvidia_dcgm_enabled
+  _nvidia_enabled
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/nvidia_driver_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/nvidia_driver_alinux2023.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nvidia_driver, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_nvidia_driver_common.rb'

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_repo/nvidia_repo_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_repo/nvidia_repo_alinux2023.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :nvidia_repo, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_nvidia_repo_common.rb'
+
+def platform
+  'rhel8'
+end
+
+def repository_key
+  'D42D0685.pub'
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/stunnel/stunnel_alinux2023.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :stunnel, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_common'
+use 'partial/_setup'
+
+action :setup do
+  # If on RHEL8 Docker, we don't install the base packages, so stunnel cannot be built.
+end
+
+action_class do
+  def dependencies
+    # tcp_wrappers-devel has been deprecated in RHEL7 and deleted in RHEL8, however it is
+    # an optional requirement not strictly necessary for either stunnel or efs-utils
+    %w(openssl-devel)
+  end
+end

--- a/cookbooks/aws-parallelcluster-shared/attributes/users_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/users_alinux2023.rb
@@ -1,0 +1,3 @@
+return unless platform?('amazon') && node['platform_version'].to_i == 2023
+
+default['cluster']['cluster_user'] = 'ec2-user'

--- a/cookbooks/aws-parallelcluster-shared/resources/os_type/os_type_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/os_type/os_type_alinux2023.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :os_type, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_os_type_common.rb'
+
+def current_os
+  "alinux#{node['platform_version'].to_i}"
+end

--- a/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_alinux2023.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :package_repos, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+unified_mode true
+
+use 'partial/_package_repos_rpm.rb'
+
+default_action :setup
+
+action :setup do
+  include_recipe 'yum'
+  # include_recipe "yum-epel"
+
+  package 'yum-utils' do
+    retries 3
+    retry_delay 5
+  end
+
+  # execute 'yum-config-manager-rhel' do
+  #   # Needed by hwloc-devel blas-devel libedit-devel and glibc-static packages
+  #   command "yum-config-manager --enable codeready-builder-for-rhel-8-rhui-rpms"
+  # end unless on_docker?
+  #
+  # execute 'yum-config-manager_skip_if_unavail' do
+  #   command "yum-config-manager --setopt=\*.skip_if_unavailable=1 --save"
+  # end
+end
+
+action :update do
+  # Do nothing
+end

--- a/cookbooks/aws-parallelcluster-shared/test/libraries/os_properties.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/libraries/os_properties.rb
@@ -36,8 +36,16 @@ class OsProperties < Inspec.resource(1)
     centos? && inspec.os.release.to_i == 7
   end
 
+  def alinux?
+    inspec.os.name == 'amazon'
+  end
+
   def alinux2?
-    inspec.os.name == 'amazon' && inspec.os.release.to_i == 2
+    alinux? && inspec.os.release.to_i == 2
+  end
+
+  def alinux2023?
+    alinux? && inspec.os.release.to_i == 2023
   end
 
   def ubuntu2004?

--- a/cookbooks/aws-parallelcluster-slurm/files/amazon-2023/dns_domain/NetworkManager.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/amazon-2023/dns_domain/NetworkManager.conf
@@ -1,0 +1,52 @@
+# Configuration file for NetworkManager.
+#
+# See "man 5 NetworkManager.conf" for details.
+#
+# The directories /usr/lib/NetworkManager/conf.d/ and /run/NetworkManager/conf.d/
+# can contain additional .conf snippets installed by packages. These files are
+# read before NetworkManager.conf and have thus lowest priority.
+# The directory /etc/NetworkManager/conf.d/ can contain additional .conf
+# snippets. Those snippets are merged last and overwrite the settings from this main
+# file.
+#
+# The files within one conf.d/ directory are read in asciibetical order.
+#
+# You can prevent loading a file /usr/lib/NetworkManager/conf.d/NAME.conf
+# by having a file NAME.conf in either /run/NetworkManager/conf.d/ or /etc/NetworkManager/conf.d/.
+# Likewise, snippets from /run can be prevented from loading by placing
+# a file with the same name in /etc/NetworkManager/conf.d/.
+#
+# If two files define the same key, the one that is read afterwards will overwrite
+# the previous one.
+
+[main]
+plugins = ifcfg-rh,
+dhcp = dhclient
+
+[logging]
+# When debugging NetworkManager, enabling debug logging is of great help.
+#
+# Logfiles contain no passwords and little sensitive information. But please
+# check before posting the file online. You can also personally hand over the
+# logfile to a NM developer to treat it confidential. Meet us on #nm on Libera.Chat.
+#
+# You can also change the log-level at runtime via
+#   $ nmcli general logging level TRACE domains ALL
+# However, usually it's cleaner to enable debug logging
+# in the configuration and restart NetworkManager so that
+# debug logging is enabled from the start.
+#
+# You will find the logfiles in syslog, for example via
+#   $ journalctl -u NetworkManager
+#
+# Please post full logfiles for bug reports without pre-filtering or truncation.
+# Also, for debugging the entire `journalctl` output can be interesting. Don't
+# limit unnecessarily with `journalctl -u`. Exceptions are if you are worried
+# about private data. Check before posting logfiles!
+#
+# Note that debug logging of NetworkManager can be quite verbose. Some messages
+# might be rate-limited by the logging daemon (see RateLimitIntervalSec, RateLimitBurst
+# in man journald.conf). Please disable rate-limiting before collecting debug logs!
+#
+#level=TRACE
+#domains=ALL

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_alinux2023.rb
@@ -1,0 +1,38 @@
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :dns_domain, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_dns_domain_common'
+use 'partial/_dns_domain_redhat'
+
+# Configure custom dns domain (only if defined) by appending the Route53 domain created within the cluster
+# ($CLUSTER_NAME.pcluster) and be listed as a "search" domain in the resolv.conf file.
+action :configure do
+  return if on_docker?
+
+  # On RHEL8 dhclient is not enabled by default
+  # Put pcluster version of NetworkManager.conf in place
+  # dhcp = dhclient needs to be added under [main] section to enable dhclient
+  # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/networking_considerations-in-adopting-rhel-8#dhcp_plugin_networking
+  cookbook_file 'NetworkManager.conf' do
+    path '/etc/NetworkManager/NetworkManager.conf'
+    source 'dns_domain/NetworkManager.conf'
+    cookbook 'aws-parallelcluster-slurm'
+    user 'root'
+    group 'root'
+    mode '0644'
+  end
+
+  action_update_search_domain
+  network_service 'Restart network service'
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/jwt_dependencies/jwt_dependencies_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/jwt_dependencies/jwt_dependencies_alinux2023.rb
@@ -1,0 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :jwt_dependencies, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_jwt_dependencies_common'

--- a/cookbooks/aws-parallelcluster-slurm/resources/munge/munge_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/munge/munge_alinux2023.rb
@@ -1,0 +1,20 @@
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :munge, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_munge_actions'
+use 'partial/_munge_rhel'
+
+def munge_libdir
+  '/usr/lib64'
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/mysql_client_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/mysql_client_alinux2023.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :mysql_client, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_common'
+use 'partial/_setup_rhel_based'

--- a/cookbooks/aws-parallelcluster-slurm/resources/slurm_dependencies/slurm_dependencies_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/slurm_dependencies/slurm_dependencies_alinux2023.rb
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :slurm_dependencies, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_slurm_dependencies_common'
+
+def dependencies
+  %w(json-c-devel http-parser-devel perl-Switch lua-devel)
+end

--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -101,6 +101,36 @@ platforms:
     attributes:
       cluster:
         base_os: alinux2
+  - name: alinux-2023  # We are adding a "-" in the name to avoid having alinux2 as prefix of alinux2023 and be able to distinguish them on Inspec
+    driver_plugin: ec2
+    driver:
+      <% if ENV['KITCHEN_ALINUX2023_AMI'] %>
+      # Use the Alinux 2023 AMI most similar to the base AMI used to build the ParallelCluster image
+      image_id: <%= ENV['KITCHEN_ALINUX2023_AMI'] %>
+      <% else %>
+      image_search:
+        name: <% if ENV['KITCHEN_PHASE']=='install' %>al2023-ami-2023*<% else %><%= pcluster_prefix %>-alinux2023-hvm-*<% end %>
+        architecture: <%= ENV['KITCHEN_ARCHITECTURE'] %>
+      <% end %>
+      block_device_mappings:
+        - device_name: /dev/xvda
+          ebs:
+            volume_size: <% if (ENV['KITCHEN_VOLUME_SIZE'] || '') == '' %> 35 <% else %> <%= ENV['KITCHEN_VOLUME_SIZE'] %> <% end %>
+            volume_type: gp3
+            delete_on_termination: true
+      <% %w(a b c d e f g h i j k l m n o p q r s t u v w x).each_with_index do | c, i | %>
+        - device_name: /dev/xvdb<%= c %>
+          virtual_name: ephemeral<%= i %>
+      <% end %>
+    transport:
+      username: ec2-user
+    attributes:
+      cluster:
+        base_os: alinux2023
+    provisioner:
+      # Package for AL2023 is not available in the default path
+      download_url: http://downloads.cinc.sh/files/stable/cinc/17.2.29/el/8/cinc-17.2.29-1.el8.x86_64.rpm
+      #download_url: http://downloads.cinc.sh/files/stable/cinc/17.2.29/el/8/cinc-17.2.29-1.el8.aarch64.rpm
   - name: rhel8
     driver_plugin: ec2
     driver:

--- a/kitchen/hooks/alinux2023/pre_converge.sh
+++ b/kitchen/hooks/alinux2023/pre_converge.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -n "${KITCHEN_INSTANCE_HOSTNAME}" ]; then
+    export KITCHEN_EC2_USER='ec2-user'
+    echo "Install libxcrypt-compat package by using SSH key: ${KITCHEN_SSH_KEY_PATH}"
+
+    KITCHEN_EC2_INSTANCE_ID=$(ssh -o StrictHostKeyChecking=no -i "${KITCHEN_SSH_KEY_PATH}" \
+      "${KITCHEN_EC2_USER}@${KITCHEN_INSTANCE_HOSTNAME}" 'sudo yum install -y libxcrypt-compat')
+fi


### PR DESCRIPTION
### Description of changes

Used new utility `os-resources.py` introduced as part of https://github.com/aws/aws-parallelcluster-cookbook/pull/2328 to create new resources for alinux2023, starting from redhat8 resources.

Relevant changes to the code:
* os_type --> Replaced rhel with alinux
* Tried to fix CloudWatch agent setup by changing `platform_url_component` to point to the same of rhel (not sure if it's correct)
* Copied network setup templates from redhat folders
* Added alinux2023 to pcluster_dcv_connect.sh script

Removed redhat_on_docker condition from:
* stunnel
* system_authentication
* efa

TODO:
* efa -> check efa_supported? condition and log messages
* lustre -> check version condition and log messages
* install_packages --> Removed postgresql packages
* Enable repository needed by hwloc-devel blas-devel libedit-devel and glibc-static packages

### Tests

* Added Alinux2023 to ec2 kitchen configuration files. Copied from rhel8 with minor changes:
  * AMI name prefix took from EC2 Amazon Linux official AMI
  * I called the suite `alinux-2023`, with an "-" in the name to avoid having alinux2 as prefix of alinux-2023 and be able to distinguish them on Inspec runs.
* Created new `pre_converge` hook to install libxcrypt-compat package, required to install Chef, leveraging the work done with https://github.com/aws/aws-parallelcluster-cookbook/pull/2342
* I had to pass a custom `provisioner/download_url` for cinc because package for AL2023 is not available in the default path.
* The validated resources are:
  * nvidia_driver
  * arm_Pl
  * c_states
  * stunnel
  * build_tools
  * chrony
  * modules
  * munge
  * dns_domain (install only)
  * jwt_dependencies
  * nfs (install only)
  * raid (install only)
  * system_authentication (install only)
  * efs (install only)

TODO:
* Add Alinux2023 to GitHub actions
* Add new os to kitchen.docker.yml config file (search for `kernel_release` version from an EC2 instance)
* Fix Inspec and ChefSpec tests conditions

### References
* https://hub.docker.com/_/amazonlinux
* https://github.com/test-kitchen/kitchen-ec2/tree/main/lib/kitchen/driver/aws/standard_platform

Known issues/FE:
* https://github.com/amazonlinux/amazon-linux-2023/issues/47
* https://github.com/amazonlinux/amazon-linux-2023/issues/146
* https://github.com/amazonlinux/amazon-linux-2023/issues/168
* https://github.com/amazonlinux/amazon-linux-2023/issues/309
* https://github.com/amazonlinux/amazon-linux-2023/issues/316
