### PR TITLE
Add support for installing Slurm from development branches

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/intel_hpc_spec.rb
@@ -24,7 +24,7 @@ control 'tag:install_intel_hpc_dependencies_downloaded' do
 end
 
 control 'tag:config_intel_hpc_enough_space_on_root_volume' do
-  only_if { !instance.custom_ami? && (os_properties.centos7? && os_properties.x86?) }
+  only_if { !os_properties.on_docker? && !instance.custom_ami? }
 
   describe 'at least 10 GB of free space on root volume' do
     subject { bash("sudo -u #{node['cluster']['cluster_user']} df --block-size GB --output=avail / | tail -n1 | cut -d G -f1") }

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -3,6 +3,7 @@ default['cluster']['slurm']['fleet_config_path'] = "#{node['cluster']['slurm_plu
 
 # Slurm attributes shared between install_slurm and configure_slurm_accounting
 default['cluster']['slurm']['commit'] = ''
+default['cluster']['slurm']['branch'] = ''
 default['cluster']['slurm']['sha256'] = '4fee743a34514d8fe487080048256f5ee032374ed5f42d0eae342110dcd59edf'
 default['cluster']['slurm']['install_dir'] = '/opt/slurm'
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
@@ -21,14 +21,19 @@ slurm_install_dir = node['cluster']['slurm']['install_dir']
 
 slurm_version = node['cluster']['slurm']['version']
 slurm_commit = node['cluster']['slurm']['commit']
-slurm_tar_name = if slurm_commit.empty?
-                   "slurm-#{slurm_version}"
-                 else
+slurm_branch = node['cluster']['slurm']['branch']
+slurm_tar_name = if !slurm_commit.empty?
                    "#{slurm_commit}"
+                 elsif !slurm_branch.empty?
+                   "#{slurm_branch}"
+                 else
+                   "slurm-#{slurm_version}"
                  end
 slurm_tarball = "#{node['cluster']['sources_dir']}/#{slurm_tar_name}.tar.gz"
 slurm_url = "https://github.com/SchedMD/slurm/archive/#{slurm_tar_name}.tar.gz"
-slurm_sha256 = node['cluster']['slurm']['sha256']
+slurm_sha256 = if slurm_branch.empty?
+                 node['cluster']['slurm']['sha256']
+               end
 
 include_recipe 'aws-parallelcluster-slurm::slurm_users'
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
@@ -104,7 +104,7 @@ bash 'copy license stuff' do
   cwd Chef::Config[:file_cache_path]
   code <<-SLURMLICENSE
     set -e
-    cd slurm-slurm-#{slurm_version}
+    cd slurm-#{slurm_tar_name}
     cp -v COPYING #{node['cluster']['license_dir']}/slurm/COPYING
     cp -v DISCLAIMER #{node['cluster']['license_dir']}/slurm/DISCLAIMER
     cp -v LICENSE.OpenSSL #{node['cluster']['license_dir']}/slurm/LICENSE.OpenSSL


### PR DESCRIPTION
### Description of changes
* Add support for building Slurm from a development branch.
* Fix issue with intel_hpc root volume free space kitchen test.

### Tests
* Manual verification of the logic to handle Slurm commit, branch and version variables.
* Manual verification that passing `nil` to the `remote_file` Chef resource `checksum` parameter disable checksum verification.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2484

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
