### PR TITLE
[develop] Add mysql_repo resource

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/kitchen.slurm-install.yml
+++ b/cookbooks/aws-parallelcluster-slurm/kitchen.slurm-install.yml
@@ -34,6 +34,15 @@ suites:
         - /mysql_client/
     attributes:
       resource: mysql_client
+  - name: mysql_repo_add
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-tests::test_resource]
+    verifier:
+      controls:
+        - mysql_repo_added
+    attributes:
+      resource: mysql_repo:add
   - name: munge
     run_list:
       - recipe[aws-parallelcluster-tests::setup]

--- a/cookbooks/aws-parallelcluster-slurm/kitchen.slurm-install.yml
+++ b/cookbooks/aws-parallelcluster-slurm/kitchen.slurm-install.yml
@@ -40,7 +40,7 @@ suites:
       - recipe[aws-parallelcluster-tests::test_resource]
     verifier:
       controls:
-        - mysql_repo_added
+        - tag:install_mysql_repo_added
     attributes:
       resource: mysql_repo:add
   - name: munge

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -148,3 +148,18 @@ def get_target_group_name(cluster_name, pool_name)
   hash_value = Digest::SHA256.hexdigest(combined_name)[0..15]
   "#{partial_cluster_name}-#{partial_pool_name}-#{hash_value}"
 end
+
+def validate_file_hash(file_path, expected_hash)
+  hash_function = yield
+  checksum = hash_function.file(file_path).hexdigest
+  if checksum != expected_hash
+    raise "Downloaded file #{file_path} checksum #{checksum} does not match expected checksum #{expected_hash}"
+  end
+end
+
+def validate_file_md5_hash(file_path, expected_hash)
+  validate_file_hash(file_path, expected_hash) do
+    require 'digest'
+    Digest::MD5
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install.rb
@@ -17,6 +17,7 @@
 
 dns_domain "Install dns related packages"
 mysql_client 'Install mysql client'
+mysql_repo 'Configure mysql repository'
 include_recipe 'aws-parallelcluster-slurm::install_jwt'
 include_recipe 'aws-parallelcluster-slurm::install_pmix'
 munge 'Install munge' do

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/mysql_repo_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/mysql_repo_amazon2.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :mysql_repo, platform: 'amazon', platform_version: '2'
+
+use 'partial/_mysql_repo_rpm.rb'
+
+def md5_signature
+  '42048ccae58835e40e37b68a3f8b91fb'
+end
+
+def file_name
+  'mysql80-community-release-el7-11.noarch.rpm'
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/mysql_repo_centos7.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/mysql_repo_centos7.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :mysql_repo, platform: 'centos' do |node|
+  node['platform_version'].to_i == 7
+end
+
+use 'partial/_mysql_repo_rpm.rb'
+
+def md5_signature
+  '42048ccae58835e40e37b68a3f8b91fb'
+end
+
+def file_name
+  'mysql80-community-release-el7-11.noarch.rpm'
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/mysql_repo_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/mysql_repo_redhat8.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :mysql_repo, platform: 'redhat' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_mysql_repo_rpm.rb'
+
+def md5_signature
+  '42048ccae58835e40e37b68a3f8b91fb'
+end
+
+def file_name
+  'mysql80-community-release-el8-9.noarch.rpm'
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/mysql_repo_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/mysql_repo_rocky8.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :mysql_repo, platform: 'rocky' do |node|
+  node['platform_version'].to_i == 8
+end
+
+use 'partial/_mysql_repo_rpm.rb'
+
+def md5_signature
+  '42048ccae58835e40e37b68a3f8b91fb'
+end
+
+def file_name
+  'mysql80-community-release-el8-9.noarch.rpm'
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/mysql_repo_ubuntu20+.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/mysql_repo_ubuntu20+.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :mysql_repo, platform: 'ubuntu' do |node|
+  node['platform_version'].to_i >= 20
+end
+
+use 'partial/_mysql_repo_deb.rb'
+
+def md5_signature
+  '42048ccae58835e40e37b68a3f8b91fb'
+end
+
+def file_name
+  'mysql-apt-config_0.8.26-1_all.deb'
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/partial/_mysql_repo_deb.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/partial/_mysql_repo_deb.rb
@@ -1,0 +1,41 @@
+unified_mode true
+default_action :add
+
+action :add do
+  remote_file local_path do
+    source repository_package
+    mode '0644'
+    retries 3
+    retry_delay 5
+    action :create_if_missing
+  end
+
+  ruby_block "Validate Repository Definition Checksum" do
+    block do
+      validate_file_md5_hash(local_path, md5_signature)
+    end
+    not_if { ::File.exist?(local_path) }
+  end
+
+  dpkg_package repository_name do
+    source local_path
+  end
+
+  apt_update 'update' do
+    action :update
+    retries 3
+    retry_delay 5
+  end
+end
+
+def repository_name
+  'MySQL Repository'
+end
+
+def repository_package
+  "https://dev.mysql.com/get/#{file_name}"
+end
+
+def local_path
+  "/tmp/#{file_name}"
+end

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/partial/_mysql_repo_rpm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_repo/partial/_mysql_repo_rpm.rb
@@ -1,0 +1,35 @@
+unified_mode true
+default_action :add
+
+action :add do
+  remote_file local_path do
+    source repository_package
+    mode '0644'
+    retries 3
+    retry_delay 5
+    action :create_if_missing
+  end
+
+  ruby_block "Validate Repository Definition Checksum" do
+    block do
+      validate_file_md5_hash(local_path, md5_signature)
+    end
+    not_if { ::File.exist?(local_path) }
+  end
+
+  package repository_name do
+    source local_path
+  end
+end
+
+def repository_name
+  'MySQL Repository'
+end
+
+def repository_package
+  "https://dev.mysql.com/get/#{file_name}"
+end
+
+def local_path
+  "/tmp/#{file_name}"
+end

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/mysql_repo_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/mysql_repo_spec.rb
@@ -1,0 +1,29 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'mysql_repo_added' do
+  if os_properties.ubuntu?
+    describe file('/etc/apt/sources.list.d/mysql.list') do
+      it { should exist }
+      its('content') { should match /mysql-apt-config/ }
+      its('content') { should match /mysql-8.0/ }
+      its('content') { should match /mysql-tools/ }
+      its('content') { should match /mysql-tools-preview/ }
+    end
+  else
+    %w(mysql-connectors-community mysql-tools-community mysql80-community).each do |repo_name|
+      describe yum.repo(repo_name) do
+        it { should exist }
+        it { should be_enabled }
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/mysql_repo_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/mysql_repo_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'mysql_repo_added' do
+control 'tag:install_mysql_repo_added' do
   if os_properties.ubuntu?
     describe file('/etc/apt/sources.list.d/mysql.list') do
       it { should exist }


### PR DESCRIPTION
### Description of changes
Add custom resource `mysql_repo` to configure mysql repository.
A custom resource was necessary since mysql provides a package (rpm/deb) that when installed configure the required repositories.
This may be useful for security patches and updates.

### Tests
* Resource tested locally on docker on all platforms.
  * Ubuntu20 is failing of a non reachable ip that seems unrelated to this change.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
