### PR TITLE
[develop] Specify version 3.2.6 to install for Nvidia DCGM

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -12,6 +12,7 @@ default['conditions']['arm_pl_supported'] = arm_instance?
 # NVidia
 default['cluster']['nvidia']['enabled'] = 'no'
 default['cluster']['nvidia']['driver_version'] = '535.54.03'
+default['cluster']['nvidia']['dcgm_version'] = '3.2.6'
 
 # DCV
 default['cluster']['dcv']['authenticator']['user'] = "dcvextauth"

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/nvidia_dcgm_ubuntu20+.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/nvidia_dcgm_ubuntu20+.rb
@@ -21,3 +21,7 @@ use 'partial/_nvidia_dcgm_common.rb'
 def _nvidia_dcgm_enabled
   _nvidia_enabled
 end
+
+def package_version
+  "1:#{node['cluster']['nvidia']['dcgm_version']}" # The single digit "1" is epoch version. Without the "1", package install fails because version does not exist. See details here: https://askubuntu.com/questions/441879/why-do-some-packages-have-extra-numbers-before-a-colon-on-the-front-of-their-ver
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_common.rb
@@ -28,6 +28,7 @@ action :setup do
   package 'datacenter-gpu-manager' do
     retries 3
     retry_delay 5
+    version package_version
   end
 
   nvidia_repo 'remove nvidia repository' do
@@ -37,4 +38,8 @@ end
 
 def _nvidia_enabled
   nvidia_enabled.nil? ? ['yes', true].include?(node['cluster']['nvidia']['enabled']) : nvidia_enabled
+end
+
+def package_version
+  node['cluster']['nvidia']['dcgm_version']
 end


### PR DESCRIPTION
DCGM started to fail GPU health check after a package update. We created a Github issue to Nvidia https://github.com/NVIDIA/DCGM/issues/134. Before, a newer good version is released, installing an older version is the solution.

Reference: Nvidia DCGM changelog: https://docs.nvidia.com/datacenter/dcgm/latest/release-notes/changelog.html

### References
Cherry-picked from https://github.com/aws/aws-parallelcluster-cookbook/pull/2552

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
