### PR TITLE
[develop] Use effective user to execute scripts from PAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Fix inconsistent scaling configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.
+- Fix users SSH keys generation when switching users without root privilege in clusters integrated with an external LDAP server through cluster configuration files.
 
 3.7.2
 ------

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/configure_pam_ssh_keygen.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/configure_pam_ssh_keygen.rb
@@ -18,7 +18,7 @@
 pam_services = %w(sudo su sshd)
 pam_config_dir = "/etc/pam.d"
 generate_ssh_key_path = "#{node['cluster']['scripts_dir']}/generate_ssh_key.sh"
-ssh_key_generator_pam_config_line = "session    optional     pam_exec.so log=/var/log/parallelcluster/pam_ssh_key_generator.log #{generate_ssh_key_path}"
+ssh_key_generator_pam_config_line = "session    optional     pam_exec.so seteuid log=/var/log/parallelcluster/pam_ssh_key_generator.log #{generate_ssh_key_path}"
 if node['cluster']["directory_service"]["generate_ssh_keys_for_users"] == 'true'
   template generate_ssh_key_path do
     source 'directory_service/generate_ssh_key.sh.erb'
@@ -44,7 +44,7 @@ else
     pam_config_file = "#{pam_config_dir}/#{pam_service}"
     delete_lines "Ensure PAM service #{pam_service} is not configured to call SSH key generation script" do
       path pam_config_file
-      pattern %r{session\s+optional\s+pam_exec\.so\s+log=/var/log/parallelcluster/pam_ssh_key_generator\.log}
+      pattern %r{session\s+optional\s+pam_exec\.so\s+seteuid\s+log=/var/log/parallelcluster/pam_ssh_key_generator\.log}
       ignore_missing true
     end
   end

--- a/cookbooks/aws-parallelcluster-environment/test/controls/directory_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/directory_service_spec.rb
@@ -78,7 +78,7 @@ control 'sssd_configured_correctly' do
   pam_services.each do |pam_service|
     describe file("/etc/pam.d/#{pam_service}") do
       it { should exist }
-      its('content') { should match %r{session\s+optional\s+pam_exec\.so\s+log=/var/log/parallelcluster/pam_ssh_key_generator\.log} }
+      its('content') { should match %r{session\s+optional\s+pam_exec\.so\s+seteuid\s+log=/var/log/parallelcluster/pam_ssh_key_generator\.log} }
     end
   end
 


### PR DESCRIPTION
When switching user with `su - <user>`+password from a non-root user to another non-root user, PAM cannot generate SSH key for the target user as the "actual user (original user)" does not have the permission. By using `euid`, the commands are executed under the "effective user (target user)".

### Tests
test_ad_integration tests on all OSes + SimpleAD + x86 have been passed.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
