### PR TITLE
Use custom_node_package and custom_awsbatchcli_package only when running system tests

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/kitchen.awsbatch-install.yml
+++ b/cookbooks/aws-parallelcluster-awsbatch/kitchen.awsbatch-install.yml
@@ -13,3 +13,12 @@ suites:
     verifier:
       controls:
         - /awsbatch_virtualenv_created/
+  - name: custom_awsbatchcli_package
+    run_list:
+      - recipe[aws-parallelcluster-awsbatch::install]
+    verifier:
+      controls:
+        - /custom_awsbatchcli_package_installed/
+    attributes:
+      cluster:
+        custom_awsbatchcli_package: https://github.com/aws/aws-parallelcluster/archive/develop.tar.gz

--- a/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_install_spec.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_install_spec.rb
@@ -9,12 +9,17 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'custom_parallelcluster_node_installed' do
-  title "custom aws-parallelcluster-node should have been installed in the node virtualenv"
+control 'custom_awsbatchcli_package_installed' do
+  title "custom aws-parallelcluster-awsbatch-cli should have been installed in the virtualenv"
   only_if { !os_properties.redhat_on_docker? }
 
-  describe command("#{node['cluster']['node_virtualenv_path']}/bin/pip freeze | grep aws-parallelcluster-node") do
+  describe command("#{node['cluster']['awsbatch_virtualenv_path']}/bin/pip freeze | grep aws-parallelcluster-awsbatch-cli") do
     its('exit_status') { should eq(0) }
-    its('stdout') { should match "aws-parallelcluster-node" }
+    its('stdout') { should match "aws-parallelcluster-awsbatch-cli" }
+  end
+
+  describe command("#{node['cluster']['awsbatch_virtualenv_path']}/bin/awsbsub --help") do
+    its('exit_status') { should eq(0) }
+    its('stdout') { should match "usage: awsbsub" }
   end
 end

--- a/cookbooks/aws-parallelcluster-entrypoints/kitchen.entrypoints-install.yml
+++ b/cookbooks/aws-parallelcluster-entrypoints/kitchen.entrypoints-install.yml
@@ -9,6 +9,14 @@ verifier:
     - cookbooks/aws-parallelcluster-shared/test
     - cookbooks/aws-parallelcluster-slurm/test
 
+provisioner:
+  attributes:
+    cluster:
+      # The following parameters are required when running install recipes on system tests
+      region: us-east-1
+      custom_node_package: https://github.com/aws/aws-parallelcluster-node/archive/develop.tar.gz
+      custom_awsbatchcli_package: https://github.com/aws/aws-parallelcluster/archive/develop.tar.gz
+
 suites:
   - name: entrypoints_install
     run_list:

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -14,7 +14,6 @@ provisioner:
     cluster:
       # right now tests depend on this parameter: we will try to remove the dependency later
       region: us-east-1
-      parallelcluster-node-version: '3.4.1'
 
 lifecycle:
   <% %w(pre post).each do |prefix| %>


### PR DESCRIPTION
These packages are not required in CI/CD because only config recipes are executed there, then they are not required by local ec2 or docker tests, because locally we execute specific tests/controls that should have all the required parameters.

With this change we're also avoiding to install always version 3.4.1 of the node and use instead a package from develop.

### Tests

* Created new test for custom awsbatch cli package installation
* Improved existing test for custom node package installation to check if the package is available on pypi

Executed:
* `bash kitchen.ec2.sh computefleet-install test custom-parallelcluster-node-rocky8`
* `bash kitchen.ec2.sh awsbatch-install test custom-awsbatchcli-package-rocky8`
