### PR TITLE
[release-3.8] Avoid to exit while trying to install a specific kernel-devel version

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
@@ -25,7 +25,6 @@ action :install_kernel_source do
   bash "Install kernel source" do
     user 'root'
     code <<-INSTALL_KERNEL_SOURCE
-    set -e
     package="#{kernel_source_package}-#{kernel_source_package_version}"
 
     # try to install kernel source for a specific release version
@@ -33,6 +32,7 @@ action :install_kernel_source do
     if [ $? -ne 0 ]; then
       # Previous releases are moved into a vault area once a new minor release version is available for at least a week.
       # https://wiki.rockylinux.org/rocky/repo/#notes-on-devel
+      set -e
       wget https://dl.rockylinux.org/vault/rocky/#{node['platform_version']}/BaseOS/$(uname -m)/os/Packages/k/${package}.rpm
       dnf install -y ./${package}.rpm
     fi

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
@@ -33,12 +33,15 @@ action :install_kernel_source do
       # Previous releases are moved into a vault area once a new minor release version is available for at least a week.
       # https://wiki.rockylinux.org/rocky/repo/#notes-on-devel
       set -e
-      wget https://dl.rockylinux.org/vault/rocky/#{node['platform_version']}/BaseOS/$(uname -m)/os/Packages/k/${package}.rpm
-      dnf install -y ./${package}.rpm
+      dnf install -y https://dl.rockylinux.org/vault/rocky/#{node['platform_version']}/BaseOS/#{node['kernel']['machine']}/os/Packages/k/${package}.rpm
     fi
     dnf clean all
     INSTALL_KERNEL_SOURCE
   end unless on_docker?
+end
+
+def kernel_source_package_version
+  node['kernel']['release']
 end
 
 def default_packages


### PR DESCRIPTION
### Description of changes

#### Avoid to exit while trying to install a specific kernel-devel version

This code has been created to try to install using `--releasever` parameter and if this command fails try to install the package from vault, anyway the `set -e` at the top of the failing was causing all the build to fail.

#### Fix kernel-devel package name for rhel8

When using `wget`, the package name must contain the architecture too.
By redefining the `kernel_source_package_version` we're avoiding to `chomp` the architecture from kernel version.
Then, use `node['kernel']['machine']` rather than `uname -m`.

### Tests
* Manually tested in a Rocky-8-EC2-Base-8.8-20230518.0.x86_64
* Verified that both `dnf install` and `wget` commands are working when passing architecture.

### References

* https://github.com/chef/ohai/blob/17-stable/lib/ohai/plugins/kernel.rb#L34
* Related to: https://github.com/aws/aws-parallelcluster-cookbook/pull/2598
* Cherry pick of #2602 
