### PR TITLE
Disable `code-duplication` pylint code-checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,8 @@ disable=raw-checker-failed,
         unused-import, # handled by flake8
         no-else-return, # A complete if else block can improve readability even with returns in the body
         wrong-import-order,
-        protected-access
+        protected-access,
+        fixme
 
 
 # Enable the message, report, category or checker with the given id(s). You can
@@ -380,4 +381,3 @@ min-public-methods=2
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception".
 overgeneral-exceptions=Exception
-

--- a/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
+++ b/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
@@ -11,6 +11,9 @@
 # limitations under the License.
 
 # pylint: disable=W0719
+
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
 import functools
 import json
 import logging

--- a/cookbooks/aws-parallelcluster-environment/files/default/ec2_udev_rules/ec2_dev_2_volid.py
+++ b/cookbooks/aws-parallelcluster-environment/files/default/ec2_udev_rules/ec2_dev_2_volid.py
@@ -1,3 +1,6 @@
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import configparser
 import os
 import re

--- a/cookbooks/aws-parallelcluster-environment/files/default/ec2_udev_rules/manageVolume.py
+++ b/cookbooks/aws-parallelcluster-environment/files/default/ec2_udev_rules/manageVolume.py
@@ -1,6 +1,10 @@
 # pylint: disable=C0103
 # pylint: disable=W0719
 # This file should name manage_volume.py by convention
+
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import argparse
 import configparser
 import os

--- a/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
@@ -24,7 +24,7 @@ control 'tag:install_intel_hpc_dependencies_downloaded' do
 end
 
 control 'tag:config_intel_hpc_enough_space_on_root_volume' do
-  only_if { !instance.custom_ami? && !(os_properties.centos7? && os_properties.x86?) }
+  only_if { !instance.custom_ami? && (os_properties.centos7? && os_properties.x86?) }
 
   describe 'at least 10 GB of free space on root volume' do
     subject { bash("sudo -u #{node['cluster']['cluster_user']} df --block-size GB --output=avail / | tail -n1 | cut -d G -f1") }

--- a/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
@@ -24,7 +24,7 @@ control 'tag:install_intel_hpc_dependencies_downloaded' do
 end
 
 control 'tag:config_intel_hpc_enough_space_on_root_volume' do
-  only_if { !instance.custom_ami? }
+  only_if { !instance.custom_ami? && !(os_properties.centos7? && os_properties.x86?) }
 
   describe 'at least 10 GB of free space on root volume' do
     subject { bash("sudo -u #{node['cluster']['cluster_user']} df --block-size GB --output=avail / | tail -n1 | cut -d G -f1") }

--- a/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_check_manager.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_check_manager.py
@@ -11,6 +11,9 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import argparse
 import logging
 import os

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
@@ -9,6 +9,10 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import argparse
 import functools
 import json

--- a/test/unit/clusterstatusmgtd/test_clusterstatusmgtd.py
+++ b/test/unit/clusterstatusmgtd/test_clusterstatusmgtd.py
@@ -8,6 +8,10 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import os
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace

--- a/test/unit/dcv/test_dcv_authenticator.py
+++ b/test/unit/dcv/test_dcv_authenticator.py
@@ -9,6 +9,10 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import json
 import string
 import time


### PR DESCRIPTION
### Description of changes
* Disable code-duplication linting checks that run using github actions
* Added `pylint: disable=R0801` as per below https://github.com/aws/aws-parallelcluster-cookbook/pull/2478 [checks](https://github.com/aws/aws-parallelcluster-cookbook/actions/runs/6395316552/job/17363720139?pr=2478)
* Adding the opposite condition ( as we install intel_hpc only for centos7) that was added in https://github.com/aws/aws-parallelcluster-cookbook/pull/2078 as the system tests fail in github actions for Ubuntu OSSes which was missed in https://github.com/aws/aws-parallelcluster-cookbook/pull/2296

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
