### PR TITLE
[develop] Adapt directory_service recipe for LoginNodes

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/recipes/config/configure_pam_ssh_keygen.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/configure_pam_ssh_keygen.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-environment
+# Recipe:: configure_pam_ssh_keygen
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+pam_services = %w(sudo su sshd)
+pam_config_dir = "/etc/pam.d"
+generate_ssh_key_path = "#{node['cluster']['scripts_dir']}/generate_ssh_key.sh"
+ssh_key_generator_pam_config_line = "session    optional     pam_exec.so log=/var/log/parallelcluster/pam_ssh_key_generator.log #{generate_ssh_key_path}"
+if node['cluster']["directory_service"]["generate_ssh_keys_for_users"] == 'true'
+  template generate_ssh_key_path do
+    source 'directory_service/generate_ssh_key.sh.erb'
+    owner 'root'
+    group 'root'
+    mode '0755'
+  end
+  pam_services.each do |pam_service|
+    pam_config_file = "#{pam_config_dir}/#{pam_service}"
+    append_if_no_line "Ensure PAM service #{pam_service} is configured to call SSH key generation script" do
+      path pam_config_file
+      line ssh_key_generator_pam_config_line
+    end
+  end
+else
+  # Remove script used to generate key if it exists and ensure PAM is not configured to try to call it
+  file generate_ssh_key_path do
+    action :delete
+    only_if { ::File.exist? generate_ssh_key_path }
+  end
+
+  pam_services.each do |pam_service|
+    pam_config_file = "#{pam_config_dir}/#{pam_service}"
+    delete_lines "Ensure PAM service #{pam_service} is not configured to call SSH key generation script" do
+      path pam_config_file
+      pattern %r{session\s+optional\s+pam_exec\.so\s+log=/var/log/parallelcluster/pam_ssh_key_generator\.log}
+      ignore_missing true
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/imds.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/imds.rb
@@ -15,7 +15,7 @@
 return if on_docker? || node['cluster']['scheduler'] == 'awsbatch'
 
 # slurm and custom schedulers will have imds access on the head node
-if node['cluster']['node_type'] == 'HeadNode'
+if %w(HeadNode LoginNode).include? node['cluster']['node_type']
 
   directory "#{node['cluster']['scripts_dir']}/imds" do
     owner 'root'

--- a/cookbooks/aws-parallelcluster-platform/recipes/config/log_rotation.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/log_rotation.rb
@@ -24,7 +24,10 @@ when 'HeadNode'
 when 'ComputeFleet'
   include_recipe 'aws-parallelcluster-platform::log_rotation_compute_fleet'
 
+when 'LoginNode'
+  Chef::Log.info("Log rotation not yet implemented for LoginNodes")
+
 else
-  raise "node_type must be HeadNode or ComputeFleet"
+  raise "node_type must be HeadNode, LoginNode or ComputeFleet"
 
 end


### PR DESCRIPTION
### Description of changes
* Configure IMDS restrictions on LoginNodes
* Configure LoginNodes to generate ssh keys for AD users 

### Tests
* I created cluster with Login Nodes configured with these recipes
* I logged in a LoginNode through the load balancer with an AD user using SSH
* I provided user's AD password
* Auth was successfull
* User's home was created
* User's ssh keys were created
* I was logged in the LoginNode user's folder as a system user with the same name
* I retrieved my ssh key
* I closed the session
* I logged into the HeadNode using the AD user ssh key
* I was successfully authenticated and logged in user's home on the HeadNode

### References 
* [CLI changes to dna.json](https://github.com/aws/aws-parallelcluster/pull/5480)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
