### PR TITLE
[develop] Export /opt/intel only when it exists.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/recipes/config/shared_storages.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/shared_storages.rb
@@ -33,14 +33,15 @@ when 'HeadNode'
     action :export
   end
 
-  # Export /opt/intel
+  # Export /opt/intel only if exists
   volume "export /opt/intel" do
     shared_dir "/opt/intel"
+    only_if { ::File.directory?("/opt/intel") }
     action :export
   end
 
 when 'ComputeFleet', 'LoginNode'
-  # Mount /opt/intel over NFS
+  # Mount /opt/intel over NFS only if it exists
   exported_intel_dir = format_directory('/opt/intel')
   volume "mount /opt/intel" do
     action :mount
@@ -50,6 +51,7 @@ when 'ComputeFleet', 'LoginNode'
     options node['cluster']['nfs']['hard_mount_options']
     retries 10
     retry_delay 6
+    only_if { ::File.directory?("/opt/intel") }
   end
 
 else


### PR DESCRIPTION
On some OS/architecture is not available, so we need a guard.


### Description of changes
* Export /opt/intel only when it exists.
  * On some OS/architecture is not available, so we need a guard.

This was changed in the linked PR since we expected this folder to be always created, but it wasn't.

### Tests
* N/A

### References
* [LoginNodes recipes](https://github.com/aws/aws-parallelcluster-cookbook/pull/2345)


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
