### PR TITLE
[Fault Tolerance] Add retry with delay to the block to copy Munge key and the blocks to start Chronyd and Munge services.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/chrony/partial/_chrony_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/chrony/partial/_chrony_common.rb
@@ -39,6 +39,8 @@ action :enable do
     supports restart: false
     reload_command chrony_reload_command
     action %i(enable start)
+    retries 5
+    retry_delay 10
   end unless redhat_on_docker?
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -60,6 +60,8 @@ def enable_munge_service
   service "munge" do
     supports restart: true
     action %i(enable start)
+    retries 5
+    retry_delay 10
   end
 end
 
@@ -111,6 +113,8 @@ def setup_munge_compute_node
       # Enforce correct permission on the key
       chmod 0600 /etc/munge/munge.key
     COMPUTE_MUNGE_KEY
+    retries 5
+    retry_delay 10
   end
 
   enable_munge_service


### PR DESCRIPTION
### Description of changes
Cherry-picked from https://github.com/aws/aws-parallelcluster-cookbook/pull/2409

### Tests
Safe change, no need to test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
