### PR TITLE
[develop] Fix the creation failure when use custom munge key

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
@@ -57,12 +57,13 @@ end
 
 def generate_munge_key
   declare_resource(:bash, 'generate_munge_key') do
-    user node['cluster']['munge']['user']
-    group node['cluster']['munge']['group']
+    user 'root'
+    group 'root'
     cwd '/tmp'
     code <<-GENERATE_KEY
       set -e
       /usr/sbin/mungekey --verbose
+      chown #{node['cluster']['munge']['user']}:#{node['cluster']['munge']['group']} /etc/munge/munge.key
       chmod 0600 /etc/munge/munge.key
     GENERATE_KEY
   end

--- a/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
@@ -23,12 +23,7 @@ property :munge_key_secret_arn, String
 
 default_action :setup_munge_key
 
-def fetch_and_decode_munge_key
-  munge_key_secret_arn_local = new_resource.munge_key_secret_arn
-  region_local = node['cluster']['region']
-  munge_user_local = node['cluster']['munge']['user']
-  munge_group_local = node['cluster']['munge']['group']
-
+def fetch_and_decode_munge_key(munge_key_secret_arn)
   declare_resource(:bash, 'fetch_and_decode_munge_key') do
     user 'root'
     group 'root'
@@ -36,7 +31,7 @@ def fetch_and_decode_munge_key
     code <<-FETCH_AND_DECODE
       set -e
       # Get encoded munge key from secrets manager
-      encoded_key=$(aws secretsmanager get-secret-value --secret-id #{munge_key_secret_arn_local} --query 'SecretString' --output text --region #{region_local})
+      encoded_key=$(aws secretsmanager get-secret-value --secret-id #{munge_key_secret_arn} --query 'SecretString' --output text --region #{node['cluster']['region']})
       # If encoded_key doesn't have a value, error and exit
       if [ -z "$encoded_key" ]; then
         echo "Error fetching munge key from Secrets Manager or the key is empty"
@@ -53,7 +48,7 @@ def fetch_and_decode_munge_key
       echo "$decoded_key" > /etc/munge/munge.key
 
       # Set ownership on the key
-      chown #{munge_user_local}:#{munge_group_local} /etc/munge/munge.key
+      chown #{node['cluster']['munge']['user']}:#{node['cluster']['munge']['group']} /etc/munge/munge.key
       # Enforce correct permission on the key
       chmod 0600 /etc/munge/munge.key
     FETCH_AND_DECODE
@@ -66,19 +61,17 @@ def generate_munge_key
     group node['cluster']['munge']['group']
     cwd '/tmp'
     code <<-GENERATE_KEY
-        set -e
-        /usr/sbin/mungekey --verbose
-        chmod 0600 /etc/munge/munge.key
+      set -e
+      /usr/sbin/mungekey --verbose
+      chmod 0600 /etc/munge/munge.key
     GENERATE_KEY
   end
 end
 
 action :setup_munge_key do
   if new_resource.munge_key_secret_arn
-    # This block will fetch the munge key from Secrets Manager
-    fetch_and_decode_munge_key
+    fetch_and_decode_munge_key(new_resource.munge_key_secret_arn)
   else
-    # This block will randomly generate a munge key
     generate_munge_key
   end
 end
@@ -86,7 +79,7 @@ end
 action :update_munge_key do
   if new_resource.munge_key_secret_arn
     # This block will fetch the munge key from Secrets Manager and replace the previous munge key
-    fetch_and_decode_munge_key
+    fetch_and_decode_munge_key(new_resource.munge_key_secret_arn)
   else
     # This block will randomly generate a munge key and replace the previous munge key
     generate_munge_key

--- a/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
@@ -70,8 +70,10 @@ end
 
 action :setup_munge_key do
   if new_resource.munge_key_secret_arn
+    # This block will fetch the munge key from Secrets Manager
     fetch_and_decode_munge_key(new_resource.munge_key_secret_arn)
   else
+    # This block will randomly generate a munge key
     generate_munge_key
   end
 end

--- a/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
@@ -62,6 +62,10 @@ def generate_munge_key
     cwd '/tmp'
     code <<-GENERATE_KEY
       set -e
+      # If the /etc/munge/munge.key already exists, the /usr/sbin/mungekey --verbose command will report an error
+      if [ -f /etc/munge/munge.key ]; then
+        rm -f /etc/munge/munge.key
+      fi
       /usr/sbin/mungekey --verbose
       chown #{node['cluster']['munge']['user']}:#{node['cluster']['munge']['group']} /etc/munge/munge.key
       chmod 0600 /etc/munge/munge.key

--- a/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
@@ -57,17 +57,12 @@ end
 
 def generate_munge_key
   declare_resource(:bash, 'generate_munge_key') do
-    user 'root'
-    group 'root'
+    user node['cluster']['munge']['user']
+    group node['cluster']['munge']['group']
     cwd '/tmp'
     code <<-GENERATE_KEY
       set -e
-      # If the /etc/munge/munge.key already exists, the /usr/sbin/mungekey --verbose command will report an error
-      if [ -f /etc/munge/munge.key ]; then
-        rm -f /etc/munge/munge.key
-      fi
-      /usr/sbin/mungekey --verbose
-      chown #{node['cluster']['munge']['user']}:#{node['cluster']['munge']['group']} /etc/munge/munge.key
+      /usr/sbin/mungekey --verbose --force
       chmod 0600 /etc/munge/munge.key
     GENERATE_KEY
   end


### PR DESCRIPTION
### Description of changes
* Fix the creation failure when use Custom Munge Key

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.