### PR TITLE
Move the NFS config file override from the setup action to configure via override_server_template

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_ubuntu22+.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_ubuntu22+.rb
@@ -29,11 +29,11 @@ action :setup do
   action_install_nfs
   action_install_nfs4
   action_disable_start_at_boot
-  node.default['nfs']['config']['server_template'] = '/etc/nfs.conf.d/parallelcluster-nfs.conf'
 end
 
 action_class do
   def override_server_template
+    node.default['nfs']['config']['server_template'] = '/etc/nfs.conf.d/parallelcluster-nfs.conf'
     edit_resource(:template, node['nfs']['config']['server_template']) do
       source 'nfs/nfs-ubuntu22+.conf.erb'
       cookbook 'aws-parallelcluster-environment'


### PR DESCRIPTION
The override_server_template function runs during bootstrapping to set the parameter needed for the OS specific config file. The setup action works locally since that action runs during local tests, but does not work during bootstrapping when the node attributes from the setup action are not present

### Tests
* Tested `nfs_headnode` locally with kitchen

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.