### PR TITLE
[release-3.8] Upgrade slurm version to 23.02.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Allow for mounting `home` as an EFS or FSx external shared storage via the `SharedStorage` section of the config file.
 
 **CHANGES**
+- Upgrade Slurm to 23.02.7 (from 23.02.6).
 - Do not wait for static nodes in maintenance to signal CFN that the head node initialization is complete.
 - Upgrade `aws-cfn-bootstrap` to version 2.0-28.
 - Upgrade Python to 3.9.17.

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -1,11 +1,6 @@
 # URLs to software packages used during install recipes
 default['cluster']['slurm']['fleet_config_path'] = "#{node['cluster']['slurm_plugin_dir']}/fleet-config.json"
 
-# Slurm attributes shared between install_slurm and configure_slurm_accounting
-default['cluster']['slurm']['commit'] = ''
-default['cluster']['slurm']['branch'] = ''
-default['cluster']['slurm']['sha256'] = 'ed44d4e591c0f91874d535cb8c9ea67dd2a38bfa4e96fa6c71687293f6a1d3bb'
-
 default['cluster']['dns_domain'] = nil
 default['cluster']['use_private_hostname'] = 'false'
 

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -3,7 +3,7 @@ default['cluster']['slurm']['fleet_config_path'] = "#{node['cluster']['slurm_plu
 
 # Slurm attributes shared between install_slurm and configure_slurm_accounting
 default['cluster']['slurm']['commit'] = ''
-default['cluster']['slurm']['branch'] = 'slurm-23.02'
+default['cluster']['slurm']['branch'] = ''
 default['cluster']['slurm']['sha256'] = 'ed44d4e591c0f91874d535cb8c9ea67dd2a38bfa4e96fa6c71687293f6a1d3bb'
 
 default['cluster']['dns_domain'] = nil

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -1,4 +1,8 @@
 # Slurm
-default['cluster']['slurm']['version'] = '23-02-6-1'
+default['cluster']['slurm']['version'] = '23-02-7-1'
+default['cluster']['slurm']['commit'] = ''
+default['cluster']['slurm']['branch'] = ''
+default['cluster']['slurm']['sha256'] = '3f60ad5b5a492312d1febb9f9167caa3aee7f8438bb032590a993f5a65c5e4db'
+default['cluster']['slurm']['base_url'] = "https://github.com/SchedMD/slurm/archive"
 # Munge
 default['cluster']['munge']['munge_version'] = '0.5.15'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
@@ -30,7 +30,7 @@ slurm_tar_name = if !slurm_commit.empty?
                    "slurm-#{slurm_version}"
                  end
 slurm_tarball = "#{node['cluster']['sources_dir']}/#{slurm_tar_name}.tar.gz"
-slurm_url = "https://github.com/SchedMD/slurm/archive/#{slurm_tar_name}.tar.gz"
+slurm_url = "#{node['cluster']['slurm']['base_url']}/#{slurm_tar_name}.tar.gz"
 slurm_sha256 = if slurm_branch.empty?
                  node['cluster']['slurm']['sha256']
                end


### PR DESCRIPTION
### Description of changes
* Revert the patch to avoid building from development branch:This reverts commit cf685408bede38a6ca2b1f704e46c4252a8ffbef.
* upgrade slurm to 23.02.7 Reference: [this](https://github.com/aws/aws-parallelcluster-cookbook/pull/2562/commits/df07c694fcd11d76a0360cf2039984ce4f89a01f))

### Tests
tarball: https://github.com/SchedMD/slurm/archive/slurm-23-02-7-1.tar.gz
* verify the checksum locally
```
* (cdk1) ➜  Downloads sha256sum slurm-slurm-23-02-7-1.tar.gz
3f60ad5b5a492312d1febb9f9167caa3aee7f8438bb032590a993f5a65c5e4db  slurm-slurm-23-02-7-1.tar.gz
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
