### PR TITLE
[release-3.8] Using YUM to install Fabric Manager instead of Dnf packages

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_rhel.rb
@@ -14,9 +14,14 @@
 
 action :install_package do
   package 'yum-plugin-versionlock'
-
-  package fabric_manager_package do
-    version fabric_manager_version
-    action %i(install lock)
+  bash "Install #{fabric_manager_package}" do
+    user 'root'
+    code <<-FABRIC_MANAGER_INSTALL
+    set -e
+    yum install -y #{fabric_manager_package}-#{fabric_manager_version}
+    yum versionlock #{fabric_manager_package}
+    FABRIC_MANAGER_INSTALL
+    retries 3
+    retry_delay 5
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
@@ -203,9 +203,14 @@ describe 'fabric_manager:setup' do
           end
 
           it 'installs fabric manager' do
-            is_expected.to install_package(fabric_manager_package)
-              .with_version(fabric_manager_version)
-              .with_action(%i(install lock))
+            is_expected.to run_bash("Install nvidia-fabric-manager")
+              .with(user: 'root')
+              .with_retries(3)
+              .with_retry_delay(5)
+              .with(code: %(    set -e
+    yum install -y #{fabric_manager_package}-#{fabric_manager_version}
+    yum versionlock #{fabric_manager_package}
+))
           end
         end
       end


### PR DESCRIPTION
### Description of changes
* The Dnf cache is not getting updated which is why we get the `No candidate version available for nvidia-fabric-manager`
* Rocky8, Rhel8 are the only OSses using Dnf_package

### Tests
* Created Rocky8 AMI manually

develop https://github.com/aws/aws-parallelcluster-cookbook/pull/2518

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
