### PR TITLE
[Login Nodes] Add loginmgtd daemon to login nodes.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/supervisord_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/supervisord_config_spec.rb
@@ -75,6 +75,25 @@ describe 'aws-parallelcluster-platform::supervisord_config' do
             .with_content("[program:pcluster_dcv_authenticator]")
         end
       end
+      context "when login node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['node_type'] = 'LoginNode'
+            node.override['cluster']['dcv_enabled'] = 'head_node'
+            allow_any_instance_of(Object).to receive(:dcv_installed?).and_return(false)
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'has the correct content' do
+          is_expected.to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
+            .with_content("[program:loginmgtd]")
+
+          is_expected.not_to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
+            .with_content("[program:pcluster_dcv_authenticator]")
+        end
+      end
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
@@ -52,4 +52,13 @@ stdout_logfile = /var/log/parallelcluster/computemgtd
 stdout_logfile_maxbytes = 0
 <% end -%>
 
+<%# LoginNode -%>
+<% when 'LoginNode' -%>
+[program:loginmgtd]
+command = <%= node['cluster']['shared_dir_login_nodes'] %>/loginmgtd.sh
+autorestart = unexpected
+exitcodes = 0
+redirect_stderr = true
+stdout_logfile = /var/log/parallelcluster/loginmgtd.log
+stdout_logfile_maxbytes = 1MB
 <% end -%>

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_login.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_login.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook:: aws-parallelcluster-slurm
-# Recipe:: config_compute
+# Recipe:: config_login
 #
 # Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
@@ -19,3 +19,5 @@
 setup_munge_compute_node
 
 include_recipe 'aws-parallelcluster-slurm::mount_slurm_dir'
+
+include_recipe 'aws-parallelcluster-slurm::login_nodes_daemon_service'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/login_nodes_daemon_service.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/login_nodes_daemon_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-slurm
+# Recipe:: login_nodes_daemon_service.rb
+#
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+load_cluster_config(node['cluster']['login_cluster_config_path'])
+
+# Create the configuration file for loginmgtd
+template "#{node['cluster']['shared_dir_login_nodes']}/loginmgtd_config.json" do
+  source 'slurm/login/loginmgtd_config.json.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  variables(
+    gracetime_period: lazy { node['cluster']['config'].dig(:LoginNodes, :Pools, 0, :GracetimePeriod) }
+  )
+end
+
+# Create the termination hook for loginmgtd
+template "#{node['cluster']['shared_dir_login_nodes']}/loginmgtd_on_termination.sh" do
+  source 'slurm/login/loginmgtd_on_termination.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
+# Create the script to run loginmgtd
+template "#{node['cluster']['shared_dir_login_nodes']}/loginmgtd.sh" do
+  source 'slurm/login/loginmgtd.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/loginmgtd.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/loginmgtd.sh.erb
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+
+# This script monitors the lifecycle state of the current AWS EC2 instance and triggers
+# a termination script when the instance state is set to "Terminated".
+# The script uses the AWS Instance Metadata Service (IMDS) to determine the state of the instance.
+# The termination script to be triggered and the termination message are read from a config JSON file.
+# The script expects a grace period in minutes as an argument, which it passes to the termination script.
+# The script runs in an infinite loop, checking the instance state every 60 seconds.
+
+CONFIG_PATH="<%= node['cluster']['shared_dir_login_nodes'] %>/loginmgtd_config.json"
+CONFIG_JSON=$(cat $CONFIG_PATH)
+TERMINATION_SCRIPT_PATH=$(echo $CONFIG_JSON | jq -r .termination_script_path)
+TERMINATION_MESSAGE=$(echo $CONFIG_JSON | jq -r .termination_message)
+GRACETIME_PERIOD=$(echo $CONFIG_JSON | jq -r .gracetime_period)
+DAEMON_SLEEP_SECONDS=60
+
+IMDS_ENDPOINT="http://169.254.169.254"
+
+while true; do
+  IMDS_TOKEN=$(curl -X PUT "$IMDS_ENDPOINT/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 3600")
+
+  INSTANCE_LIFECYCLE_STATE=$(curl -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" -v "$IMDS_ENDPOINT/latest/meta-data/autoscaling/target-lifecycle-state")
+  if [[ "$INSTANCE_LIFECYCLE_STATE" == "Terminated" ]]; then
+    break
+  fi
+  sleep $DAEMON_SLEEP_SECONDS
+done
+
+bash "$TERMINATION_SCRIPT_PATH" "$TERMINATION_MESSAGE" "$GRACETIME_PERIOD"

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/loginmgtd_config.json.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/loginmgtd_config.json.erb
@@ -1,0 +1,5 @@
+{
+  "termination_script_path": "<%= node['cluster']['shared_dir_login_nodes'] %>/loginmgtd_on_termination.sh",
+  "termination_message": "The system will be terminated within <%= @gracetime_period %> minutes.",
+  "gracetime_period": "<%= @gracetime_period %>"
+}

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/loginmgtd_on_termination.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/loginmgtd_on_termination.sh.erb
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -ex
+
+# This script is used to handle the termination of login nodes instances within an AWS cluster.
+# It restricts SSH access to a default user, notifies logged-in users of the upcoming termination,
+# waits for a given "grace period", then notifies of the imminent shutdown.
+# It is invoked with two parameters: a termination message and a gracetime period in minutes.
+# The termination message will be broadcast to all logged in users, and the grace period defines
+# how long the script should wait before the final system shutdown.
+
+DEFAULT_USER=<%= node['cluster']['cluster_user'] %>
+TERMINATION_MESSAGE=$1
+GRACETIME_PERIOD=$2
+
+echo "AllowUsers $DEFAULT_USER" >> /etc/ssh/sshd_config
+systemctl reload sshd
+wall "$TERMINATION_MESSAGE"


### PR DESCRIPTION
### Description of changes
Add `loginmgtd` daemon to login nodes. 
The daemon is responsible to notify all logged users about system termination and prevent further logins when the autoscaling group schedules the termination of the login node.

This PR has been created from the original https://github.com/aws/aws-parallelcluster-cookbook/pull/2366

**Limitations of this PR**
1. The daemon should be executed by cluster administrator, not root
2. The permission mask for the daemon scripts should be 0744, but it's not 0755 to bypass a limitation in the way supervisord is configured to run the script.
3. The daemon is currently defined as a script in cookbook, but it should rather be implemented as a python script in aws-parallelcluster-node package in order to be consistent with the other cluster daemons.

### Tests
1. Manually tested on AL2, Centos7, Ubuntu2004, RHEL8 that: 
    1. daemon gets automatically started by supervisord
    2. daemon sends the notification of system termination to every logged user
    3. new ssh logins are not blocked for the cluster default user
    5. the login node terminates as expected after the gracetime period.

Note: Chef and kitchen tests will be added in a follow up PR.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.