### PR TITLE
Add keys management for Login Nodes to avoid MITM warning

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/files/login_nodes/keys-manager.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/login_nodes/keys-manager.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+set -e
+#
+# Manage the creation and usage of the keys in the login nodes
+#
+# --create                      Create the required keys in the specified folder
+# --import                      Copy the keys from the specified folder to the ssh folder
+# --folder_keys <folder_path>   Full path of the folder which contains the generated keys
+# --help                        Print this help message
+
+function error() {
+  >&2 echo "[ERROR] $1"
+  exit 1
+}
+
+function info() {
+  echo "[INFO] $1"
+}
+
+function help() {
+  local -- cmd=$(basename "$0")
+  cat <<EOF
+
+  Usage: ${cmd} [OPTION]...
+
+  Manage the creation and usage of the keys in the login nodes
+
+  --create                      Create the required keys in the specified folder
+  --import                      Copy the keys from the specified folder to the ssh folder
+  --folder-path <folder_path>   Full path of the folder which contains the generated keys
+  --help                        Print this help message
+EOF
+}
+
+function create_keys() {
+  info "Creating host keys"
+  ssh-keygen -t ecdsa -f "$FOLDER_PATH/ssh_host_ecdsa_key" -q -P ""
+  ssh-keygen -t ed25519 -f "$FOLDER_PATH/ssh_host_ed25519_key" -q -P ""
+  if is_not_alinux; then
+      ssh-keygen -t rsa -f "$FOLDER_PATH/ssh_host_rsa_key" -q -P ""
+  fi
+  if is_ubuntu; then
+    ssh-keygen -t dsa -f "$FOLDER_PATH/ssh_host_dsa_key" -q -P ""
+  fi
+}
+
+function import_keys() {
+  info "Importing host keys"
+  rm -f /etc/ssh/ssh_host_*
+  cp "$FOLDER_PATH/ssh_host_ecdsa"* /etc/ssh/
+  cp "$FOLDER_PATH/ssh_host_ed25519"* /etc/ssh/
+  if is_not_alinux; then
+      cp "$FOLDER_PATH/ssh_host_rsa"* /etc/ssh/
+  fi
+  if is_ubuntu; then
+    cp "$FOLDER_PATH/ssh_host_dsa"* /etc/ssh/
+    chown root:root /etc/ssh/ssh_host_*
+    chmod 600 /etc/ssh/ssh_host_*_key
+  else
+    chown root:ssh_keys /etc/ssh/ssh_host_*
+    chmod 640 /etc/ssh/ssh_host_*_key
+  fi
+  chmod 644 /etc/ssh/ssh_host_*_key.pub
+}
+
+function is_not_alinux() {
+  if grep -q "Amazon" <<< "$OS"; then
+    return 1
+  fi
+  return 0
+}
+
+function is_ubuntu() {
+  if grep -q "Ubuntu" <<< "$OS"; then
+    return 0
+  fi
+  return 1
+}
+
+main() {
+  # Global values
+  CREATE="false"
+  IMPORT="false"
+  FOLDER_PATH=""
+  OS=$(grep '^NAME' /etc/os-release)
+
+  # Parse options
+  while [ $# -gt 0 ] ; do
+      case "$1" in
+          --create)         CREATE="true"; shift;;
+          --import)         IMPORT="true"; shift;;
+          --folder-path)    FOLDER_PATH="$2"; shift 2;;
+          --help)           help; exit 0;;
+          *)                help; error "Unrecognized option '$1'";;
+      esac
+  done
+
+  [ -z "$FOLDER_PATH" ] && error "You must provide a valid path for the generated keys"
+
+  if [ $CREATE == "true" ]; then
+      create_keys
+  fi
+
+  if [ $IMPORT == "true" ]; then
+      import_keys
+  fi
+
+  exit 0
+}
+
+main "$@"

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -548,3 +548,36 @@ suites:
       cluster:
         node_type: LoginNode
         head_node_private_ip: '127.0.0.1'
+  - name: login_nodes_headnode_keys_configuration
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-environment::login_nodes_keys]
+    verifier:
+      controls:
+        - head_node_directory_initialized
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-platform::directories
+        - resource:nfs
+      cluster:
+        node_type: 'HeadNode'
+        scheduler: 'slurm'
+        shared_dir_login_nodes: '/opt/shared_login_nodes'
+
+  - name: login_nodes_keys_configuration
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-environment::login_nodes_keys]
+    verifier:
+      controls:
+        - login_node_configuration_initialized
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-platform::directories
+        - resource:nfs
+        - recipe:aws-parallelcluster-environment::mock_login_node_keys
+      cluster:
+        node_type: 'LoginNode'
+        scheduler: 'slurm'
+        head_node_private_ip: '127.0.0.1'
+        shared_dir_login_nodes: '/opt/parallelcluster/shared_login_nodes'

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/login_nodes_keys.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/login_nodes_keys.rb
@@ -1,0 +1,79 @@
+#
+# Cookbook:: aws-parallelcluster-environment
+# Recipe:: login_nodes_keys
+# frozen_string_literal: true
+
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+return if on_docker? || node['cluster']['scheduler'] == 'awsbatch'
+
+script_name = "keys-manager.sh"
+head_node_keys_manager_script_dir = "#{node['cluster']['scripts_dir']}/login_nodes"
+keys_dir = "#{node['cluster']['shared_dir_login_nodes']}"
+
+case node['cluster']['node_type']
+when 'ComputeFleet'
+  # Do nothing
+when 'HeadNode'
+
+  directory head_node_keys_manager_script_dir do
+    owner 'root'
+    group 'root'
+    mode '0744'
+    recursive true
+  end
+
+  cookbook_file head_node_keys_manager_script_dir + '/' + script_name do
+    source 'login_nodes/keys-manager.sh'
+    owner 'root'
+    group 'root'
+    mode '0744'
+  end
+
+  volume "export keys_manager_script_dir" do
+    shared_dir "#{head_node_keys_manager_script_dir}"
+    action :export
+  end
+
+  execute 'Initialize Login Nodes keys' do
+    command "bash #{head_node_keys_manager_script_dir}/#{script_name} --create --folder-path #{keys_dir}"
+    user 'root'
+  end
+
+when 'LoginNode'
+  keys_manager_script_dir = "#{node['cluster']['scripts_dir']}/utils"
+
+  directory keys_manager_script_dir do
+    owner 'root'
+    group 'root'
+    mode '0744'
+    recursive true
+  end
+
+  volume "mount keys_manager_script_dir" do
+    action :mount
+    shared_dir "#{keys_manager_script_dir}"
+    device(lazy { "#{node['cluster']['head_node_private_ip']}:#{head_node_keys_manager_script_dir}" })
+    fstype 'nfs'
+    options node['cluster']['nfs']['hard_mount_options']
+    retries 10
+    retry_delay 6
+  end
+
+  execute 'Import Login Nodes keys' do
+    command "bash #{keys_manager_script_dir}/#{script_name} --import --folder-path #{keys_dir}"
+    user 'root'
+  end
+else
+  raise "node_type must be HeadNode or ComputeFleet or LoginNode"
+end

--- a/cookbooks/aws-parallelcluster-environment/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/init.rb
@@ -19,6 +19,7 @@ cloudwatch "Configure CloudWatch" do
 end
 include_recipe "aws-parallelcluster-environment::network_interfaces"
 include_recipe 'aws-parallelcluster-environment::imds'
+include_recipe "aws-parallelcluster-environment::login_nodes_keys"
 include_recipe "aws-parallelcluster-environment::directory_service"
 
 # Custom action setup must be executed after cfnconfig file creation

--- a/cookbooks/aws-parallelcluster-environment/recipes/test/mock_login_node_keys.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/test/mock_login_node_keys.rb
@@ -1,0 +1,33 @@
+return if on_docker?
+
+keys_manager_script_dir = "#{node['cluster']['scripts_dir']}/login_nodes"
+keys_dir = "#{node['cluster']['shared_dir_login_nodes']}"
+script_name = "keys-manager.sh"
+
+directory keys_dir
+
+directory keys_manager_script_dir do
+  owner 'root'
+  group 'root'
+  mode '0744'
+  recursive true
+end
+
+cookbook_file "#{keys_manager_script_dir}/#{script_name}" do
+  source 'login_nodes/keys-manager.sh'
+  owner 'root'
+  group 'root'
+  mode '0744'
+  action :create_if_missing
+end
+
+nfs_export keys_manager_script_dir do
+  network '127.0.0.1/32'
+  writeable true
+  options ['no_root_squash']
+end
+
+execute 'Initialize Login Nodes keys' do
+  command "bash #{keys_manager_script_dir}/#{script_name} --create --folder-path #{keys_dir}"
+  user 'root'
+end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/login_nodes_keys_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/login_nodes_keys_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-environment::login_nodes_keys' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      context "when awsbatch scheduler" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['scheduler'] = 'awsbatch'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'does not create login_nodes directory' do
+          is_expected.to_not create_directory("#{node['cluster']['scripts_dir']}/login_nodes")
+        end
+      end
+
+      context "when compute node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['node_type'] = 'ComputeFleet'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'does not create login_nodes directory' do
+          is_expected.to_not create_directory("#{node['cluster']['scripts_dir']}/login_nodes")
+        end
+      end
+
+      context "when slurm scheduler and head node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['node_type'] = 'HeadNode'
+            node.override['cluster']['scheduler'] = 'slurm'
+            node.override['cluster']['shared_dir_login_nodes'] = '/opt/shared_login_nodes'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'creates the login_nodes directory' do
+          is_expected.to create_directory("#{node['cluster']['scripts_dir']}/login_nodes").with(
+            owner: 'root',
+            group: 'root',
+            mode:  '0744'
+          )
+        end
+
+        it 'creates keys-manager.sh script' do
+          is_expected.to create_cookbook_file("#{node['cluster']['scripts_dir']}/login_nodes/keys-manager.sh").with(
+            source: 'login_nodes/keys-manager.sh',
+            owner: "root",
+            group: "root",
+            mode: "0744"
+          )
+        end
+
+        it "exports keys_manager_script_dir" do
+          is_expected.to export_volume('export keys_manager_script_dir').with(
+            shared_dir: "#{node['cluster']['scripts_dir']}/login_nodes"
+          )
+        end
+
+        it "creates login nodes keys" do
+          is_expected.to run_execute("Initialize Login Nodes keys")
+            .with(command: "bash #{node['cluster']['scripts_dir']}/login_nodes/keys-manager.sh --create --folder-path #{node['cluster']['shared_dir_login_nodes']}")
+        end
+      end
+
+      context "when slurm scheduler and login node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['node_type'] = 'LoginNode'
+            node.override['cluster']['scheduler'] = 'slurm'
+            node.override['cluster']['shared_dir_login_nodes'] = '/opt/parallelcluster/shared_login_nodes'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'creates the login_nodes directory' do
+          is_expected.to create_directory("#{node['cluster']['scripts_dir']}/utils").with(
+            owner: 'root',
+            group: 'root',
+            mode:  '0744'
+          )
+        end
+
+        it 'mount keys_manager_script_dir' do
+          is_expected.to mount_volume('mount keys_manager_script_dir').with(
+            shared_dir: "#{node['cluster']['scripts_dir']}/utils",
+            fstype: 'nfs',
+            options: "hard,_netdev,noatime",
+            retries: 10,
+            retry_delay: 6
+          )
+        end
+
+        it "import login nodes keys" do
+          is_expected.to run_execute("Import Login Nodes keys")
+            .with(command: "bash #{node['cluster']['scripts_dir']}/utils/keys-manager.sh --import --folder-path #{node['cluster']['shared_dir_login_nodes']}")
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/test/controls/login_nodes_keys_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/login_nodes_keys_spec.rb
@@ -1,0 +1,93 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+keys_manager_script_dir = "/opt/parallelcluster/scripts/login_nodes"
+key_types = %w(ecdsa ed25519)
+is_not_amazon = !os_properties.amazon_family?
+is_ubuntu = os_properties.ubuntu?
+if is_not_amazon
+  key_types << 'rsa'
+end
+if is_ubuntu
+  key_types << 'dsa'
+end
+
+control 'head_node_directory_initialized' do
+  only_if { instance.head_node? && node['cluster']['scheduler'] != 'awsbatch' }
+  describe directory(keys_manager_script_dir) do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0744' }
+  end
+
+  describe bash('cat /etc/exports') do
+    its('exit_status') { should eq(0) }
+    its('stdout') { should match /^#{keys_manager_script_dir} / }
+  end
+
+  key_types.each do |type|
+    describe file('/opt/shared_login_nodes/ssh_host_' + type + '_key') do
+      it { should exist }
+      its('content') { should_not be_empty }
+    end
+
+    describe file('/opt/shared_login_nodes/ssh_host_' + type + '_key.pub') do
+      it { should exist }
+      its('content') { should_not be_empty }
+    end
+  end
+end
+
+control 'login_node_configuration_initialized' do
+  only_if { instance.login_node? && node['cluster']['scheduler'] != 'awsbatch' }
+
+  describe mount('/opt/parallelcluster/scripts/utils') do
+    it { should be_mounted }
+    its('device') { should eq "127.0.0.1:/opt/parallelcluster/scripts/login_nodes" }
+    its('type') { should eq 'nfs4' }
+    its('options') { should include 'hard' }
+    its('options') { should include '_netdev' }
+    its('options') { should include 'noatime' }
+  end
+
+  describe bash('cat /etc/exports') do
+    its('exit_status') { should eq(0) }
+    its('stdout') { should match /^#{keys_manager_script_dir} / }
+  end
+
+  key_types.each do |type|
+    describe file('/etc/ssh/ssh_host_' + type + '_key') do
+      it { should exist }
+      its('owner') { should eq 'root' }
+      if is_ubuntu
+        its('mode') { should cmp '0600' }
+        its('group') { should eq 'root' }
+      else
+        its('mode') { should cmp '0640' }
+        its('group') { should eq 'ssh_keys' }
+      end
+      its('content') { should_not be_empty }
+    end
+
+    describe file('/etc/ssh/ssh_host_' + type + '_key.pub') do
+      it { should exist }
+      its('mode') { should cmp '0644' }
+      its('owner') { should eq 'root' }
+      if is_ubuntu
+        its('group') { should eq 'root' }
+      else
+        its('group') { should eq 'ssh_keys' }
+      end
+      its('content') { should_not be_empty }
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
* Add keys management for Login Nodes to avoid MITM warning

### Tests
* Added unit tests and kitchen tests for HeadNode and LoginNode. Verified for all the OSes
* Manual tests to verify all the keys are generated and moved as expected in ALinux

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.