### PR TITLE
Fix installation of kernel-devel on Rocky 8

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
@@ -19,6 +19,17 @@ end
 use 'partial/_install_packages_common.rb'
 use 'partial/_install_packages_rhel_amazon.rb'
 
+action :install_kernel_source do
+  bash "Install kernel source" do
+    user 'root'
+    code <<-INSTALL_KERNEL_SOURCE
+    set -e
+    dnf install -y #{kernel_source_package}-#{kernel_source_package_version} --releasever #{node['platform_version']}
+    dnf clean all
+    INSTALL_KERNEL_SOURCE
+  end
+end
+
 def default_packages
   # environment-modules required by EFA, Intel MPI and ARM PL
   # iptables needed for IMDS setup

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
@@ -27,7 +27,7 @@ action :install_kernel_source do
     dnf install -y #{kernel_source_package}-#{kernel_source_package_version} --releasever #{node['platform_version']}
     dnf clean all
     INSTALL_KERNEL_SOURCE
-  end
+  end unless on_docker?
 end
 
 def default_packages

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/partial/_install_packages_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/partial/_install_packages_common.rb
@@ -39,7 +39,7 @@ action :install_extras do
 end
 
 action :setup do
-  action_install_base_packages
   action_install_kernel_source
+  action_install_base_packages
   action_install_extras
 end


### PR DESCRIPTION
### Description of changes
* Use the `--releasever` option to make sure the repos from the same minor release as the currently running kernel are used when installing kernel-devel.
* Install kernel-devel before installing the base packages to avoid dkms pulling kernel-devel from the wrong repos.

### Tests
* Manual run of kitchen tests;
* Verified that the right version of kernel-devel is installed.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
