### PR TITLE
Modify permissions of /etc/sysconfig directory

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_compute.rb
@@ -24,7 +24,7 @@ end
 directory '/etc/sysconfig' do
   user 'root'
   group 'root'
-  mode '0644'
+  mode '0755'
 end
 
 template "/etc/sysconfig/slurmd" do


### PR DESCRIPTION
Directory permissions set to 0644 incorrectly leading to permissions problems when a non-root user tries to read files from /etc/sysconfig


### Description of changes
* Changed default permissions of a directory. Suspect that this was originally done inadvertently as a directory should not have perms of 0644

### Tests
* n/a

### References
* Found during a debug of https://groups.google.com/g/slurm-users/c/TGYoK82KRvk

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
