### PR TITLE
[develop][fix] Add mock munge key logic in compute setup recipe during kitchen tests

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -101,6 +101,10 @@ def setup_munge_key(shared_dir)
 end
 
 def setup_munge_compute_node
+  if kitchen_test?
+    # FIXME: Mock munge key in shared directory.
+    include_recipe 'aws-parallelcluster-slurm::mock_munge_key'
+  end
   setup_munge_key(node['cluster']['shared_dir'])
   enable_munge_service
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/test/mock_munge_key.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/test/mock_munge_key.rb
@@ -5,10 +5,16 @@ munge_dirs.each do |munge_dir|
     mode '0700'
   end
 
-  file "#{munge_dir}/.munge.key" do
-    mode '0600'
-    content 'munge-key'
-    owner node['cluster']['munge']['user']
-    group node['cluster']['munge']['group']
+  bash "mock_munge_key" do
+    user 'root'
+    group 'root'
+    code <<-MOCK_KEY
+      set -e
+      munge_directory=#{munge_dir}
+      encoded_key='lWXJDxgGhJxIVqLdbaycUICm12u0gHtcDFslGGxJlyLoVIQJFuskDfkK8wjvQfhT5pkeyuxA+vjgg9R+E+ftPVTsVLHaf4bx3RmEfe30bZo79Yg+GhTRJRzV401/VaTlVEGFwMcJhmVKrXX/MbfnIdMwWNgCL8swUELbFOI4CG0='
+      decoded_key=$(echo $encoded_key | base64 -d)
+      echo "${decoded_key}" > ${munge_directory}/.munge.key
+      chmod 0600 ${munge_directory}/.munge.key
+    MOCK_KEY
   end
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/test/mock_munge_key.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/test/mock_munge_key.rb
@@ -6,6 +6,7 @@ munge_dirs.each do |munge_dir|
   end
 
   file "#{munge_dir}/.munge.key" do
+    mode '0600'
     content 'munge-key'
     owner node['cluster']['munge']['user']
     group node['cluster']['munge']['group']


### PR DESCRIPTION
### Description of changes
* Fix Kitchen tests on compute nodes caused by not existed Munge Key

### References
* Failed kitchen tests on Jenkins
  * https://jenkins-commercial-dev.parallelcluster.ds9.nice.aws.a2z.com/blue/organizations/jenkins/kitchen_tests_3/detail/kitchen_tests_3/1407/pipeline

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.