### PR TITLE
Increase EFS-utils watchdog poll interval to 10s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Assign Slurm dynamic nodes a priority (weight) of 1000 by default. This allows Slurm to prioritize idle static nodes over idle dynamic ones.
 - Create a Slurm partition-nodelist mapping JSON file to be used by the node package daemons to recognize PC-managed Slurm partitions and nodelists.
 - Upgrade NVIDIA driver to version 470.199.02.
+- Increase EFS-utils watchdog poll interval to 10 seconds. Note: This change is meaningful only if [EncryptionInTransit](https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-EfsSettings-EncryptionInTransit) is set to `true`, because watchdog does not run otherwise.
 
 **BUG FIXES**
 

--- a/cookbooks/aws-parallelcluster-environment/metadata.rb
+++ b/cookbooks/aws-parallelcluster-environment/metadata.rb
@@ -14,6 +14,7 @@ supports 'centos', '= 7.0'
 supports 'ubuntu', '>= 20.04'
 supports 'redhat', '= 8.7'
 
+depends 'line', '~> 4.5.2'
 depends 'nfs', '~> 5.0.0'
 
 depends 'aws-parallelcluster-shared', '~> 3.7.0'

--- a/cookbooks/aws-parallelcluster-environment/resources/efs/efs_alinux2.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/efs_alinux2.rb
@@ -29,4 +29,5 @@ action :install_utils do
     retries 3
     retry_delay 5
   end
+  action_increase_poll_interval
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_common.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_common.rb
@@ -17,3 +17,13 @@ def get_package_version(package_name)
   end
   version
 end
+
+action :increase_poll_interval do
+  # An interval too short could affect HPC workload performance
+  replace_or_add "increase EFS-utils watchdog poll interval" do
+    path "/etc/amazon/efs/efs-utils.conf"
+    pattern "poll_interval_sec = 1$"
+    line "poll_interval_sec = 10"
+    replace_only true
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_install_from_tar.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_install_from_tar.rb
@@ -55,4 +55,5 @@ action :install_utils do
     cwd node['cluster']['sources_dir']
     code install_script_code(efs_utils_tarball, package_name, package_version)
   end
+  action_increase_poll_interval
 end

--- a/cookbooks/aws-parallelcluster-environment/test/controls/efs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/efs_spec.rb
@@ -15,6 +15,12 @@ control 'tag:install_efs_utils_installed' do
   describe package('amazon-efs-utils') do
     it { should be_installed }
   end
+
+  describe file("/etc/amazon/efs/efs-utils.conf") do
+    its('content') do
+      should match('poll_interval_sec = 10')
+    end
+  end
 end
 
 control 'efs_mounted' do


### PR DESCRIPTION
The default poll frequency is 1s, which could impact HPC workload performance

### Tests
* There is a new check in kitchen test and passed on all OSes


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.