### PR TITLE
[develop][fix] Avoid store decoded binary data in bash varibles in rotation script

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
@@ -59,6 +59,7 @@ if [ -n "${SECRET_ARN}" ]; then
   fi
 
   # Decode munge key and write to munge.key file
+  decoded_key=$(printf "%s" "${encoded_key}" | base64 -d)
   if [ $? -ne 0 ]; then
     echo "Error decoding the munge key with base64"
     exit 1

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_munge_key.sh.erb
@@ -59,20 +59,19 @@ if [ -n "${SECRET_ARN}" ]; then
   fi
 
   # Decode munge key and write to munge.key file
-  decoded_key=$(printf "%s" "${encoded_key}" | base64 -d)
   if [ $? -ne 0 ]; then
     echo "Error decoding the munge key with base64"
     exit 1
   fi
 
   # Check munge key size
-  key_size=$(printf "%s" "${decoded_key}" | wc -c)
+  key_size=$(printf "%s" "${encoded_key}" | base64 -d | wc -c)
   if [ $key_size -lt 32 ] || [ $key_size -gt 1024 ]; then
     echo "Fetched munge key size is out of valid range [256-8192 bits]."
     exit 1
   fi
 
-  printf "%s" "${decoded_key}" > ${MUNGE_KEY_FILE}
+  printf "%s" "${encoded_key}" | base64 -d > ${MUNGE_KEY_FILE}
 
   # Set ownership on the key
   chown ${MUNGE_USER}:${MUNGE_GROUP} ${MUNGE_KEY_FILE}


### PR DESCRIPTION
### Description of changes
* Avoid store decoded binary data in bash varibles in rotation script

### Tests
* Manually tests passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.
