### PR TITLE
[Rocky]Update Volume Size for Rocky to be similar to Rhel8

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
@@ -38,6 +38,9 @@ action :run do
     # load cluster config into a node object
     load_cluster_config(node['cluster']['cluster_config_path'])
   when 'ComputeFleet'
+    if kitchen_test?
+      fetch_cluster_config(node['cluster']['cluster_config_path']) unless ::File.exist?(node['cluster']['cluster_config_path'])
+    end
     raise "Cluster config not found in #{node['cluster']['cluster_config_path']}" unless ::File.exist?(node['cluster']['cluster_config_path'])
     # load cluster config into a node object
     load_cluster_config(node['cluster']['cluster_config_path'])

--- a/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
@@ -24,7 +24,7 @@ control 'tag:install_intel_hpc_dependencies_downloaded' do
 end
 
 control 'tag:config_intel_hpc_enough_space_on_root_volume' do
-  only_if { !instance.custom_ami? }
+  only_if { !instance.custom_ami? && (os_properties.centos7? && os_properties.x86?) }
 
   describe 'at least 10 GB of free space on root volume' do
     subject { bash("sudo -u #{node['cluster']['cluster_user']} df --block-size GB --output=avail / | tail -n1 | cut -d G -f1") }

--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -142,7 +142,7 @@ platforms:
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
-            volume_size: <% if (ENV['KITCHEN_VOLUME_SIZE'] || '') == '' %> 35 <% else %> <%= ENV['KITCHEN_VOLUME_SIZE'] %> <% end %>
+            volume_size: <% if (ENV['KITCHEN_VOLUME_SIZE'] || '') == '' %> 40 <% else %> <%= ENV['KITCHEN_VOLUME_SIZE'] %> <% end %>
             volume_type: gp2
             delete_on_termination: true
       <% %w(a b c d e f g h i j k l m n o p q r s t u v w x).each_with_index do | c, i | %>


### PR DESCRIPTION
### Description of changes
* Update the Volume Size of Rocky to 40Gb (for kitchen testing) as the Image is created with a snapshot of size 40Gb using pipelines. 
* Add Condition for downloading fake_cluster_config on Compute Nodes during Kitchen tests


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
