### PR TITLE
[develop] Replace nvidia-persistenced with parallelcluster_nvidia service

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/libraries/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-platform/libraries/nvidia.rb
@@ -8,3 +8,13 @@ end
 def graphic_instance?
   !Mixlib::ShellOut.new("lspci | grep -i -o 'NVIDIA'").run_command.stdout.strip.empty?
 end
+
+#
+# Check if a process is running
+#
+def is_process_running(process_name)
+  ps = Mixlib::ShellOut.new("ps aux | grep '#{process_name}' | egrep -v \"grep .*#{process_name}\"")
+  ps.run_command
+
+  !ps.stdout.strip.empty?
+end

--- a/cookbooks/aws-parallelcluster-platform/templates/nvidia/parallelcluster_nvidia_service.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/nvidia/parallelcluster_nvidia_service.erb
@@ -1,0 +1,20 @@
+# This systemd service file, designed to trigger the creation device block file /dev/nvidia0
+# The service start nvidia-persistenced if it is not already started or execute the command nvidia-smi.
+
+[Unit]
+Description=ParallelCluster NVIDIA Daemon
+Wants=syslog.target
+
+[Service]
+<% if @is_nvidia_persistenced_running -%>
+  Type=simple
+  ExecStart=/usr/bin/nvidia-smi
+  RemainAfterExit=yes
+<% else %>
+  Type=forking
+  ExecStart=/usr/bin/nvidia-persistenced --user root
+  ExecStopPost=/bin/rm -rf /var/run/nvidia-persistenced
+<% end %>
+
+[Install]
+WantedBy=multi-user.target

--- a/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_spec.rb
@@ -56,7 +56,7 @@ control 'tag:config_nvidia_uvm_and_persistenced_on_graphic_instances' do
     its('content') { should include("uvm") }
   end
 
-  describe service('nvidia-persistenced') do
+  describe service('parallelcluster_nvidia') do
     it { should be_enabled }
     it { should be_running }
   end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurmd_systemd_service.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurmd_systemd_service.rb
@@ -24,7 +24,7 @@ template '/etc/systemd/system/slurmd.service' do
   action :create
 end
 
-# Add systemd dependency between slurmd and nvidia-persistenced for NVIDIA GPU nodes
+# Add systemd dependency between slurmd and parallelcluster_nvidia for NVIDIA GPU nodes
 if graphic_instance? && nvidia_installed?
   directory '/etc/systemd/system/slurmd.service.d' do
     user 'root'

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurmd_nvidia_persistenced.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/compute/slurmd_nvidia_persistenced.conf.erb
@@ -1,3 +1,3 @@
 [Unit]
-After=nvidia-persistenced.service
-Wants=nvidia-persistenced.service
+After=parallelcluster_nvidia.service
+Wants=parallelcluster_nvidia.service

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/config_slurmd_systemd_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/config_slurmd_systemd_service_spec.rb
@@ -41,12 +41,12 @@ control 'tag:config_systemd_slurmd_service_nvidia_gpu_nodes' do
 
   describe 'Check slurmd systemd "after" dependencies'
   describe command('systemctl list-dependencies --after --plain slurmd.service') do
-    its('stdout') { should include "nvidia-persistenced.service" }
+    its('stdout') { should include "parallelcluster_nvidia.service" }
   end
 
   describe 'Check slurmd systemd requirement dependencies'
   describe command('systemctl list-dependencies --plain slurmd.service') do
-    its('stdout') { should include "nvidia-persistenced.service" }
+    its('stdout') { should include "parallelcluster_nvidia.service" }
   end
 
   describe 'Check that slurmd systemd drop-in configuration exists'


### PR DESCRIPTION
`parallelcluster_nvidia` service ensures the creation of the block devices `/dev/nvidia0` and it is needed by the `slurmd` service.

`parallelcluster_nvidia` starts the `nvidia-persistenced` or runs `nvidia-smi` to avoid race condition with other services and avoids conflicts when using DLAMI with a gpu instance.

### Tests
* Modified ChefSpec to verify new changes.
* `bash kitchen.ec2.sh platform-config test nvidia-uvm-alinux2`

### References
Backport of: https://github.com/aws/aws-parallelcluster-cookbook/pull/2341

