### PR TITLE
Install libdbus-1-dev to build the slurm cgroups v2 plugin for Ubuntu 2204

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_ubuntu22.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_ubuntu22.rb
@@ -29,5 +29,5 @@ def default_packages
      r-base libblas-dev libffi-dev libxml2-dev
      libgcrypt20-dev libevent-dev iproute2 python3 python3-pip
      libatlas-base-dev libglvnd-dev iptables libcurl4-openssl-dev
-     coreutils moreutils curl python3-parted environment-modules)
+     coreutils moreutils curl python3-parted environment-modules libdbus-1-dev)
 end


### PR DESCRIPTION
### Tests
* Ran first and second stage global build and test pipelines to build and test the image for Ubuntu 2204

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.