### PR TITLE
[Test] Add Rocky8 to tests.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/cloudwatch_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/cloudwatch_spec.rb
@@ -33,7 +33,16 @@ describe 'cloudwatch:setup' do
       cached(:signature_path) { "#{package_path}.sig" }
 
       context "when not on arm" do
-        cached(:platform_url_component) { platform == 'amazon' ? 'amazon_linux' : platform }
+        cached(:platform_url_component) do
+          case platform
+          when 'amazon'
+            'amazon_linux'
+          when 'rocky'
+            'redhat'
+          else
+            platform
+          end
+        end
         cached(:package_url) { "#{package_url_prefix}/#{platform_url_component}/amd64/latest/amazon-cloudwatch-agent.#{package_extension}" }
         cached(:chef_run) do
           runner = runner(platform: platform, version: version, step_into: ['cloudwatch']) do |node|
@@ -105,7 +114,7 @@ describe 'cloudwatch:setup' do
           case platform
           when 'amazon'
             'amazon_linux'
-          when 'centos'
+          when 'centos', 'rocky'
             'redhat'
           else
             platform

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
@@ -28,7 +28,7 @@ describe 'efa:setup' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       cached(:prerequisites) do
-        if platform == 'redhat'
+        if %(redhat rocky).include?(platform)
           %w(environment-modules libibverbs-utils librdmacm-utils rdma-core-devel)
         elsif platform == 'amazon'
           %w(environment-modules libibverbs-utils librdmacm-utils)
@@ -162,7 +162,7 @@ describe 'efa:configure' do
         runner(platform: platform, version: version, step_into: ['efa'])
       end
 
-      if %w(amazon centos redhat).include?(platform)
+      if %w(amazon centos redhat rocky).include?(platform)
         it 'does nothing' do
           ConvergeEfa.configure(chef_run)
           is_expected.to configure_efa('configure')

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/ephemeral_drives_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/ephemeral_drives_spec.rb
@@ -13,7 +13,7 @@ end
 describe 'ephemeral_drives:setup' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
-      cached(:network_target) { platform == 'redhat' ? 'network-online.target' : 'network.target' }
+      cached(:network_target) { %(redhat rocky).include?(platform) ? 'network-online.target' : 'network.target' }
       cached(:chef_run) do
         runner = runner(platform: platform, version: version, step_into: ['ephemeral_drives'])
         ConvergeEphemeralDrives.setup(runner)

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/network_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/network_service_spec.rb
@@ -31,6 +31,7 @@ describe 'network_service:restart' do
           'amazon' => 'network',
           'centos' => 'network',
           'redhat' => 'NetworkManager',
+          'rocky' => 'NetworkManager',
           'ubuntu' => 'systemd-resolved',
         }[platform]
       end
@@ -59,6 +60,7 @@ describe 'network_service:reload' do
           'amazon' => 'network',
           'centos' => 'network',
           'redhat' => 'NetworkManager',
+          'rocky' => 'NetworkManager',
           'ubuntu' => 'systemd-resolved',
         }[platform]
       end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/nfs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/nfs_spec.rb
@@ -97,7 +97,7 @@ describe 'nfs:configure' do
           end
         end
 
-      elsif platform == 'redhat'
+      elsif %(redhat rocky).include?(platform)
         it 'uses nfs config template shipped with nfs cookbook' do
           is_expected.to create_template(server_template)
             .with(source: "#{server_template}.erb")

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/raid_mount_unmount_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/raid_mount_unmount_spec.rb
@@ -11,7 +11,7 @@ describe 'raid:mount' do
     context "on #{platform}#{version}" do
       cached(:venv_path) { 'venv' }
       cached(:raid_superblock_version) do
-        platform == 'redhat' || "#{platform}#{version}" == 'ubuntu20.04' || "#{platform}#{version}" == 'ubuntu22.04' ? '1.2' : '0.90'
+        %(redhat rocky).include?(platform) || "#{platform}#{version}" == 'ubuntu20.04' || "#{platform}#{version}" == 'ubuntu22.04' ? '1.2' : '0.90'
       end
       cached(:chef_run) do
         runner = runner(

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/system_authentication_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/system_authentication_spec.rb
@@ -25,7 +25,7 @@ describe 'system_authentication:setup' do
         case platform
         when 'amazon', 'centos'
           %w(sssd sssd-tools sssd-ldap authconfig)
-        when 'redhat'
+        when 'redhat', 'rocky'
           %w(sssd sssd-tools sssd-ldap authselect oddjob-mkhomedir)
         else
           %w(sssd sssd-tools sssd-ldap)

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
@@ -93,7 +93,7 @@ describe 'gdrcopy:gdrcopy_arch' do
       context 'on arm instance' do
         cached(:expected_arch) do
           case platform
-          when 'amazon', 'redhat'
+          when 'amazon', 'redhat', 'rocky'
             'aarch64'
           else
             'arm64'

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/modules_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/modules_spec.rb
@@ -36,7 +36,7 @@ for_all_oses do |platform, version|
         case platform
         when 'ubuntu'
           "/usr/share/modules/init/.modulespath"
-        when 'redhat'
+        when 'redhat', 'rocky'
           '/etc/environment-modules/modulespath'
         else
           "/usr/share/Modules/init/.modulespath"

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_repo_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_repo_spec.rb
@@ -86,7 +86,7 @@ describe 'nvidia_repo:add' do
         case platform
         when 'amazon', 'centos'
           'rhel7'
-        when 'redhat'
+        when 'redhat', 'rocky'
           'rhel8'
         when 'ubuntu'
           "ubuntu#{version.delete('.')}"

--- a/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_rocky8.rb
@@ -30,7 +30,7 @@ action :setup do
     retry_delay 5
   end
 
-  execute 'yum-config-manager-rhel' do
+  execute 'yum-config-manager-powertools' do
     # Needed by hwloc-devel blas-devel libedit-devel and glibc-static packages
     command "yum-config-manager --enable powertools"
   end

--- a/cookbooks/aws-parallelcluster-shared/spec/spec_helper.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/spec_helper.rb
@@ -43,6 +43,7 @@ def for_all_oses
     %w(ubuntu 20.04),
     %w(ubuntu 22.04),
     %w(redhat 8),
+    %w(rocky 8),
   ].each do |platform, version|
     yield(platform, version)
   end

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/resources/os_type_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/resources/os_type_spec.rb
@@ -24,6 +24,8 @@ describe 'os_type:validate' do
           "centos#{version.to_i}"
         when 'redhat'
           "rhel#{version.to_i}"
+        when 'rocky'
+          "rocky#{version.to_i}"
         else
           raise "Unsupported OS #{platform}"
         end

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/resources/package_repos_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/resources/package_repos_spec.rb
@@ -68,6 +68,29 @@ describe 'package_repos:setup' do
           is_expected.to periodic_apt_update('')
         end
 
+      when 'rocky'
+        it 'installs yum' do
+          expect(chef_run).to include_recipe('yum')
+        end
+
+        it 'installs yum-epel' do
+          is_expected.to include_recipe('yum-epel')
+        end
+
+        it 'installs yum-utils' do
+          is_expected.to install_package('yum-utils').with(retries: 3).with(retry_delay: 5)
+        end
+
+        it 'enables powertools' do
+          is_expected.to run_execute('yum-config-manager-powertools')
+            .with(command: 'yum-config-manager --enable powertools')
+        end
+
+        it 'skips unavailable repos' do
+          is_expected.to run_execute('yum-config-manager_skip_if_unavail')
+            .with(command: 'yum-config-manager --setopt=*.skip_if_unavailable=1 --save')
+        end
+
       else
         pending "Implement for #{platform}"
       end


### PR DESCRIPTION
### Description of changes
Add Rocky8 to kitchen and spec tests.

### Tests
* Verified that ` ./kitchen.ec2.sh platform-install test nvidia-gdrcopy` launches test for Rocky8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
