### PR TITLE
[develop] Use Slurm install dir variable in update_slurm_database_password.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **BUG FIXES**
 - Fix inconsistent scaling configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.
 - Fix users SSH keys generation when switching users without root privilege in clusters integrated with an external LDAP server through cluster configuration files.
-- Fix disabling Slurm power save mode when setting ScaledownIdletime = -1 
+- Fix disabling Slurm power save mode when setting ScaledownIdletime = -1
+- Fix hard-coded path to Slurm installation dir in `update_slurm_database_password.sh` script for Slurm Accounting.
 
 3.7.2
 ------

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
@@ -37,7 +37,8 @@ template "#{node['cluster']['scripts_dir']}/slurm/update_slurm_database_password
   mode '0700'
   variables(
     secret_arn: lazy { node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database, :PasswordSecretArn) },
-    region: node['cluster']['region']
+    region: node['cluster']['region'],
+    slurm_install_dir: node['cluster']['slurm']['install_dir']
   )
   sensitive true
 end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_slurm_database_password.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_slurm_database_password.sh.erb
@@ -10,7 +10,7 @@
 
 set -e
 
-SLURMDBD_CONFIG_FILE="/opt/slurm/etc/slurm_parallelcluster_slurmdbd.conf"
+SLURMDBD_CONFIG_FILE="<%= @slurm_install_dir %>/etc/slurm_parallelcluster_slurmdbd.conf"
 SLURMDBD_PROPERTY="StoragePass"
 SECRET_ARN="<%= @secret_arn %>"
 REGION="<%= @region %>"


### PR DESCRIPTION
### Description of changes
* Fix small bug that would make the configuration of Slurm Accounting fail in case the Slurm install directory is not set as default (`/opt/slurm`).

### Tests
* To be tested directly in pipeline

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2590

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
