### PR TITLE
[develop] Install kernel-devel for Rocky Linux from vault

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
@@ -20,11 +20,22 @@ use 'partial/_install_packages_common.rb'
 use 'partial/_install_packages_rhel_amazon.rb'
 
 action :install_kernel_source do
+  # Previous releases are moved into a vault area once a new minor release version is available for at least a week.
+  # https://wiki.rockylinux.org/rocky/repo/#notes-on-devel
   bash "Install kernel source" do
     user 'root'
     code <<-INSTALL_KERNEL_SOURCE
     set -e
-    dnf install -y #{kernel_source_package}-#{kernel_source_package_version} --releasever #{node['platform_version']}
+    package="#{kernel_source_package}-#{kernel_source_package_version}"
+
+    # try to install kernel source for a specific release version
+    dnf install -y ${package} --releasever #{node['platform_version']}
+    if [ $? -ne 0 ]; then
+      # Previous releases are moved into a vault area once a new minor release version is available for at least a week.
+      # https://wiki.rockylinux.org/rocky/repo/#notes-on-devel
+      wget https://dl.rockylinux.org/vault/rocky/#{node['platform_version']}/BaseOS/$(uname -m)/os/Packages/k/${package}.rpm
+      dnf install -y ./${package}.rpm
+    fi
     dnf clean all
     INSTALL_KERNEL_SOURCE
   end unless on_docker?


### PR DESCRIPTION
Previous releases are moved into a vault area once a new minor release version is available for at least a week. This means we cannot use `--releasever` to install 8.8 version because it is not more available in the repo.

On RHEL8 instead all versions of the packages will remain available.

With this patch we're downloading this specific package from vault and installing it.

## Tests

Manual execution of the new steps.

## References

* https://wiki.rockylinux.org/rocky/repo/#notes-on-devel
* Follow up of https://github.com/aws/aws-parallelcluster-cookbook/pull/2564
* Related to https://github.com/aws/aws-parallelcluster/pull/5936
