### PR TITLE
Add GitHub action step to free disk space before executing System tests

### DIFF
--- a/.github/workflows/dokken-system-tests.yml
+++ b/.github/workflows/dokken-system-tests.yml
@@ -38,6 +38,28 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@main
+      - name: Free disk space
+        id: free-disk-space
+        run: |
+          df -h /
+          echo "Removing tool cache"
+          # Ref https://github.com/orgs/community/discussions/25678
+          sudo rm -rf /opt/hostedtoolcache
+          echo "Removing docker images"
+          sudo docker image prune --all --force || true
+          echo "Removing large packages" 
+          # Ref https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+          sudo apt-get remove -y '^aspnetcore-.*'
+          sudo apt-get remove -y '^dotnet-.*' --fix-missing
+          sudo apt-get remove -y 'php.*' --fix-missing
+          sudo apt-get remove -y '^mongodb-.*' --fix-missing
+          sudo apt-get remove -y '^mysql-.*' --fix-missing
+          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+          echo "Removing large directories"
+          rm -rf /usr/share/dotnet/
+          df -h /
       - name: Get changed files
         id: changed-files-excluding-tests
         uses: tj-actions/changed-files@v35.6.0

--- a/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 #
-# Cookbook:: aws-parallelcluster
 # Recipe:: aws_batch
 #
-# Copyright:: 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at


### PR DESCRIPTION
Add GitHub action step to free disk space before executing System tests

System tests were failing with: `no space left on device` error.
With this patch we're removing pre-cached/pre-installed tools not required for our tests.

Space is passing from:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   66G   18G  79% /
```
to:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   44G   40G  53% /
```

Did a minor change in one of the cookbook file to trigger system tests.

References:
* https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
* https://github.com/orgs/community/discussions/25678
* https://github.com/jlumbroso/free-disk-space

