### PR TITLE
Configure log rotation and Cloudwatch log collection on login nodes

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
@@ -115,7 +115,8 @@
       ],
       "node_roles": [
         "ComputeFleet",
-        "HeadNode"
+        "HeadNode",
+        "LoginNode"
       ],
       "feature_conditions": []
     },
@@ -133,7 +134,8 @@
         "ubuntu"
       ],
       "node_roles": [
-        "ComputeFleet"
+        "ComputeFleet",
+        "LoginNode"
       ],
       "feature_conditions": []
     },
@@ -153,7 +155,8 @@
       ],
       "node_roles": [
         "ComputeFleet",
-        "HeadNode"
+        "HeadNode",
+        "LoginNode"
       ],
       "feature_conditions": []
     },
@@ -445,7 +448,8 @@
         "amazon"
       ],
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "LoginNode"
       ],
       "feature_conditions": [
         {

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config_schema.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config_schema.json
@@ -20,7 +20,7 @@
           },
           "node_roles": {
             "type": "array",
-            "items": {"type": "string", "enum": ["HeadNode", "ComputeFleet"]}
+            "items": {"type": "string", "enum": ["HeadNode", "ComputeFleet", "LoginNode"]}
           },
           "feature_conditions": {
             "type": "array",

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -24,6 +24,24 @@ suites:
         scheduler: slurm
         cw_logging_enabled: "true"
         log_group_name: test
+  - name: cloudwatch-loginnode
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-tests::test_resource]
+    verifier:
+      controls:
+        - /tag:config_cloudwatch/
+        - cloudwatch_logfiles_configuration_loginnode
+    attributes:
+      resource: cloudwatch:configure
+      dependencies:
+        - recipe:aws-parallelcluster-platform::cookbook_virtualenv
+        - resource:cloudwatch:setup
+      cluster:
+        node_type: LoginNode
+        scheduler: slurm
+        cw_logging_enabled: "true"
+        log_group_name: test
   - name: ebs_mount
     run_list:
       - recipe[aws-parallelcluster-tests::setup]
@@ -133,8 +151,8 @@ suites:
       controls:
         - /lustre_mounted/
     attributes:
-      resource: 'lustre:mount {"fsx_fs_id_array": "FROM_HOOK-lustre_mount-fsx_fs_id_array", 
-                               "fsx_fs_type_array": ["LUSTRE"], 
+      resource: 'lustre:mount {"fsx_fs_id_array": "FROM_HOOK-lustre_mount-fsx_fs_id_array",
+                               "fsx_fs_type_array": ["LUSTRE"],
                                "fsx_shared_dir_array": ["shared_dir"],
                                "fsx_dns_name_array": "FROM_HOOK-lustre_mount-fsx_dns_name_array",
                                "fsx_mount_name_array": "FROM_HOOK-lustre_mount-fsx_mount_name_array",
@@ -151,8 +169,8 @@ suites:
       controls:
         - /lustre_unmounted/
     attributes:
-      resource: 'lustre:unmount {"fsx_fs_id_array": "FROM_HOOK-lustre_mount-fsx_fs_id_array", 
-                                 "fsx_fs_type_array": ["LUSTRE"], 
+      resource: 'lustre:unmount {"fsx_fs_id_array": "FROM_HOOK-lustre_mount-fsx_fs_id_array",
+                                 "fsx_fs_type_array": ["LUSTRE"],
                                  "fsx_shared_dir_array": ["shared_dir"],
                                  "fsx_dns_name_array": "FROM_HOOK-lustre_mount-fsx_dns_name_array",
                                  "fsx_mount_name_array": "FROM_HOOK-lustre_mount-fsx_mount_name_array",
@@ -161,8 +179,8 @@ suites:
         - recipe:aws-parallelcluster-platform::cookbook_virtualenv
         - resource:ec2_udev_rules
         - resource:lustre
-        - 'resource:lustre:mount {"fsx_fs_id_array": "FROM_HOOK-lustre_mount-fsx_fs_id_array", 
-                                  "fsx_fs_type_array": ["LUSTRE"], 
+        - 'resource:lustre:mount {"fsx_fs_id_array": "FROM_HOOK-lustre_mount-fsx_fs_id_array",
+                                  "fsx_fs_type_array": ["LUSTRE"],
                                   "fsx_shared_dir_array": ["shared_dir"],
                                   "fsx_dns_name_array": "FROM_HOOK-lustre_mount-fsx_dns_name_array",
                                   "fsx_mount_name_array": "FROM_HOOK-lustre_mount-fsx_mount_name_array",

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
@@ -56,7 +56,7 @@ control 'tag:config_cloudwatch_configured' do
 
   describe file('/usr/local/etc/cloudwatch_agent_config_schema.json') do
     it { should exist }
-    its('sha256sum') { should eq '27ebc3dc858094d6cb4454ce8ca230e0828716b50c2d2b1199eb9150fec0a04a' }
+    its('sha256sum') { should eq '9019c9235fe54091db4c225fe6be552b229c958ab8a87fa94b5a875545bbfd87' }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0644' }
@@ -76,4 +76,59 @@ control 'tag:config_cloudwatch_configured' do
       its('exit_status') { should eq 0 }
     end
   end
+
+  describe file('/etc/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.d/file_amazon-cloudwatch-agent.json') do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0644' }
+  end unless os_properties.on_docker?
+end
+
+control 'cloudwatch_logfiles_configuration_loginnode' do
+  title "Check CloudWatch configuration generated on login nodes"
+
+  # TODO: add directory service enablement in the context of the test and add the corresponding log files.
+  expected_log_files = %w(
+    /var/log/cloud-init.log
+    /var/log/cloud-init-output.log
+    /var/log/supervisord.log
+  )
+  unexpected_log_files = %w(
+    /var/log/messages
+    /var/log/syslog
+    /var/log/cfn-init.log
+    /var/log/chef-client.log
+    /var/log/parallelcluster/bootstrap_error_msg
+    /var/log/parallelcluster/clustermgtd
+    /var/log/parallelcluster/clustermgtd.events
+    /var/log/parallelcluster/slurm_resume.events
+    /var/log/parallelcluster/compute_console_output.log
+    /var/log/parallelcluster/computemgtd
+    /var/log/parallelcluster/slurm_resume.log
+    /var/log/parallelcluster/slurm_suspend.log
+    /var/log/parallelcluster/slurm_fleet_status_manager.log
+    /var/log/slurmd.log
+    /var/log/slurmctld.log
+    /var/log/slurmdbd.log
+    /var/log/parallelcluster/pcluster_dcv_authenticator.log
+    /var/log/parallelcluster/pcluster_dcv_connect.log
+    /var/log/dcv/server.log
+    /var/log/dcv/sessionlauncher.log
+    /var/log/dcv/agent.*.log
+    /var/log/dcv/dcv-xsession.*.log
+    /var/log/dcv/Xdcv.*.log
+    /var/log/parallelcluster/slurm_health_check.log
+    /var/log/parallelcluster/slurm_health_check.events
+    /var/log/parallelcluster/clusterstatusmgtd
+  )
+
+  describe file('/etc/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.d/file_amazon-cloudwatch-agent.json') do
+    expected_log_files.each do |log_file|
+      its('content') { should include(log_file) }
+    end
+    unexpected_log_files.each do |log_file|
+      its('content') { should_not include(log_file) }
+    end
+  end unless os_properties.on_docker?
 end

--- a/cookbooks/aws-parallelcluster-platform/recipes/config/log_rotation_login_node.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/log_rotation_login_node.rb
@@ -12,22 +12,20 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-return if node['cluster']['log_rotation_enabled'] != 'true'
-
 # TODO: move the logrotate configuration of the various services to the corresponding recipes/cookbooks.
+logrotate_conf_dir = node['cluster']['logrotate_conf_dir']
+logrotate_template_dir = 'log_rotation/'
 
-case node['cluster']['node_type']
+config_files = %w(
+  parallelcluster_cloud_init_log_rotation
+  parallelcluster_cloud_init_output_log_rotation
+  parallelcluster_supervisord_log_rotation
+)
 
-when 'HeadNode'
-  include_recipe 'aws-parallelcluster-platform::log_rotation_head_node'
-
-when 'ComputeFleet'
-  include_recipe 'aws-parallelcluster-platform::log_rotation_compute_fleet'
-
-when 'LoginNode'
-  include_recipe 'aws-parallelcluster-platform::log_rotation_login_node'
-
-else
-  raise "node_type must be HeadNode, LoginNode or ComputeFleet"
-
+if node['cluster']["directory_service"]["generate_ssh_keys_for_users"] == 'true'
+  config_files += %w(
+    parallelcluster_pam_ssh_key_generator_log_rotation
+  )
 end
+
+generate_logrotate_configs(config_files, logrotate_conf_dir, logrotate_template_dir)

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/log_rotation_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/log_rotation_spec.rb
@@ -273,7 +273,6 @@ describe 'aws-parallelcluster-platform::log_rotation' do
           end
         end
       end
-
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/log_rotation_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/log_rotation_spec.rb
@@ -217,6 +217,63 @@ describe 'aws-parallelcluster-platform::log_rotation' do
           end
         end
       end
+
+      context "in the login node when log_rotation enabled and pam ssh key generation is enabled" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['node_type'] = "LoginNode"
+            node.override['cluster']['log_rotation_enabled'] = 'true'
+            node.override['cluster']["directory_service"]["generate_ssh_keys_for_users"] = 'true'
+            node.override['cluster']["scheduler"] = 'slurm'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        expected_config_files = %w(
+          parallelcluster_cloud_init_log_rotation
+          parallelcluster_supervisord_log_rotation
+          parallelcluster_cloud_init_output_log_rotation
+          parallelcluster_pam_ssh_key_generator_log_rotation
+        )
+        unexpected_config_files = %w(
+          parallelcluster_bootstrap_error_msg_log_rotation
+          parallelcluster_cfn_init_log_rotation
+          parallelcluster_chef_client_log_rotation
+          parallelcluster_dcv_log_rotation
+          parallelcluster_clustermgtd_log_rotation
+          parallelcluster_clusterstatusmgtd_log_rotation
+          parallelcluster_slurm_fleet_status_manager_log_rotation
+          parallelcluster_slurm_resume_log_rotation
+          parallelcluster_slurm_suspend_log_rotation
+          parallelcluster_slurmctld_log_rotation
+          parallelcluster_slurmdbd_log_rotation
+          parallelcluster_compute_console_output_log_rotation
+          parallelcluster_clustermgtd_events_log_rotation
+          parallelcluster_slurm_resume_events_log_rotation
+          parallelcluster_computemgtd_log_rotation
+          parallelcluster_slurmd_log_rotation
+        )
+
+        it 'creates the correct logrotate config files' do
+          expected_config_files.each do |config_file|
+            output_file = log_rotation_path + config_file
+            template_file = 'log_rotation/' + config_file + '.erb'
+            is_expected.to create_template(output_file).with(
+              source: template_file,
+              mode:  '0644'
+            )
+          end
+        end
+
+        it 'does not create unexpected logrotate config files' do
+          unexpected_config_files.each do |config_file|
+            output_file = log_rotation_path + config_file
+            is_expected.to_not create_template(output_file)
+          end
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
### Description of changes
* Configure ParallelCluster-managed log rotation on login nodes.
* Configure CloudWatch log collection for login nodes.

### Tests
* Add ChefSpec test for log rotation configuration for login nodes.
* Add InSpec test for CloudWatch log collection configuration for login nodes.

### References
* https://github.com/aws/aws-parallelcluster/pull/5489

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.