### PR TITLE
Fix bug introduced with DatabaseName functionality

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster_slurmdbd.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster_slurmdbd.conf
@@ -6,7 +6,7 @@
 {#    #}DbdHost={{ head_node_config.head_node_hostname }}
 {#    #}StorageHost={{ scaling_config.Database.Uri | uri_host }}
 {#    #}StoragePort={{ scaling_config.Database.Uri | uri_port }}
-{#    #}{% if scaling_config.Database.DatabaseName is defined %}
+{#    #}{% if scaling_config.Database.DatabaseName is defined and scaling_config.Database.DatabaseName is not none %}
 {#        #}StorageLoc={{ scaling_config.Database.DatabaseName }}
 {#    #}{% else %}
 {#        #}{# Dashes in StorageLoc cause issues with the database creation #}

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/sample_input_slurm_accounting.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/sample_input_slurm_accounting.yaml
@@ -27,3 +27,4 @@ Scheduling:
             Uri: test.databaseserver.com
             UserName: test_admin
             PasswordSecretArn: arn:aws:secretsmanager:us-east-1:111111111111:secret:Secret-xxxxxxxx-xxxxx
+            DatabaseName: null


### PR DESCRIPTION
### Description of changes
When Slurm Accounting is used but DatabaseName is not defined in the input config, it is rendered as `null` in the config on the cluster, which is translated to `none` in Jinja2.
This means that the value passes the `is defined` test in Jinja2.
Fix the if condition in Jinja2 to check if `DatabaseName` is not `none` before trying to set it in `StorageLoc` in the slurmdbd configuration.

### Tests
* Fix the unit test to have `DatabaseName` equal to `null` in the case when Slurm Accounting is used with default database name.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2538

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.