### PR TITLE
[develop] Use EFS id instead of DNS in fstab

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_mount_umount.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_mount_umount.rb
@@ -72,7 +72,7 @@ action :mount do
 
     # Enable the mount dir
     mount efs_shared_dir do
-      device "#{efs_fs_id}.efs.#{node['cluster']['region']}.#{node['cluster']['aws_domain']}:#{mount_point}"
+      device "#{efs_fs_id}:#{mount_point}"
       fstype 'efs'
       options mount_options
       dump 0

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efs_spec.rb
@@ -297,7 +297,7 @@ describe 'efs:mount' do
 
         it 'enables shared dir mount if already mounted' do
           is_expected.to enable_mount('/shared_dir_2')
-            .with(device: 'id_2.efs.REGION.DOMAIN:/')
+            .with(device: 'id_2:/')
             .with(fstype: 'efs')
             .with(dump: 0)
             .with(pass: 0)
@@ -306,7 +306,7 @@ describe 'efs:mount' do
             .with(retry_delay: 6)
 
           is_expected.to enable_mount('/shared_dir_3')
-            .with(device: 'id_3.efs.REGION.DOMAIN:/')
+            .with(device: 'id_3:/')
             .with(fstype: 'efs')
             .with(dump: 0)
             .with(pass: 0)


### PR DESCRIPTION
According to https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-helper-ec2-linux.html, EFS can be mounted both with EFS id and DNS. Starting from https://github.com/aws/aws-parallelcluster-cookbook/pull/1588, we started to use a mixture of two approach.

To improve consistency in the code style, this commit uses EFS id instead of DNS in fstab


### Tests
The following tests have been passed
```
{%- import 'common.jinja2' as common with context -%}
test-suites:
  storage:
    test_efs.py::test_efs_compute_az:
      dimensions:
      - regions: ["ca-central-1"]
        instances: {{ common.INSTANCES_DEFAULT_X86 }}
        oss: ["alinux2"]
        schedulers: ["slurm"]
    test_efs.py::test_multiple_efs:
      dimensions:
      - regions: [ "ca-central-1" ]
        instances: {{ common.INSTANCES_DEFAULT_ARM }}
        oss: ["ubuntu2004"]
        schedulers: [ "slurm" ]
        benchmarks:
          - mpi_variants: ["intelmpi"]
            num_instances: [5] # Change the head node instance type if you'd test more than 30 instances
            slots_per_instance: 2
            osu_benchmarks:
              collective: ["osu_alltoall"]
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
