### PR TITLE
Configure partition to run jobs on nodes exclusively allocated based on the JobExclusiveAllocation parameter

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/config_renderer.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/config_renderer.py
@@ -189,7 +189,7 @@ class QueueRenderer:
             partition += " Default=YES"
 
         if self.job_exclusive_allocation:
-            partition += " OverSubscribe=NO"
+            partition += " OverSubscribe=EXCLUSIVE"
 
         partition += f"{self._custom_settings()}"
         return partition

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_with_job_exc_alloc/expected_outputs/pcluster/slurm_parallelcluster_queue_jls_enabled_partition.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_with_job_exc_alloc/expected_outputs/pcluster/slurm_parallelcluster_queue_jls_enabled_partition.conf
@@ -3,4 +3,4 @@
 NodeName=queue_jls_enabled-dy-cr_1-[1-10] CPUs=4 RealMemory=7296 State=CLOUD Feature=dynamic,c4.xlarge,cr_1 Weight=1000
 
 NodeSet=queue_jls_enabled_nodes Nodes=queue_jls_enabled-dy-cr_1-[1-10]
-PartitionName=queue_jls_enabled Nodes=queue_jls_enabled_nodes MaxTime=INFINITE State=UP Default=YES OverSubscribe=NO
+PartitionName=queue_jls_enabled Nodes=queue_jls_enabled_nodes MaxTime=INFINITE State=UP Default=YES OverSubscribe=EXCLUSIVE


### PR DESCRIPTION
### Description of changes
* Set [OverSubscribe/EXCLUSIVE](https://slurm.schedmd.com/slurm.conf.html#OPT_EXCLUSIVE) to partitions with `JobExclusiveAllocation` enabled
* This will ensure that jobs targeting nodes in the partition are allocated exclusively to them at any given time.

### Tests
* Unit tests to confirm slurm.conf is configured as expected
* Manual tests in a cluster:


scontrol show partitions

```
PartitionName=queue-0
   ...
   PriorityJobFactor=1 PriorityTier=1 RootOnly=NO ReqResv=NO OverSubscribe=EXCLUSIVE
   ...

PartitionName=queue-1
   ...
   MaxNodes=UNLIMITED MaxTime=UNLIMITED MinNodes=0 LLN=NO MaxCPUsPerNode=UNLIMITED MaxCPUsPerSocket=UNLIMITED
   ...

PartitionName=queue-2
   ...
   PriorityJobFactor=1 PriorityTier=1 RootOnly=NO ReqResv=NO OverSubscribe=EXCLUSIVE
   ...
```

Job Submission:
```
sbatch --wrap "srun sleep 30" --nodelist "queue-0-dy-compute-resource-0-1";sbatch --wrap "srun sleep 30" --nodelist "queue-0-dy-compute-resource-0-1"
```

/var/log/parallelcluster/slurm_resume.log
```
[slurm_plugin.resume:_get_slurm_resume] - INFO - Slurm Resume File content: {'jobs': [{'extra': None, 'job_id': 1, 'features': None, 'nodes_alloc': 'queue-0-dy-compute-resource-0-1', 'nodes_resume': 'queue-0-dy-compute-resource-0-1', 'oversubscribe': 'NO', 'partition': 'queue-0', 'reservation': None}], 'all_nodes_resume': 'queue-0-dy-compute-resource-0-1'}
...

```


Job Queue:
```
Every 2.0s: squeue                                                                                                                                                                        Fri Jul  7 11:15:26 2023

JOBID PARTITION     NAME     USER ST   TIME  NODES NODELIST(REASON)
 1   queue-0     wrap ec2-user CF   0:05      1 queue-0-dy-compute-resource-0-1
 2   queue-0     wrap ec2-user PD   0:00      1 (Resources)

...

Every 2.0s: squeue                                                                                                                                                                   Fri Jul  7 11:14:18 2023

JOBID PARTITION     NAME     USER ST   TIME  NODES NODELIST(REASON)
 2   queue-0     wrap ec2-user PD   0:00      1 (Resources)
 1   queue-0     wrap ec2-user  R   0:19      1 queue-0-dy-compute-resource-0-1

...

Every 2.0s: squeue                                                                                                                                                                        Fri Jul  7 11:14:46 2023

JOBID PARTITION     NAME     USER ST   TIME  NODES NODELIST(REASON)
 2   queue-0     wrap ec2-user  R   0:16      1 queue-0-dy-compute-resource-0-1
```

Node `queue-0-dy-compute-resource-0-1` has 2 vCPUs but is only available to `Job 2` after `Job 1` has completed running.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2294

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.