### PR TITLE
Disable deprecated flake8-mypy Python tox check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-docstrings, flake8-bugbear, flake8-mypy, flake8-colors, pep8-naming]
+        additional_dependencies: [flake8-docstrings, flake8-bugbear, flake8-colors, pep8-naming]
 
   - repo: https://github.com/timothycrosley/isort
     rev: 5.12.0

--- a/tox.ini
+++ b/tox.ini
@@ -117,7 +117,6 @@ deps =
     flake8
     flake8-docstrings
     flake8-bugbear
-    flake8-mypy
     # flake8-import-order # delegated to isort
     flake8-colors
     pep8-naming


### PR DESCRIPTION
### Description of changes
- Disable deprecated flake8-mypy Python tox check, which caused problems in the GitHub actions on the repository.

### References
- https://github.com/aws/aws-parallelcluster/pull/5750
- https://github.com/aws/aws-parallelcluster-node/pull/571

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
