### PR TITLE
[kitchen tests] Fix GPU health check kitchen tests on Amazon Linux 2 Deep Learning AMI

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/test/controls/config_health_check_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/config_health_check_spec.rb
@@ -52,7 +52,7 @@ control 'tag:config_gpu_health_check_execution' do
 
   if instance.graphic?
     if instance.dcgmi_gpu_accel_supported?
-      if os_properties.arm? && (os_properties.centos7? || os_properties.alinux2?)
+      if (os_properties.arm? && (os_properties.centos7? || os_properties.alinux2?)) || (os_properties.alinux2? && node['cluster']['nvidia']['enabled'] == 'no')
         describe command("#{slurm_install_dir}/etc/pcluster/.slurm_plugin/scripts/health_checks/gpu_health_check.sh") do
           its('exit_status') { should eq 0 }
           its('stdout') { should match /The GPU Health Check has been executed but the NVIDIA DCGM Diagnostic tool is not available in this system/ }


### PR DESCRIPTION
### Description of changes
The Nvidia softwares on Deep Learning AMIs are pre-installed and not managed by ParallelCluster. On Amazon Linux 2 Deep Learning AMI, although Nvidia driver is installed, DCGM is not. On Ubuntu 2004 Deep Learning AMI, both Nvidia driver and DCGM are installed. Therefore, the condition of GPU health check kitchen test is changed accordingly.

Note: `['nvidia']['enabled'] == 'no'` means the Nvidia softwares are not managed by ParallelCluster

### Tests
Kitchen tests have been passed

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.