### PR TITLE
[release-3.8] - Fix GDRCopy installation on RHEL derivatives

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_centos7.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_centos7.rb
@@ -24,7 +24,7 @@ def gdrcopy_enabled?
 end
 
 def gdrcopy_platform
-  '.el7'
+  'el7'
 end
 
 def gdrcopy_arch

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_redhat8.rb
@@ -24,7 +24,7 @@ def gdrcopy_enabled?
 end
 
 def gdrcopy_platform
-  '.el8'
+  'el8'
 end
 
 def gdrcopy_arch

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_rocky8.rb
@@ -24,7 +24,7 @@ def gdrcopy_enabled?
 end
 
 def gdrcopy_platform
-  '.el8'
+  'el8'
 end
 
 def gdrcopy_arch

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
@@ -157,8 +157,9 @@ describe 'gdrcopy:setup' do
       cached(:gdrcopy_platform) do
         platforms = {
           'amazon2' => 'amzn-2',
-          'centos7' => '.el8',
-          'rhel8' => '.el7',
+          'centos7' => 'el7',
+          'rhel8' => 'el8',
+          'rocky8' => 'el8',
           'ubuntu20.04' => 'Ubuntu20_04',
           'ubuntu22.04' => 'Ubuntu22_04',
         }


### PR DESCRIPTION
### Description of changes
* Remove a dot in the definition of `gdrcopy_platform` for CentOS 7, RHEL 8 and Rocky 8.

### Tests
* Ran kitchen tests for all affected OSs
    * When testing CentOS 7 with test kitchen on EC2 I was getting a problem earlier in the installation of the NVIDIA drivers. This needs to be further tested internally.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2572

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
