### PR TITLE
Add retry to fix sporadic nfs service failure

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/partial/_configure.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/partial/_configure.rb
@@ -24,6 +24,8 @@ action :configure do
     service node['nfs']['service']['server'] do
       action %i(restart enable)
       supports restart: true
+      retries 5
+      retry_delay 10
     end unless on_docker?
   else
     service node['nfs']['service']['server'] do


### PR DESCRIPTION
This failure causes cluster creation failure. It happened about once every 200 times.


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.