### PR TITLE
[develop] Use cinc in place of chef for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,8 @@ jobs:
       - uses: actions/checkout@main
       - uses: actionshub/chef-install@main
         with:
-          version: 22.10.1013
+          omnitruckUrl: omnitruck.cinc.sh
+          project: cinc-workstation
       - name: Run ChefSpec on ${{ matrix.cookbook }}
         run: |
           cd ${{ matrix.cookbook }}

--- a/.github/workflows/dokken-system-tests.yml
+++ b/.github/workflows/dokken-system-tests.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install Chef
         if: steps.changed-files-excluding-tests.outputs.any_changed == 'true' && needs.check-labels.outputs.skip_system_tests != 'true'
         uses: actionshub/chef-install@main
+        with:
+          omnitruckUrl: omnitruck.cinc.sh
+          project: cinc-workstation
       - name: Kitchen Test Install
         if: steps.changed-files-excluding-tests.outputs.any_changed == 'true' && needs.check-labels.outputs.skip_system_tests != 'true'
         uses: actionshub/test-kitchen@main

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ They are automatically executed as GitHub actions, see definition in `.github/ci
 Kitchen is used to automatically test cookbooks across any combination of platforms and test suites.
 It requires cinc-workstation to be installed on your environment:
 
+`brew install --cask cinc-workstation` on MacOS
+
+or
+
 `curl -L https://omnitruck.cinc.sh/install.sh | sudo bash -s -- -P cinc-workstation -v 23`
 
 Make sure you have set a locale in your local shell environment, by exporting the `LC_ALL` and `LANG` variables, 


### PR DESCRIPTION
* With this change is easier to use updated/alternative versions of cinc in GitHub actions (e.g. 18.2.7)
* Improved readme.

### Tests
* GitHub actions

