### PR TITLE
[Release 3.8] Ensure the initial internal efs filesystem is not remou…

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/recipes/config/efs.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/efs.rb
@@ -18,7 +18,7 @@ iam_array = node['cluster']['efs_iam_authorizations'].split(',')
 
 # Identify the previously mounted filesystems and remove them from the set of filesystems to mount
 shared_dir_array.each_with_index do |dir, index|
-  next unless node['cluster']['internal_shared_dirs'].include?(dir) || dir == "/home" || dir == "home"
+  next unless node['cluster']['internal_shared_dirs'].include?(dir) || dir == "/home" || dir == "home" || dir == node['cluster']['internal_initial_shared_dir']
   shared_dir_array.delete(dir)
   id_array.delete_at(index)
   encryption_array.delete_at(index)


### PR DESCRIPTION
…nted with the efs recipe

The efs recipe scans the list of efs filesystems provided in the dna.json file and mounts them.  We need an exclusion in the logic to prevent the initial shared filesystem from being mounted again after it is configured for the internal data mount points: /opt/intel, /opt/slurm, /home, /opt/parallelcluster/shared, and /opt/parallelcluster/shared_login_nodes.

### Tests
* Created a cluster and checked that the mount point was no longer available for /opt/parallelcluster/init_shared

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
