### PR TITLE
[Release-3.7] Upgrade Slurm to 23.02.5 and also Pmix and libjwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.7.1
+------
+**CHANGES**
+- Upgrade Slurm to 23.02.5 (from 23.02.4).
+- Upgrade Pmix to 4.2.6 (from 3.2.3).
+- Upgrade libjwt to 1.15.3 (from 1.12.0).
+
+
 3.7.0
 ------
 

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -3,7 +3,7 @@ default['cluster']['slurm']['fleet_config_path'] = "#{node['cluster']['slurm_plu
 
 # Slurm attributes shared between install_slurm and configure_slurm_accounting
 default['cluster']['slurm']['commit'] = ''
-default['cluster']['slurm']['sha256'] = '7290143a71ce2797d0df3423f08396fd5c0ae4504749ff372d6860b2d6a3a1b0'
+default['cluster']['slurm']['sha256'] = '4fee743a34514d8fe487080048256f5ee032374ed5f42d0eae342110dcd59edf'
 default['cluster']['slurm']['install_dir'] = '/opt/slurm'
 
 default['cluster']['dns_domain'] = nil

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -1,4 +1,4 @@
 # Slurm
-default['cluster']['slurm']['version'] = '23-02-4-1'
+default['cluster']['slurm']['version'] = '23-02-5-1'
 # Munge
 default['cluster']['munge']['munge_version'] = '0.5.15'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_jwt.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_jwt.rb
@@ -15,10 +15,10 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-jwt_version = '1.12.0'
+jwt_version = '1.15.3'
 jwt_url = "https://github.com/benmcollins/libjwt/archive/refs/tags/v#{jwt_version}.tar.gz"
 jwt_tarball = "#{node['cluster']['sources_dir']}/libjwt-#{jwt_version}.tar.gz"
-jwt_sha256 = 'eaf5d8b31d867c02dde767efa2cf494840885a415a3c9a62680bf870a4511bee'
+jwt_sha256 = 'cb2fd95123689e7d209a3a8c060e02f68341c9a5ded524c0cd881a8cd20d711f'
 
 remote_file jwt_tarball do
   source jwt_url
@@ -37,7 +37,7 @@ bash 'libjwt' do
   cwd Chef::Config[:file_cache_path]
   code <<-LIBJWT
     set -e
-    tar xf #{jwt_tarball}
+    tar xf #{jwt_tarball} --no-same-owner
     cd libjwt-#{jwt_version}
     autoreconf --force --install
     ./configure --prefix=/opt/libjwt

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pmix.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pmix.rb
@@ -16,9 +16,9 @@
 # limitations under the License.
 
 # PMIx software
-pmix_version = '3.2.3'
+pmix_version = '4.2.6'
 pmix_url = "https://github.com/openpmix/openpmix/releases/download/v#{pmix_version}/pmix-#{pmix_version}.tar.gz"
-pmix_sha256 = '1325a1355d0794196bb47665053fdbc588f9183aa5385f3581b668427316306e'
+pmix_sha256 = '2085615d1b8d72d944b4580cfd0ec958ce9050f9c7585081351ddaf1d63fe201'
 pmix_tarball = "#{node['cluster']['sources_dir']}/pmix-#{pmix_version}.tar.gz"
 
 remote_file pmix_tarball do
@@ -36,7 +36,7 @@ bash 'Install PMIx' do
   cwd Chef::Config[:file_cache_path]
   code <<-PMIX
     set -e
-    tar xf #{pmix_tarball}
+    tar xf #{pmix_tarball} --no-same-owner
     cd pmix-#{pmix_version}
     ./autogen.pl
     ./configure --prefix=/opt/pmix

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_spec.rb
@@ -121,7 +121,7 @@ control 'tag:install_slurm_shared_libraries_compiled' do
     its('group') { should eq 'root' }
   end
 
-  describe file("#{slurm_library_folder}/mpi_pmix_v3.so") do
+  describe file("#{slurm_library_folder}/mpi_pmix_v4.so") do
     it { should exist }
     its('mode') { should cmp '0755' }
     its('owner') { should eq 'root' }


### PR DESCRIPTION
### Description of changes
* Upgrade Slurm to version 23.02.5
* Upgrade Pmix to version 4.2.6
* Upgrade Libjwt to version 1.15.3

### Tests
* Created a custom AMI and launched the schedulers test suite in our internal Jenkins
  * Test completed successfully 

### References
* [Changes in integration-tests](https://github.com/aws/aws-parallelcluster/pull/5694)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
