### PR TITLE
[develop] Skip ephemeral drives mount check for custom AMIs (e.g. DLAMI)

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/test/controls/ephemeral_drives_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/ephemeral_drives_spec.rb
@@ -88,7 +88,8 @@ control 'tag:config_ephemeral_drives_service_and_mount' do
       end
     end
 
-    if ephemeral_devs.any?
+    if ephemeral_devs.any? && !instance.custom_ami?
+      # In custom AMIs the LVM can be already formatted and mounted on another folder (e.g. /opt/dlami/nvme)
       describe directory(node['cluster']['ephemeral_dir']) do
         it { should exist }
         it { should be_writable }


### PR DESCRIPTION
### Description of changes
In custom AMIs, like U20 DLAMI, the Logical Volume already exists, we're skipping to mount it in the scratch folder, so the test cannot be executed.

DLAMI U20:
```
ParallelCluster - LVM (/dev/vg.01/lv_ephemeral) already exists
...
ParallelCluster - LVM (/dev/vg.01/lv_ephemeral) already mounted on (/opt/dlami/nvme)
```
vs U20 base AMI:
```
ParallelCluster - LVM (/dev/vg.01/lv_ephemeral) not mounted, mounting on (/scratch)
```

### Tests
* Verified with `bash kitchen.ec2.sh environment-config verify ephemeral-drives-mounted-ubuntu20` passing `cluster: os: ubuntu20-custom`
