### PR TITLE
Fixes for CodeQL

### DIFF
--- a/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
+++ b/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
@@ -68,7 +68,7 @@ def log_exception(
 ):
     def decorator_log_exception(function):
         @functools.wraps(function)
-        def wrapper_log_expection(*args, **kwargs):  # pylint: disable=R1710
+        def wrapper_log_exception(*args, **kwargs):  # pylint: disable=R1710
             try:
                 return function(*args, **kwargs)
             except catch_exception as e:
@@ -77,8 +77,9 @@ def log_exception(
                     if exception_to_raise:
                         raise exception_to_raise
                     raise
+                return None
 
-        return wrapper_log_expection
+        return wrapper_log_exception
 
     return decorator_log_exception
 

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config_util.py
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config_util.py
@@ -158,6 +158,7 @@ def remove_backup():
     try:
         os.remove(LOG_CONFIGS_BAK_PATH)
     except FileNotFoundError:
+        # No need to remove the file, as the file isn't found anyway
         pass
 
 

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
@@ -64,7 +64,7 @@ control 'tag:config_cloudwatch_configured' do
 
   describe file('/usr/local/bin/cloudwatch_agent_config_util.py') do
     it { should exist }
-    its('sha256sum') { should eq '980b0ba6e5922fe2983d3e866ac970622f59a26a4829b8262466739582176525' }
+    its('sha256sum') { should eq 'b816b4891a5e8f1e7ac94616db7927f7955ba72a8f53ec1b320402a2ac9c9b7f' }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0644' }


### PR DESCRIPTION
### Description of changes
CodeQL findings:
- In clusterstatusmgtd.py, adding a "return None" at the end to mitigate the implicit return. Case is not specified for what to return when the parameter "raise_on_error" is false when an error occurs, so returning an explicit None.
- Also fixed small typo in clusterstatusmgtd.py
- In cloudwatch_agent_config_util.py, added an explanatory comment for why there's a pass for a FileNotFoundError.

Going to Security > Code Scanning and typing "pr:2449" shows that the CodeQL alerts don't show up anymore!

### References
* https://github.com/aws/aws-parallelcluster-cookbook/security/code-scanning/63
* https://github.com/aws/aws-parallelcluster-cookbook/security/code-scanning/62

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
