### PR TITLE
[Dependencies] Upgrade NVIDIA driver to version 535.129.03 and CUDA Toolkit to version 12.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Do not wait for static nodes in maintenance to signal CFN that the head node initialization is complete.
 - Upgrade `aws-cfn-bootstrap` to version 2.0-28.
 - Upgrade Python to 3.9.17.
+- Upgrade NVIDIA driver to version 535.129.03.
+- Upgrade CUDA Toolkit to version 12.2.2
 - Use Open Source NVIDIA GPU drivers (OpenRM) as NVIDIA kernel module for Linux instead of NVIDIA closed source module.
 - Upgrade EFA installer to `1.29.0`.
   - Efa-driver: `efa-2.6.0-1`

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -11,7 +11,7 @@ default['conditions']['arm_pl_supported'] = arm_instance?
 
 # NVidia
 default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '535.54.03'
+default['cluster']['nvidia']['driver_version'] = '535.129.03'
 default['cluster']['nvidia']['dcgm_version'] = '3.2.6'
 
 # DCV

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/cuda.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/cuda.rb
@@ -20,9 +20,9 @@ return unless nvidia_enabled?
 # Cuda installer from https://developer.nvidia.com/cuda-toolkit-archive
 # Cuda installer naming: cuda_11.8.0_520.61.05_linux
 cuda_version = '12.2'
-cuda_patch = '0'
+cuda_patch = '2'
 cuda_complete_version = "#{cuda_version}.#{cuda_patch}"
-cuda_version_suffix = '535.54.03'
+cuda_version_suffix = '535.104.05'
 cuda_arch = arm_instance? ? 'linux_sbsa' : 'linux'
 cuda_url = "https://developer.download.nvidia.com/compute/cuda/#{cuda_complete_version}/local_installers/cuda_#{cuda_complete_version}_#{cuda_version_suffix}_#{cuda_arch}.run"
 cuda_samples_version = '12.2'

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cuda_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cuda_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe 'aws-parallelcluster-platform::cuda' do
   cached(:cuda_version) { '12.2' }
-  cached(:cuda_patch) { '0' }
+  cached(:cuda_patch) { '2' }
   cached(:cuda_complete_version) { "#{cuda_version}.#{cuda_patch}" }
-  cached(:cuda_version_suffix) { '535.54.03' }
+  cached(:cuda_version_suffix) { '535.104.05' }
 
   context 'when nvidia not enabled' do
     cached(:chef_run) do


### PR DESCRIPTION
### Description of changes
Upgrade NVIDIA driver to version 535.129.03 and CUDA Toolkit to version 12.2.2.

Notice that the CUDA Toolkit suffix is 535.104.05 rather than 535.129.03. This is expected for CUDA Toolkit 12.2.2, see [download page](https://developer.nvidia.com/cuda-12-2-2-download-archive?target_os=Linux&target_arch=x86_64&Distribution=CentOS&target_version=7&target_type=runfile_local)

### Tests
1. Build AMI
2.  Integration Tests:
    1. test_cluster_with_gpu_health_checks
    2. test_dcv_configuration
    3. test_slurm
    4. test_fabric (ongoing)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
