### PR TITLE
Move ulimit check back to config since it fails on jenkins

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/users_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/users_spec.rb
@@ -18,9 +18,6 @@ control 'tag:install_users_ulimit_configured' do
   describe limits_conf("/etc/security/limits.d/00_all_limits.conf") do
     its('*') { should include ['-', 'nofile', "10000"] }
   end
-  describe bash("sudo -u #{user} bash -c 'ulimit -Sn'") do
-    its('stdout') { should cmp >= '8192' }
-  end
 end
 
 control 'tag:config_admin_user_and_group_correctly_defined' do
@@ -34,5 +31,13 @@ control 'tag:config_admin_user_and_group_correctly_defined' do
   describe group(node['cluster']['cluster_admin_group']) do
     it { should exist }
     its('gid') { should eq node['cluster']['cluster_admin_group_id'] }
+  end
+end
+
+control 'tag:config_ulimit_is_not_lower_than_8192' do
+  only_if { !instance.custom_ami? }
+
+  describe bash("sudo -u #{user} bash -c 'ulimit -Sn'") do
+    its('stdout') { should cmp >= '8192' }
   end
 end


### PR DESCRIPTION
### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2394

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
