### PR TITLE
[develop] Fix ScaledownIdletime = -1 to SuspendTime conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **BUG FIXES**
 - Fix inconsistent scaling configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.
 - Fix users SSH keys generation when switching users without root privilege in clusters integrated with an external LDAP server through cluster configuration files.
+- Fix disabling Slurm power save mode when setting ScaledownIdletime = -1 
 
 3.7.2
 ------

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster.conf
@@ -5,7 +5,7 @@
 {% set ns = namespace(has_static=false) %}
 
 SlurmctldHost={{ head_node_config.head_node_hostname }}({{ head_node_config.head_node_ip }})
-SuspendTime={{ scaling_config.ScaledownIdletime * 60 }}
+SuspendTime={{ -1 if scaling_config.ScaledownIdletime == -1 else scaling_config.ScaledownIdletime * 60 }}
 ResumeTimeout={{ compute_node_bootstrap_timeout }}
 {% if scaling_config.EnableMemoryBasedScheduling %}
 SelectTypeParameters=CR_CPU_Memory

--- a/test/unit/slurm/test_slurm_config_generator/test_generating_slurm_config_flexible_instance_types/expected_outputs/slurm_parallelcluster.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generating_slurm_config_flexible_instance_types/expected_outputs/slurm_parallelcluster.conf
@@ -4,7 +4,7 @@
 # options
 
 SlurmctldHost=ip-1-0-0-0(ip.1.0.0.0)
-SuspendTime=600
+SuspendTime=-1
 ResumeTimeout=1600
 SelectTypeParameters=CR_CPU
 

--- a/test/unit/slurm/test_slurm_config_generator/test_generating_slurm_config_flexible_instance_types/sample_input.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generating_slurm_config_flexible_instance_types/sample_input.yaml
@@ -384,5 +384,5 @@ Scheduling:
       UseEc2Hostnames: false
     EnableMemoryBasedScheduling: false
     QueueUpdateStrategy: COMPUTE_FLEET_STOP
-    ScaledownIdletime: 10
+    ScaledownIdletime: -1
     Database: null


### PR DESCRIPTION
### Description of changes
* Fix ScaledownIdletime to SuspendTime conversion when ScaledownIdletime is set to -1 into cluster configuration. SuspendTime cannot be lower than -1, as it is not an accepted value by Slurm.

### Tests
* unit tests added

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
