### PR TITLE
Remove config inspec controls for Spack while it is disabled

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/test/controls/spack_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/spack_spec.rb
@@ -65,7 +65,7 @@ control 'install_spack_can_install_packages' do
   end
 end
 
-control 'tag:config_spack_packages_config_exist' do
+control 'config_spack_packages_config_exist' do
   title 'Check that spack has packages.yaml'
 
   only_if { !os_properties.on_docker? && instance.head_node? }


### PR DESCRIPTION
### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
