### PR TITLE
Add Spack installation resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   Useful for development purposes only.
 - Avoid to start NFS server on compute nodes.
 - Add support for Login Nodes.
+- Install [Spack](https://spack.io) by default in the cluster user's home directory.
 
 **CHANGES**
 - Assign Slurm dynamic nodes a priority (weight) of 1000 by default. This allows Slurm to prioritize idle static nodes over idle dynamic ones.

--- a/cookbooks/aws-parallelcluster-platform/files/spack/modules.yaml
+++ b/cookbooks/aws-parallelcluster-platform/files/spack/modules.yaml
@@ -1,0 +1,15 @@
+modules:
+  default:
+    enable:
+      - tcl
+    tcl:
+      projections:
+        all: '{name}/{version}-{compiler.name}-{compiler.version}'
+      all:
+        conflict:
+          - '{name}'
+        environment:
+          set:
+            '{name}_ROOT': '{prefix}'
+        # Automatically load dependencies
+        autoload: all

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
@@ -169,6 +169,18 @@ suites:
       resource: nvidia_repo:remove
       dependencies:
         - resource:nvidia_repo:add
+  - name: spack
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-tests::test_resource]
+    verifier:
+      controls:
+        - /tag:install_spack/
+    attributes:
+      resource: spack
+      dependencies:
+        - recipe:aws-parallelcluster-platform::directories
+        - resource:efa
   - name: modules
     run_list:
       - recipe[aws-parallelcluster-tests::setup]

--- a/cookbooks/aws-parallelcluster-platform/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install.rb
@@ -33,3 +33,4 @@ include_recipe "aws-parallelcluster-platform::nvidia_install"
 include_recipe "aws-parallelcluster-platform::intel_mpi"
 arm_pl 'Install ARM Performance Library'
 intel_hpc 'Setup Intel HPC'
+spack 'install Spack'

--- a/cookbooks/aws-parallelcluster-platform/resources/spack/partial/_spack_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/spack/partial/_spack_common.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+unified_mode true
+default_action :setup
+
+property :spack_user, String, required: false,
+         default: node['cluster']['cluster_user']
+
+property :spack_root, String, required: false,
+         default: "/home/#{node['cluster']['cluster_user']}/spack"
+
+action :install_spack do
+  return if on_docker?
+
+  package_repos 'update package repos'
+
+  install_packages 'install spack dependencies' do
+    packages dependencies
+    action :install
+  end
+
+  git new_resource.spack_root do
+    repository 'https://github.com/spack/spack'
+    user new_resource.spack_user
+    group new_resource.spack_user
+  end
+
+  template '/etc/profile.d/spack.sh' do
+    cookbook 'aws-parallelcluster-platform'
+    source 'spack/spack.sh.erb'
+    owner 'root'
+    group 'root'
+    mode  '0755'
+    variables(spack_root: new_resource.spack_root)
+  end
+
+  spack = "#{new_resource.spack_root}/bin/spack"
+  spack_configs_dir = "#{new_resource.spack_root}/etc/spack"
+  arch_target = `#{spack} arch -t`.strip
+
+  # Find libfabric version to be used in package configs
+  libfabric_version = nil
+  ::File.open(libfabric_path).each do |line|
+    if line.include?('Version:')
+      libfabric_version = line.split[1].strip
+      break
+    end
+  end
+
+  # Pull architecture dependent package config
+  begin
+    template "#{spack_configs_dir}/packages.yaml" do
+      cookbook 'aws-parallelcluster-platform'
+      source "spack/packages-#{arch_target}.yaml.erb"
+      owner new_resource.spack_user
+      group new_resource.spack_user
+      variables(libfabric_version: libfabric_version)
+    end
+  rescue Chef::Exceptions::FileNotFound
+    Chef::Log.warn "Could not find template for #{arch_target}"
+  end
+
+  cookbook_file "#{spack_configs_dir}/modules.yaml" do
+    cookbook 'aws-parallelcluster-platform'
+    source 'spack/modules.yaml'
+    owner new_resource.spack_user
+    group new_resource.spack_user
+    mode '0755'
+  end
+
+  bash 'setup Spack' do
+    user new_resource.spack_user
+    group new_resource.spack_user
+    code <<-SPACK
+      source #{new_resource.spack_root}/share/spack/setup-env.sh
+
+      # Generate Spack user's compilers.yaml config with preinstalled compilers
+      #{spack} compiler add --scope site
+
+      # Add external packages to Spack user's packages.yaml config
+      #{spack} external find --scope site
+
+      # Remove all autotools/buildtools packages. These versions need to be managed by spack or it will
+      # eventually end up in a version mismatch (e.g. when compiling gmp).
+      #{spack} tags build-tools | xargs -I {} #{spack} config --scope site rm packages:{}
+    SPACK
+  end
+
+  node.default['cluster']['spack']['user'] = new_resource.spack_user
+  node.default['cluster']['spack']['root'] = new_resource.spack_root
+  node.default['cluster']['libfabric_version'] = libfabric_version
+  node_attributes 'dump node attributes'
+end
+
+# Binaries are currently only available for alinux. However, there is an issue verifying binaries with alinux due to gpg2.
+# This action should be included under OS specific setup actions when binaries are supported.
+action :add_binaries do
+  unless spack_installed?
+    Chef::Log.warn 'Spack root directory not found, ensure that Spack is installed before adding binaries'
+    return
+  end
+
+  spack = "#{new_resource.spack_root}/bin/spack"
+
+  bash 'add binaries' do
+    user new_resource.spack_user
+    group new_resource.spack_user
+    code <<-SPACK
+      [ -z "${CI_PROJECT_DIR}" ] && #{spack} mirror add --scope site "aws-pcluster" "https://binaries.spack.io/develop/aws-pcluster-$(spack arch -t | sed -e 's?_avx512??1')" || true
+      #{spack} buildcache keys --install --trust
+    SPACK
+  end
+end
+
+action_class do
+  def spack_installed?
+    ::Dir.exist?(new_resource.spack_root)
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/spack/spack_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/spack/spack_amazon2.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :spack, platform: 'amazon', platform_version: '2'
+
+use 'partial/_spack_common.rb'
+
+def dependencies
+  %w(autoconf automake bison byacc cscope ctags diffstat doxygen elfutils flex gcc gcc-c++ gcc-gfortran git
+     indent intltool libtool patch patchutils rcs rpm-build rpm-sign subversion swig system-rpm-config systemtap
+     curl findutils hostname iproute redhat-lsb-core python3 python3-setuptools unzip python-boto3)
+end
+
+def libfabric_path
+  '/opt/amazon/efa/lib64/pkgconfig/libfabric.pc'
+end
+
+action :setup do
+  action_install_spack
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/spack/spack_centos7.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/spack/spack_centos7.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :spack, platform: 'centos' do |node|
+  node['platform_version'].to_i == 7
+end
+
+use 'partial/_spack_common.rb'
+
+def dependencies
+  %w(autoconf automake bison byacc cscope ctags diffstat doxygen elfutils flex gcc gcc-c++ gcc-gfortran git
+     indent intltool libtool patch patchutils rcs rpm-build rpm-sign subversion swig system-rpm-config systemtap
+     curl findutils hostname iproute redhat-lsb-core python3 python3-setuptools unzip python-boto3)
+end
+
+def libfabric_path
+  '/opt/amazon/efa/lib64/pkgconfig/libfabric.pc'
+end
+
+action :setup do
+  action_install_spack
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/spack/spack_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/spack/spack_redhat8.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :spack, platform: 'redhat' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_spack_common.rb'
+
+def dependencies
+  %w(autoconf automake bison byacc cscope ctags diffstat doxygen elfutils flex gcc gcc-c++ gcc-gfortran git
+     indent intltool libtool patch patchutils rcs rpm-build rpm-sign subversion swig system-rpm-config systemtap
+     curl findutils hostname iproute redhat-lsb-core python3 python3-setuptools unzip python3-boto3)
+end
+
+def libfabric_path
+  '/opt/amazon/efa/lib64/pkgconfig/libfabric.pc'
+end
+
+action :setup do
+  action_install_spack
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/spack/spack_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/spack/spack_ubuntu20.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :spack, platform: 'ubuntu', platform_version: '20.04'
+
+use 'partial/_spack_common.rb'
+
+def dependencies
+  %w(build-essential ca-certificates coreutils curl environment-modules gfortran git gpg
+     lsb-release python3 python3-distutils python3-venv unzip zip)
+end
+
+def libfabric_path
+  '/opt/amazon/efa/lib/pkgconfig/libfabric.pc'
+end
+
+action :setup do
+  action_install_spack
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/spack/spack_ubuntu22.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/spack/spack_ubuntu22.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :spack, platform: 'ubuntu', platform_version: '22.04'
+
+use 'partial/_spack_common.rb'
+
+def dependencies
+  %w(build-essential ca-certificates coreutils curl environment-modules gfortran git gpg
+     lsb-release python3 python3-distutils python3-venv unzip zip)
+end
+
+def libfabric_path
+  '/opt/amazon/efa/lib/pkgconfig/libfabric.pc'
+end
+
+action :setup do
+  action_install_spack
+  action_fix_compilers
+end
+
+# Spack does not properly set paths when it finds both gcc11 and gcc12 in /usr/bin
+action :fix_compilers do
+  unless spack_installed?
+    Chef::Log.warn 'Spack root directory not found, ensure that Spack is installed before fixing compilers'
+    return
+  end
+
+  replace_or_add 'fix gcc12 cxx path' do
+    path "#{node['cluster']['spack']['root']}/etc/spack/compilers.yaml"
+    pattern '      cxx: null'
+    line '      cxx: /usr/bin/g++'
+    replace_only true
+  end
+
+  replace_or_add 'fix gcc12 f77 path' do
+    path "#{node['cluster']['spack']['root']}/etc/spack/compilers.yaml"
+    pattern '      f77: null'
+    line '      f77: /usr/bin/g++'
+    replace_only true
+  end
+
+  replace_or_add 'fix gcc12 fc path' do
+    path "#{node['cluster']['spack']['root']}/etc/spack/compilers.yaml"
+    pattern '      fc: null'
+    line '      fc: /usr/bin/g++'
+    replace_only true
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/templates/spack/packages-aarch64.yaml.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/spack/packages-aarch64.yaml.erb
@@ -1,0 +1,11 @@
+---  # aarch64 packages (Basically only compiler)
+packages:
+  gcc:
+    compiler: [gcc]
+    require:
+      - one_of: ["gcc@12 +binutils ^binutils@2.37 target=aarch64"]
+  all:
+    compiler: [gcc, clang]
+    permissions:
+      read: world
+      write: user

--- a/cookbooks/aws-parallelcluster-platform/templates/spack/packages-icelake.yaml.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/spack/packages-icelake.yaml.erb
@@ -1,0 +1,73 @@
+---  # Icelake packages
+packages:
+  gcc:
+    require:
+      - one_of: ["gcc@12 %gcc +binutils ^binutils@2.37 target=x86_64_v3"]
+  gromacs:
+    require:
+      - one_of: ["gromacs@2020.1 +lapack+blas %intel ^intel-oneapi-mkl"]
+  intel-mpi:
+    variants: +external-libfabric
+  intel-oneapi-compilers:
+    require:
+      - one_of: ["intel-oneapi-compilers %gcc target=x86_64_v3"]
+  intel-oneapi-mpi:
+    variants: +external-libfabric generic-names=True
+  lammps:
+    require:
+      - one_of: ["lammps@develop lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package +intel %intel ^intel-oneapi-mkl"]
+  libidn2:
+    require:
+      - one_of: ['cflags=-std=c18', '%gcc']
+  libfabric:
+    buildable: false
+    externals:
+      - modules:
+          - libfabric-aws/<%= @libfabric_version %>
+        spec: libfabric@<%= @libfabric_version %> fabrics=efa
+  libunistring:
+    require:
+      - one_of: ['cflags=-std=c18', '%gcc']
+  mpas-model:
+    require:
+      - one_of: ["precision=single %intel ^parallelio+pnetcdf"]
+  mpich:
+    require:
+      - one_of: ["mpich pmi=pmi2 device=ch4 netmod=ofi +slurm"]
+  openfoam:
+    require:
+      - one_of: ["openfoam %gcc ^scotch@6.0.9"]
+  openmpi:
+    variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
+  palace:
+    require:
+      - one_of: ["palace ^fmt@9.1.0"]
+  py-devito:
+    require:
+      - one_of: ["+mpi %intel"]
+  quantum-espresso:
+    require:
+      - one_of: ["quantum-espresso@6.6 %intel ^intel-oneapi-mkl+cluster"]
+  slurm:
+    buildable: false
+    externals:
+      - prefix: /opt/slurm/
+        spec: slurm@<%= node['cluster']['slurm']['version'] %> +pmix
+  wrf:
+    require:
+      - one_of: ["wrf@4 build_type=dm+sm %intel"]
+  all:
+    compiler: [intel, gcc, clang]
+    permissions:
+      read: world
+      write: user
+    providers:
+      blas: [intel-oneapi-mkl, intel-mkl]
+      daal: [intel-oneapi-dal, intel-daal]
+      fftw-api: [intel-oneapi-mkl, intel-mkl]
+      ipp: [intel-oneapi-ipp, intel-ipp]
+      lapack: [intel-oneapi-mkl, intel-mkl]
+      mkl: [intel-oneapi-mkl, intel-mkl]
+      mpi: [intel-oneapi-mpi, openmpi, mpich]
+      tbb: [intel-oneapi-tbb, intel-tbb]
+      scalapack: [intel-oneapi-mkl, intel-mkl]

--- a/cookbooks/aws-parallelcluster-platform/templates/spack/packages-neoverse_n1.yaml.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/spack/packages-neoverse_n1.yaml.erb
@@ -1,0 +1,56 @@
+---  # Neoverse N1 packages
+packages:
+  acfl:
+    target: [aarch64]
+    compiler: [gcc]
+  gcc:
+    compiler: [gcc]
+    require:
+      - one_of: ["gcc@12 +binutils ^binutils@2.37 target=aarch64"]
+  gromacs:
+    require:
+      - one_of: ["gromacs@2021.3 %gcc ^fftw^openmpi"]
+  libfabric:
+    buildable: false
+    externals:
+      - modules:
+          - libfabric-aws/<%= @libfabric_version %>
+        spec: libfabric@<%= @libfabric_version %> fabrics=efa
+  llvm:
+    variants: ~lldb
+  nvhpc:
+    compiler: [gcc]
+    target: [aarch64]
+  mpich:
+    require:
+      - one_of: ["mpich pmi=pmi2 device=ch4 netmod=ofi +slurm"]
+  openfoam:
+    require:
+      - one_of: ["openfoam %gcc ^scotch@6.0.9"]
+  openmpi:
+    variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
+  palace:
+    require:
+      - one_of: ["palace cxxflags=\"-include cstdint\" ^fmt@9.1.0"]
+  py-devito:
+    require:
+      - one_of: ["py-devito %gcc +mpi"]
+  quantum-espresso:
+    require:
+      - one_of: ["quantum-espresso@6.6 %gcc ^armpl-gcc"]
+  slurm:
+    buildable: false
+    externals:
+      - prefix: /opt/slurm/
+        spec: slurm@<%= node['cluster']['slurm']['version'] %> +pmix
+  all:
+    compiler: [nvhpc, gcc, clang]
+    providers:
+      blas: [armpl-gcc, openblas]
+      fftw-api: [armpl-gcc, fftw]
+      lapack: [armpl-gcc, openblas]
+      mpi: [openmpi, mpich]
+      scalapack: [netlib-scalapack]
+    permissions:
+      read: world
+      write: user

--- a/cookbooks/aws-parallelcluster-platform/templates/spack/packages-skylake_avx512.yaml.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/spack/packages-skylake_avx512.yaml.erb
@@ -1,0 +1,73 @@
+---  # Skylake packages
+packages:
+  gcc:
+    require:
+      - one_of: ["gcc@12 %gcc +binutils ^binutils@2.37 target=x86_64_v3"]
+  gromacs:
+    require:
+      - one_of: ["+lapack+blas%intel ^intel-oneapi-mkl"]
+  intel-mpi:
+    variants: +external-libfabric
+  intel-oneapi-compilers:
+    require:
+      - one_of: ["intel-oneapi-compilers %gcc target=x86_64_v3"]
+  intel-oneapi-mpi:
+    variants: +external-libfabric generic-names=True
+  lammps:
+    require:
+      - one_of: ["lammps@develop lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package +intel %intel ^intel-oneapi-mkl"]
+  libidn2:
+    require:
+      - one_of: ['cflags=-std=c18', '%gcc']
+  libfabric:
+    buildable: false
+    externals:
+      - modules:
+          - libfabric-aws/<%= @libfabric_version %>
+        spec: libfabric@<%= @libfabric_version %> fabrics=efa
+  libunistring:
+    require:
+      - one_of: ['cflags=-std=c18', '%gcc']
+  mpas-model:
+    require:
+      - one_of: ["mpas-model %intel precision=single ^parallelio+pnetcdf"]
+  mpich:
+    require:
+      - one_of: ["mpich pmi=pmi2 device=ch4 netmod=ofi +slurm"]
+  openfoam:
+    require:
+      - one_of: ["openfoam %gcc ^scotch@6.0.9"]
+  openmpi:
+    variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
+  palace:
+    require:
+      - one_of: ["palace ^fmt@9.1.0"]
+  py-devito:
+    require:
+      - one_of: ["py-devito %intel +mpi"]
+  quantum-espresso:
+    require:
+      - one_of: ["quantum-espresso@6.6 %intel ^intel-oneapi-mkl+cluster"]
+  slurm:
+    buildable: false
+    externals:
+      - prefix: /opt/slurm/
+        spec: slurm@<%= node['cluster']['slurm']['version'] %> +pmix
+  wrf:
+    require:
+      - one_of: ["wrf@4 build_type=dm+sm  %intel"]
+  all:
+    compiler: [intel, gcc, clang]
+    permissions:
+      read: world
+      write: user
+    providers:
+      blas: [intel-oneapi-mkl, intel-mkl]
+      daal: [intel-oneapi-dal, intel-daal]
+      fftw-api: [intel-oneapi-mkl, intel-mkl]
+      ipp: [intel-oneapi-ipp, intel-ipp]
+      lapack: [intel-oneapi-mkl, intel-mkl]
+      mkl: [intel-oneapi-mkl, intel-mkl]
+      mpi: [intel-oneapi-mpi, openmpi, mpich]
+      tbb: [intel-oneapi-tbb, intel-tbb]
+      scalapack: [intel-oneapi-mkl, intel-mkl]

--- a/cookbooks/aws-parallelcluster-platform/templates/spack/packages-zen2.yaml.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/spack/packages-zen2.yaml.erb
@@ -1,0 +1,80 @@
+---  # Zen2/3 packages
+packages:
+  aocc:
+    require:
+      - one_of: ["aocc +license-agreed %gcc target=x86_64_v3"]
+  gcc:
+    require:
+      - one_of: ["gcc@12 %gcc +binutils ^binutils@2.37 target=x86_64_v3"]
+  gromacs:
+    require:
+      - one_of: ["+lapack+blas %intel ^intel-oneapi-mkl"]
+  intel-mpi:
+    variants: +external-libfabric
+  intel-oneapi-compilers:
+    require:
+      - one_of: ["intel-oneapi-compilers %gcc target=x86_64_v3"]
+  intel-oneapi-mpi:
+    variants: +external-libfabric generic-names=True
+  lammps:
+    require:
+      - one_of: ["lammps_sizes=bigbig +molecule +kspace +rigid +asphere +opt +openmp +openmp-package %intel ^intel-oneapi-mkl"]
+  libidn2:
+    require:
+      - one_of: ['cflags=-std=c18', '%gcc']
+  libfabric:
+    buildable: false
+    externals:
+      - modules:
+          - libfabric-aws/<%= @libfabric_version %>
+        spec: libfabric@<%= @libfabric_version %> fabrics=efa
+  libunistring:
+    require:
+      - one_of: ['cflags=-std=c18', '%gcc']
+  mpas-model:
+    require:
+      - one_of: ["precision=single %intel ^parallelio+pnetcdf"]
+  mpich:
+    require:
+      - one_of: ["mpich pmi=pmi2 device=ch4 netmod=ofi +slurm"]
+  openfoam:
+    require:
+      - one_of: ["openfoam %gcc ^scotch@6.0.9"]
+  openmpi:
+    variants: ~atomics ~cuda ~cxx ~cxx_exceptions ~internal-hwloc ~java +legacylaunchers ~lustre ~memchecker +pmi +romio ~singularity +vt +wrapper-rpath fabrics=ofi schedulers=slurm
+  palace:
+    require:
+      - one_of: ["palace ^fmt@9.1.0"]
+  # TODO: Find out if we can get higher perf using intel-mkl with MKL_DEBUG_TYPE=5 or similar.
+  py-devito:
+    require:
+      - one_of: ["py-devito %intel +mpi"]
+  quantum-espresso:
+    require:
+      - one_of: ["quantum-espresso@6.6 %intel ^intel-mkl"]
+  slurm:
+    buildable: false
+    externals:
+      - prefix: /opt/slurm/
+        spec: slurm@<%= node['cluster']['slurm']['version'] %> +pmix
+  stream:
+    require:
+      - one_of: ["stream@5.10 +openmp cflags=\"-qopt-streaming-stores=always -mcmodel=large -O3 -shared-intel -qopenmp -DSTREAM_ARRAY_SIZE=268435456 -DNTIMES=100\""]
+  wrf:
+    require:
+      - one_of: ["wrf@4 build_type=dm+sm %intel", "wrf@4.2.2 +netcdf_classic fflags=\"-fp-model fast=2 -no-heap-arrays -no-prec-div -no-prec-sqrt -fno-common\" build_type=dm+sm %intel"]
+  all:
+    compiler: [intel, gcc, clang]
+    permissions:
+      read: world
+      write: user
+    providers:
+      blas: [intel-oneapi-mkl, intel-mkl]
+      daal: [intel-oneapi-dal, intel-daal]
+      fftw-api: [intel-oneapi-mkl, intel-mkl]
+      ipp: [intel-oneapi-ipp, intel-ipp]
+      lapack: [intel-oneapi-mkl, intel-mkl]
+      mkl: [intel-oneapi-mkl, intel-mkl]
+      mpi: [intel-oneapi-mpi, openmpi, mpich]
+      tbb: [intel-oneapi-tbb, intel-tbb]
+      scalapack: [intel-oneapi-mkl, intel-mkl]

--- a/cookbooks/aws-parallelcluster-platform/templates/spack/spack.sh.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/spack/spack.sh.erb
@@ -1,0 +1,2 @@
+export SPACK_ROOT=<%= @spack_root %>
+source <%= @spack_root %>/share/spack/setup-env.sh

--- a/cookbooks/aws-parallelcluster-platform/test/controls/spack_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/spack_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Copyright:: 2013-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+control 'tag:install_spack_correctly_installed' do
+  only_if { !os_properties.on_docker? }
+
+  describe directory(node['cluster']['spack']['root']) do
+    it { should exist }
+    it { should be_owned_by (node['cluster']['spack']['user']).to_s }
+    it { should be_grouped_into (node['cluster']['spack']['user']).to_s }
+  end
+
+  describe directory("#{node['cluster']['spack']['root']}/share/spack") do
+    it { should exist }
+    it { should be_owned_by (node['cluster']['spack']['user']).to_s }
+    it { should be_grouped_into (node['cluster']['spack']['user']).to_s }
+  end
+
+  describe file('/etc/profile.d/spack.sh') do
+    it { should exist }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+  end
+
+  describe file("#{node['cluster']['spack']['root']}/etc/spack/compilers.yaml") do
+    it { should exist }
+    it { should be_owned_by (node['cluster']['spack']['user']).to_s }
+    it { should be_grouped_into (node['cluster']['spack']['user']).to_s }
+  end
+
+  spack = "#{node['cluster']['spack']['root']}/bin/spack"
+  describe "spack commands can run as cluster default user #{node['cluster']['spack']['user']}" do
+    subject { bash("su - #{node['cluster']['spack']['user']} -c '#{spack} find'") }
+    its('exit_status') { should eq(0) }
+  end
+
+  describe "spack config audits pass" do
+    subject { bash("#{spack} audit configs") }
+    its('exit_status') { should eq(0) }
+  end
+end
+
+control 'tag:install_spack_can_install_packages' do
+  only_if { !os_properties.on_docker? }
+  spack = "#{node['cluster']['spack']['root']}/bin/spack"
+
+  describe "spack can install packages as cluster default user #{node['cluster']['spack']['user']}" do
+    subject { bash("sudo su - #{node['cluster']['spack']['user']} -c '#{spack} install xz'") }
+    its('exit_status') { should eq(0) }
+  end
+
+  describe "spack can install packages as root" do
+    subject { bash("sudo su - -c '#{spack} install pkgconf'") }
+    its('exit_status') { should eq(0) }
+  end
+end


### PR DESCRIPTION
Description of changes
- Create a basic resource to install Spack in the default cluster user's home directory.
- Add cluster dependent Spack packages.yaml files and configure Spack to find compilers and external directories
- Add binaries to Spack if they are successfully verified

Tests
Inspec tests to ensure that Spack directories have been created correctly and that user can successfully run spack find and spack install.
EC2 ./kitchen.ec2.sh platform-install verify spack -c 5