### PR TITLE
Avoid checking ScalingStrategy parameter at compile time

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_resume.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_resume.rb
@@ -51,6 +51,6 @@ template "#{node['cluster']['slurm_plugin_dir']}/parallelcluster_slurm_resume.co
     head_node_hostname: on_docker? ? 'local_hostname' : node['ec2']['local_hostname'],
     clustermgtd_heartbeat_file_path: "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat",
     instance_id: on_docker? ? 'instance_id' : node['ec2']['instance_id'],
-    scaling_strategy: node['cluster']['config'].dig(:Scheduling, :ScalingStrategy)
+    scaling_strategy: lazy { node['cluster']['config'].dig(:Scheduling, :ScalingStrategy) }
   )
 end


### PR DESCRIPTION
### Description of changes
The recipe `config_slurm_resume` is processed also at compile time.
This causes failures since the value for the ScalingStrategy parameter is retrieved from the configuration that is available only at config time. By adding `lazy` we ensure that the parameter isn't checked at compile time.
* Avoid checking ScalingStrategy parameter at compile time.

### Tests
* Manually validated by a peer launching a cluster.
 
### References
* [Original PR](https://github.com/aws/aws-parallelcluster-cookbook/commit/d754cf9c17bf4ce6a100588d92b74382c8d88ba8)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
