### PR TITLE
[Dependencies] Upgrade GDRCopy to version 2.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Libfabric-aws: `libfabric-aws-1.19.0-1`
   - Rdma-core: `rdma-core-46.0-1`
   - Open MPI: `openmpi40-aws-4.1.6-1`
+- Upgrade GDRCopy to version 2.4.
 
 **BUG FIXES**
 - Fix inconsistent scaling configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_amazon2.rb
@@ -22,7 +22,7 @@ def gdrcopy_enabled?
 end
 
 def gdrcopy_platform
-  'unknown_distro'
+  'amzn-2'
 end
 
 def gdrcopy_arch

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_ubuntu20+.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_ubuntu20+.rb
@@ -31,7 +31,7 @@ def installation_code
   CUDA=/usr/local/cuda ./build-deb-packages.sh
   dpkg -i gdrdrv-dkms_#{gdrcopy_version_extended}_#{gdrcopy_arch}.#{gdrcopy_platform}.deb
   dpkg -i libgdrapi_#{gdrcopy_version_extended}_#{gdrcopy_arch}.#{gdrcopy_platform}.deb
-  dpkg -i gdrcopy-tests_#{gdrcopy_version_extended}_#{gdrcopy_arch}.#{gdrcopy_platform}.deb
+  dpkg -i gdrcopy-tests_#{gdrcopy_version_extended}_#{gdrcopy_arch}.#{gdrcopy_platform}+cuda*.deb
   dpkg -i gdrcopy_#{gdrcopy_version_extended}_#{gdrcopy_arch}.#{gdrcopy_platform}.deb
   COMMAND
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
@@ -12,8 +12,8 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-property :gdrcopy_version, String, default: '2.3'
-property :gdrcopy_checksum, String, default: 'b85d15901889aa42de6c4a9233792af40dd94543e82abe0439e544c87fd79475'
+property :gdrcopy_version, String, default: '2.4'
+property :gdrcopy_checksum, String, default: '39e74d505ca16160567f109cc23478580d157da897f134989df1d563e55f7a5b'
 
 unified_mode true
 default_action :setup

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common_rhel.rb
@@ -23,8 +23,8 @@ end
 def installation_code
   <<~COMMAND
   CUDA=/usr/local/cuda ./build-rpm-packages.sh
-  rpm -q gdrcopy-kmod-#{gdrcopy_version_extended}dkms || rpm -i gdrcopy-kmod-#{gdrcopy_version_extended}dkms.noarch#{gdrcopy_platform}.rpm
-  rpm -q gdrcopy-#{gdrcopy_version_extended}.#{gdrcopy_arch} || rpm -i gdrcopy-#{gdrcopy_version_extended}.#{gdrcopy_arch}#{gdrcopy_platform}.rpm
-  rpm -q gdrcopy-devel-#{gdrcopy_version_extended}.noarch || rpm -i gdrcopy-devel-#{gdrcopy_version_extended}.noarch#{gdrcopy_platform}.rpm
+  rpm -q gdrcopy-kmod-#{gdrcopy_version_extended}dkms || rpm -Uvh gdrcopy-kmod-#{gdrcopy_version_extended}dkms.#{gdrcopy_platform}.noarch.rpm
+  rpm -q gdrcopy-#{gdrcopy_version_extended}.#{gdrcopy_arch} || rpm -Uvh gdrcopy-#{gdrcopy_version_extended}.#{gdrcopy_platform}.#{gdrcopy_arch}.rpm
+  rpm -q gdrcopy-devel-#{gdrcopy_version_extended}.noarch || rpm -Uvh gdrcopy-devel-#{gdrcopy_version_extended}.#{gdrcopy_platform}.noarch.rpm
   COMMAND
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
@@ -156,7 +156,7 @@ describe 'gdrcopy:setup' do
       cached(:gdrcopy_arch) { 'gdrcopy_arch' }
       cached(:gdrcopy_platform) do
         platforms = {
-          'amazon2' => 'unknown_distro',
+          'amazon2' => 'amzn-2',
           'centos7' => '.el8',
           'rhel8' => '.el7',
           'ubuntu20.04' => 'Ubuntu20_04',
@@ -214,13 +214,13 @@ describe 'gdrcopy:setup' do
           expect(installation_code).to match(%r{CUDA=/usr/local/cuda ./build-deb-packages.sh})
           expect(installation_code).to match(/dpkg -i gdrdrv-dkms_#{gdrcopy_version}-1_#{gdrcopy_arch}.#{gdrcopy_platform}.deb/)
           expect(installation_code).to match(/dpkg -i libgdrapi_#{gdrcopy_version}-1_#{gdrcopy_arch}.#{gdrcopy_platform}.deb/)
-          expect(installation_code).to match(/dpkg -i gdrcopy-tests_#{gdrcopy_version}-1_#{gdrcopy_arch}.#{gdrcopy_platform}.deb/)
+          expect(installation_code).to match(/dpkg -i gdrcopy-tests_#{gdrcopy_version}-1_#{gdrcopy_arch}.#{gdrcopy_platform}\+cuda\*.deb/)
           expect(installation_code).to match(/dpkg -i gdrcopy_#{gdrcopy_version}-1_#{gdrcopy_arch}.#{gdrcopy_platform}.deb/)
         else
           expect(installation_code).to match(%r{CUDA=/usr/local/cuda ./build-rpm-packages.sh})
-          expect(installation_code).to match(/rpm -q gdrcopy-kmod-#{gdrcopy_version}-1dkms || rpm -i gdrcopy-kmod-#{gdrcopy_version}-1dkms.noarch#{gdrcopy_platform}.rpm/)
-          expect(installation_code).to match(/rpm -q gdrcopy-#{gdrcopy_version}-1.#{gdrcopy_arch} || rpm -i gdrcopy-#{gdrcopy_version}-1.#{gdrcopy_arch}#{gdrcopy_platform}.rpm/)
-          expect(installation_code).to match(/rpm -q gdrcopy-devel-#{gdrcopy_version}-1.noarch || rpm -i gdrcopy-devel-#{gdrcopy_version}-1.noarch#{gdrcopy_platform}.rpm/)
+          expect(installation_code).to match(/rpm -q gdrcopy-kmod-#{gdrcopy_version}-1dkms || rpm -Uvh gdrcopy-kmod-#{gdrcopy_version}-1dkms.#{gdrcopy_platform}.noarch.rpm/)
+          expect(installation_code).to match(/rpm -q gdrcopy-#{gdrcopy_version}-1.#{gdrcopy_arch} || rpm -Uvh gdrcopy-#{gdrcopy_version}-1.#{gdrcopy_platform}.#{gdrcopy_arch}.rpm/)
+          expect(installation_code).to match(/rpm -q gdrcopy-devel-#{gdrcopy_version}-1.noarch || rpm -Uvh gdrcopy-devel-#{gdrcopy_version}-1.#{gdrcopy_platform}.noarch.rpm/)
         end
       end
 


### PR DESCRIPTION
Cherry-pick from https://github.com/aws/aws-parallelcluster-cookbook/pull/2560

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
