### PR TITLE
Move Intel HPC configuration after setup of shared folder

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/config.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/config.rb
@@ -18,6 +18,12 @@ include_recipe "aws-parallelcluster-shared::setup_envars"
 
 include_recipe 'aws-parallelcluster-platform::config'
 include_recipe "aws-parallelcluster-environment::config"
+
+# Intel HPC must be configured after the setup of the shared folder (i.e. /opt/intel)
+intel_hpc 'Configure Intel HPC' do
+  action :configure
+end
+
 include_recipe 'aws-parallelcluster-computefleet::config'
 include_recipe 'aws-parallelcluster-slurm::config'
 include_recipe 'aws-parallelcluster-awsbatch::config'

--- a/cookbooks/aws-parallelcluster-platform/recipes/config.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config.rb
@@ -21,9 +21,6 @@ chrony 'enable Amazon Time Sync' do
   action :enable
 end
 include_recipe 'aws-parallelcluster-platform::dcv'
-intel_hpc 'Configure Intel HPC' do
-  action :configure
-end
 # Supervisord configuration must be executed after DCV because dcv external authenticator is part of it
 include_recipe 'aws-parallelcluster-platform::supervisord_config'
 fetch_config 'Fetch and load cluster configs'


### PR DESCRIPTION
### Description of changes

The config step of the Intel HPC installer installs rpms from `/opt/intel/rpms/`. This folder must be mounted before executing intel hpc installation steps.

Without this patch the installation works for the head node but fails for the compute nodes because unable to see the rpms in the shared folder.
```
* bash[install intel hpc platform] action run[2023-07-12T09:42:23+00:00] INFO: Processing bash[install intel hpc platform] action run (/etc/chef/local-mode-cache/cache/cookbooks/aws-parallelcluster-platform/resources/intel_hpc/intel_hpc_centos7.rb line 226)
      [execute] Loaded plugins: fastestmirror, versionlock
                Skipping: /opt/intel/rpms/*, filename does not end in .rpm.
                Nothing to do
```

### Tests
* Tested cluster creation by using a custom cookbook pointing to this patch.
```
DevSettings:
  Cookbook:
    ChefCookbook: https://github.com/enrico-usai/aws-parallelcluster-cookbook/tarball/refs/heads/wip/intelhpc
```
Test result (without the patch the file was missing).
```
[centos@queue1-st-queue1-cr1-1 ~]$ less /var/log/cloud-init-output.log
...
           Installed:
                  intel-hpc-platform-compat-hpc.x86_64 0:2018.0-7.el7
                  intel-hpc-platform-compat-hpc-advisory.x86_64 0:2018.0-7.el7
                  intel-hpc-platform-core.x86_64 0:2018.0-7.el7
                  intel-hpc-platform-core-advisory.x86_64 0:2018.0-7.el7
                  intel-hpc-platform-core-intel-runtime.x86_64 0:2018.0-7.el7
                  intel-hpc-platform-core-intel-runtime-advisory.x86_64 0:2018.0-7.el7
                  intel-hpc-platform-hpc-cluster.x86_64 0:2018.0-7.el7

                Complete!
[2023-07-12T11:17:42+00:00] INFO: bash[install intel hpc platform] ran successfully


[centos@queue1-st-queue1-cr1-1 ~]$ cat /etc/intel-hpc-platform-release
# Created by intel-hpc-platform-core
# Modified by intel-hpc-platform-%{_package}
#
# This file must contain the field "INTEL_HPC_PLATFORM_VERSION"
# compliant to Posix* environment variable format
# Value must be a string of specification section identifiers,
# with each section identifier seperated by a colon.
INTEL_HPC_PLATFORM_VERSION=core-2018.0:core-intel-runtime-2018.0:hpc-cluster-2018.0:compat-hpc-2018.0
export INTEL_HPC_PLATFORM_VERSION
```


### References
* Issue introduced by: https://github.com/aws/aws-parallelcluster-cookbook/pull/2290/commits/b53c2b5cb667051c5afd3566e1634aefaa72ca01

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.