### PR TITLE
Update NVIDIA driver to account for what is available from Canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Assign Slurm dynamic nodes a priority (weight) of 1000 by default. This allows Slurm to prioritize idle static nodes over idle dynamic ones.
 - Create a Slurm partition-nodelist mapping JSON file to be used by the node package daemons to recognize PC-managed Slurm partitions and nodelists.
+- Upgrade NVIDIA driver to version 470.199.02.
 
 **BUG FIXES**
 

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -11,7 +11,7 @@ default['conditions']['arm_pl_supported'] = arm_instance?
 
 # NVidia
 default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '470.182.03'
+default['cluster']['nvidia']['driver_version'] = '470.199.02'
 
 # DCV
 default['cluster']['dcv']['authenticator']['user'] = "dcvextauth"


### PR DESCRIPTION
### Description of changes
* Update the driver since Canonical only publishes one version at a time https://answers.launchpad.net/ubuntu/+source/fabric-manager-470/+question/707220

### Tests
* Ran kitchen tests on Jenkins and locally ran the following
  * install nvidia-fabric-manager on all OSes
  * install nvidia-driver on all OSes
  * config nvidia-fabric-manager on Ubuntu 2204 (other images were not available)

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.