### PR TITLE
[develop][kitchen-test] Fix GPU health check kitchen test on Alinux2 deep learning AMI

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/test/controls/config_health_check_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/config_health_check_spec.rb
@@ -52,7 +52,7 @@ control 'tag:config_gpu_health_check_execution' do
 
   if instance.graphic?
     if instance.dcgmi_gpu_accel_supported?
-      if (os_properties.arm? && (os_properties.centos7? || os_properties.alinux2?)) || (os_properties.alinux2? && node['cluster']['nvidia']['enabled'] == 'no')
+      if (os_properties.arm? && (os_properties.centos7? || os_properties.alinux2?)) || (os_properties.alinux2? && (node['cluster']['nvidia']['enabled'] == 'no' || node['cluster']['nvidia']['enabled'] == false))
         describe command("#{slurm_install_dir}/etc/pcluster/.slurm_plugin/scripts/health_checks/gpu_health_check.sh") do
           its('exit_status') { should eq 0 }
           its('stdout') { should match /The GPU Health Check has been executed but the NVIDIA DCGM Diagnostic tool is not available in this system/ }


### PR DESCRIPTION
Alinux2 deep learning AMI has Nvidia GPU driver but does not have DCGM. Therefore, the expected message should be "The GPU Health Check has been executed but the NVIDIA DCGM Diagnostic tool is not available in this system". When running the tests `node['cluster']['nvidia']['enabled'] == 'no'/false` means deep learning AMI is used. This commit add the check on `false` fix the test. `node['cluster']['nvidia']['enabled']` can be a boolean(true/false) or string ("yes"/"no")(See `def nvidia_enabled?` for example)

### Tests
* config_gpu_health_check_execution has been passed

### References
* This is a bug fix of the previous PR https://github.com/aws/aws-parallelcluster-cookbook/pull/2375

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
