### PR TITLE
[release-3.8] Fail build image when using a kernel version not supported by FSx for Lustre

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_redhat8.rb
@@ -27,15 +27,11 @@ action :setup do
   version = node['platform_version']
   log "Installing FSx for Lustre. Platform version: #{version}, kernel version: #{node['cluster']['kernel_release']}"
   if version.to_f < 8.2
-    log "FSx for Lustre is not supported in this RHEL version #{version}, supported versions are >= 8.2" do
-      level :warn
-    end
+    raise "FSx for Lustre is not supported in this RHEL version #{version}, supported versions are >= 8.2"
   elsif version.to_f == 8.7 && (node['cluster']['kernel_release'].include?("4.18.0-425.3.1.el8") || node['cluster']['kernel_release'].include?("4.18.0-425.13.1.el8_7"))
     # Rhel8.7 kernel 4.18.0-425.3.1.el8 and 4.18.0-425.13.1.el8_7 has broken kABI compat
     # See https://access.redhat.com/solutions/6985596 and https://github.com/openzfs/zfs/issues/14724
-    log "FSx for Lustre is not supported in kernel version #{node['cluster']['kernel_release']} of RHEL #{version}, please update the kernel version" do
-      level :warn
-    end
+    raise "FSx for Lustre is not supported in kernel version #{node['cluster']['kernel_release']} of RHEL #{version}, please update the kernel version"
   else
     action_install_lustre
   end

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_rocky8.rb
@@ -27,15 +27,11 @@ action :setup do
   version = node['platform_version']
   log "Installing FSx for Lustre. Platform version: #{version}, kernel version: #{node['cluster']['kernel_release']}"
   if version.to_f < 8.2
-    log "FSx for Lustre is not supported in this Rocky Linux version #{version}, supported versions are >= 8.2" do
-      level :warn
-    end
+    raise "FSx for Lustre is not supported in this Rocky Linux version #{version}, supported versions are >= 8.2"
   elsif version.to_f == 8.7 && (node['cluster']['kernel_release'].include?("4.18.0-425.3.1.el8") || node['cluster']['kernel_release'].include?("4.18.0-425.13.1.el8_7"))
     # Rhel8.7 kernel 4.18.0-425.3.1.el8 and 4.18.0-425.13.1.el8_7 has broken kABI compat
     # See https://access.redhat.com/solutions/6985596 and https://github.com/openzfs/zfs/issues/14724
-    log "FSx for Lustre is not supported in kernel version #{node['cluster']['kernel_release']} of Rocky Linux, please update the kernel version" do
-      level :warn
-    end
+    raise "FSx for Lustre is not supported in kernel version #{node['cluster']['kernel_release']} of Rocky Linux, please update the kernel version"
   else
     action_install_lustre
   end

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_rocky8.rb
@@ -31,7 +31,7 @@ action :setup do
   elsif version.to_f == 8.7 && (node['cluster']['kernel_release'].include?("4.18.0-425.3.1.el8") || node['cluster']['kernel_release'].include?("4.18.0-425.13.1.el8_7"))
     # Rhel8.7 kernel 4.18.0-425.3.1.el8 and 4.18.0-425.13.1.el8_7 has broken kABI compat
     # See https://access.redhat.com/solutions/6985596 and https://github.com/openzfs/zfs/issues/14724
-    raise "FSx for Lustre is not supported in kernel version #{node['cluster']['kernel_release']} of Rocky Linux, please update the kernel version"
+    raise "FSx for Lustre is not supported in kernel version #{node['cluster']['kernel_release']} of Rocky Linux #{version}, please update the kernel version"
   else
     action_install_lustre
   end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_setup_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_setup_spec.rb
@@ -153,35 +153,15 @@ describe 'lustre:setup' do
     end
   end
 
-  context "on redhat lower than 8.2" do
-    cached(:chef_run) do
-      runner = runner(
-        platform: 'redhat', version: '8',
-        step_into: ['lustre']
-      ) do |node|
-        node.automatic['platform_version'] = "8.1"
-        node.override['cluster']['kernel_release'] = "4.18.0-147.9.1.el8"
-      end
-      Lustre.setup(runner)
-    end
-
-    it 'can not install lustre' do
-      expect { chef_run }.to(raise_error do |error|
-        expect(error).to be_a(Exception)
-        expect(error.message).to include("FSx for Lustre is not supported in this RHEL version 8.1, supported versions are >= 8.2")
-      end)
-    end
-  end
-
-  [%w(8.7 4.18.0-425.3.1.el8.x86_64), %w(8.7 4.18.0-425.13.1.el8_7.x86_64)].each do |platform_version, kernel_version|
-    context "on redhat #{platform_version} with kernel #{kernel_version}" do
+  [%w(redhat RHEL), ["rocky", "Rocky Linux"]].each do |platform, platform_string|
+    context "on #{platform} lower than 8.2" do
       cached(:chef_run) do
         runner = runner(
-          platform: 'redhat', version: '8',
+          platform: platform, version: '8',
           step_into: ['lustre']
         ) do |node|
-          node.automatic['platform_version'] = platform_version
-          node.override['cluster']['kernel_release'] = kernel_version
+          node.automatic['platform_version'] = "8.1"
+          node.override['cluster']['kernel_release'] = "4.18.0-147.9.1.el8"
         end
         Lustre.setup(runner)
       end
@@ -189,60 +169,82 @@ describe 'lustre:setup' do
       it 'can not install lustre' do
         expect { chef_run }.to(raise_error do |error|
           expect(error).to be_a(Exception)
-          expect(error.message).to include("FSx for Lustre is not supported in kernel version #{kernel_version} of RHEL #{platform_version}, please update the kernel version")
+          expect(error.message).to include("FSx for Lustre is not supported in this #{platform_string} version 8.1, supported versions are >= 8.2")
         end)
       end
     end
-  end
 
-  [%w(193 2), %w(240 3), %w(305 4), %w(348 5), %w(372 6), %w(425 7), %w(477 8)].each do |kernel_patch, minor_version|
-    context "on redhat with kernel from 4.18.0-#{kernel_patch}.3.1.el8 supporting lustre" do
+    [%w(8.7 4.18.0-425.3.1.el8.x86_64), %w(8.7 4.18.0-425.13.1.el8_7.x86_64)].each do |platform_version, kernel_version|
+      context "on #{platform} #{platform_version} with kernel #{kernel_version}" do
+        cached(:chef_run) do
+          runner = runner(
+            platform: platform, version: '8',
+            step_into: ['lustre']
+          ) do |node|
+            node.automatic['platform_version'] = platform_version
+            node.override['cluster']['kernel_release'] = kernel_version
+          end
+          Lustre.setup(runner)
+        end
+
+        it 'can not install lustre' do
+          expect { chef_run }.to(raise_error do |error|
+            expect(error).to be_a(Exception)
+            expect(error.message).to include("FSx for Lustre is not supported in kernel version #{kernel_version} of #{platform_string} #{platform_version}, please update the kernel version")
+          end)
+        end
+      end
+    end
+
+    [%w(193 2), %w(240 3), %w(305 4), %w(348 5), %w(372 6), %w(425 7), %w(477 8), %w(513 9)].each do |kernel_patch, minor_version|
+      context "on #{platform} with kernel from 4.18.0-#{kernel_patch}.3.1.el8 supporting lustre" do
+        cached(:chef_run) do
+          runner = runner(
+            platform: platform, version: '8',
+            step_into: ['lustre']
+          ) do |node|
+            node.override['cluster']['kernel_release'] = "4.18.0-#{kernel_patch}.9.1.el8"
+          end
+          Lustre.setup(runner)
+        end
+
+        it 'installs lustre packages from repository and installs kernel module lnet' do
+          is_expected.to create_yum_repository("aws-fsx")
+            .with(baseurl: "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8.#{minor_version}/$basearch")
+            .with(gpgkey: 'https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc')
+            .with(retries: 3)
+            .with(retry_delay: 5)
+
+          is_expected.to run_execute('yum-config-manager_skip_if_unavail')
+            .with(command: "yum-config-manager --setopt=\*.skip_if_unavailable=1 --save")
+
+          is_expected.to install_package(%w(kmod-lustre-client lustre-client dracut))
+            .with(retries: 3)
+            .with(retry_delay: 5)
+
+          is_expected.to install_kernel_module("lnet")
+        end
+      end
+    end
+
+    context "kernel release does not match expected format" do
       cached(:chef_run) do
         runner = runner(
-          platform: 'redhat', version: '8',
+          platform: platform, version: '8',
           step_into: ['lustre']
         ) do |node|
-          node.override['cluster']['kernel_release'] = "4.18.0-#{kernel_patch}.9.1.el8"
+          node.automatic['platform_version'] = "8.2"
+          node.override['cluster']['kernel_release'] = 'unexpected.format'
         end
         Lustre.setup(runner)
       end
 
-      it 'installs lustre packages from repository and installs kernel module lnet' do
-        is_expected.to create_yum_repository("aws-fsx")
-          .with(baseurl: "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8.#{minor_version}/$basearch")
-          .with(gpgkey: 'https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc')
-          .with(retries: 3)
-          .with(retry_delay: 5)
-
-        is_expected.to run_execute('yum-config-manager_skip_if_unavail')
-          .with(command: "yum-config-manager --setopt=\*.skip_if_unavailable=1 --save")
-
-        is_expected.to install_package(%w(kmod-lustre-client lustre-client dracut))
-          .with(retries: 3)
-          .with(retry_delay: 5)
-
-        is_expected.to install_kernel_module("lnet")
+      it 'raises error' do
+        expect { chef_run }.to(raise_error do |error|
+          expect(error).to be_a(Exception)
+          expect(error.message).to include("Unable to retrieve the kernel patch version from unexpected.format.")
+        end)
       end
-    end
-  end
-
-  context "kernel release does not match expected format" do
-    cached(:chef_run) do
-      runner = runner(
-        platform: 'redhat', version: '8',
-        step_into: ['lustre']
-      ) do |node|
-        node.automatic['platform_version'] = "8.2"
-        node.override['cluster']['kernel_release'] = 'unexpected.format'
-      end
-      Lustre.setup(runner)
-    end
-
-    it 'raises error' do
-      expect { chef_run }.to(raise_error do |error|
-        expect(error).to be_a(Exception)
-        expect(error.message).to include("Unable to retrieve the kernel patch version from unexpected.format.")
-      end)
     end
   end
 

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_setup_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_setup_spec.rb
@@ -166,8 +166,10 @@ describe 'lustre:setup' do
     end
 
     it 'can not install lustre' do
-      is_expected.to write_log("FSx for Lustre is not supported in this RHEL version 8.1, supported versions are >= 8.2")
-        .with(level: :warn)
+      expect { chef_run }.to(raise_error do |error|
+        expect(error).to be_a(Exception)
+        expect(error.message).to include("FSx for Lustre is not supported in this RHEL version 8.1, supported versions are >= 8.2")
+      end)
     end
   end
 
@@ -185,8 +187,10 @@ describe 'lustre:setup' do
       end
 
       it 'can not install lustre' do
-        is_expected.to write_log("FSx for Lustre is not supported in kernel version #{kernel_version} of RHEL #{platform_version}, please update the kernel version")
-          .with(level: :warn)
+        expect { chef_run }.to(raise_error do |error|
+          expect(error).to be_a(Exception)
+          expect(error.message).to include("FSx for Lustre is not supported in kernel version #{kernel_version} of RHEL #{platform_version}, please update the kernel version")
+        end)
       end
     end
   end

--- a/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
@@ -86,12 +86,10 @@ end
 control 'tag:install_lustre_lnet_kernel_module_enabled' do
   title "Verify that lnet kernel module is enabled"
   only_if { !os_properties.on_docker? && !os_properties.alinux2? }
-  unless os_properties.redhat? && inspec.os.release.to_f == 8.7 && (node['cluster']['kernel_release'].include?("4.18.0-425.3.1.el8") || node['cluster']['kernel_release'].include?("4.18.0-425.13.1.el8_7"))
-    describe kernel_module("lnet") do
-      it { should be_loaded }
-      it { should_not be_disabled }
-      it { should_not be_blacklisted }
-    end
+  describe kernel_module("lnet") do
+    it { should be_loaded }
+    it { should_not be_disabled }
+    it { should_not be_blacklisted }
   end
 end
 


### PR DESCRIPTION
Cherry pick of https://github.com/aws/aws-parallelcluster-cookbook/pull/2557