### PR TITLE
Remove PostgreSQL packages

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_amazon2.rb
@@ -25,8 +25,7 @@ def default_packages
   %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
      libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
      httpd boost-devel system-lsb mlocate atlas-devel glibc-static iproute
-     libffi-devel dkms libedit-devel postgresql-devel postgresql-server
-     sendmail cmake byacc libglvnd-devel libgcrypt-devel libevent-devel
+     libffi-devel dkms libedit-devel sendmail cmake byacc libglvnd-devel libgcrypt-devel libevent-devel
      libxml2-devel perl-devel tar gzip bison flex gcc gcc-c++ patch
      rpm-build rpm-sign system-rpm-config cscope ctags diffstat doxygen elfutils
      gcc-gfortran git indent intltool patchutils rcs subversion swig systemtap curl

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_centos7.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_centos7.rb
@@ -26,7 +26,7 @@ def default_packages
      libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
      httpd boost-devel redhat-lsb mlocate R atlas-devel
      blas-devel libffi-devel dkms libedit-devel jq
-     libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
+     libical-devel sendmail libxml2-devel libglvnd-devel
      python python-pip libssh2-devel libgcrypt-devel libevent-devel glibc-static bind-utils
      iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
      coreutils moreutils curl environment-modules bzip2)

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_redhat8.rb
@@ -27,7 +27,7 @@ def default_packages
      libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
      httpd boost-devel redhat-lsb mlocate R atlas-devel
      blas-devel libffi-devel dkms libedit-devel jq
-     libical-devel postgresql-devel postgresql-server sendmail libxml2-devel libglvnd-devel
+     libical-devel sendmail libxml2-devel libglvnd-devel
      python2 python2-pip libgcrypt-devel libevent-devel glibc-static bind-utils
      iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock
      coreutils moreutils curl environment-modules gcc gcc-c++ bzip2)


### PR DESCRIPTION
The PostgreSQL packages have been added long time ago to support _"PBSPro on RHEL based OSes"_. 
Since PBSPro is not supported anymore we can safely remove the packages.

### References

https://github.com/aws/aws-parallelcluster-cookbook/commit/8d96814c7050b067c91dc3342d05710ff14c5cc9

