### PR TITLE
Update NFS configure to stop the service on compute nodes and the test to check that the service is stopped

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/partial/_configure.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/partial/_configure.rb
@@ -14,15 +14,20 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 action :configure do
-  return if node['cluster']['node_type'] != "HeadNode"
-  node.force_override['nfs']['threads'] = node['cluster']['nfs']['threads']
+  if node['cluster']['node_type'] == "HeadNode"
+    node.force_override['nfs']['threads'] = node['cluster']['nfs']['threads']
 
-  override_server_template
+    override_server_template
 
-  # Explicitly restart NFS server for thread setting to take effect
-  # and enable it to start at boot
-  service node['nfs']['service']['server'] do
-    action %i(restart enable)
-    supports restart: true
-  end unless on_docker?
+    # Explicitly restart NFS server for thread setting to take effect
+    # and enable it to start at boot
+    service node['nfs']['service']['server'] do
+      action %i(restart enable)
+      supports restart: true
+    end unless on_docker?
+  else
+    service node['nfs']['service']['server'] do
+      action %i(stop disable)
+    end unless on_docker?
+  end
 end

--- a/cookbooks/aws-parallelcluster-environment/test/controls/nfs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/nfs_spec.rb
@@ -50,7 +50,7 @@ control 'tag:config_nfs_correctly_installed_on_compute_node' do
   only_if { instance.compute_node? && !os_properties.on_docker? }
 
   describe 'check for nfs server protocol' do
-    subject { command "sudo -u #{node['cluster']['cluster_user']} rpcinfo -p localhost | awk '{print $2$5}' | grep 4nfs" }
+    subject { command "sudo -u #{node['cluster']['cluster_user']} systemctl status #{node['nfs']['service']['server']} | grep inactive" }
     its('exit_status') { should eq 0 }
   end
 end


### PR DESCRIPTION
The NFS server was not actually stopped in local kitchen tests so the tests would pass but when it was stopped on compute nodes, it failed.  Updating the configure to reflect that and updating our test environment to check for the specific status of the service, instead of a byproduct.

### Tests
* Ran `./kitchen.ec2.sh environment-config test nfs-computefleet -c 5` locally and it is passing
* Ran `./kitchen.ec2.sh environment-config test nfs-headnode -c 5` locally and it is passing

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2340

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.