### PR TITLE
[develop] DynamoDB retries

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -36,7 +36,7 @@ def dynamodb_info(aws_connection_timeout_seconds: 30, aws_read_timeout_seconds: 
                                 user: 'root',
                                 timeout: shell_timout_seconds).run_command.stdout.strip
 
-  raise "Failed when retrieving Compute info from DynamoDB" if output == "None"
+  raise "Failed when retrieving Compute info from DynamoDB" if output.nil? || output.empty? || output == "None"
 
   slurm_nodename = output
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
@@ -31,6 +31,8 @@ end
 if node['cluster']['node_type'] == "ComputeFleet"
 
   ruby_block "retrieve compute node info" do
+    retries 12
+    retry_delay 10
     block do
       slurm_nodename = dynamodb_info
       node.force_default['cluster']['slurm_nodename'] = slurm_nodename


### PR DESCRIPTION
### Description of changes
* Fix raise when no dynamoDB entry is found

  When dynamoDB entry isn't yet present, the command output is an empty string

* Add retries when no dynamoDB entry is found
  
  Add retries when no dynamoDB entry is found, for a total wait time of 2 additional minutes.

### Tests
manually tested:
* calling recipe
* including the change in a cluster

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.