### PR TITLE
Remove obsolete params from slurm config

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/cgroup.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/cgroup.conf.erb
@@ -1,7 +1,6 @@
 ###
 # Slurm cgroup support configuration file
 ###
-CgroupAutomount=yes
 ConstrainCores=yes
 #
 # WARNING!!! The slurm_parallelcluster_cgroup.conf file included below can be updated by the pcluster process.

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -32,7 +32,6 @@ TreeWidth=65533
 SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,cloud_dns,node_reg_mem_percent=<%= node['cluster']['slurm_node_reg_mem_percent'] %>
 TreeWidth=30
 <% end -%>
-CommunicationParameters=NoAddrCache
 SuspendProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_suspend
 ResumeProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_resume
 ResumeFailProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_suspend


### PR DESCRIPTION
### Description of changes
With Slurm 23.11 `NoAddrCache` and `CgroupAutomount` params became obsolete and a warning message is shown if they are specified in the config.

This PR removes them from the slurm config provided by parallelcluster.

### Tests
* A warning message was shown in slurmctld log suggesting to remove them from the config.
* An updated config was used in a manual test while validating the new slurm version before the upgrade.

### References
* N/A

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
