### PR TITLE
[develop] Add validator in rotation script to check custom munge key size

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
@@ -32,6 +32,13 @@ if [ -n "${SECRET_ARN}" ]; then
     exit 1
   fi
 
+  # Check munge key size
+  key_size=$(echo "${decoded_key}" | wc -c)
+  if [ $key_size -lt 32 ] || [ $key_size -gt 1024 ]; then
+    echo "Fetched munge key size is out of valid range [256-8192 bits]."
+    exit 1
+  fi
+
   echo "${decoded_key}" > ${MUNGE_KEY_FILE}
 
   # Set ownership on the key


### PR DESCRIPTION
### Description of changes
* Add validator in rotation script to check custom munge key size in range [256-8192] bits

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.