### PR TITLE
[Release 3.8] Add kitchen tests for internal shared efs

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -609,7 +609,6 @@ suites:
         node_type: 'HeadNode'
         scheduler: 'slurm'
         shared_dir_login_nodes: '/opt/shared_login_nodes'
-
   - name: login_nodes_keys_configuration
     run_list:
       - recipe[aws-parallelcluster-tests::setup]
@@ -627,3 +626,61 @@ suites:
         scheduler: 'slurm'
         head_node_private_ip: '127.0.0.1'
         shared_dir_login_nodes: '/opt/parallelcluster/shared_login_nodes'
+  - name: shared_internal_storage_headnode
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-environment::backup_internal_use_efs]
+      - recipe[aws-parallelcluster-environment::mount_internal_use_efs]
+      - recipe[aws-parallelcluster-environment::restore_internal_use_efs]
+    verifier:
+      controls:
+        - mount_shared_compute_efs
+        - mount_shared_login_efs
+        - mount_intel_efs
+        - mount_slurm_efs
+    attributes:
+      cluster:
+        node_type: 'HeadNode'
+        scheduler: 'slurm'
+        internal_shared_storage_type: 'efs'
+        efs_shared_dirs: '/opt/parallelcluster/init_shared'
+        efs_fs_ids: 'fs-03ad31942a4205839' # Existing FS, needs to be set when running the test
+        ebs_shared_dirs: ''
+  - name: shared_internal_storage_compute
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-environment::backup_internal_use_efs]
+      - recipe[aws-parallelcluster-environment::mount_internal_use_efs]
+      - recipe[aws-parallelcluster-environment::restore_internal_use_efs]
+    verifier:
+      controls:
+        - mount_shared_compute_efs
+        - mount_intel_efs
+        - mount_slurm_efs
+    attributes:
+      cluster:
+        node_type: 'ComputeFleet'
+        scheduler: 'slurm'
+        internal_shared_storage_type: 'efs'
+        efs_shared_dirs: '/opt/parallelcluster/init_shared'
+        efs_fs_ids: 'fs-03ad31942a4205839' # Existing FS, needs to be set when running the test
+        ebs_shared_dirs: ''
+  - name: shared_internal_storage_login
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-environment::backup_internal_use_efs]
+      - recipe[aws-parallelcluster-environment::mount_internal_use_efs]
+      - recipe[aws-parallelcluster-environment::restore_internal_use_efs]
+    verifier:
+      controls:
+        - mount_shared_login_efs
+        - mount_intel_efs
+        - mount_slurm_efs
+    attributes:
+      cluster:
+        node_type: 'LoginNode'
+        scheduler: 'slurm'
+        internal_shared_storage_type: 'efs'
+        efs_shared_dirs: '/opt/parallelcluster/init_shared'
+        efs_fs_ids: 'fs-03ad31942a4205839' # Existing FS, needs to be set when running the test
+        ebs_shared_dirs: ''

--- a/cookbooks/aws-parallelcluster-environment/test/controls/mount_internal_use_ebs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/mount_internal_use_ebs_spec.rb
@@ -9,10 +9,10 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'mount_home_efs' do
+control 'mount_home' do
   title 'Check if the home directory in mounted'
 
-  only_if { !os_properties.on_docker? }
+  only_if { !os_properties.on_docker? && (instance.compute_node? or instance.login_node?) }
 
   describe mount('/home') do
     it { should be_mounted }
@@ -21,10 +21,10 @@ control 'mount_home_efs' do
   end
 end
 
-control 'mount_shared_compute_efs' do
+control 'mount_shared_compute' do
   title 'Check if the shared directory is mounted'
 
-  only_if { !os_properties.on_docker? && (instance.compute_node? or instance.head_node?) }
+  only_if { !os_properties.on_docker? && instance.compute_node? }
 
   describe mount('/opt/parallelcluster/shared') do
     it { should be_mounted }
@@ -33,10 +33,10 @@ control 'mount_shared_compute_efs' do
   end
 end
 
-control 'mount_shared_login_efs' do
+control 'mount_shared_login' do
   title 'Check if the shared directory is mounted'
 
-  only_if { !os_properties.on_docker? && (instance.login_node? or instance.head_node?) }
+  only_if { !os_properties.on_docker? && instance.login_node? }
 
   describe mount('/opt/parallelcluster/shared_login_nodes') do
     it { should be_mounted }
@@ -45,44 +45,18 @@ control 'mount_shared_login_efs' do
   end
 end
 
-control 'mount_intel_efs' do
-  title 'Check the shared intel dir is available'
+control 'shared_storages_compute_and_login' do
+  title 'Check the shared storages configuration for compute node'
 
-  only_if { !os_properties.on_docker? }
+  only_if { !os_properties.on_docker? && (instance.compute_node? or instance.login_node?) }
 
   describe 'Check that /opt/intel dir has been mounted'
   describe mount("/opt/intel") do
     it { should be_mounted }
+    its('device') { should eq "127.0.0.1:/opt/intel" }
     its('type') { should eq 'nfs4' }
     its('options') { should include 'hard' }
     its('options') { should include '_netdev' }
-  end
-
-  describe directory("/opt/intel/mpi") do
-    it { should exist }
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-    its('mode') { should cmp '0755' }
-  end
-end
-
-control 'mount_slurm_efs' do
-  title 'Check the shared slurm dir is available'
-
-  only_if { !os_properties.on_docker? }
-
-  describe 'Check that /opt/intel dir has been mounted'
-  describe mount("/opt/slurm") do
-    it { should be_mounted }
-    its('type') { should eq 'nfs4' }
-    its('options') { should include 'hard' }
-    its('options') { should include '_netdev' }
-  end
-
-  describe directory("/opt/slurm/bin") do
-    it { should exist }
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-    its('mode') { should cmp '0755' }
+    its('options') { should include 'noatime' }
   end
 end


### PR DESCRIPTION
Adds the shared_internal_storage_* test suites for enviornment-config  
Updates the matching mount_internal_use_efs_spec controls  
Adds the mount_internal_use_ebs_spec controls for the case of ebs

### Tests
* Ran kitchen tests locally using an existing EFS file system for mounting the internal shared data
* shared_internal_storage_headnode
* shared_internal_storage_compute
* shared_internal_storage_login

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
