### PR TITLE
[Login Nodes] Improve security posture for loginmgtd by executing it as cluster admin and restricting access to the involved scripts.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
@@ -56,6 +56,8 @@ stdout_logfile_maxbytes = 0
 <% when 'LoginNode' -%>
 [program:loginmgtd]
 command = <%= node['cluster']['shared_dir_login_nodes'] %>/loginmgtd.sh
+user = <%= node['cluster']['cluster_admin_user'] %>
+environment = HOME="/home/<%= node['cluster']['cluster_admin_user'] %>",USER="<%= node['cluster']['cluster_admin_user'] %>"
 autorestart = unexpected
 exitcodes = 0
 redirect_stderr = true

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/login_nodes_daemon_service.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/login_nodes_daemon_service.rb
@@ -20,8 +20,8 @@ load_cluster_config(node['cluster']['login_cluster_config_path'])
 # Create the configuration file for loginmgtd
 template "#{node['cluster']['shared_dir_login_nodes']}/loginmgtd_config.json" do
   source 'slurm/login/loginmgtd_config.json.erb'
-  owner 'root'
-  group 'root'
+  owner node['cluster']['cluster_admin_user']
+  group node['cluster']['cluster_admin_user']
   mode '0644'
   variables(
     gracetime_period: lazy { node['cluster']['config'].dig(:LoginNodes, :Pools, 0, :GracetimePeriod) }
@@ -31,15 +31,23 @@ end
 # Create the termination hook for loginmgtd
 template "#{node['cluster']['shared_dir_login_nodes']}/loginmgtd_on_termination.sh" do
   source 'slurm/login/loginmgtd_on_termination.sh.erb'
-  owner 'root'
-  group 'root'
-  mode '0755'
+  owner node['cluster']['cluster_admin_user']
+  group node['cluster']['cluster_admin_user']
+  mode '0744'
 end
 
 # Create the script to run loginmgtd
 template "#{node['cluster']['shared_dir_login_nodes']}/loginmgtd.sh" do
   source 'slurm/login/loginmgtd.sh.erb'
+  owner node['cluster']['cluster_admin_user']
+  group node['cluster']['cluster_admin_user']
+  mode '0744'
+end
+
+# Create sudoers entry to let pcluster-admin user execute loginmgtd privileged actions
+template '/etc/sudoers.d/99-parallelcluster-loginmgtd' do
+  source 'slurm/login/99-parallelcluster-loginmgtd.erb'
   owner 'root'
   group 'root'
-  mode '0755'
+  mode '0600'
 end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/login_nodes_daemon_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/login_nodes_daemon_service_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::login_nodes_daemon_service' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner(platform: platform, version: version).converge(described_recipe)
+      end
+
+      it 'creates the loginmgtd configuration with the correct attributes' do
+        is_expected.to create_template('/opt/parallelcluster/shared_login_nodes/loginmgtd_config.json').with(
+          source: 'slurm/login/loginmgtd_config.json.erb',
+          owner: 'pcluster-admin',
+          group: 'pcluster-admin',
+          mode:  '0644'
+        )
+      end
+
+      it 'creates the loginmgtd script with the correct attributes' do
+        is_expected.to create_template('/opt/parallelcluster/shared_login_nodes/loginmgtd.sh').with(
+          source: 'slurm/login/loginmgtd.sh.erb',
+          owner: 'pcluster-admin',
+          group: 'pcluster-admin',
+          mode:  '0744'
+        )
+      end
+
+      it 'creates the loginmgtd termination hook script with the correct attributes' do
+        is_expected.to create_template('/opt/parallelcluster/shared_login_nodes/loginmgtd_on_termination.sh').with(
+          source: 'slurm/login/loginmgtd_on_termination.sh.erb',
+          owner: 'pcluster-admin',
+          group: 'pcluster-admin',
+          mode:  '0744'
+        )
+      end
+
+      it 'creates the loginmgtd sudoers configuration with the correct attributes' do
+        is_expected.to create_template('/etc/sudoers.d/99-parallelcluster-loginmgtd').with(
+          source: 'slurm/login/99-parallelcluster-loginmgtd.erb',
+          owner: 'root',
+          group: 'root',
+          mode:  '0600'
+        )
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/99-parallelcluster-loginmgtd.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/99-parallelcluster-loginmgtd.erb
@@ -1,0 +1,3 @@
+Cmnd_Alias LOGINMGTD_HOOKS_COMMANDS = <%= node['cluster']['shared_dir_login_nodes'] %>/loginmgtd_on_termination.sh
+
+<%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: LOGINMGTD_HOOKS_COMMANDS

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/loginmgtd.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/loginmgtd.sh.erb
@@ -7,6 +7,9 @@ set -ex
 # The termination script to be triggered and the termination message are read from a config JSON file.
 # The script expects a grace period in minutes as an argument, which it passes to the termination script.
 # The script runs in an infinite loop, checking the instance state every 60 seconds.
+#
+# This script must be executed as <%= node['cluster']['cluster_admin_user'] %> because
+# because only this user has sudoers privileges to execute the termination hook.
 
 CONFIG_PATH="<%= node['cluster']['shared_dir_login_nodes'] %>/loginmgtd_config.json"
 CONFIG_JSON=$(cat $CONFIG_PATH)
@@ -27,4 +30,4 @@ while true; do
   sleep $DAEMON_SLEEP_SECONDS
 done
 
-bash "$TERMINATION_SCRIPT_PATH" "$TERMINATION_MESSAGE" "$GRACETIME_PERIOD"
+sudo "$TERMINATION_SCRIPT_PATH" "$TERMINATION_MESSAGE" "$GRACETIME_PERIOD"

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/loginmgtd_on_termination.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/login/loginmgtd_on_termination.sh.erb
@@ -7,6 +7,8 @@ set -ex
 # It is invoked with two parameters: a termination message and a gracetime period in minutes.
 # The termination message will be broadcast to all logged in users, and the grace period defines
 # how long the script should wait before the final system shutdown.
+#
+# This script must be executed as root.
 
 DEFAULT_USER=<%= node['cluster']['cluster_user'] %>
 TERMINATION_MESSAGE=$1


### PR DESCRIPTION
### Description of changes
 Improve security posture for loginmgtd by executing it as cluster admin and restricting access to the involved scripts.

### Tests
Manually tested:
1. loginmgtd is running as pcluster-admin
2. loginmgtd is able to send the termination notification
3. the scripts have 0744 owned by pcluster-admin

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.