### PR TITLE
[Dependencies] Use GDRCopy v2.3.1 in Centos7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Libfabric-aws: `libfabric-aws-1.19.0-1`
   - Rdma-core: `rdma-core-46.0-1`
   - Open MPI: `openmpi40-aws-4.1.6-1`
-- Upgrade GDRCopy to version 2.4.
+- Upgrade GDRCopy to version 2.4 in all supported OSes, except for Centos 7 where version 2.3.1 is used.
 
 **BUG FIXES**
 - Fix inconsistent scaling configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_centos7.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_centos7.rb
@@ -16,8 +16,22 @@ provides :gdrcopy, platform: 'centos' do |node|
   node['platform_version'].to_i == 7
 end
 
+node.default['gdrcopy_version'] = '2.3.1'
+node.default['gdrcopy_checksum'] = '59b3cc97a4fc6008a5407506d9e67ecc4144cfad61c261217fabcb671cd30ca8'
+
 use 'partial/_gdrcopy_common.rb'
 use 'partial/_gdrcopy_common_rhel.rb'
+
+# The installation code must be overridden in Centos7
+# because it has GDRCopy pinned to v2.3.1.
+def installation_code
+  <<~COMMAND
+  CUDA=/usr/local/cuda ./build-rpm-packages.sh
+  rpm -q gdrcopy-kmod-#{gdrcopy_version_extended}dkms || rpm -Uvh gdrcopy-kmod-#{gdrcopy_version_extended}dkms.noarch.#{gdrcopy_platform}.rpm
+  rpm -q gdrcopy-#{gdrcopy_version_extended}.#{gdrcopy_arch} || rpm -Uvh gdrcopy-#{gdrcopy_version_extended}.#{gdrcopy_arch}.#{gdrcopy_platform}.rpm
+  rpm -q gdrcopy-devel-#{gdrcopy_version_extended}.noarch || rpm -Uvh gdrcopy-devel-#{gdrcopy_version_extended}.noarch.#{gdrcopy_platform}.rpm
+  COMMAND
+end
 
 def gdrcopy_enabled?
   !arm_instance? && nvidia_enabled?

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
@@ -12,8 +12,8 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-property :gdrcopy_version, String, default: '2.4'
-property :gdrcopy_checksum, String, default: '39e74d505ca16160567f109cc23478580d157da897f134989df1d563e55f7a5b'
+property :gdrcopy_version, String, default: node['gdrcopy_version'] || '2.4'
+property :gdrcopy_checksum, String, default: node['gdrcopy_checksum'] || '39e74d505ca16160567f109cc23478580d157da897f134989df1d563e55f7a5b'
 
 unified_mode true
 default_action :setup

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
@@ -217,6 +217,11 @@ describe 'gdrcopy:setup' do
           expect(installation_code).to match(/dpkg -i libgdrapi_#{gdrcopy_version}-1_#{gdrcopy_arch}.#{gdrcopy_platform}.deb/)
           expect(installation_code).to match(/dpkg -i gdrcopy-tests_#{gdrcopy_version}-1_#{gdrcopy_arch}.#{gdrcopy_platform}\+cuda\*.deb/)
           expect(installation_code).to match(/dpkg -i gdrcopy_#{gdrcopy_version}-1_#{gdrcopy_arch}.#{gdrcopy_platform}.deb/)
+        elsif platform == 'centos'
+          expect(installation_code).to match(%r{CUDA=/usr/local/cuda ./build-rpm-packages.sh})
+          expect(installation_code).to match(/rpm -q gdrcopy-kmod-#{gdrcopy_version}-1dkms || rpm -Uvh gdrcopy-kmod-#{gdrcopy_version}-1dkms.noarch.#{gdrcopy_platform}.rpm/)
+          expect(installation_code).to match(/rpm -q gdrcopy-#{gdrcopy_version}-1.#{gdrcopy_arch} || rpm -Uvh gdrcopy-#{gdrcopy_version}-1.#{gdrcopy_arch}.#{gdrcopy_platform}.rpm/)
+          expect(installation_code).to match(/rpm -q gdrcopy-devel-#{gdrcopy_version}-1.noarch || rpm -Uvh gdrcopy-devel-#{gdrcopy_version}-1.noarch.#{gdrcopy_platform}.rpm/)
         else
           expect(installation_code).to match(%r{CUDA=/usr/local/cuda ./build-rpm-packages.sh})
           expect(installation_code).to match(/rpm -q gdrcopy-kmod-#{gdrcopy_version}-1dkms || rpm -Uvh gdrcopy-kmod-#{gdrcopy_version}-1dkms.#{gdrcopy_platform}.noarch.rpm/)


### PR DESCRIPTION
Cherry-picked from https://github.com/aws/aws-parallelcluster-cookbook/pull/2575

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
