### PR TITLE
[release-3.8] Add support for passing Slurm patches from S3

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
@@ -55,6 +55,25 @@ remote_directory "#{node['cluster']['sources_dir']}/slurm_patches" do
   recursive true
 end
 
+# Copy Slurm patches from S3 if passed via dna.json
+if !node['cluster']['slurm_patches_s3_archive'].nil? && !node['cluster']['slurm_patches_s3_archive'].empty?
+  remote_object 'Retrieve Custom Slurm Settings' do
+    url node['cluster']['slurm_patches_s3_archive']
+    destination "#{node['cluster']['sources_dir']}/slurm_patches_from_s3.tar.gz"
+    sensitive true
+  end
+
+  bash 'extract Slurm patches from archive' do
+    user 'root'
+    group 'root'
+    cwd "#{node['cluster']['sources_dir']}/slurm_patches"
+    code <<-UNTAR
+    set -e
+    tar xf #{node['cluster']['sources_dir']}/slurm_patches_from_s3.tar.gz
+    UNTAR
+  end
+end
+
 # Install Slurm
 bash 'make install' do
   not_if { redhat_on_docker? }


### PR DESCRIPTION
### Description of changes
* Add support for passing an URL for an archive containing Slurm patches to be used when building Slurm via the build-image Extra Chef Attributes.

### Tests
* Manual run of build-image using some patches from an S3 bucket.

### References
* https://github.com/aws/aws-parallelcluster/pull/5927

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.