### PR TITLE
[develop] Define inspec test for node-attributes resource

### DIFF
--- a/cookbooks/aws-parallelcluster-shared/kitchen.shared-install.yml
+++ b/cookbooks/aws-parallelcluster-shared/kitchen.shared-install.yml
@@ -24,3 +24,12 @@ suites:
         - /tag:install_package_repos/
     attributes:
       resource: package_repos
+  - name: node_attributes
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-tests::test_resource]
+    verifier:
+      controls:
+        - /node_attributes_created/
+    attributes:
+      resource: node_attributes


### PR DESCRIPTION
* Test code is already executed as part of image build process (because it contains the `tag:install` prefix).
* With this change we're permitting to manually run it from local.

### Tests
```
 bash kitchen.ec2.sh shared-install test node-attributes-ubuntu20
...
  ✔  tag:install_node_attributes_created: Test the generation of the node attributes json file
     ✔  File /etc/chef/node_attributes.json is expected to exist
     ✔  File /etc/chef/node_attributes.json content is expected to match /^    "cluster": \{$/


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 2 successful, 0 failures, 0 skipped
```
