### PR TITLE
[Dependencies] Fix to use GDRCopy v2.3.1 only in Centos7.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_centos7.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_centos7.rb
@@ -16,11 +16,16 @@ provides :gdrcopy, platform: 'centos' do |node|
   node['platform_version'].to_i == 7
 end
 
-node.default['gdrcopy_version'] = '2.3.1'
-node.default['gdrcopy_checksum'] = '59b3cc97a4fc6008a5407506d9e67ecc4144cfad61c261217fabcb671cd30ca8'
-
 use 'partial/_gdrcopy_common.rb'
 use 'partial/_gdrcopy_common_rhel.rb'
+
+def gdrcopy_version
+  '2.3.1'
+end
+
+def gdrcopy_checksum
+  '59b3cc97a4fc6008a5407506d9e67ecc4144cfad61c261217fabcb671cd30ca8'
+end
 
 # The installation code must be overridden in Centos7
 # because it has GDRCopy pinned to v2.3.1.

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
@@ -12,8 +12,13 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-property :gdrcopy_version, String, default: node['gdrcopy_version'] || '2.4'
-property :gdrcopy_checksum, String, default: node['gdrcopy_checksum'] || '39e74d505ca16160567f109cc23478580d157da897f134989df1d563e55f7a5b'
+def gdrcopy_version
+  '2.4'
+end
+
+def gdrcopy_checksum
+  '39e74d505ca16160567f109cc23478580d157da897f134989df1d563e55f7a5b'
+end
 
 unified_mode true
 default_action :setup
@@ -23,11 +28,11 @@ action :setup do
   return if on_docker?
 
   # Save gdrcopy version for InSpec tests
-  node.default['cluster']['nvidia']['gdrcopy']['version'] = new_resource.gdrcopy_version
+  node.default['cluster']['nvidia']['gdrcopy']['version'] = gdrcopy_version
   node.default['cluster']['nvidia']['gdrcopy']['service'] = gdrcopy_service
   node_attributes 'dump node attributes'
 
-  gdrcopy_tarball = "#{node['cluster']['sources_dir']}/gdrcopy-#{new_resource.gdrcopy_version}.tar.gz"
+  gdrcopy_tarball = "#{node['cluster']['sources_dir']}/gdrcopy-#{gdrcopy_version}.tar.gz"
 
   directory node['cluster']['sources_dir'] do
     recursive true
@@ -38,7 +43,7 @@ action :setup do
     mode '0644'
     retries 3
     retry_delay 5
-    checksum new_resource.gdrcopy_checksum
+    checksum gdrcopy_checksum
     action :create_if_missing
   end
 
@@ -58,7 +63,7 @@ action :setup do
     code <<-GDRCOPY_INSTALL
     set -e
     tar -xf #{gdrcopy_tarball}
-    cd gdrcopy-#{new_resource.gdrcopy_version}/packages
+    cd gdrcopy-#{gdrcopy_version}/packages
     #{installation_code}
     GDRCOPY_INSTALL
   end
@@ -85,7 +90,7 @@ end
 action :configure do
   return if on_docker?
   # Save gdrcopy version for InSpec tests
-  node.default['cluster']['nvidia']['gdrcopy']['version'] = new_resource.gdrcopy_version
+  node.default['cluster']['nvidia']['gdrcopy']['version'] = gdrcopy_version
   node.default['cluster']['nvidia']['gdrcopy']['service'] = gdrcopy_service
   node_attributes 'dump node attributes'
 

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
@@ -1,11 +1,9 @@
 require 'spec_helper'
 
 class ConvergeGdrcopy
-  def self.setup(chef_run, gdrcopy_version: nil, gdrcopy_checksum: nil)
+  def self.setup(chef_run)
     chef_run.converge_dsl('aws-parallelcluster-platform') do
       gdrcopy 'setup' do
-        gdrcopy_version gdrcopy_version
-        gdrcopy_checksum gdrcopy_checksum
         action :setup
       end
     end
@@ -40,7 +38,7 @@ describe 'gdrcopy:gdrcopy_enabled?' do
         end
       end
       cached(:resource) do
-        ConvergeGdrcopy.setup(chef_run, gdrcopy_version: gdrcopy_version)
+        ConvergeGdrcopy.setup(chef_run)
         chef_run.find_resource('gdrcopy', 'setup')
       end
 
@@ -122,6 +120,54 @@ describe 'gdrcopy:gdrcopy_arch' do
   end
 end
 
+describe 'gdrcopy:gdrcopy_version' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(false)
+        runner = runner(platform: platform, version: version, step_into: ['gdrcopy'])
+        ConvergeGdrcopy.setup(runner)
+      end
+      cached(:resource) do
+        chef_run.find_resource('gdrcopy', 'setup')
+      end
+
+      it 'returns the expected gdrcopy version' do
+        expected_gdrcopy_version = if platform == "centos"
+                                     "2.3.1"
+                                   else
+                                     "2.4"
+                                   end
+        expect(resource.gdrcopy_version).to eq(expected_gdrcopy_version)
+      end
+    end
+  end
+end
+
+describe 'gdrcopy:gdrcopy_checksum' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(false)
+        runner = runner(platform: platform, version: version, step_into: ['gdrcopy'])
+        ConvergeGdrcopy.setup(runner)
+      end
+      cached(:resource) do
+        chef_run.find_resource('gdrcopy', 'setup')
+      end
+
+      it 'returns the expected gdrcopy checksum' do
+        expected_gdrcopy_checksum = if platform == "centos"
+                                      "59b3cc97a4fc6008a5407506d9e67ecc4144cfad61c261217fabcb671cd30ca8"
+                                    else
+                                      "39e74d505ca16160567f109cc23478580d157da897f134989df1d563e55f7a5b"
+                                    end
+        expect(resource.gdrcopy_checksum).to eq(expected_gdrcopy_checksum)
+      end
+    end
+  end
+end
+
 describe 'gdrcopy:setup' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version} when gdrcopy not enabled" do
@@ -140,8 +186,14 @@ describe 'gdrcopy:setup' do
 
     context "on #{platform}#{version} when gdrcopy enabled" do
       cached(:sources_dir) { 'sources_dir' }
-      cached(:gdrcopy_version) { 'gdrcopy_version' }
-      cached(:gdrcopy_checksum) { 'gdrcopy_checksum' }
+      cached(:gdrcopy_version) { platform == 'centos' ? '2.3.1' : '2.4' }
+      cached(:gdrcopy_checksum) do
+        if platform == 'centos'
+          '59b3cc97a4fc6008a5407506d9e67ecc4144cfad61c261217fabcb671cd30ca8'
+        else
+          '39e74d505ca16160567f109cc23478580d157da897f134989df1d563e55f7a5b'
+        end
+      end
       cached(:gdrcopy_service) { platform == 'ubuntu' ? 'gdrdrv' : 'gdrcopy' }
       cached(:gdrcopy_tarball) { "#{sources_dir}/gdrcopy-#{gdrcopy_version}.tar.gz" }
       cached(:gdrcopy_url) { "https://github.com/NVIDIA/gdrcopy/archive/refs/tags/v#{gdrcopy_version}.tar.gz" }
@@ -173,7 +225,7 @@ describe 'gdrcopy:setup' do
         runner = runner(platform: platform, version: version, step_into: ['gdrcopy']) do |node|
           node.override['cluster']['sources_dir'] = sources_dir
         end
-        ConvergeGdrcopy.setup(runner, gdrcopy_version: gdrcopy_version, gdrcopy_checksum: gdrcopy_checksum)
+        ConvergeGdrcopy.setup(runner)
       end
       cached(:node) { chef_run.node }
 


### PR DESCRIPTION
Cherry-picked from https://github.com/aws/aws-parallelcluster-cookbook/pull/2578

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
