### PR TITLE
Add ARM PL v23.04.1 for Ubuntu 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Rdma-core: `rdma-core-46.0-1`
   - Open MPI: `openmpi40-aws-4.1.5-1`
 - Upgrade Slurm to version 23.02.3.
+- Upgrade ARM PL to version 23.04.1 for Ubuntu 22.04 only.
 
 **BUG FIXES**
 - Fix cluster creation failure with Ubuntu Deep Learning AMI on GPU instances and DCV enabled.

--- a/cookbooks/aws-parallelcluster-platform/resources/arm_pl/arm_pl_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/arm_pl/arm_pl_ubuntu20.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :arm_pl, platform: 'ubuntu' do |node|
+  node['platform_version'].to_i == 20
+end
+
+use 'partial/_arm_pl_common.rb'
+
+action_class do
+  def armpl_platform
+    "Ubuntu-#{node['platform_version']}"
+  end
+
+  def modulefile_dir
+    "/usr/share/modules/modulefiles"
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/arm_pl/arm_pl_ubuntu22.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/arm_pl/arm_pl_ubuntu22.rb
@@ -13,10 +13,15 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 provides :arm_pl, platform: 'ubuntu' do |node|
-  node['platform_version'].to_i >= 20
+  node['platform_version'].to_i == 22
 end
 
 use 'partial/_arm_pl_common.rb'
+
+property :armpl_major_minor_version, String, default: '23.04'
+property :armpl_patch_version, String, default: '1'
+property :gcc_major_minor_version, String, default: '11.3'
+property :gcc_patch_version, String, default: '0'
 
 action_class do
   def armpl_platform

--- a/cookbooks/aws-parallelcluster-platform/resources/arm_pl/partial/_arm_pl_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/arm_pl/partial/_arm_pl_common.rb
@@ -91,6 +91,12 @@ action :setup do
   # create armpl module directory
   directory "#{modulefile_dir}/armpl"
 
+  armpl_license_dir = if new_resource.armpl_major_minor_version == "21.0"
+                        "/opt/arm/armpl/#{armpl_version}/arm-performance-libraries_#{new_resource.armpl_major_minor_version}_gcc-#{new_resource.gcc_major_minor_version}/license_terms"
+                      else
+                        "/opt/arm/armpl/#{armpl_version}/arm-performance-libraries_#{armpl_version}_gcc-#{new_resource.gcc_major_minor_version}/license_terms"
+                      end
+
   # arm performance library modulefile configuration
   template "#{modulefile_dir}/armpl/#{armpl_version}" do
     source 'arm_pl/armpl_modulefile.erb'
@@ -101,6 +107,7 @@ action :setup do
     variables(
       armpl_version: armpl_version,
       armpl_major_minor_version: new_resource.armpl_major_minor_version,
+      armpl_license_dir: armpl_license_dir,
       gcc_major_minor_version: new_resource.gcc_major_minor_version
     )
   end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/arm_pl_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/arm_pl_spec.rb
@@ -15,8 +15,20 @@ describe 'arm_pl:setup' do
     context "on #{platform}#{version} x86" do
       cached(:aws_region) { 'test_region' }
       cached(:aws_domain) { 'test_domain' }
-      cached(:armpl_major_minor_version) { '21.0' }
-      cached(:armpl_patch_version) { '0' }
+      cached(:armpl_major_minor_version) do
+        if platform == 'ubuntu' && version == '22.04'
+          '23.04'
+        else
+          '21.0'
+        end
+      end
+      cached(:armpl_patch_version) do
+        if platform == 'ubuntu' && version == '22.04'
+          '1'
+        else
+          '0'
+        end
+      end
 
       cached(:armpl_platform) do
         case platform
@@ -29,7 +41,14 @@ describe 'arm_pl:setup' do
         end
       end
 
-      cached(:gcc_major_minor_version) { '9.3' }
+      cached(:gcc_major_minor_version) do
+        if platform == 'ubuntu' && version == '22.04'
+          '11.3'
+        else
+          '9.3'
+        end
+      end
+
       cached(:gcc_patch_version) { '0' }
       cached(:sources_dir) { 'sources_test_dir' }
       cached(:modulefile_dir) { platform == 'ubuntu' ? '/usr/share/modules/modulefiles' : '/usr/share/Modules/modulefiles' }
@@ -116,6 +135,11 @@ describe 'arm_pl:setup' do
         end
 
         it 'creates arm performance library modulefile configuration' do
+          armpl_license_dir = if armpl_major_minor_version == "21.0"
+                                "/opt/arm/armpl/#{armpl_version}/arm-performance-libraries_#{armpl_major_minor_version}_gcc-#{gcc_major_minor_version}/license_terms"
+                              else
+                                "/opt/arm/armpl/#{armpl_version}/arm-performance-libraries_#{armpl_version}_gcc-#{gcc_major_minor_version}/license_terms"
+                              end
           is_expected.to create_template("#{modulefile_dir}/armpl/#{armpl_version}").with(
             source: 'arm_pl/armpl_modulefile.erb',
             user: 'root',
@@ -124,6 +148,7 @@ describe 'arm_pl:setup' do
             variables: {
               armpl_version: armpl_version,
               armpl_major_minor_version: armpl_major_minor_version,
+              armpl_license_dir: armpl_license_dir,
               gcc_major_minor_version: gcc_major_minor_version,
             }
           )

--- a/cookbooks/aws-parallelcluster-platform/templates/arm_pl/armpl_modulefile.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/arm_pl/armpl_modulefile.erb
@@ -28,7 +28,7 @@ puts stderr "At compile time add '-I<armpl_include>' and at link time"
   }
 
   # Add license path
-  setenv ARM_LICENSE_DIR $root/arm-performance-libraries_${major_minor_version}_gcc-${gcc_version}/license_terms
+  setenv ARM_LICENSE_DIR <%= @armpl_license_dir %>
 
   # Load the pre-installed gcc module
   module load $root/modulefiles/armpl/gcc-${gcc_version}

--- a/cookbooks/aws-parallelcluster-platform/test/controls/arm_pl_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/arm_pl_spec.rb
@@ -11,7 +11,6 @@
 
 control 'tag:install_arm_pl_installed' do
   title "Check ARM Performance libraries installation"
-  only_if { !os_properties.ubuntu2204? }
   only_if { os_properties.arm? && !os_properties.on_docker? }
 
   armpl_major_minor_version = node['cluster']['armpl']['major_minor_version']
@@ -21,6 +20,14 @@ control 'tag:install_arm_pl_installed' do
   armpl_module_general_name = "armpl/#{armpl_version}"
   armpl_module_name = "armpl/#{armpl_version}_gcc-#{gcc_major_minor_version}"
   gcc_module_name = "armpl/gcc-#{gcc_major_minor_version}"
+
+  if os_properties.ubuntu2204?
+    armpl_script_dir = "/opt/arm/#{armpl_module_general_name}/arm-performance-libraries_#{armpl_version}_gcc-#{gcc_major_minor_version}"
+    armpl_install_dir = "/opt/arm/#{armpl_module_general_name}/armpl_#{armpl_version}_gcc-#{gcc_major_minor_version}"
+  else
+    armpl_script_dir = "/opt/arm/#{armpl_module_general_name}/arm-performance-libraries_#{armpl_major_minor_version}_gcc-#{gcc_major_minor_version}"
+    armpl_install_dir = "/opt/arm/#{armpl_module_general_name}/armpl_#{armpl_major_minor_version}_gcc-#{gcc_major_minor_version}"
+  end
 
   setup = "unset MODULEPATH && source /etc/profile.d/modules.sh"
 
@@ -33,28 +40,26 @@ control 'tag:install_arm_pl_installed' do
     its('stderr') { should match /#{gcc_module_name}/ }
   end
 
-  describe bash("ls /opt/arm/#{armpl_module_general_name}/arm-performance-libraries_#{armpl_major_minor_version}_gcc-#{gcc_major_minor_version}/license_terms") do
+  describe bash("ls #{armpl_script_dir}/license_terms") do
     its('stdout') { should include 'license_agreement.txt' }
     its('stdout') { should include 'third_party_licenses.txt' }
   end
 
-  arm_version = node['cluster']['armpl']['major_minor_version']
-  arm_pl_installation = "armpl_#{arm_version}_gcc-9.3"
   test_software = "fftw_dft_r2c_1d_c_example"
 
   scl_centos7 = "scl enable devtoolset-8" if os_properties.centos?
 
   describe bash("#{setup} && module load #{armpl_module_general_name} && "\
-                "cd /opt/arm/armpl/#{armpl_version}/armpl_#{armpl_major_minor_version}_gcc-#{gcc_major_minor_version}/examples && "\
+                "cd #{armpl_install_dir}/examples && "\
                 "make clean && #{scl_centos7} make") do
     its('exit_status') { should eq(0) }
     its('stdout') { should match /testing: no example difference files were generated/i }
     its('stdout') { should match /test passed ok/i }
   end
 
-  describe bash("sudo bash -c 'unset MODULEPATH && source /etc/profile.d/modules.sh && module load armpl && cd /opt/arm/armpl/#{arm_version}.0/#{arm_pl_installation}/examples &&  \
-    gcc -c -I/opt/arm/armpl/#{arm_version}.0/#{arm_pl_installation}/include #{test_software}.c -o #{test_software}.o && \
-    gcc #{test_software}.o -L/opt/arm/armpl/#{arm_version}.0/#{arm_pl_installation}/lib -o #{test_software}.exe -larmpl_lp64 -lm && \
+  describe bash("sudo bash -c 'unset MODULEPATH && source /etc/profile.d/modules.sh && module load armpl && cd #{armpl_install_dir}/examples &&  \
+    gcc -c -I#{armpl_install_dir}/include #{test_software}.c -o #{test_software}.o && \
+    gcc #{test_software}.o -L#{armpl_install_dir}/lib -o #{test_software}.exe -larmpl_lp64 -lm && \
     ./#{test_software}.exe'") do
     its('exit_status') { should eq(0) }
     its('stdout') { should match /ARMPL example: FFT of a real sequence using fftw_plan_dft_r2c_1d/ }
@@ -63,7 +68,6 @@ end
 
 control 'tag:install_arm_pl_gcc_installed' do
   title "Check ARM Performance libraries installation"
-  only_if { !os_properties.ubuntu2204? }
   only_if { os_properties.arm? && !os_properties.on_docker? }
 
   gcc_major_minor_version = node['cluster']['armpl']['gcc']['major_minor_version']


### PR DESCRIPTION
ARM PL v23 changes the directory structure for the installed files to include the patch version.   
This requires refactoring the resource to include this change in the modulefile for armpl to identify the license

### Tests
* Ran `platform-install test arm-pl-*` for all OSes

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.