### PR TITLE
[release-3.7] Generate RSA Host key for alinux2 platforms

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/files/login_nodes/keys-manager.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/login_nodes/keys-manager.sh
@@ -36,9 +36,7 @@ function create_keys() {
   info "Creating host keys"
   ssh-keygen -t ecdsa -f "$FOLDER_PATH/ssh_host_ecdsa_key" -q -P ""
   ssh-keygen -t ed25519 -f "$FOLDER_PATH/ssh_host_ed25519_key" -q -P ""
-  if is_not_alinux; then
-      ssh-keygen -t rsa -f "$FOLDER_PATH/ssh_host_rsa_key" -q -P ""
-  fi
+  ssh-keygen -t rsa -f "$FOLDER_PATH/ssh_host_rsa_key" -q -P ""
   if is_ubuntu; then
     ssh-keygen -t dsa -f "$FOLDER_PATH/ssh_host_dsa_key" -q -P ""
   fi
@@ -49,9 +47,7 @@ function import_keys() {
   rm -f /etc/ssh/ssh_host_*
   cp "$FOLDER_PATH/ssh_host_ecdsa"* /etc/ssh/
   cp "$FOLDER_PATH/ssh_host_ed25519"* /etc/ssh/
-  if is_not_alinux; then
-      cp "$FOLDER_PATH/ssh_host_rsa"* /etc/ssh/
-  fi
+  cp "$FOLDER_PATH/ssh_host_rsa"* /etc/ssh/
   if is_ubuntu; then
     cp "$FOLDER_PATH/ssh_host_dsa"* /etc/ssh/
     chown root:root /etc/ssh/ssh_host_*
@@ -61,13 +57,6 @@ function import_keys() {
     chmod 640 /etc/ssh/ssh_host_*_key
   fi
   chmod 644 /etc/ssh/ssh_host_*_key.pub
-}
-
-function is_not_alinux() {
-  if grep -q "Amazon" <<< "$OS"; then
-    return 1
-  fi
-  return 0
 }
 
 function is_ubuntu() {

--- a/cookbooks/aws-parallelcluster-environment/test/controls/login_nodes_keys_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/login_nodes_keys_spec.rb
@@ -10,12 +10,8 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 keys_manager_script_dir = "/opt/parallelcluster/scripts/login_nodes"
-key_types = %w(ecdsa ed25519)
-is_not_amazon = !os_properties.amazon_family?
+key_types = %w(ecdsa ed25519 rsa)
 is_ubuntu = os_properties.ubuntu?
-if is_not_amazon
-  key_types << 'rsa'
-end
 if is_ubuntu
   key_types << 'dsa'
 end


### PR DESCRIPTION
- Cherry-picked from: https://github.com/aws/aws-parallelcluster-cookbook/pull/2422

### Description of changes
- This matches the behaviour from the base OS which also generates RSA host keys
- This is also to avoid _sshd_ from having errors when an ssh client attempts signature verification using RSA
```
error: Could not load host key: /etc/ssh/ssh_host_rsa_key
```
- We still have `ed25519` and `ecdsa` host keys which are more secure and take precedence

### Tests
* Updated  existing Kitchen test to confirm that RSA host key is generated on `alinux2`
* Ran kitchen tests for (`login-nodes-keys-configuration-*` and `login-nodes-headnode-keys-configuration-*`)

- login-nodes-headnode-keys-configuration-alinux2
```
  ✔  head_node_directory_initialized: Directory /opt/parallelcluster/scripts/login_nodes
     ✔  Directory /opt/parallelcluster/scripts/login_nodes is expected to exist
     ✔  Directory /opt/parallelcluster/scripts/login_nodes owner is expected to eq "root"
     ✔  Directory /opt/parallelcluster/scripts/login_nodes group is expected to eq "root"
     ✔  Directory /opt/parallelcluster/scripts/login_nodes mode is expected to cmp == "0744"
     ✔  Bash command cat /etc/exports exit_status is expected to eq 0
     ✔  Bash command cat /etc/exports stdout is expected to match /^\/opt\/parallelcluster\/scripts\/login_nodes /
     ✔  File /opt/shared_login_nodes/ssh_host_ecdsa_key is expected to exist
     ✔  File /opt/shared_login_nodes/ssh_host_ecdsa_key content is expected not to be empty
     ✔  File /opt/shared_login_nodes/ssh_host_ecdsa_key.pub is expected to exist
     ✔  File /opt/shared_login_nodes/ssh_host_ecdsa_key.pub content is expected not to be empty
     ✔  File /opt/shared_login_nodes/ssh_host_ed25519_key is expected to exist
     ✔  File /opt/shared_login_nodes/ssh_host_ed25519_key content is expected not to be empty
     ✔  File /opt/shared_login_nodes/ssh_host_ed25519_key.pub is expected to exist
     ✔  File /opt/shared_login_nodes/ssh_host_ed25519_key.pub content is expected not to be empty
     ✔  File /opt/shared_login_nodes/ssh_host_rsa_key is expected to exist
     ✔  File /opt/shared_login_nodes/ssh_host_rsa_key content is expected not to be empty
     ✔  File /opt/shared_login_nodes/ssh_host_rsa_key.pub is expected to exist
     ✔  File /opt/shared_login_nodes/ssh_host_rsa_key.pub content is expected not to be empty
```

- login-nodes-keys-configuration-alinux2

```
  ✔  login_node_configuration_initialized: Mount /opt/parallelcluster/scripts/utils
     ✔  Mount /opt/parallelcluster/scripts/utils is expected to be mounted
     ✔  Mount /opt/parallelcluster/scripts/utils device is expected to eq "127.0.0.1:/opt/parallelcluster/scripts/login_nodes"
     ✔  Mount /opt/parallelcluster/scripts/utils type is expected to eq "nfs4"
     ✔  Mount /opt/parallelcluster/scripts/utils options is expected to include "hard"
     ✔  Mount /opt/parallelcluster/scripts/utils options is expected to include "_netdev"
     ✔  Mount /opt/parallelcluster/scripts/utils options is expected to include "noatime"
     ✔  Bash command cat /etc/exports exit_status is expected to eq 0
     ✔  Bash command cat /etc/exports stdout is expected to match /^\/opt\/parallelcluster\/scripts\/login_nodes /
     ✔  File /etc/ssh/ssh_host_ecdsa_key is expected to exist
     ✔  File /etc/ssh/ssh_host_ecdsa_key owner is expected to eq "root"
     ✔  File /etc/ssh/ssh_host_ecdsa_key mode is expected to cmp == "0640"
     ✔  File /etc/ssh/ssh_host_ecdsa_key group is expected to eq "ssh_keys"
     ✔  File /etc/ssh/ssh_host_ecdsa_key content is expected not to be empty
     ✔  File /etc/ssh/ssh_host_ecdsa_key.pub is expected to exist
     ✔  File /etc/ssh/ssh_host_ecdsa_key.pub mode is expected to cmp == "0644"
     ✔  File /etc/ssh/ssh_host_ecdsa_key.pub owner is expected to eq "root"
     ✔  File /etc/ssh/ssh_host_ecdsa_key.pub group is expected to eq "ssh_keys"
     ✔  File /etc/ssh/ssh_host_ecdsa_key.pub content is expected not to be empty
     ✔  File /etc/ssh/ssh_host_ed25519_key is expected to exist
     ✔  File /etc/ssh/ssh_host_ed25519_key owner is expected to eq "root"
     ✔  File /etc/ssh/ssh_host_ed25519_key mode is expected to cmp == "0640"
     ✔  File /etc/ssh/ssh_host_ed25519_key group is expected to eq "ssh_keys"
     ✔  File /etc/ssh/ssh_host_ed25519_key content is expected not to be empty
     ✔  File /etc/ssh/ssh_host_ed25519_key.pub is expected to exist
     ✔  File /etc/ssh/ssh_host_ed25519_key.pub mode is expected to cmp == "0644"
     ✔  File /etc/ssh/ssh_host_ed25519_key.pub owner is expected to eq "root"
     ✔  File /etc/ssh/ssh_host_ed25519_key.pub group is expected to eq "ssh_keys"
     ✔  File /etc/ssh/ssh_host_ed25519_key.pub content is expected not to be empty
     ✔  File /etc/ssh/ssh_host_rsa_key is expected to exist
     ✔  File /etc/ssh/ssh_host_rsa_key owner is expected to eq "root"
     ✔  File /etc/ssh/ssh_host_rsa_key mode is expected to cmp == "0640"
     ✔  File /etc/ssh/ssh_host_rsa_key group is expected to eq "ssh_keys"
     ✔  File /etc/ssh/ssh_host_rsa_key content is expected not to be empty
     ✔  File /etc/ssh/ssh_host_rsa_key.pub is expected to exist
     ✔  File /etc/ssh/ssh_host_rsa_key.pub mode is expected to cmp == "0644"
     ✔  File /etc/ssh/ssh_host_rsa_key.pub owner is expected to eq "root"
     ✔  File /etc/ssh/ssh_host_rsa_key.pub group is expected to eq "ssh_keys"
     ✔  File /etc/ssh/ssh_host_rsa_key.pub content is expected not to be empty
```

### References
* https://github.dev/aws/aws-parallelcluster-cookbook/pull/2361

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
