### PR TITLE
Allow more waiting time for X server to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Open MPI: `openmpi40-aws-4.1.5-1`
 
 **BUG FIXES**
+- Fix cluster creation failure with Ubuntu Deep Learning AMI on GPU instances and DCV enabled.
 
 3.6.1
 ------

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
@@ -89,7 +89,7 @@ action_class do
     execute 'Wait for X to start' do
       user 'root'
       command "pidof X || pidof Xorg"
-      retries 5
+      retries 10
       retry_delay 5
     end
   end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -834,7 +834,7 @@ describe 'dcv:configure' do
           is_expected.to run_execute('Wait for X to start').with(
             user: 'root',
             command: "pidof X || pidof Xorg",
-            retries: 5,
+            retries: 10,
             retry_delay: 5
           )
         end


### PR DESCRIPTION
### Description of changes
* On Deep Learning AMIs, X server takes longer to start. Prior to this change, cluster creation would fail when using Deep Learning AMIs on GPU instances with DCV enabled

### Tests
* Manually tested cluster creation
* Kitchen test for Deep Learning AMIs on GPU instances will be enabled in our internal testing process.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.