### PR TITLE
Fixes usage of instance types data file during rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 
 **BUG FIXES**
+- Fixed usage of instance types data file during rollback.
 
 3.7.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 
 **BUG FIXES**
-- Fixed usage of instance types data file during rollback.
+- Fix inconsistent scaling configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.
 
 3.7.0
 ------

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -58,5 +58,6 @@ default['cluster']['bootstrap_error_path'] = "#{node['cluster']['log_base_dir']}
 default['cluster']['cluster_s3_bucket'] = nil
 default['cluster']['cluster_config_s3_key'] = nil
 default['cluster']['cluster_config_version'] = nil
+default['cluster']['instance_types_data_version'] = nil
 default['cluster']['change_set_s3_key'] = nil
 default['cluster']['instance_types_data_s3_key'] = nil

--- a/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
@@ -24,12 +24,12 @@ action :run do
       ::FileUtils.cp_r(node['cluster']['instance_types_data_path'], node['cluster']['previous_instance_types_data_path'], remove_destination: true)
 
       fetch_change_set
-      fetch_instance_type_data(node['cluster']['instance_types_data_path']) unless ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path'])
+      fetch_instance_type_data unless ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path'])
       Chef::Log.info("Backing up old shared storages data from (#{node['cluster']['shared_storages_mapping_path']}) to (#{node['cluster']['previous_shared_storages_mapping_path']})")
       ::FileUtils.cp_r(node['cluster']['shared_storages_mapping_path'], node['cluster']['previous_shared_storages_mapping_path'], remove_destination: true)
     else
       fetch_cluster_config(node['cluster']['cluster_config_path']) unless ::File.exist?(node['cluster']['cluster_config_path'])
-      fetch_instance_type_data(node['cluster']['instance_types_data_path']) unless ::File.exist?(node['cluster']['instance_types_data_path'])
+      fetch_instance_type_data unless ::File.exist?(node['cluster']['instance_types_data_path'])
     end
 
     # ensure config is shared also with login nodes
@@ -99,7 +99,7 @@ action_class do # rubocop:disable Metrics/BlockLength
                      remove_destination: true) unless !::File.exist?(node['cluster']['previous_cluster_config_path'])
   end
 
-  def fetch_instance_type_data(instance_type_path)
+  def fetch_instance_type_data
     if kitchen_test? && !node['interact_with_s3']
       remote_file "copy fake instance type data" do
         path node['cluster']['instance_types_data_path']
@@ -107,8 +107,8 @@ action_class do # rubocop:disable Metrics/BlockLength
       end
     else
       # Copy instance type infos file from S3 URI
-      version_id = node['cluster']['cluster_config_version'] unless node['cluster']['cluster_instance_types_data_version'].nil?
-      fetch_s3_object("copy_instance_type_data_from_s3", node['cluster']['instance_types_data_s3_key'], instance_type_path, version_id)
+      instance_version_id = node['cluster']['instance_types_data_version'] unless node['cluster']['instance_types_data_version'].nil?
+      fetch_s3_object("copy_instance_type_data_from_s3", node['cluster']['instance_types_data_s3_key'], node['cluster']['instance_types_data_path'], instance_version_id)
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
@@ -5,6 +5,7 @@ describe 'fetch_config:run' do
     cached(:cluster_config_path) { 'cluster_config_path' }
     cached(:previous_cluster_config_path) { 'previous_cluster_config_path' }
     cached(:instance_types_data_path) { 'instance_types_data_path' }
+    cached(:previous_instance_types_data_path) { 'previous_instance_types_data_path' }
     cached(:chef_run) do
       runner = ChefSpec::Runner.new(
         platform: 'ubuntu', step_into: %w(fetch_config)
@@ -13,6 +14,7 @@ describe 'fetch_config:run' do
         node.override['cluster']['cluster_config_path'] = cluster_config_path
         node.override['cluster']['previous_cluster_config_path'] = previous_cluster_config_path
         node.override['cluster']['instance_types_data_path'] = instance_types_data_path
+        node.override['cluster']['previous_instance_types_data_path'] = previous_instance_types_data_path
         node.override['cluster']['node_type'] = 'HeadNode'
       end
       runner.converge_dsl do
@@ -38,6 +40,7 @@ describe 'fetch_config:run' do
       cached(:cluster_config_path) { 'cluster_config_path' }
       cached(:previous_cluster_config_path) { 'previous_cluster_config_path' }
       cached(:instance_types_data_path) { 'instance_types_data_path' }
+      cached(:previous_instance_types_data_path) { 'previous_instance_types_data_path' }
       cached(:chef_run) do
         runner = ChefSpec::Runner.new(
           platform: 'ubuntu', step_into: %w(fetch_config)

--- a/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
@@ -24,6 +24,7 @@ default['cluster']['login_cluster_config_path'] = "#{node['cluster']['shared_dir
 default['cluster']['login_previous_cluster_config_path'] = "#{node['cluster']['shared_dir_login_nodes']}/previous-cluster-config.yaml"
 default['cluster']['change_set_path'] = "#{node['cluster']['shared_dir']}/change-set.json"
 default['cluster']['instance_types_data_path'] = "#{node['cluster']['shared_dir']}/instance-types-data.json"
+default['cluster']['previous_instance_types_data_path'] = "#{node['cluster']['shared_dir']}/previous-instance-types-data.json"
 
 default['cluster']['scheduler'] = 'slurm'
 default['cluster']['node_type'] = nil


### PR DESCRIPTION
### Description of changes
* It saves a instance_types_data_version so that when an update rollback occurs, we can restore the previous instance_type_data
* The logic added is similar to that used for cluster_config_version

### Tests
* Manual Test - Created a cluster, updated cluster with config file that changed instance type, checked for Key Error
* Integration Test - Similar to manual

### References
* PR for main repo: https://github.com/aws/aws-parallelcluster/pull/5664
* Github known issue: https://github.com/aws/aws-parallelcluster/wiki/(3.0.0%E2%80%903.6.1)-Cluster-update-rollback-can-fail-when-modifying-the-list-of-instance-types-declared-in-the-Compute-Resources

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
