### PR TITLE
[release-3.8] Increase retries when no dynamoDB entry is found

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
@@ -31,7 +31,7 @@ end
 if node['cluster']['node_type'] == "ComputeFleet"
 
   ruby_block "retrieve compute node info" do
-    retries 12
+    retries 30
     retry_delay 10
     block do
       slurm_nodename = dynamodb_info


### PR DESCRIPTION
### Description of changes
* Increase retries when no dynamoDB entry is found, from 2 to 5 minutes

### Tests
n/a

### References
n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
