### PR TITLE
Remove `custom_node_package` from attributes in kitchen tests

### DIFF
--- a/kitchen.validate-config.yml
+++ b/kitchen.validate-config.yml
@@ -21,7 +21,6 @@ _common_cluster_attributes: &_common_cluster_attributes
   cluster_config_s3_key: <%= ENV['CLUSTER_CONFIG_S3_KEY'] %>
   instance_types_data_s3_key: <%= ENV['INSTANCE_TYPES_DATA_S3_KEY'] %>
   os: <%= ENV['OS'] %>
-  custom_node_package: <%= ENV['PARALLELCLUSTER_NODE_URL'] %>
   dcv_enabled: 'head_node'
   dcv_port: '8443'
   enable_efa: 'efa'


### PR DESCRIPTION
### Description of changes
* `custom_node_package` is a dev variable which should not be used by users. Setting it in the common attribute makes the tests simulate a non-realistic scenario.

### Tests
* To be tested in pipeline.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
