### PR TITLE
Set --no-cc-version-check flag to build on ubuntu 22.04 (#2389)

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
@@ -61,13 +61,14 @@ action :setup do
   end
 
   # Install driver
+  # TODO remove --no-cc-version-check when we can update ubuntu 22 images
   bash 'nvidia.run advanced' do
     user 'root'
     group 'root'
     cwd '/tmp'
     code <<-NVIDIA
       set -e
-      ./nvidia.run --silent --dkms --disable-nouveau
+      ./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check
       rm -f /tmp/nvidia.run
     NVIDIA
     creates '/usr/bin/nvidia-smi'


### PR DESCRIPTION
The gcc compiler used to build the kernel on Ubuntu 22.04 images we use is 11.3, but the gcc apt package seems to install 11.4 for use in the terminal.  This flag will prevent the NVIDIA driver from failing to install due to the minor version difference in gcc.


### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2389

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
