### PR TITLE
[Release 3.8] Disable Spack until the feature is complete

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/install.rb
@@ -23,4 +23,5 @@ lustre 'Install FSx options'
 efs 'Install efs-utils'
 stunnel 'Install stunnel'
 system_authentication "Install packages required for directory service integration"
-spack 'Install Spack'
+# TODO: Disable spack until the feature is complete
+# spack 'Install Spack'


### PR DESCRIPTION
Spack was initially added with several optimizations for a range of applications in mind.  This resulted in several packages.yaml files for different OS families and make opinionated choices about what to install and how.  This could conflict with some power users' use of the installation.  Because of this the final released implementation is on hold until consensus can be reached for what to release.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
