### PR TITLE
[Dependencies] Use OpenRM as NVIDIA kernel module for Linux instead of NVIDIA closed source module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Upgrade `aws-cfn-bootstrap` to version 2.0-28.
 - Upgrade Python to 3.9.17.
+- Use OpenRM as NVIDIA kernel module for Linux instead of NVIDIA closed source module.
 
 **BUG FIXES**
 - Fix inconsistent scaling configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade `aws-cfn-bootstrap` to version 2.0-28.
 - Upgrade Python to 3.9.17.
 - Use OpenRM as NVIDIA kernel module for Linux instead of NVIDIA closed source module.
+- Upgrade EFA installer to `1.29.0`.
+  - Efa-driver: `efa-2.6.0-1`
+  - Efa-config: `efa-config-1.15-1`
+  - Efa-profile: `efa-profile-1.5-1`
+  - Libfabric-aws: `libfabric-aws-1.19.0-1`
+  - Rdma-core: `rdma-core-46.0-1`
+  - Open MPI: `openmpi40-aws-4.1.6-1`
 
 **BUG FIXES**
 - Fix inconsistent scaling configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.

--- a/cookbooks/aws-parallelcluster-environment/resources/efa/partial/_common.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efa/partial/_common.rb
@@ -17,8 +17,8 @@
 # EFA setup: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html
 #
 
-property :efa_version, String, default: '1.26.1'
-property :efa_checksum, String, default: 'c616994c924f54ebfabfab32b7fe8ac56947fae00a0ff453d975e298d174fc96'
+property :efa_version, String, default: '1.29.0'
+property :efa_checksum, String, default: '836655f87015547e733e7d9f7c760e4e24697f8bbc261bb5f3560abd4206bc36'
 
 action :setup do
   if efa_installed? && !::File.exist?(efa_tarball)

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 # parallelcluster default source dir defined in attributes
 source_dir = '/opt/parallelcluster/sources'
-efa_version = '1.26.1'
-efa_checksum = 'c616994c924f54ebfabfab32b7fe8ac56947fae00a0ff453d975e298d174fc96'
+efa_version = '1.29.0'
+efa_checksum = '836655f87015547e733e7d9f7c760e4e24697f8bbc261bb5f3560abd4206bc36'
 
 class ConvergeEfa
   def self.setup(chef_run)

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
@@ -68,7 +68,7 @@ action :setup do
     cwd '/tmp'
     code <<-NVIDIA
       set -e
-      #{compiler_version} ./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check
+      #{compiler_version} ./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check -m=kernel-open
       rm -f /tmp/nvidia.run
     NVIDIA
     creates '/usr/bin/nvidia-smi'

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
@@ -211,7 +211,7 @@ describe 'nvidia_driver:setup' do
               cwd: '/tmp',
               creates: '/usr/bin/nvidia-smi'
             )
-            .with_code(%r{CC=/usr/bin/gcc10-gcc ./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check})
+            .with_code(%r{CC=/usr/bin/gcc10-gcc ./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check -m=kernel-open})
             .with_code(%r{rm -f /tmp/nvidia.run})
         end
       else
@@ -226,7 +226,7 @@ describe 'nvidia_driver:setup' do
               cwd: '/tmp',
               creates: '/usr/bin/nvidia-smi'
             )
-            .with_code(%r{./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check})
+            .with_code(%r{./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check -m=kernel-open})
             .with_code(%r{rm -f /tmp/nvidia.run})
         end
       end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_spec.rb
@@ -16,10 +16,22 @@ control 'tag:install_expected_versions_of_nvidia_driver_installed' do
   end
 
   expected_nvidia_driver_version = node['cluster']['nvidia']['driver_version']
+  expected_nvidia_kernel_license = 'Dual MIT/GPL'
+  expected_nvidia_kernel_module = "NVRM version: NVIDIA UNIX Open Kernel Module"
 
   describe "nvidia driver version is expected to be #{expected_nvidia_driver_version}" do
     subject { command('modinfo -F version nvidia').stdout.strip }
     it { should eq expected_nvidia_driver_version }
+  end
+
+  describe "nvidia kernel module is expected to be licensed as #{expected_nvidia_kernel_license}" do
+    subject { command('modinfo -F license nvidia').stdout.strip }
+    it { should eq expected_nvidia_kernel_license }
+  end
+
+  describe "nvidia kernel module is expected to be #{expected_nvidia_kernel_module}" do
+    subject { command('cat /proc/driver/nvidia/version').stdout.strip }
+    it { should include expected_nvidia_kernel_module }
   end
 end
 


### PR DESCRIPTION
### Description of changes
Use OpenRM as NVIDIA kernel module for Linux instead of NVIDIA closed source module.

### Tests
1. Build AMI (with validation enabled) both with kernel 5.10.192 and kernel 5.10.198
2. Executed integ tests with kernel 5.10.192:
    1. test_efa, test_fabric, test_dcv_configuration, test_slurm: succeeded
    3. test_cluster_with_gpu_health_checks failed, but due to a known issue not related to NVIDIA/EFA.
3. Executed integ tests with kernel 5.10.198:
    1. test_efa, test_fabric,  test_dcv_configuration, test_slurm: succeeded
    3. test_cluster_with_gpu_health_checks failed, but due to a known issue not related to NVIDIA/EFA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
