### PR TITLE
Add NVSwitch Device Id for P5 instance

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
@@ -78,12 +78,14 @@ suites:
         - 'resource:package { "package_name": "dkms" }'
         - resource:build_tools
         - recipe:aws-parallelcluster-platform::nvidia_install
+#        - resource:fabric_manager:configure # Needed for Multi-gpu instance like p5.48xlarge
       resource: gdrcopy:configure
       cluster:
         nvidia:
           enabled: true
     driver:
       instance_type: g4dn.2xlarge
+#      instance_type: p5.48xlarge
   - name: intel_hpc
     run_list:
       - recipe[aws-parallelcluster-tests::setup]

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
@@ -63,8 +63,10 @@ end
 
 # Get number of nv switches
 def get_nvswitches
-  # NVSwitch device id is 10de:1af1
-  nvswitch_check = Mixlib::ShellOut.new("lspci -d 10de:1af1 | wc -l")
-  nvswitch_check.run_command
-  nvswitch_check.stdout.strip.to_i
+  #  A100 (P4) and H100(P5) systems have NVSwitches
+  # NVSwitch device id is 10de:1af1 for P4 instance
+  # NVSwitch device id is 10de:22a3 for P5 instance
+  nvswitch_check_p4 = shell_out("lspci -d 10de:1af1 | wc -l")
+  nvswitch_check_p5 = shell_out("lspci -d 10de:22a3 | wc -l")
+  nvswitch_check_p4.stdout.strip.to_i + nvswitch_check_p5.stdout.strip.to_i
 end

--- a/cookbooks/aws-parallelcluster-slurm/kitchen.slurm-config.yml
+++ b/cookbooks/aws-parallelcluster-slurm/kitchen.slurm-config.yml
@@ -84,10 +84,12 @@ suites:
         - /gpu_health_check_execution/
     driver:
       instance_type: g4dn.xlarge
+#      instance_type: p5.48xlarge
     attributes:
       dependencies:
         - recipe:aws-parallelcluster-slurm::mock_slurm
         - resource:node_attributes
+#        - resource:fabric_manager:configure # Needed for Multi-gpu instance like p5.48xlarge
       cluster:
         node_type: HeadNode
         scheduler: 'slurm'


### PR DESCRIPTION
The NVSwitch device ID for p5.48xlarge address is different than the one we have been using.
This address is used for enabling and starting nvidia-fabricmanager

Tests
Locally tested on Cluster and Kitchen test
./kitchen.ec2.sh slurm-config test nvidia-gdrcopy-ubuntu2004

Related PR -> https://github.com/aws/aws-parallelcluster-cookbook/pull/2431/files

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
