### PR TITLE
Fix missing munge service enablement on head node

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/munge_key_manager.rb
@@ -32,6 +32,15 @@ def restart_munge_service
   end
 end
 
+def enable_munge_service
+  declare_resource(:service, "munge") do
+    supports restart: true
+    action :enable
+    retries 5
+    retry_delay 10
+  end
+end
+
 def share_munge_key_to_dir(shared_dir)
   declare_resource(:bash, 'share_munge_key') do
     user 'root'
@@ -80,6 +89,7 @@ def generate_munge_key
   #  and not within the `fetch_and_decode_munge_key` method because the `update_munge_key.sh` script,
   #  which is called by `fetch_and_decode_munge_key`, already includes these two operations.
   restart_munge_service
+  enable_munge_service
   share_munge
 end
 


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes. This was lost during the developments of the custom munge key recipes.

### Tests
* Successful run of the munge kitchen tests.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
