### PR TITLE
[Tests]Configure Fabric Manager and nvidia persistence for running Sanity Checks 

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
@@ -63,29 +63,29 @@ suites:
     driver:
       # The only instance type that supports this test is p4d.24xlarge, skipped otherwise
       instance_type: p4d.24xlarge
-  - name: nvidia_gdrcopy
-    # doesn't work on Docker
-    run_list:
-      - recipe[aws-parallelcluster-tests::setup]
-      - recipe[aws-parallelcluster-tests::test_resource]
-    verifier:
-      controls:
-        - /tag:config_.*gdrcopy/
-    attributes:
-      dependencies:
-        - resource:package_repos
-        - resource:install_packages:install_kernel_source
-        - 'resource:package { "package_name": "dkms" }'
-        - resource:build_tools
-        - recipe:aws-parallelcluster-platform::nvidia_install
-#        - resource:fabric_manager:configure # Needed for Multi-gpu instance like p5.48xlarge
-      resource: gdrcopy:configure
-      cluster:
-        nvidia:
-          enabled: true
-    driver:
-      instance_type: g4dn.2xlarge
-#      instance_type: p5.48xlarge
+    - name: nvidia_gdrcopy
+      # doesn't work on Docker
+      run_list:
+        - recipe[aws-parallelcluster-tests::setup]
+        - recipe[aws-parallelcluster-tests::test_resource]
+      verifier:
+        controls:
+          - /tag:config_.*gdrcopy/
+      attributes:
+        dependencies:
+          - resource:package_repos
+          - resource:install_packages:install_kernel_source
+          - 'resource:package { "package_name": "dkms" }'
+          - resource:build_tools
+          - recipe:aws-parallelcluster-platform::nvidia_install
+#          - resource:fabric_manager:configure # Needed for Multi-gpu instance like p5.48xlarge
+#          - recipe:aws-parallelcluster-platform::nvidia_uvm # Needed for running Sanity checks in Multi-gpu instance like p5.48xlarge
+        resource: gdrcopy:configure
+        cluster:
+          nvidia:
+            enabled: true
+      driver:
+        instance_type: g4dn.2xlarge
   - name: intel_hpc
     run_list:
       - recipe[aws-parallelcluster-tests::setup]


### PR DESCRIPTION
Adding configuration recipes of Fabric Manager and parallelcluster_nvidia while testing multi-gpu instances like p5


### Tests
* Locally ` ./kitchen.ec2.sh platform-config test nvidia-gdrcopy-ubuntu2004`


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
