### PR TITLE
[develop] Add a script of checking if there's running LoginNodes inside HeadNode used in munge key rotation script

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
@@ -83,3 +83,7 @@ end
 def is_custom_munge_key_updated?
   config_parameter_changed?(%w(DevSettings MungeKeySettings MungeKeySecretArn))
 end
+
+def is_login_nodes_pool_name_updated?
+  config_parameter_changed?(%w(LoginNodes Pools 0 Name))
+end

--- a/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
@@ -11,6 +11,7 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+# rubocop:disable Style/SingleArgumentDig
 
 # Helpers functions used by update recipe steps.
 require 'chef/mixin/shell_out'
@@ -86,4 +87,11 @@ end
 
 def is_login_nodes_pool_name_updated?
   config_parameter_changed?(['LoginNodes', 'Pools', 0, 'Name'])
+end
+
+def is_login_nodes_removed?
+  require 'yaml'
+  config = YAML.safe_load(File.read(node['cluster']['cluster_config_path']))
+  previous_config = YAML.safe_load(File.read(node['cluster']['previous_cluster_config_path']))
+  previous_config.dig("LoginNodes") and !config.dig("LoginNodes")
 end

--- a/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
@@ -85,5 +85,5 @@ def is_custom_munge_key_updated?
 end
 
 def is_login_nodes_pool_name_updated?
-  config_parameter_changed?(%w(LoginNodes Pools 0 Name))
+  config_parameter_changed?(['LoginNodes', 'Pools', 0, 'Name'])
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_check_login_stopped_script.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_check_login_stopped_script.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+# rubocop:disable Style/SingleArgumentDig
+template "#{node['cluster']['scripts_dir']}/slurm/check_login_nodes_stopped.sh" do
+  source 'slurm/head_node/check_login_nodes_stopped.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0700'
+  variables(
+    cluster_name: node['cluster']['cluster_name'] || node['cluster']['stack_name'],
+    login_nodes_pool_name: lazy { node['cluster']['config'].dig(:LoginNodes, :Pools, 0, :Name) },
+    region: node['cluster']['region']
+  )
+  only_if do
+    node['cluster']['config'].dig(:LoginNodes)
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
@@ -227,11 +227,10 @@ template "#{node['cluster']['scripts_dir']}/slurm/check_login_nodes_status.sh" d
   variables(
     stack_name: node['cluster']['cluster_name'] || node['cluster']['stack_name'],
     login_nodes_pool_name: lazy do
-      if lazy { node['cluster']['config']['LoginNodes'].nil? }
-        nil
-      else
-        lazy { node['cluster']['config'].dig(:LoginNodes, :Pools, 0, :Name) }
-      end
+      # rubocop:disable Style/SingleArgumentDig
+      login_nodes_config = node['cluster']['config'].dig(:LoginNodes)
+      # rubocop:enable Style/SingleArgumentDig
+      login_nodes_config ? login_nodes_config.dig(:Pools, 0, :Name) : nil
     end,
     region: node['cluster']['region']
   )

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
@@ -219,6 +219,24 @@ execute "check slurmctld status" do
   retry_delay 2
 end unless redhat_on_docker?
 
+template "#{node['cluster']['scripts_dir']}/slurm/check_login_nodes_status.sh" do
+  source 'slurm/head_node/check_login_nodes_status.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  variables(
+    stack_name: node['cluster']['cluster_name'] || node['cluster']['stack_name'],
+    login_nodes_pool_name: lazy do
+      if lazy { node['cluster']['config']['LoginNodes'].nil? }
+        nil
+      else
+        lazy { node['cluster']['config'].dig(:LoginNodes, :Pools, 0, :Name) }
+      end
+    end,
+    region: node['cluster']['region']
+  )
+end
+
 template "#{node['cluster']['scripts_dir']}/slurm/update_munge_key.sh" do
   source 'slurm/head_node/update_munge_key.sh.erb'
   owner 'root'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
@@ -14,6 +14,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+# rubocop:disable Style/SingleArgumentDig
 
 include_recipe 'aws-parallelcluster-slurm::config_munge_key'
 
@@ -219,21 +220,19 @@ execute "check slurmctld status" do
   retry_delay 2
 end unless redhat_on_docker?
 
-template "#{node['cluster']['scripts_dir']}/slurm/check_login_nodes_status.sh" do
-  source 'slurm/head_node/check_login_nodes_status.sh.erb'
+template "#{node['cluster']['scripts_dir']}/slurm/check_login_nodes_stopped.sh" do
+  source 'slurm/head_node/check_login_nodes_stopped.sh.erb'
   owner 'root'
   group 'root'
-  mode '0755'
+  mode '0700'
   variables(
-    stack_name: node['cluster']['cluster_name'] || node['cluster']['stack_name'],
-    login_nodes_pool_name: lazy do
-      # rubocop:disable Style/SingleArgumentDig
-      login_nodes_config = node['cluster']['config'].dig(:LoginNodes)
-      # rubocop:enable Style/SingleArgumentDig
-      login_nodes_config ? login_nodes_config.dig(:Pools, 0, :Name) : nil
-    end,
+    cluster_name: node['cluster']['cluster_name'] || node['cluster']['stack_name'],
+    login_nodes_pool_name: lazy { node['cluster']['config'].dig(:LoginNodes, :Pools, 0, :Name) },
     region: node['cluster']['region']
   )
+  only_if do
+    node['cluster']['config'].dig(:LoginNodes)
+  end
 end
 
 template "#{node['cluster']['scripts_dir']}/slurm/update_munge_key.sh" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
@@ -14,7 +14,6 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-# rubocop:disable Style/SingleArgumentDig
 
 include_recipe 'aws-parallelcluster-slurm::config_munge_key'
 
@@ -220,20 +219,7 @@ execute "check slurmctld status" do
   retry_delay 2
 end unless redhat_on_docker?
 
-template "#{node['cluster']['scripts_dir']}/slurm/check_login_nodes_stopped.sh" do
-  source 'slurm/head_node/check_login_nodes_stopped.sh.erb'
-  owner 'root'
-  group 'root'
-  mode '0700'
-  variables(
-    cluster_name: node['cluster']['cluster_name'] || node['cluster']['stack_name'],
-    login_nodes_pool_name: lazy { node['cluster']['config'].dig(:LoginNodes, :Pools, 0, :Name) },
-    region: node['cluster']['region']
-  )
-  only_if do
-    node['cluster']['config'].dig(:LoginNodes)
-  end
-end
+include_recipe 'aws-parallelcluster-slurm::config_check_login_stopped_script'
 
 template "#{node['cluster']['scripts_dir']}/slurm/update_munge_key.sh" do
   source 'slurm/head_node/update_munge_key.sh.erb'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -14,6 +14,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+# rubocop:disable Style/SingleArgumentDig
 
 execute 'stop clustermgtd' do
   command "#{cookbook_virtualenv_path}/bin/supervisorctl stop clustermgtd"
@@ -202,22 +203,26 @@ ruby_block "Update Slurm Accounting" do
 end unless on_docker?
 
 # Update check login nodes status script to update pool name
-template "#{node['cluster']['scripts_dir']}/slurm/check_login_nodes_status.sh" do
-  source 'slurm/head_node/check_login_nodes_status.sh.erb'
+template "#{node['cluster']['scripts_dir']}/slurm/check_login_nodes_stopped.sh" do
+  source 'slurm/head_node/check_login_nodes_stopped.sh.erb'
   owner 'root'
   group 'root'
-  mode '0755'
+  mode '0700'
   variables(
-    stack_name: node['cluster']['cluster_name'] || node['cluster']['stack_name'],
-    login_nodes_pool_name: lazy do
-      # rubocop:disable Style/SingleArgumentDig
-      login_nodes_config = node['cluster']['config'].dig(:LoginNodes)
-      # rubocop:enable Style/SingleArgumentDig
-      login_nodes_config ? login_nodes_config.dig(:Pools, 0, :Name) : nil
-    end,
+    cluster_name: node['cluster']['cluster_name'] || node['cluster']['stack_name'],
+    login_nodes_pool_name: lazy { node['cluster']['config'].dig(:LoginNodes, :Pools, 0, :Name) },
     region: node['cluster']['region']
   )
-  only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_login_nodes_pool_name_updated? }
+  only_if do
+    node['cluster']['config'].dig(:LoginNodes) &&
+      ::File.exist?(node['cluster']['previous_cluster_config_path']) &&
+      is_login_nodes_pool_name_updated?
+  end
+end
+
+file "#{node['cluster']['scripts_dir']}/slurm/check_login_nodes_stopped.sh" do
+  action :delete
+  only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_login_nodes_removed? }
 end
 
 # Update munge key rotation script to update secret arn

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -201,7 +201,9 @@ ruby_block "Update Slurm Accounting" do
   only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_slurm_database_updated? }
 end unless on_docker?
 
-# Update check login nodes status script to update pool name
+# Cover the following two scenarios:
+# - a cluster without login nodes is updated to have login nodes;
+# - a cluster with login nodes is updated to use another pool name.
 if ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_login_nodes_pool_name_updated?
   include_recipe 'aws-parallelcluster-slurm::config_check_login_stopped_script'
 end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/check_login_nodes_status.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/check_login_nodes_status.sh.erb
@@ -7,8 +7,6 @@
 #
 # Usage: ./check_if_has_running_login_nodes.sh
 
-#!/bin/bash
-
 STACK_NAME="<%= @stack_name %>"
 LOGIN_NODES_POOL_NAME="<%= @login_nodes_pool_name %>"
 REGION="<%= @region %>"

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/check_login_nodes_status.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/check_login_nodes_status.sh.erb
@@ -17,44 +17,18 @@ if [[ -z "${LOGIN_NODES_POOL_NAME}" ]]; then
     exit 0
 fi
 
-# List all Load Balancers
-load_balancers=$(aws elbv2 describe-load-balancers --region ${REGION})
-
-# Iterate over Load Balancers to find the one with matching tags
-load_balancer_arn=''
-for arn in $(echo "${load_balancers}" | jq -r '.LoadBalancers[].LoadBalancerArn'); do
-    # Get tags for the current Load Balancer
-    tags=$(aws elbv2 describe-tags --resource-arns "${arn}" --region ${REGION})
-
-    # Check if the tags match the desired stack name and login nodes pool name
-    stack_name_match=$(echo "${tags}" | jq -r --arg key "parallelcluster:cluster-name" --arg value "${STACK_NAME}" '.TagDescriptions[] | select(.Tags[]? | (.Key == $key and .Value == $value))')
-    login_nodes_pool_name_match=$(echo "${tags}" | jq -r --arg key "parallelcluster:login-nodes-pool" --arg value "${LOGIN_NODES_POOL_NAME}" '.TagDescriptions[] | select(.Tags[]? | (.Key == $key and .Value == $value))')
-
-    # If both tags are found, store the ARN and break the loop
-    if [[ -n "${stack_name_match}" && -n "${login_nodes_pool_name_match}" ]]; then
-        load_balancer_arn="${arn}"
-        break
-    fi
-done
-
-# Output result
-if [[ -n "${load_balancer_arn}" ]]; then
-    echo "Load Balancer ARN found: ${load_balancer_arn}"
-else
-    echo "No Load Balancer found for the specified stack and login nodes pool."
-    exit 1
-fi
-
 # Get Target Group ARN associated with the Load Balancer
 target_group_arn=$(aws elbv2 describe-target-groups \
-    --load-balancer-arn $load_balancer_arn \
+    --names "${STACK_NAME}-${LOGIN_NODES_POOL_NAME}-TargetGroup" \
     --query "TargetGroups[0].TargetGroupArn" \
     --output text \
     --region ${REGION})
 
 # Exit if Target Group is not found
-if [[ -z $target_group_arn ]]; then
-    echo "No Target Group found for the specified Load Balancer."
+if [[ -n "${target_group_arn}" ]]; then
+    echo "TargetGroup ARN found: ${target_group_arn}"
+else
+    echo "No Target Group found for the specified stack and login nodes pool."
     exit 1
 fi
 

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/check_login_nodes_status.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/check_login_nodes_status.sh.erb
@@ -1,0 +1,77 @@
+#!/bin/bash
+# This script checks whether there are running login nodes in a specified AWS ParallelCluster stack and login nodes pool.
+# It first retrieves the ARN of the Load Balancer associated with the specified stack and login nodes pool.
+# If a Load Balancer is found, it then retrieves the ARN of the Target Group associated with the Load Balancer.
+# Lastly, it checks the health of the targets in the Target Group to determine the number of healthy and unhealthy login nodes.
+# If there are any healthy or unhealthy nodes found, it concludes that there are running login nodes.
+#
+# Usage: ./check_if_has_running_login_nodes.sh
+
+#!/bin/bash
+
+STACK_NAME="<%= @stack_name %>"
+LOGIN_NODES_POOL_NAME="<%= @login_nodes_pool_name %>"
+REGION="<%= @region %>"
+
+# Check if LOGIN_NODES_POOL_NAME is empty
+if [[ -z "${LOGIN_NODES_POOL_NAME}" ]]; then
+    echo "No LoginNodes are specified. Please refer to ParallelCluster official documentation for more information."
+    exit 0
+fi
+
+# List all Load Balancers
+load_balancers=$(aws elbv2 describe-load-balancers --region ${REGION})
+
+# Iterate over Load Balancers to find the one with matching tags
+load_balancer_arn=''
+for arn in $(echo "${load_balancers}" | jq -r '.LoadBalancers[].LoadBalancerArn'); do
+    # Get tags for the current Load Balancer
+    tags=$(aws elbv2 describe-tags --resource-arns "${arn}" --region ${REGION})
+
+    # Check if the tags match the desired stack name and login nodes pool name
+    stack_name_match=$(echo "${tags}" | jq -r --arg key "parallelcluster:cluster-name" --arg value "${STACK_NAME}" '.TagDescriptions[] | select(.Tags[]? | (.Key == $key and .Value == $value))')
+    login_nodes_pool_name_match=$(echo "${tags}" | jq -r --arg key "parallelcluster:login-nodes-pool" --arg value "${LOGIN_NODES_POOL_NAME}" '.TagDescriptions[] | select(.Tags[]? | (.Key == $key and .Value == $value))')
+
+    # If both tags are found, store the ARN and break the loop
+    if [[ -n "${stack_name_match}" && -n "${login_nodes_pool_name_match}" ]]; then
+        load_balancer_arn="${arn}"
+        break
+    fi
+done
+
+# Output result
+if [[ -n "${load_balancer_arn}" ]]; then
+    echo "Load Balancer ARN found: ${load_balancer_arn}"
+else
+    echo "No Load Balancer found for the specified stack and login nodes pool."
+    exit 1
+fi
+
+# Get Target Group ARN associated with the Load Balancer
+target_group_arn=$(aws elbv2 describe-target-groups \
+    --load-balancer-arn $load_balancer_arn \
+    --query "TargetGroups[0].TargetGroupArn" \
+    --output text \
+    --region ${REGION})
+
+# Exit if Target Group is not found
+if [[ -z $target_group_arn ]]; then
+    echo "No Target Group found for the specified Load Balancer."
+    exit 1
+fi
+
+# Get the number of healthy and unhealthy targets
+target_healths=$(aws elbv2 describe-target-health \
+    --target-group-arn $target_group_arn \
+    --region ${REGION})
+
+healthy_count=$(echo $target_healths | jq -r '.TargetHealthDescriptions[] | select(.TargetHealth.State == "healthy") | .Target.Id' | wc -l)
+unhealthy_count=$(echo $target_healths | jq -r '.TargetHealthDescriptions[] | select(.TargetHealth.State != "healthy") | .Target.Id' | wc -l)
+
+# Check if there are running login nodes
+total_nodes=$((healthy_count + unhealthy_count))
+if [[ $total_nodes -gt 0 ]]; then
+    echo "Login nodes are running."
+else
+    echo "Login nodes are stopped."
+fi

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/check_login_nodes_status.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/check_login_nodes_status.sh.erb
@@ -7,6 +7,8 @@
 #
 # Usage: ./check_if_has_running_login_nodes.sh
 
+set -e
+
 STACK_NAME="<%= @stack_name %>"
 LOGIN_NODES_POOL_NAME="<%= @login_nodes_pool_name %>"
 REGION="<%= @region %>"
@@ -17,9 +19,37 @@ if [[ -z "${LOGIN_NODES_POOL_NAME}" ]]; then
     exit 0
 fi
 
+# List all Load Balancers
+load_balancers=$(aws elbv2 describe-load-balancers --region ${REGION})
+
+# Iterate over Load Balancers to find the one with matching tags
+load_balancer_arn=''
+for arn in $(echo "${load_balancers}" | jq -r '.LoadBalancers[].LoadBalancerArn'); do
+    # Get tags for the current Load Balancer
+    tags=$(aws elbv2 describe-tags --resource-arns "${arn}" --region ${REGION})
+
+    # Check if the tags match the desired stack name and login nodes pool name
+    stack_name_match=$(echo "${tags}" | jq -r --arg key "parallelcluster:cluster-name" --arg value "${STACK_NAME}" '.TagDescriptions[] | select(.Tags[]? | (.Key == $key and .Value == $value))')
+    login_nodes_pool_name_match=$(echo "${tags}" | jq -r --arg key "parallelcluster:login-nodes-pool" --arg value "${LOGIN_NODES_POOL_NAME}" '.TagDescriptions[] | select(.Tags[]? | (.Key == $key and .Value == $value))')
+
+    # If both tags are found, store the ARN and break the loop
+    if [[ -n "${stack_name_match}" && -n "${login_nodes_pool_name_match}" ]]; then
+        load_balancer_arn="${arn}"
+        break
+    fi
+done
+
+# Output result
+if [[ -n "${load_balancer_arn}" ]]; then
+    echo "Load Balancer ARN found: ${load_balancer_arn}"
+else
+    echo "No Load Balancer found for the specified stack and login nodes pool."
+    exit 1
+fi
+
 # Get Target Group ARN associated with the Load Balancer
 target_group_arn=$(aws elbv2 describe-target-groups \
-    --names "${STACK_NAME}-${LOGIN_NODES_POOL_NAME}-TargetGroup" \
+    --load-balancer-arn $load_balancer_arn \
     --query "TargetGroups[0].TargetGroupArn" \
     --output text \
     --region ${REGION})
@@ -28,7 +58,7 @@ target_group_arn=$(aws elbv2 describe-target-groups \
 if [[ -n "${target_group_arn}" ]]; then
     echo "TargetGroup ARN found: ${target_group_arn}"
 else
-    echo "No Target Group found for the specified stack and login nodes pool."
+    echo "No Target Group found for the specified Load Balancer."
     exit 1
 fi
 

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/check_login_nodes_stopped.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/check_login_nodes_stopped.sh.erb
@@ -9,15 +9,9 @@
 
 set -e
 
-STACK_NAME="<%= @stack_name %>"
+CLUSTER_NAME="<%= @cluster_name %>"
 LOGIN_NODES_POOL_NAME="<%= @login_nodes_pool_name %>"
 REGION="<%= @region %>"
-
-# Check if LOGIN_NODES_POOL_NAME is empty
-if [[ -z "${LOGIN_NODES_POOL_NAME}" ]]; then
-    echo "No LoginNodes are specified. Please refer to ParallelCluster official documentation for more information."
-    exit 0
-fi
 
 # List all Load Balancers
 load_balancers=$(aws elbv2 describe-load-balancers --region ${REGION})
@@ -29,11 +23,12 @@ for arn in $(echo "${load_balancers}" | jq -r '.LoadBalancers[].LoadBalancerArn'
     tags=$(aws elbv2 describe-tags --resource-arns "${arn}" --region ${REGION})
 
     # Check if the tags match the desired stack name and login nodes pool name
-    stack_name_match=$(echo "${tags}" | jq -r --arg key "parallelcluster:cluster-name" --arg value "${STACK_NAME}" '.TagDescriptions[] | select(.Tags[]? | (.Key == $key and .Value == $value))')
+    cluster_name_match=$(echo "${tags}" | jq -r --arg key "parallelcluster:cluster-name" --arg value "${CLUSTER_NAME}" '.TagDescriptions[] | select(.Tags[]? | (.Key == $key and .Value == $value))')
     login_nodes_pool_name_match=$(echo "${tags}" | jq -r --arg key "parallelcluster:login-nodes-pool" --arg value "${LOGIN_NODES_POOL_NAME}" '.TagDescriptions[] | select(.Tags[]? | (.Key == $key and .Value == $value))')
 
     # If both tags are found, store the ARN and break the loop
-    if [[ -n "${stack_name_match}" && -n "${login_nodes_pool_name_match}" ]]; then
+    # For now, there's only one pool of login nodes per cluster.
+    if [[ -n "${cluster_name_match}" && -n "${login_nodes_pool_name_match}" ]]; then
         load_balancer_arn="${arn}"
         break
     fi
@@ -43,7 +38,7 @@ done
 if [[ -n "${load_balancer_arn}" ]]; then
     echo "Load Balancer ARN found: ${load_balancer_arn}"
 else
-    echo "No Load Balancer found for the specified stack and login nodes pool."
+    echo "No Load Balancer found for the cluster ${CLUSTER_NAME} and login nodes pool ${LOGIN_NODES_POOL_NAME}."
     exit 1
 fi
 
@@ -58,7 +53,7 @@ target_group_arn=$(aws elbv2 describe-target-groups \
 if [[ -n "${target_group_arn}" ]]; then
     echo "TargetGroup ARN found: ${target_group_arn}"
 else
-    echo "No Target Group found for the specified Load Balancer."
+    echo "No Target Group found for the specified Load Balancer ${load_balancer_arn}."
     exit 1
 fi
 
@@ -73,7 +68,9 @@ unhealthy_count=$(echo $target_healths | jq -r '.TargetHealthDescriptions[] | se
 # Check if there are running login nodes
 total_nodes=$((healthy_count + unhealthy_count))
 if [[ $total_nodes -gt 0 ]]; then
-    echo "Login nodes are running."
-else
-    echo "Login nodes are stopped."
+    echo "Login nodes are running. Please stop them before updating the munge key."
+    exit 1
 fi
+
+echo "Login nodes are stopped."
+exit 0

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
@@ -15,6 +15,21 @@ MUNGE_USER="<%= @munge_user %>"
 MUNGE_GROUP="<%= @munge_group %>"
 SHARED_DIRECTORY_COMPUTE="<%= @shared_directory_compute %>"
 SHARED_DIRECTORY_LOGIN="<%= @shared_directory_login %>"
+CHECK_LOGIN_NODES_SCRIPT_PATH="<%= node['cluster']['scripts_dir'] %>/slurm/check_login_nodes_status.sh"
+
+# Create a temporary file to store the output
+TEMP_FILE=$(mktemp)
+
+# Check if login nodes are running
+$CHECK_LOGIN_NODES_SCRIPT_PATH > $TEMP_FILE
+if grep -q "Login nodes are running." $TEMP_FILE; then
+    echo "Login nodes are running. Please stop them before updating the munge key."
+    rm $TEMP_FILE  # Clean up the temporary file
+    exit 1
+fi
+
+# Clean up the temporary file
+rm $TEMP_FILE
 
 # Check compute fleet status
 compute_fleet_status=$(get-compute-fleet-status.sh)

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
@@ -17,9 +17,12 @@ SHARED_DIRECTORY_COMPUTE="<%= @shared_directory_compute %>"
 SHARED_DIRECTORY_LOGIN="<%= @shared_directory_login %>"
 CHECK_LOGIN_NODES_SCRIPT_PATH="<%= node['cluster']['scripts_dir'] %>/slurm/check_login_nodes_stopped.sh"
 
-# Check if login nodes are running
-if ! $CHECK_LOGIN_NODES_SCRIPT_PATH; then
-    exit 1
+# Check if the script exists
+if [ -f "$CHECK_LOGIN_NODES_SCRIPT_PATH" ]; then
+    # Check if login nodes are running
+    if ! $CHECK_LOGIN_NODES_SCRIPT_PATH; then
+        exit 1
+    fi
 fi
 
 # Check compute fleet status

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
@@ -15,21 +15,12 @@ MUNGE_USER="<%= @munge_user %>"
 MUNGE_GROUP="<%= @munge_group %>"
 SHARED_DIRECTORY_COMPUTE="<%= @shared_directory_compute %>"
 SHARED_DIRECTORY_LOGIN="<%= @shared_directory_login %>"
-CHECK_LOGIN_NODES_SCRIPT_PATH="<%= node['cluster']['scripts_dir'] %>/slurm/check_login_nodes_status.sh"
-
-# Create a temporary file to store the output
-TEMP_FILE=$(mktemp)
+CHECK_LOGIN_NODES_SCRIPT_PATH="<%= node['cluster']['scripts_dir'] %>/slurm/check_login_nodes_stopped.sh"
 
 # Check if login nodes are running
-$CHECK_LOGIN_NODES_SCRIPT_PATH > $TEMP_FILE
-if grep -q "Login nodes are running." $TEMP_FILE; then
-    echo "Login nodes are running. Please stop them before updating the munge key."
-    rm $TEMP_FILE  # Clean up the temporary file
+if ! $CHECK_LOGIN_NODES_SCRIPT_PATH; then
     exit 1
 fi
-
-# Clean up the temporary file
-rm $TEMP_FILE
 
 # Check compute fleet status
 compute_fleet_status=$(get-compute-fleet-status.sh)


### PR DESCRIPTION
### Description of changes
* Add a script of checking if there's runing LoginNodes inside HeadNode using the same way as CLI does

### References
* [What CLI does](https://github.com/aws/aws-parallelcluster/blob/08a76e09ed3c6495aec6e1e7d42020c1232f853b/cli/src/pcluster/models/cluster.py#L749)
* This PR is based on [[develop] Add IAM policies for checking LoginNodes status script inside HeadNode](https://github.com/aws/aws-parallelcluster/pull/5725)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.