### PR TITLE
[develop] Remove useless mechanism to retrieve OS minor version from RHEL and Rocky

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -6,6 +6,8 @@ default['cluster']['proxy'] = 'NONE'
 default['cluster']['nfs']['threads'] = [[node['cpu']['cores'].to_i * 4, 8].max, 256].min
 
 # Kernel release version used to select Lustre version
+# This is a mechanism used to mock kernel release on docker system-tests, see kitchen.docker.yml:
+# when kernel_release is defined, it will be used, otherwise the release version will be taken from ohai.
 default['cluster']['kernel_release'] = node['kernel']['release'] unless default['cluster'].key?('kernel_release')
 
 # CloudWatch

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_centos7.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_centos7.rb
@@ -104,6 +104,13 @@ def find_centos_minor_version
   os_minor_version
 end
 
+def find_kernel_patch_version
+  # kernel release is in the form 3.10.0-1127.8.2.el7.x86_64
+  kernel_patch_version = node['cluster']['kernel_release'].match(/^\d+\.\d+\.\d+-(\d+)\..*$/)
+  raise "Unable to retrieve the kernel patch version from #{node['cluster']['kernel_release']}." unless kernel_patch_version
+  kernel_patch_version[1]
+end
+
 action_class do
   def base_url
     "https://fsx-lustre-client-repo.s3.amazonaws.com/#{base_url_prefix(arm_instance?)}/7.#{find_centos_minor_version}/#{node['kernel']['machine']}/"

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_redhat8.rb
@@ -37,28 +37,10 @@ action :setup do
   end
 end
 
-def find_os_minor_version
-  os_minor_version = ''
-  kernel_patch_version = find_kernel_patch_version
-
-  # kernel patch versions under 193 are prior to RHEL 8.2
-  # kernel patch version number can be retrieved from https://access.redhat.com/articles/3078#RHEL8
-  os_minor_version = '2' if kernel_patch_version >= '193'
-  os_minor_version = '3' if kernel_patch_version >= '240'
-  os_minor_version = '4' if kernel_patch_version >= '305'
-  os_minor_version = '5' if kernel_patch_version >= '348'
-  os_minor_version = '6' if kernel_patch_version >= '372'
-  os_minor_version = '7' if kernel_patch_version >= '425'
-  os_minor_version = '8' if kernel_patch_version >= '477'
-  os_minor_version = '9' if kernel_patch_version >= '513'
-
-  os_minor_version
-end
-
 action_class do
   def base_url
     # https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html#lustre-client-rhel
-    "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8.#{find_os_minor_version}/$basearch"
+    "https://fsx-lustre-client-repo.s3.amazonaws.com/el/#{node['platform_version']}/$basearch"
   end
 
   def public_key

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/lustre_rocky8.rb
@@ -37,28 +37,10 @@ action :setup do
   end
 end
 
-def find_os_minor_version
-  os_minor_version = ''
-  kernel_patch_version = find_kernel_patch_version
-
-  # kernel patch versions under 193 are prior to RHEL 8.2
-  # kernel patch version number can be retrieved from https://access.redhat.com/articles/3078#RHEL8
-  os_minor_version = '2' if kernel_patch_version >= '193'
-  os_minor_version = '3' if kernel_patch_version >= '240'
-  os_minor_version = '4' if kernel_patch_version >= '305'
-  os_minor_version = '5' if kernel_patch_version >= '348'
-  os_minor_version = '6' if kernel_patch_version >= '372'
-  os_minor_version = '7' if kernel_patch_version >= '425'
-  os_minor_version = '8' if kernel_patch_version >= '477'
-  os_minor_version = '9' if kernel_patch_version >= '513'
-
-  os_minor_version
-end
-
 action_class do
   def base_url
     # https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html#lustre-client-rhel
-    "https://fsx-lustre-client-repo.s3.amazonaws.com/el/8.#{find_os_minor_version}/$basearch"
+    "https://fsx-lustre-client-repo.s3.amazonaws.com/el/#{node['platform_version']}/$basearch"
   end
 
   def public_key

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_install_lustre_centos_redhat.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_install_lustre_centos_redhat.rb
@@ -35,10 +35,3 @@ action :install_lustre do
 
   kernel_module 'lnet' unless redhat_on_docker? || rocky_on_docker?
 end
-
-def find_kernel_patch_version
-  # kernel release is in the form 3.10.0-1127.8.2.el7.x86_64
-  kernel_patch_version = node['cluster']['kernel_release'].match(/^\d+\.\d+\.\d+-(\d+)\..*$/)
-  raise "Unable to retrieve the kernel patch version from #{node['cluster']['kernel_release']}." unless kernel_patch_version
-  kernel_patch_version[1]
-end

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_install_lustre_centos_redhat.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_install_lustre_centos_redhat.rb
@@ -28,10 +28,12 @@ action :install_lustre do
     command "yum-config-manager --setopt=\*.skip_if_unavailable=1 --save"
   end
 
+  # TODO: restore installation on docker when Lustre is available for RH8.9
+  # See: https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html
   package %w(kmod-lustre-client lustre-client dracut) do
     retries 3
     retry_delay 5
-  end
+  end unless redhat_on_docker? || rocky_on_docker?
 
   kernel_module 'lnet' unless redhat_on_docker? || rocky_on_docker?
 end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_setup_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_setup_spec.rb
@@ -203,6 +203,7 @@ describe 'lustre:setup' do
             platform: platform, version: '8',
             step_into: ['lustre']
           ) do |node|
+            node.automatic['platform_version'] = "8.#{minor_version}"
             node.override['cluster']['kernel_release'] = "4.18.0-#{kernel_patch}.9.1.el8"
           end
           Lustre.setup(runner)
@@ -224,26 +225,6 @@ describe 'lustre:setup' do
 
           is_expected.to install_kernel_module("lnet")
         end
-      end
-    end
-
-    context "kernel release does not match expected format" do
-      cached(:chef_run) do
-        runner = runner(
-          platform: platform, version: '8',
-          step_into: ['lustre']
-        ) do |node|
-          node.automatic['platform_version'] = "8.2"
-          node.override['cluster']['kernel_release'] = 'unexpected.format'
-        end
-        Lustre.setup(runner)
-      end
-
-      it 'raises error' do
-        expect { chef_run }.to(raise_error do |error|
-          expect(error).to be_a(Exception)
-          expect(error.message).to include("Unable to retrieve the kernel patch version from unexpected.format.")
-        end)
       end
     end
   end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_setup_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_setup_spec.rb
@@ -294,10 +294,7 @@ end
 describe 'lustre:find_centos_minor_version' do
   context "centos version is not 7" do
     cached(:chef_run) do
-      runner = runner(
-        platform: 'centos', version: '7',
-        step_into: ['lustre']
-      ) do |node|
+      runner = runner(platform: 'centos', version: '7', step_into: ['lustre']) do |node|
         node.automatic['platform_version'] = "8"
       end
       Lustre.setup(runner)

--- a/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
@@ -27,7 +27,9 @@ control 'tag:install_lustre_client_installed' do
     end
   end
 
-  if os_properties.redhat? && inspec.os.release.to_f >= 8.2
+  if os_properties.redhat? && inspec.os.release.to_f >= 8.2 && !os_properties.on_docker?
+    # TODO: restore installation and check on docker when Lustre is available for RH8.9
+    # See: https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html
     unless inspec.os.release.to_f == 8.7 && (node['cluster']['kernel_release'].include?("4.18.0-425.3.1.el8") || node['cluster']['kernel_release'].include?("4.18.0-425.13.1.el8_7"))
       describe package('kmod-lustre-client') do
         it { should be_installed }

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -38,13 +38,13 @@ platforms:
     attributes:
       cluster:
         base_os: alinux2
-        kernel_release: '5.10.157-139.675.amzn2.fake-value'
   - name: centos7
     driver:
       image: <% if ENV['KITCHEN_CENTOS7_IMAGE'] %> <%= ENV['KITCHEN_CENTOS7_IMAGE'] %> <% else %> dokken/centos-7 <% end %>
     attributes:
       cluster:
         base_os: centos7
+        # Since the kernel version of the docker images is not in the expected pattern, set a fake kernel value to permit to install Lustre on docker.
         kernel_release: '3.10.0-1160.76.1.el7.fake-value'
   - name: ubuntu2004
     driver:
@@ -52,6 +52,7 @@ platforms:
     attributes:
       cluster:
         base_os: ubuntu2004
+        # Since the kernel version of the docker images is not compatible (6.2.0-1016-azure), set a fake kernel value to permit to install Lustre on docker.
         kernel_release: '5.15.0-1028-aws'
   - name: ubuntu2204
     driver:
@@ -59,6 +60,7 @@ platforms:
     attributes:
       cluster:
         base_os: ubuntu2204
+        # Since the kernel version of the docker images is not compatible (6.2.0-1016-azure), set a fake kernel value to permit to install Lustre on docker.
         kernel_release: '5.15.0-1028-aws'
   - name: rhel8
     driver:
@@ -68,6 +70,8 @@ platforms:
     attributes:
       cluster:
         base_os: rhel8
+        # Since the kernel version of the docker images is not in the expected pattern, set a fake kernel value to permit to install Lustre on docker.
+        # Specific kernel versions are not compatible with Lustre.
         kernel_release: '4.18.0-477.13.1.el8_7.fake-value' # Use 477 version to match 8.8 kernel version available on docker
   - name: rocky8
     driver:
@@ -75,4 +79,6 @@ platforms:
     attributes:
       cluster:
         base_os: rocky8
+        # Since the kernel version of the docker images is not in the expected pattern, set a fake kernel value to permit to install Lustre on docker.
+        # Specific kernel versions are not compatible with Lustre.
         kernel_release: '4.18.0-477.10.1.el8_8.fake-value'


### PR DESCRIPTION
This mechanism was used on CentOS 7, to retrieve the OS minor version from the kernel version and use it to download the right version of the Lustre client.

This mechanism is not required for RHEL and Rocky because the minor version automatically changes when updating the kernel. This is reflected in the `/etc/os-release` file too.

This change will permit us to automatically support new minor versions when they will be available, without the need to update the internal mapping.



### Tests
* `bash kitchen.ec2.sh environment-install destroy lustre-rhel8`

I had to temporary skip installation and test of lustre client on rhel/rocky on docker.
Latest dokken/rockylinux-8 image is 8.9 and there is no Lustre client available for it.

Previously installation was passing because we were setting a fake `kernel_release` version attribute through `kitchen.docker.yml`.

### References

https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html

