### PR TITLE
Add restart to service "supervisord"

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/recipes/finalize.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/finalize.rb
@@ -14,5 +14,5 @@
 # Restart supervisord
 service "supervisord" do
   supports restart: true
-  action %i(enable start)
+  action %i(enable start restart)
 end unless on_docker?


### PR DESCRIPTION
### Description of changes
* The restart is needed in order to actually restart the service in case it was already enabled in the ami. If the service was enabled in the AMI, supervisord would have been started without the complete configuration resulting in not starting the ParallelCluster process.

### Tests
* Tested with manually EC2 kitchen tests
