### PR TITLE
[release-3.7][unit-tests] Remove pytest HTML report from tox

### DIFF
--- a/test/unit/requirements.txt
+++ b/test/unit/requirements.txt
@@ -2,7 +2,6 @@ mock
 pytest
 pytest-cov
 pytest-datadir
-pytest-html
 pytest-mock
 assertpy
 jsonschema

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@ setenv =
         {toxinidir}/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm:\
         {toxinidir}/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts
 commands =
-    nocov: pytest -l -v --basetemp={envtmpdir} --html=report.html {[vars]test_dirs}
-    cov: pytest -l -v --basetemp={envtmpdir} --html=report.html --cov-report=xml --cov={[vars]cov_dirs} --cov-append {[vars]test_dirs}
+    nocov: pytest -l -v --basetemp={envtmpdir} {[vars]test_dirs}
+    cov: pytest -l -v --basetemp={envtmpdir} --cov-report=xml --cov={[vars]cov_dirs} --cov-append {[vars]test_dirs}
 
 # Section used to define common variables used by multiple testenvs.
 [vars]


### PR DESCRIPTION
1. A recent release of [pytest-html](https://pypi.org/project/pytest-html/#history) caused tox command fail. e.g. https://github.com/aws/aws-parallelcluster-cookbook/actions/runs/6087259960/job/16547410880
2. After looking at the code, especially `.github/workflows/ci.yaml`, the HTML report is not used anywhere.

Therefore, this commit will stop tox from generating any HTML report and remove the pytest-html dependency.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
