### PR TITLE
Check AD connection and sync user db with remote directory service

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/libraries/directory_service_utils.rb
+++ b/cookbooks/aws-parallelcluster-environment/libraries/directory_service_utils.rb
@@ -1,0 +1,24 @@
+#
+# Parse parameter DomainReadOnlyUser: cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=sirena,dc=com
+# and return the actual Name of the ReadOnly user
+def _get_cn_subparam(param)
+  tokens = param.split(",") unless param.blank?
+  tokens.each do |token|
+    return token if token.include? "cn"
+  end
+  ""
+end
+
+def domain_service_read_only_user_name(param)
+  cn_token = _get_cn_subparam(param)
+  if cn_token.blank?
+    Chef::Log.info("Failed to retrieve the ReadOnlyUser from #{param}")
+    name = 'ReadOnlyUser'
+    Chef::Log.info("Falling back to the default UserName #{name}")
+  else
+    name = cn_token.split("=")[1]
+    Chef::Log.info("UserName for ReadOnly directory service user set to #{name}")
+  end
+
+  name
+end

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/directory_service.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/directory_service.rb
@@ -251,3 +251,13 @@ end
     sensitive true
   end
 end unless on_docker?
+
+if %w(HeadNode LoginNode).include? node['cluster']['node_type']
+  read_only_user = domain_service_read_only_user_name(node['cluster']['directory_service']['domain_read_only_user'])
+
+  execute 'Check AD connection and sync user data with remote directory service' do
+    command "getent passwd #{read_only_user}"
+    user 'root'
+    ignore_failure true
+  end
+end


### PR DESCRIPTION
### Description of changes
* Checks the connection with the remote directory service and force an enumeration of the remote users.
This will ensure that homes created in other hosts are properly mapped to the right user names instead of user ids.

* Failures are ignored to allow the successful creation of the cluster even in case of misconfiguration or unavailability of the DirectoryService

This MUST be merged after the linked PR

## References
* [Add Readonly user in LoginNode dna.json](https://github.com/aws/aws-parallelcluster/pull/5519)

### Tests
* Validated through existing Kitchen tests that 
  * if the value DomainReadOnlyUser exist and it is properly formatted the right user name is returned
  * if the value is not present or not properly formatted a Log message is shown and the default name `ReadOnlyUser` is used
  * I launched a cluster and verified that both the HeadNode and LoginNode were launched correctly and the behavior was the one expected 

* Dedicated unit tests will be added in a following PR



### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
