### PR TITLE
[develop] Adapt base recipes to configure LoginNodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Allow to override aws-parallelcluster-node package at cluster creation and update time (only on the head node during update).
   Useful for development purposes only.
 - Avoid to start NFS server on compute nodes.
+- Add support for Login Nodes.
 
 **CHANGES**
 - Assign Slurm dynamic nodes a priority (weight) of 1000 by default. This allows Slurm to prioritize idle static nodes over idle dynamic ones.

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/config/update_computefleet_status.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/config/update_computefleet_status.rb
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 unless node['cluster']['scheduler'] == 'awsbatch'
-  load_cluster_config
+  case node['cluster']['node_type']
+  when 'HeadNode'
+    load_cluster_config(node['cluster']['cluster_config_path'])
+  else
+    raise "node_type must be HeadNode"
+  end
 end
 
 include_recipe 'aws-parallelcluster-slurm::update_computefleet_status' if node['cluster']['scheduler'] == 'slurm'

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -52,5 +52,6 @@ default['cluster']['scheduler_queue_name'] = nil
 default['cluster']['head_node_home_path'] = '/home'
 default['cluster']['shared_dir_compute'] = node['cluster']['shared_dir']
 default['cluster']['shared_dir_head'] = node['cluster']['shared_dir']
+default['cluster']['shared_dir_login'] = node['cluster']['shared_login_nodes_dir']
 
 default['cluster']['head_node_private_ip'] = nil

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -52,6 +52,6 @@ default['cluster']['scheduler_queue_name'] = nil
 default['cluster']['head_node_home_path'] = '/home'
 default['cluster']['shared_dir_compute'] = node['cluster']['shared_dir']
 default['cluster']['shared_dir_head'] = node['cluster']['shared_dir']
-default['cluster']['shared_dir_login'] = node['cluster']['shared_login_nodes_dir']
+default['cluster']['shared_dir_login'] = node['cluster']['shared_dir_login_nodes']
 
 default['cluster']['head_node_private_ip'] = nil

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/write_cloudwatch_agent_json.py
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/write_cloudwatch_agent_json.py
@@ -26,7 +26,7 @@ def parse_args():
     parser.add_argument(
         "--node-role",
         required=True,
-        choices=["HeadNode", "ComputeFleet"],
+        choices=["HeadNode", "ComputeFleet", "LoginNode"],
         help="Role this node plays in the cluster " "(i.e., is it a compute node or the head node?)",
     )
     parser.add_argument("--scheduler", required=True, choices=["slurm", "awsbatch"], help="Scheduler")

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -477,13 +477,28 @@ suites:
       - recipe[aws-parallelcluster-environment::raid]
     verifier:
       controls:
-        - raid_compute
+        - raid_compute_and_login
     attributes:
       dependencies:
         - resource:nfs
         - recipe:aws-parallelcluster-environment::mock_compute_raid
       cluster:
         node_type: ComputeFleet
+        raid_shared_dir: raid1
+        head_node_private_ip: '127.0.0.1'
+  - name: raid_login
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-environment::raid]
+    verifier:
+      controls:
+        - raid_compute_and_login
+    attributes:
+      dependencies:
+        - resource:nfs
+        - recipe:aws-parallelcluster-environment::mock_compute_raid
+      cluster:
+        node_type: LoginNode
         raid_shared_dir: raid1
         head_node_private_ip: '127.0.0.1'
   - name: shared_storages_compute

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -338,13 +338,28 @@ suites:
       - recipe[aws-parallelcluster-environment::ebs]
     verifier:
       controls:
-        - ebs_compute
+        - ebs_compute_and_login
     attributes:
       dependencies:
         - resource:nfs
         - recipe:aws-parallelcluster-environment::mock_compute_ebs
       cluster:
         node_type: ComputeFleet
+        ebs_shared_dirs: ebs1,ebs2
+        head_node_private_ip: '127.0.0.1'
+  - name: ebs_login
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-environment::ebs]
+    verifier:
+      controls:
+        - ebs_compute_and_login
+    attributes:
+      dependencies:
+        - resource:nfs
+        - recipe:aws-parallelcluster-environment::mock_compute_ebs
+      cluster:
+        node_type: LoginNode
         ebs_shared_dirs: ebs1,ebs2
         head_node_private_ip: '127.0.0.1'
   - name: ephemeral_drives_mounted

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -454,13 +454,14 @@ suites:
         scheduler: slurm
         head_node_imds_secured: 'true'
         head_node_imds_allowed_users: ['root', 'nobody']
-  - name: mount_shared
+  - name: mount_shared_compute
     run_list:
       - recipe[aws-parallelcluster-tests::setup]
       - recipe[aws-parallelcluster-environment::mount_shared]
     verifier:
       controls:
-        - mount_shared
+        - mount_home
+        - mount_shared_compute
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-platform::directories
@@ -468,6 +469,24 @@ suites:
         - recipe:aws-parallelcluster-environment::mock_export_directories
       cluster:
         node_type: 'ComputeFleet'
+        head_node_private_ip: '127.0.0.1'
+        head_node_home_path: '/fake_headnode_home'
+        shared_dir_head: '/fake_headnode_shared'
+  - name: mount_shared_login
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-environment::mount_shared]
+    verifier:
+      controls:
+        - mount_home
+        - mount_shared_login
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-platform::directories
+        - resource:nfs
+        - recipe:aws-parallelcluster-environment::mock_export_directories
+      cluster:
+        node_type: 'LoginNode'
         head_node_private_ip: '127.0.0.1'
         head_node_home_path: '/fake_headnode_home'
         shared_dir_head: '/fake_headnode_shared'

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -507,11 +507,25 @@ suites:
       - recipe[aws-parallelcluster-environment::shared_storages]
     verifier:
       controls:
-        - shared_storages_compute
+        - shared_storages_compute_and_login
     attributes:
       dependencies:
         - resource:nfs
         - recipe:aws-parallelcluster-environment::mock_compute_shared_storages
       cluster:
         node_type: ComputeFleet
+        head_node_private_ip: '127.0.0.1'
+  - name: shared_storages_login
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-environment::shared_storages]
+    verifier:
+      controls:
+        - shared_storages_compute_and_login
+    attributes:
+      dependencies:
+        - resource:nfs
+        - recipe:aws-parallelcluster-environment::mock_compute_shared_storages
+      cluster:
+        node_type: LoginNode
         head_node_private_ip: '127.0.0.1'

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/ebs.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/ebs.rb
@@ -21,7 +21,7 @@ when 'HeadNode'
     not_if { node['cluster']['ebs_shared_dirs'].split(',').empty? }
   end unless on_docker?
 
-when 'ComputeFleet'
+when 'ComputeFleet', 'LoginNode'
   # Parse shared directory info and turn into an array
   shared_dir_array = node['cluster']['ebs_shared_dirs'].split(',')
 
@@ -39,5 +39,5 @@ when 'ComputeFleet'
   end
 
 else
-  raise "node_type must be HeadNode or ComputeFleet"
+  raise "node_type must be HeadNode, LoginNode or ComputeFleet"
 end

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/mount_home.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/mount_home.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+volume "mount /home" do
+  action :mount
+  shared_dir '/home'
+  device(lazy { "#{node['cluster']['head_node_private_ip']}:#{node['cluster']['head_node_home_path']}" })
+  fstype 'nfs'
+  options node['cluster']['nfs']['hard_mount_options']
+  retries 10
+  retry_delay 6
+end

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/mount_shared.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/mount_shared.rb
@@ -15,16 +15,7 @@ return if on_docker?
 
 case node['cluster']['node_type']
 when 'ComputeFleet'
-  # TODO Extract as subrecipe
-  volume "mount /home" do
-    action :mount
-    shared_dir '/home'
-    device(lazy { "#{node['cluster']['head_node_private_ip']}:#{node['cluster']['head_node_home_path']}" })
-    fstype 'nfs'
-    options node['cluster']['nfs']['hard_mount_options']
-    retries 10
-    retry_delay 6
-  end
+  include_recipe 'aws-parallelcluster-environment::mount_home'
 
   # Mount /opt/parallelcluster/shared over NFS
   volume "mount #{node['cluster']['shared_dir_compute']}" do
@@ -38,16 +29,7 @@ when 'ComputeFleet'
   end
 
 when 'LoginNode'
-  # TODO Extract as subrecipe
-  volume "mount /home" do
-    action :mount
-    shared_dir '/home'
-    device(lazy { "#{node['cluster']['head_node_private_ip']}:#{node['cluster']['head_node_home_path']}" })
-    fstype 'nfs'
-    options node['cluster']['nfs']['hard_mount_options']
-    retries 10
-    retry_delay 6
-  end
+  include_recipe 'aws-parallelcluster-environment::mount_home'
 
   # Mount /opt/parallelcluster/shared_login_nodes over NFS
   volume "mount #{node['cluster']['shared_dir_login']}" do

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/mount_shared.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/mount_shared.rb
@@ -13,7 +13,9 @@
 
 return if on_docker?
 
-if node['cluster']['node_type'] == "ComputeFleet"
+case node['cluster']['node_type']
+when 'ComputeFleet'
+  # TODO Extract as subrecipe
   volume "mount /home" do
     action :mount
     shared_dir '/home'
@@ -34,4 +36,31 @@ if node['cluster']['node_type'] == "ComputeFleet"
     retries 10
     retry_delay 6
   end
+
+when 'LoginNode'
+  # TODO Extract as subrecipe
+  volume "mount /home" do
+    action :mount
+    shared_dir '/home'
+    device(lazy { "#{node['cluster']['head_node_private_ip']}:#{node['cluster']['head_node_home_path']}" })
+    fstype 'nfs'
+    options node['cluster']['nfs']['hard_mount_options']
+    retries 10
+    retry_delay 6
+  end
+
+  # Mount /opt/parallelcluster/shared_login_nodes over NFS
+  volume "mount #{node['cluster']['shared_dir_login']}" do
+    action :mount
+    shared_dir node['cluster']['shared_dir_login']
+    device(lazy { "#{node['cluster']['head_node_private_ip']}:#{node['cluster']['shared_dir_login']}" })
+    fstype 'nfs'
+    options node['cluster']['nfs']['hard_mount_options']
+    retries 10
+    retry_delay 6
+  end
+when 'HeadNode'
+  Chef::Log.info("Nothing to mount in the HeadNode")
+else
+  raise "node_type must be HeadNode, LoginNode or ComputeFleet"
 end

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/raid.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/raid.rb
@@ -26,7 +26,7 @@ when 'HeadNode'
     not_if { raid_shared_dir.empty? }
   end
 
-when 'ComputeFleet'
+when 'ComputeFleet', 'LoginNode'
   volume "mount raid volume over NFS" do
     action :mount
     shared_dir raid_shared_dir
@@ -38,5 +38,5 @@ when 'ComputeFleet'
   end
 else
 
-  raise "node_type must be HeadNode or ComputeFleet"
+  raise "node_type must be HeadNode, LoginNode or ComputeFleet"
 end

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/shared_storages.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/shared_storages.rb
@@ -28,6 +28,14 @@ when 'HeadNode'
     options ['no_root_squash']
   end unless on_docker?
 
+  # Export /opt/parallelcluster/shared_login_nodes
+  # TODO restrict this share to login nodes only
+  nfs_export node['cluster']['shared_login_nodes_dir'] do
+    network get_vpc_cidr_list
+    writeable true
+    options ['no_root_squash']
+  end unless on_docker?
+
   # Export /opt/intel if it exists
   nfs_export "/opt/intel" do
     network get_vpc_cidr_list
@@ -36,7 +44,7 @@ when 'HeadNode'
     only_if { ::File.directory?("/opt/intel") }
   end unless on_docker?
 
-when 'ComputeFleet'
+when 'ComputeFleet', 'LoginNode'
   # Mount /opt/intel over NFS
   exported_intel_dir = format_directory('/opt/intel')
   mount '/opt/intel' do

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
@@ -40,7 +40,7 @@ control 'tag:config_cloudwatch_configured' do
 
   describe file('/usr/local/bin/write_cloudwatch_agent_json.py') do
     it { should exist }
-    its('sha256sum') { should eq '4fc20cdb5f3e08f23192842bcf96a8e44bf269bf8d1b6121d225ecc999db433e' }
+    its('sha256sum') { should eq 'cf304d5c8fa3dd6b5866b28d4a866d5190d7282adeda3adbb39b8bed116ab30c' }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0755' }

--- a/cookbooks/aws-parallelcluster-environment/test/controls/ebs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/ebs_spec.rb
@@ -61,10 +61,10 @@ control 'ebs_unexported' do
   end
 end
 
-control 'ebs_compute' do
+control 'ebs_compute_and_login' do
   title 'Check the ebs configuration for compute node'
 
-  only_if { !os_properties.on_docker? && instance.compute_node? }
+  only_if { !os_properties.on_docker? && (instance.compute_node? or instance.login_node?) }
 
   describe 'Check that ebs dirs have been created and mounted'
   directories = %w(ebs1 ebs2)

--- a/cookbooks/aws-parallelcluster-environment/test/controls/mount_shared_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/mount_shared_spec.rb
@@ -9,18 +9,36 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'mount_shared' do
+control 'mount_home' do
   title 'Check if the home and the shared directories are mounted'
 
-  only_if { !os_properties.on_docker? && instance.compute_node? }
+  only_if { !os_properties.on_docker? && (instance.compute_node? or instance.login_node?) }
 
   describe mount('/home') do
     it { should be_mounted }
     its('type') { should eq 'nfs4' }
     its('options') { should include 'rw' }
   end
+end
+
+control 'mount_shared_compute' do
+  title 'Check if the home and the shared directories are mounted'
+
+  only_if { !os_properties.on_docker? && instance.compute_node? }
 
   describe mount('/opt/parallelcluster/shared') do
+    it { should be_mounted }
+    its('type') { should eq 'nfs4' }
+    its('options') { should include 'rw' }
+  end
+end
+
+control 'mount_shared_login' do
+  title 'Check if the home and the shared directories are mounted'
+
+  only_if { !os_properties.on_docker? && instance.login_node? }
+
+  describe mount('/opt/parallelcluster/shared_login_nodes') do
     it { should be_mounted }
     its('type') { should eq 'nfs4' }
     its('options') { should include 'rw' }

--- a/cookbooks/aws-parallelcluster-environment/test/controls/raid_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/raid_spec.rb
@@ -83,10 +83,10 @@ control 'raid_unexported' do
   end
 end
 
-control 'raid_compute' do
-  title 'Check the raid configuration for compute node'
+control 'raid_compute_and_login' do
+  title 'Check the raid configuration for compute node and login nodes'
 
-  only_if { !os_properties.on_docker? && instance.compute_node? }
+  only_if { !os_properties.on_docker? && (instance.compute_node? or instance.login_node?) }
 
   describe 'Check that raid dirs have been created and mounted'
   directories = %w(raid1)

--- a/cookbooks/aws-parallelcluster-environment/test/controls/raid_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/raid_spec.rb
@@ -100,11 +100,12 @@ control 'raid_compute' do
     end
 
     describe mount("/#{directory}") do
+      # The _netdev option is ignored in mount(8) by default. The options is used by initscripts only.
+      # It is not reported in /etc/mtab for raid volumes
       it { should be_mounted }
       its('device') { should eq "127.0.0.1:/#{directory}" }
       its('type') { should eq 'nfs4' }
       its('options') { should include 'hard' }
-      its('options') { should include '_netdev' }
       its('options') { should include 'noatime' }
     end
   end

--- a/cookbooks/aws-parallelcluster-environment/test/controls/shared_storages_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/shared_storages_spec.rb
@@ -9,10 +9,10 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'shared_storages_compute' do
+control 'shared_storages_compute_and_login' do
   title 'Check the shared storages configuration for compute node'
 
-  only_if { !os_properties.on_docker? && instance.compute_node? }
+  only_if { !os_properties.on_docker? && (instance.compute_node? or instance.login_node?) }
 
   describe 'Check that /opt/intel dir has been mounted'
   describe mount("/opt/intel") do

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
@@ -115,10 +115,21 @@ suites:
       - recipe[aws-parallelcluster-platform::cluster_user]
     verifier:
       controls:
-        - cluster_user_compute
+        - cluster_user_compute_and_login
     attributes:
       cluster:
         node_type: ComputeFleet
+        cluster_user: test_user
+  - name: cluster_user_login
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-platform::cluster_user]
+    verifier:
+      controls:
+        - cluster_user_compute_and_login
+    attributes:
+      cluster:
+        node_type: LoginNode
         cluster_user: test_user
   - name: cluster_user_head
     run_list:

--- a/cookbooks/aws-parallelcluster-platform/recipes/config/cluster_user.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/cluster_user.rb
@@ -50,7 +50,7 @@ when 'HeadNode'
     not_if { ::File.exist?("/home/#{node['cluster']['cluster_user']}/.ssh/known_hosts") }
   end
 
-when 'ComputeFleet'
+when 'ComputeFleet', 'LoginNode'
 
   # Setup cluster user
   user node['cluster']['cluster_user'] do
@@ -60,5 +60,5 @@ when 'ComputeFleet'
     shell '/bin/bash'
   end
 else
-  raise "node_type must be HeadNode or ComputeFleet"
+  raise "node_type must be HeadNode, LoginNode or ComputeFleet"
 end

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/cuda.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/cuda.rb
@@ -27,13 +27,15 @@ cuda_arch = arm_instance? ? 'linux_sbsa' : 'linux'
 cuda_url = "https://developer.download.nvidia.com/compute/cuda/#{cuda_complete_version}/local_installers/cuda_#{cuda_complete_version}_#{cuda_version_suffix}_#{cuda_arch}.run"
 cuda_samples_version = '11.8'
 cuda_samples_url = "https://github.com/NVIDIA/cuda-samples/archive/refs/tags/v#{cuda_samples_version}.tar.gz"
+tmp_cuda_run = '/tmp/cuda.run'
+tmp_cuda_sample_archive = '/tmp/cuda-sample.tar.gz'
 
 node.default['cluster']['nvidia']['cuda']['version'] = cuda_version
 node.default['cluster']['nvidia']['cuda_samples_version'] = cuda_samples_version
 node_attributes 'Save cuda and cuda samples versions for InSpec tests'
 
 # Get CUDA run file
-remote_file "/tmp/cuda.run" do
+remote_file tmp_cuda_run do
   source cuda_url
   mode '0755'
   retries 3
@@ -55,7 +57,7 @@ bash 'cuda.run advanced' do
 end
 
 # Get CUDA Sample Files
-remote_file "/tmp/cuda-sample.tar.gz" do
+remote_file tmp_cuda_sample_archive do
   source cuda_samples_url
   mode '0644'
   retries 3

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/directories.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/directories.rb
@@ -21,6 +21,7 @@ directory node['cluster']['scripts_dir']
 directory node['cluster']['license_dir']
 directory node['cluster']['configs_dir']
 directory node['cluster']['shared_dir']
+directory node['cluster']['shared_login_nodes_dir']
 
 # Create ParallelCluster log folder
 directory node['cluster']['log_base_dir'] do

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/directories.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/directories.rb
@@ -21,7 +21,7 @@ directory node['cluster']['scripts_dir']
 directory node['cluster']['license_dir']
 directory node['cluster']['configs_dir']
 directory node['cluster']['shared_dir']
-directory node['cluster']['shared_login_nodes_dir']
+directory node['cluster']['shared_dir_login_nodes']
 
 # Create ParallelCluster log folder
 directory node['cluster']['log_base_dir'] do

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
@@ -17,11 +17,13 @@ default_action :setup
 
 property :nvidia_driver_version, String
 
+tmp_nvidia_run = '/tmp/nvidia.run'
+
 action :setup do
   return unless nvidia_driver_enabled?
   return if on_docker?
 
-  remote_file "/tmp/nvidia.run" do
+  remote_file tmp_nvidia_run do
     source nvidia_driver_url
     mode '0755'
     retries 3

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 describe 'fetch_config:run' do
-  context "when running from kitchen" do
+  context "when running a HeadNode from kitchen" do
     cached(:cluster_config_path) { 'cluster_config_path' }
+    cached(:previous_cluster_config_path) { 'previous_cluster_config_path' }
     cached(:instance_types_data_path) { 'instance_types_data_path' }
     cached(:chef_run) do
       runner = ChefSpec::Runner.new(
@@ -10,7 +11,9 @@ describe 'fetch_config:run' do
       ) do |node|
         node.override['kitchen'] = true
         node.override['cluster']['cluster_config_path'] = cluster_config_path
+        node.override['cluster']['previous_cluster_config_path'] = previous_cluster_config_path
         node.override['cluster']['instance_types_data_path'] = instance_types_data_path
+        node.override['cluster']['node_type'] = 'HeadNode'
       end
       runner.converge_dsl do
         fetch_config 'run' do
@@ -29,4 +32,33 @@ describe 'fetch_config:run' do
         .with(source: "file://#{kitchen_instance_types_data_path}")
     end
   end
+
+  %w(ComputeFleet LoginNode).each do |node_type|
+    context "when running a #{node_type} from kitchen" do
+      cached(:cluster_config_path) { 'cluster_config_path' }
+      cached(:previous_cluster_config_path) { 'previous_cluster_config_path' }
+      cached(:instance_types_data_path) { 'instance_types_data_path' }
+      cached(:chef_run) do
+        runner = ChefSpec::Runner.new(
+          platform: 'ubuntu', step_into: %w(fetch_config)
+        ) do |node|
+          node.override['kitchen'] = true
+          node.override['cluster']['cluster_config_path'] = cluster_config_path
+          node.override['cluster']['login_cluster_config_path'] = cluster_config_path
+          node.override['cluster']['node_type'] = node_type
+        end
+        allow(File).to receive(:exist?).with(cluster_config_path).and_return(true)
+        runner.converge_dsl do
+          fetch_config 'run' do
+            action :run
+          end
+        end
+      end
+
+      it "reads config from shared folder" do
+        is_expected.to run_ruby_block("load cluster configuration")
+      end
+    end
+  end
+
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
@@ -60,5 +60,4 @@ describe 'fetch_config:run' do
       end
     end
   end
-
 end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/cluster_user_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/cluster_user_spec.rb
@@ -20,10 +20,10 @@ control 'tag:config_cluster_user' do
   end unless os_properties.redhat_on_docker?
 end
 
-control 'cluster_user_compute' do
-  title 'Check the cluster user configuration for compute node'
+control 'cluster_user_compute_and_login' do
+  title 'Check the cluster user configuration for compute node and login nodes'
 
-  only_if { !os_properties.on_docker? && instance.compute_node? }
+  only_if { !os_properties.on_docker? && (instance.compute_node? or instance.login_node?)}
 
   describe 'Check that cluster user exist'
   describe user('test_user') do

--- a/cookbooks/aws-parallelcluster-platform/test/controls/cluster_user_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/cluster_user_spec.rb
@@ -23,7 +23,7 @@ end
 control 'cluster_user_compute_and_login' do
   title 'Check the cluster user configuration for compute node and login nodes'
 
-  only_if { !os_properties.on_docker? && (instance.compute_node? or instance.login_node?)}
+  only_if { !os_properties.on_docker? && (instance.compute_node? or instance.login_node?) }
 
   describe 'Check that cluster user exist'
   describe user('test_user') do

--- a/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
@@ -4,7 +4,7 @@ default['cluster']['scripts_dir'] = "#{node['cluster']['base_dir']}/scripts"
 default['cluster']['license_dir'] = "#{node['cluster']['base_dir']}/licenses"
 default['cluster']['configs_dir'] = "#{node['cluster']['base_dir']}/configs"
 default['cluster']['shared_dir'] = "#{node['cluster']['base_dir']}/shared"
-default['cluster']['shared_login_nodes_dir'] = "#{node['cluster']['base_dir']}/shared_login_nodes"
+default['cluster']['shared_dir_login_nodes'] = "#{node['cluster']['base_dir']}/shared_login_nodes"
 default['cluster']['log_base_dir'] = '/var/log/parallelcluster'
 default['cluster']['etc_dir'] = '/etc/parallelcluster'
 
@@ -20,6 +20,8 @@ default['cluster']['system_pyenv_root'] = "#{node['cluster']['base_dir']}/pyenv"
 
 default['cluster']['cluster_config_path'] = "#{node['cluster']['shared_dir']}/cluster-config.yaml"
 default['cluster']['previous_cluster_config_path'] = "#{node['cluster']['shared_dir']}/previous-cluster-config.yaml"
+default['cluster']['login_cluster_config_path'] = "#{node['cluster']['shared_dir_login_nodes']}/cluster-config.yaml"
+default['cluster']['login_previous_cluster_config_path'] = "#{node['cluster']['shared_dir_login_nodes']}/previous-cluster-config.yaml"
 default['cluster']['change_set_path'] = "#{node['cluster']['shared_dir']}/change-set.json"
 default['cluster']['instance_types_data_path'] = "#{node['cluster']['shared_dir']}/instance-types-data.json"
 

--- a/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
@@ -4,6 +4,7 @@ default['cluster']['scripts_dir'] = "#{node['cluster']['base_dir']}/scripts"
 default['cluster']['license_dir'] = "#{node['cluster']['base_dir']}/licenses"
 default['cluster']['configs_dir'] = "#{node['cluster']['base_dir']}/configs"
 default['cluster']['shared_dir'] = "#{node['cluster']['base_dir']}/shared"
+default['cluster']['shared_login_nodes_dir'] = "#{node['cluster']['base_dir']}/shared_login_nodes"
 default['cluster']['log_base_dir'] = '/var/log/parallelcluster'
 default['cluster']['etc_dir'] = '/etc/parallelcluster'
 

--- a/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
@@ -61,11 +61,12 @@ end
 #
 # load cluster configuration file into node object
 #
-def load_cluster_config
+def load_cluster_config(config_path)
   ruby_block "load cluster configuration" do
     block do
       require 'yaml'
-      config = YAML.safe_load(File.read(node['cluster']['cluster_config_path']))
+      Chef::Log.info("Reading Config from #{config_path}")
+      config = YAML.safe_load(File.read(config_path))
       Chef::Log.debug("Config read #{config}")
       node.override['cluster']['config'].merge! config
     end

--- a/cookbooks/aws-parallelcluster-shared/test/libraries/instance.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/libraries/instance.rb
@@ -16,6 +16,10 @@ class Instance < Inspec.resource(1)
     inspec.node['cluster']['node_type'] == 'ComputeFleet'
   end
 
+  def login_node?
+    inspec.node['cluster']['node_type'] == 'LoginNode'
+  end
+
   def dcgmi_gpu_accel_supported?
     unsupported_gpu_accel_list = ["g2."]
     !inspec.node['ec2']['instance_type'].start_with?(*unsupported_gpu_accel_list)

--- a/cookbooks/aws-parallelcluster-slurm/kitchen.slurm-config.yml
+++ b/cookbooks/aws-parallelcluster-slurm/kitchen.slurm-config.yml
@@ -160,3 +160,17 @@ suites:
         local_hostname: dokken
         local_ipv4: 172.17.1.15
       ipaddress: 172.17.1.15
+  - name: mount_slurm_dir
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-slurm::mount_slurm_dir]
+    verifier:
+      controls:
+        - mount_slurm_dir
+    attributes:
+      dependencies:
+        - resource:nfs
+        - recipe:aws-parallelcluster-slurm::mock_slurm_dir
+      cluster:
+        node_type: ComputeFleet
+        head_node_private_ip: '127.0.0.1'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config.rb
@@ -22,6 +22,8 @@ when 'HeadNode'
   include_recipe 'aws-parallelcluster-slurm::config_head_node'
 when 'ComputeFleet'
   include_recipe 'aws-parallelcluster-slurm::config_compute'
+when 'LoginNode'
+  include_recipe 'aws-parallelcluster-slurm::config_login'
 else
   raise "node_type must be HeadNode or ComputeFleet"
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_compute.rb
@@ -24,16 +24,7 @@ directory '/var/spool/slurmd' do
   mode '0700'
 end
 
-# Mount /opt/slurm over NFS
-# Computemgtd config is under /opt/slurm/etc/pcluster; all compute nodes share a config
-mount "#{node['cluster']['slurm']['install_dir']}" do
-  device(lazy { "#{node['cluster']['head_node_private_ip']}:#{node['cluster']['slurm']['install_dir']}" })
-  fstype "nfs"
-  options node['cluster']['nfs']['hard_mount_options']
-  action %i(mount enable)
-  retries 10
-  retry_delay 6
-end
+include_recipe 'aws-parallelcluster-slurm::mount_slurm_dir'
 
 # Check to see if is GPU instance with Nvidia installed
 Chef::Log.warn("GPU instance but no Nvidia drivers found") if graphic_instance? && !nvidia_installed?

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_login.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_login.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-slurm
+# Recipe:: config_compute
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: rename, find a better name that include login nodes
+setup_munge_compute_node
+
+# TODO: double-check if it may be useful in Login Nodes
+#  Create directory configured as SlurmdSpoolDir
+# directory '/var/spool/slurmd' do
+#   user node['cluster']['slurm']['user']
+#   group node['cluster']['slurm']['group']
+#   mode '0700'
+# end
+
+# Mount /opt/slurm over NFS
+mount "#{node['cluster']['slurm']['install_dir']}" do
+  device(lazy { "#{node['cluster']['head_node_private_ip']}:#{node['cluster']['slurm']['install_dir']}" })
+  fstype "nfs"
+  options node['cluster']['nfs']['hard_mount_options']
+  action %i(mount enable)
+  retries 10
+  retry_delay 6
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/mount_slurm_dir.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/mount_slurm_dir.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-#
-# Cookbook:: aws-parallelcluster-slurm
-# Recipe:: config_compute
-#
 # Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
@@ -15,7 +11,13 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: rename, find a better name that include login nodes
-setup_munge_compute_node
-
-include_recipe 'aws-parallelcluster-slurm::mount_slurm_dir'
+# Mount /opt/slurm over NFS
+# Computemgtd config is under /opt/slurm/etc/pcluster; all compute nodes share a config
+mount "#{node['cluster']['slurm']['install_dir']}" do
+  device(lazy { "#{node['cluster']['head_node_private_ip']}:#{node['cluster']['slurm']['install_dir']}" })
+  fstype "nfs"
+  options node['cluster']['nfs']['hard_mount_options']
+  action %i(mount enable)
+  retries 10
+  retry_delay 6
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/test/mock_munge_key.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/test/mock_munge_key.rb
@@ -1,0 +1,10 @@
+munge_user_dir = "/home/#{node['cluster']['cluster_user']}/.munge"
+directory munge_user_dir do
+  mode '1777'
+end
+
+file "#{munge_user_dir}/.munge.key" do
+  content 'munge-key'
+  owner node['cluster']['munge']['user']
+  group node['cluster']['munge']['group']
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/test/mock_slurm_dir.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/test/mock_slurm_dir.rb
@@ -1,0 +1,12 @@
+return if on_docker?
+
+slurm_install_dir = '/opt/slurm'
+directory slurm_install_dir do
+  mode '1777'
+end
+
+nfs_export slurm_install_dir do
+  network '127.0.0.1/32'
+  writeable true
+  options ['no_root_squash']
+end

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/mount_slurm_dir_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/mount_slurm_dir_spec.rb
@@ -1,0 +1,22 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'mount_slurm_dir' do
+  title 'Check if the slurm install dir is mounted'
+
+  only_if { !os_properties.on_docker? && (instance.compute_node? or instance.login_node?) }
+
+  describe mount('/opt/slurm') do
+    it { should be_mounted }
+    its('type') { should eq 'nfs4' }
+    its('options') { should include 'rw' }
+  end
+end


### PR DESCRIPTION
### Description of changes
Each one of the following has a dedicated commit to make it easier to understand the PR

* Small preliminary fixes
    * Define helper method to identify LoginNodes 
    * Remove _netdev check from raid volumes test
    * Add LoginNode role in CloudWatch agent configuration 

* Cluster User
    * Configure cluster user in LoginNodes
    * Test cluster user configuration in LoginNodes 

* EBS volumes
    * Mount EBS volumes in LoginNodes
    * Test ebs volume configuration in LoginNodes 

* raid volumes
    * Mount raid volumes in LoginNodes
    * Test raid volume configuration in LoginNodes 

* dedicated shared folder for login nodes
    * Create shared_login_nodes directory 
    * Export shared_login_nodes directory 
    * Test /opt/intel folder configuration in LoginNodes 

* mounting of home and shared folders
    * Mount home and shared_login_nodes directories in login nodes 
    * Extract mount /home as subrecipe 
    * Test shared volumes configuration in LoginNodes 

* Slurm related configs
    * Setup munge and mount /opt/slurm in login nodes 
    * Validate that /opt/slurm is mounted in Compute and Login nodes 

Note the above test should be extended to validate also the munge configuration recipe. I did an attempt to create a mock environment for the test but the munge service still wasn't starting. Since the recipe is working (as my manual tests showed) I considered out-of-scope for this PR spending further time on this mock environment.

* Fixes in the logic used to retrieve the cluster config
    * Define current and previous config path for LoginNodes 
    * Ensure cluster config is retrieved only by the HeadNode 
    * LoadClusterConfig take the config path as parameter 

### Tests
* Most of the changes were successfully tested with unit tests
* I also manually launched a cluster with these changes in the recipes plus others required in the parallelcluster package and validated that I was able to log into a login node and have basic interactions with slurm (querying the cluster config, submitting a job, querying job status and job result)

### References
* [Changes in parallelcluster package](https://github.com/aws/aws-parallelcluster/pull/5446).

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
