### PR TITLE
Update the keys that are generated by pcluster from RSA keys to ED25519 for AD users

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/templates/directory_service/generate_ssh_key.sh.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/directory_service/generate_ssh_key.sh.erb
@@ -17,8 +17,8 @@ user_ssh_dir="${user_home_dir}/.ssh"
 
 mkdir -m 0700 "${user_ssh_dir}"
 
-ssh-keygen -q -t rsa -f "${user_ssh_dir}/id_rsa" -N ''
-cat "${user_ssh_dir}/id_rsa.pub" >> "${user_ssh_dir}/authorized_keys"
+ssh-keygen -q -t ed25519 -f "${user_ssh_dir}/id_ed25519" -N ''
+cat "${user_ssh_dir}/id_ed25519.pub" >> "${user_ssh_dir}/authorized_keys"
 chmod 0600 "${user_ssh_dir}/authorized_keys"
 ssh-keyscan <%=  node['hostname'] %> > "${user_ssh_dir}/known_hosts"
 chmod 0600 "${user_ssh_dir}/known_hosts"

--- a/cookbooks/aws-parallelcluster-environment/test/controls/directory_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/directory_service_spec.rb
@@ -71,7 +71,7 @@ control 'sssd_configured_correctly' do
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0755' }
-    its('content') { should match /ssh-keygen -q -t rsa/ }
+    its('content') { should match /ssh-keygen -q -t ed25519/ }
   end
 
   pam_services = %w(sudo su sshd)

--- a/cookbooks/aws-parallelcluster-platform/recipes/config/cluster_user.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/cluster_user.rb
@@ -27,16 +27,16 @@ when 'HeadNode'
     cwd "/home/#{node['cluster']['cluster_user']}"
     code <<-KEYGEN
       set -e
-      su - #{node['cluster']['cluster_user']} -c \"ssh-keygen -q -t rsa -f ~/.ssh/id_rsa -N ''\"
+      su - #{node['cluster']['cluster_user']} -c \"ssh-keygen -q -t ed25519 -f ~/.ssh/id_ed25519 -N ''\"
     KEYGEN
-    not_if { ::File.exist?("/home/#{node['cluster']['cluster_user']}/.ssh/id_rsa") }
+    not_if { ::File.exist?("/home/#{node['cluster']['cluster_user']}/.ssh/id_ed25519") }
   end
 
   bash "copy_and_perms" do
     cwd "/home/#{node['cluster']['cluster_user']}"
     code <<-PERMS
       set -e
-      su - #{node['cluster']['cluster_user']} -c \"cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys && chmod 0600 ~/.ssh/authorized_keys && touch ~/.ssh/authorized_keys_cluster\"
+      su - #{node['cluster']['cluster_user']} -c \"cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys && chmod 0600 ~/.ssh/authorized_keys && touch ~/.ssh/authorized_keys_cluster\"
     PERMS
     not_if { ::File.exist?("/home/#{node['cluster']['cluster_user']}/.ssh/authorized_keys_cluster") }
   end


### PR DESCRIPTION
### Tests
* Jenkins second stage kitchen tests

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.