### PR TITLE
Configure external slurmdbd daemon

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
@@ -24,6 +24,23 @@ template "#{node['cluster']['slurm']['install_dir']}/etc/slurmdbd.conf" do
   action :create_if_missing
 end
 
+template "#{node['cluster']['slurm']['install_dir']}/etc/slurm_external_slurmdbd.conf" do
+  source 'slurm/external_slurmdbd/slurm_external_slurmdbd.conf.erb'
+  owner "#{node['cluster']['slurm']['user']}"
+  group "#{node['cluster']['slurm']['group']}"
+  mode '0600'
+  action :create_if_missing
+  variables(
+    dbd_host: "localhost",
+    storage_host: node['dbms_uri'],
+    # TODO: expose additional CFN Parameter in template
+    storage_port: 3306,
+    storage_loc: node['dbms_database_name'],
+    storage_user: node['dbms_username']
+  )
+  only_if { node['is_external_slurmdbd'] }
+end
+
 file "#{node['cluster']['slurm']['install_dir']}/etc/slurm_parallelcluster_slurmdbd.conf" do
   owner "#{node['cluster']['slurm']['user']}"
   group "#{node['cluster']['slurm']['group']}"

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
@@ -77,7 +77,7 @@ execute "wait for slurm database" do
   command "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn"
   retries node['cluster']['slurmdbd_response_retries']
   retry_delay 10
-end unless on_docker?
+end unless on_docker? || node['is_external_slurmdbd']
 
 bash "bootstrap slurm database" do
   user 'root'
@@ -108,4 +108,4 @@ bash "bootstrap slurm database" do
     # This is not important for the scope of this script, so we return 0.
     exit 0
   BOOTSTRAP
-end unless on_docker?
+end unless on_docker? || node['is_external_slurmdbd']

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/external_slurmdbd/slurm_external_slurmdbd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/external_slurmdbd/slurm_external_slurmdbd.conf.erb
@@ -1,0 +1,9 @@
+# slurm_external_slurmdbd.conf is managed by external configuration.
+# Do not modify.
+# Please add user-specific slurmdbd configuration options in slurmdbd.conf
+DbdHost=<%= @dbd_host %>
+StorageHost=<%= @storage_host %>
+StoragePort=<%= @storage_port %>
+StorageLoc=<%= @storage_loc %>
+StorageUser=<%= @storage_user %>
+StoragePass=dummy

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_slurm_database_password.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_slurm_database_password.sh.erb
@@ -10,7 +10,11 @@
 
 set -e
 
+<% if node['is_external_slurmdbd'] %>
+SLURMDBD_CONFIG_FILE="/opt/slurm/etc/slurm_external_slurmdbd.conf"
+<% else %>
 SLURMDBD_CONFIG_FILE="/opt/slurm/etc/slurm_parallelcluster_slurmdbd.conf"
+<% end %>
 SLURMDBD_PROPERTY="StoragePass"
 SECRET_ARN="<%= @secret_arn %>"
 REGION="<%= @region %>"

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurmdbd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurmdbd.conf.erb
@@ -6,11 +6,11 @@ StorageType=accounting_storage/mysql
 
 # Conditional inclusion based on 'is_external_slurmdbd' attribute
 <% if node['is_external_slurmdbd'] %>
-  # WARNING!!! The slurm_external_slurmdbd.conf file included below can be updated by the pcluster process.
-  # Please do not edit it.
-  include slurm_external_slurmdbd.conf
+# WARNING!!! The slurm_external_slurmdbd.conf file included below can be updated by the pcluster process.
+# Please do not edit it.
+include slurm_external_slurmdbd.conf
 <% else %>
-  # WARNING!!! The slurm_parallelcluster_slurmdbd.conf file included below can be updated by the pcluster process.
-  # Please do not edit it.
-  include slurm_parallelcluster_slurmdbd.conf
+# WARNING!!! The slurm_parallelcluster_slurmdbd.conf file included below can be updated by the pcluster process.
+# Please do not edit it.
+include slurm_parallelcluster_slurmdbd.conf
 <% end %>


### PR DESCRIPTION
### Description of changes
* Create new include file for slurmdbd.conf relevant only for external slurmdbd.
* Avoid calling `sacctmgr` when configuring an external slurmdbd (the client commands seem to require access to a full Slurm configuration).

### Tests
* Successful manual tests

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
