### PR TITLE
[release-3.7] Add support for installing Slurm from development branches and build Slurm from 23.02 devel branch

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,8 @@ disable=raw-checker-failed,
         unused-import, # handled by flake8
         no-else-return, # A complete if else block can improve readability even with returns in the body
         wrong-import-order,
-        protected-access
+        protected-access,
+        fixme
 
 
 # Enable the message, report, category or checker with the given id(s). You can
@@ -380,4 +381,3 @@ min-public-methods=2
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception".
 overgeneral-exceptions=Exception
-

--- a/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
+++ b/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
@@ -11,6 +11,9 @@
 # limitations under the License.
 
 # pylint: disable=W0719
+
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
 import functools
 import json
 import logging

--- a/cookbooks/aws-parallelcluster-environment/files/default/ec2_udev_rules/ec2_dev_2_volid.py
+++ b/cookbooks/aws-parallelcluster-environment/files/default/ec2_udev_rules/ec2_dev_2_volid.py
@@ -1,3 +1,6 @@
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import configparser
 import os
 import re

--- a/cookbooks/aws-parallelcluster-environment/files/default/ec2_udev_rules/manageVolume.py
+++ b/cookbooks/aws-parallelcluster-environment/files/default/ec2_udev_rules/manageVolume.py
@@ -1,6 +1,10 @@
 # pylint: disable=C0103
 # pylint: disable=W0719
 # This file should name manage_volume.py by convention
+
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import argparse
 import configparser
 import os

--- a/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
@@ -24,7 +24,7 @@ control 'tag:install_intel_hpc_dependencies_downloaded' do
 end
 
 control 'tag:config_intel_hpc_enough_space_on_root_volume' do
-  only_if { !instance.custom_ami? }
+  only_if { !instance.custom_ami? && (os_properties.centos7? && os_properties.x86?) }
 
   describe 'at least 10 GB of free space on root volume' do
     subject { bash("sudo -u #{node['cluster']['cluster_user']} df --block-size GB --output=avail / | tail -n1 | cut -d G -f1") }

--- a/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
@@ -24,7 +24,7 @@ control 'tag:install_intel_hpc_dependencies_downloaded' do
 end
 
 control 'tag:config_intel_hpc_enough_space_on_root_volume' do
-  only_if { !instance.custom_ami? && (os_properties.centos7? && os_properties.x86?) }
+  only_if { !os_properties.on_docker? && !instance.custom_ami? }
 
   describe 'at least 10 GB of free space on root volume' do
     subject { bash("sudo -u #{node['cluster']['cluster_user']} df --block-size GB --output=avail / | tail -n1 | cut -d G -f1") }

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -3,6 +3,7 @@ default['cluster']['slurm']['fleet_config_path'] = "#{node['cluster']['slurm_plu
 
 # Slurm attributes shared between install_slurm and configure_slurm_accounting
 default['cluster']['slurm']['commit'] = ''
+default['cluster']['slurm']['branch'] = ''
 default['cluster']['slurm']['sha256'] = '4fee743a34514d8fe487080048256f5ee032374ed5f42d0eae342110dcd59edf'
 default['cluster']['slurm']['install_dir'] = '/opt/slurm'
 

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -3,7 +3,7 @@ default['cluster']['slurm']['fleet_config_path'] = "#{node['cluster']['slurm_plu
 
 # Slurm attributes shared between install_slurm and configure_slurm_accounting
 default['cluster']['slurm']['commit'] = ''
-default['cluster']['slurm']['branch'] = ''
+default['cluster']['slurm']['branch'] = 'slurm-23.02'
 default['cluster']['slurm']['sha256'] = '4fee743a34514d8fe487080048256f5ee032374ed5f42d0eae342110dcd59edf'
 default['cluster']['slurm']['install_dir'] = '/opt/slurm'
 

--- a/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_check_manager.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_check_manager.py
@@ -11,6 +11,9 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import argparse
 import logging
 import os

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
@@ -9,6 +9,10 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import argparse
 import functools
 import json

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
@@ -27,14 +27,19 @@ slurm_install_dir = node['cluster']['slurm']['install_dir']
 
 slurm_version = node['cluster']['slurm']['version']
 slurm_commit = node['cluster']['slurm']['commit']
-slurm_tar_name = if slurm_commit.empty?
-                   "slurm-#{slurm_version}"
-                 else
+slurm_branch = node['cluster']['slurm']['branch']
+slurm_tar_name = if !slurm_commit.empty?
                    "#{slurm_commit}"
+                 elsif !slurm_branch.empty?
+                   "#{slurm_branch}"
+                 else
+                   "slurm-#{slurm_version}"
                  end
 slurm_tarball = "#{node['cluster']['sources_dir']}/#{slurm_tar_name}.tar.gz"
 slurm_url = "https://github.com/SchedMD/slurm/archive/#{slurm_tar_name}.tar.gz"
-slurm_sha256 = node['cluster']['slurm']['sha256']
+slurm_sha256 = if slurm_branch.empty?
+                 node['cluster']['slurm']['sha256']
+               end
 
 # Setup slurm group
 group slurm_group do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
@@ -141,7 +141,7 @@ bash 'copy license stuff' do
   cwd Chef::Config[:file_cache_path]
   code <<-SLURMLICENSE
     set -e
-    cd slurm-slurm-#{slurm_version}
+    cd slurm-#{slurm_tar_name}
     cp -v COPYING #{node['cluster']['license_dir']}/slurm/COPYING
     cp -v DISCLAIMER #{node['cluster']['license_dir']}/slurm/DISCLAIMER
     cp -v LICENSE.OpenSSL #{node['cluster']['license_dir']}/slurm/LICENSE.OpenSSL

--- a/test/unit/clusterstatusmgtd/test_clusterstatusmgtd.py
+++ b/test/unit/clusterstatusmgtd/test_clusterstatusmgtd.py
@@ -8,6 +8,10 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import os
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace

--- a/test/unit/dcv/test_dcv_authenticator.py
+++ b/test/unit/dcv/test_dcv_authenticator.py
@@ -9,6 +9,10 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+
+# FIXME: Fix Code Duplication
+# pylint: disable=R0801
+
 import json
 import string
 import time


### PR DESCRIPTION
### Description of changes
* Add support for building Slurm from a development branch.
* Build slurm from development branch `slurm-23.02`.
* Fix issue with intel_hpc root volume free space kitchen test.

### Tests
* Manual verification of the logic to handle Slurm commit, branch and version variables.
* Manual verification that passing `nil` to the `remote_file` Chef resource `checksum` parameter disable checksum verification.

### References
- https://github.com/aws/aws-parallelcluster-cookbook/pull/2485

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
