### PR TITLE
[develop] Remove aws-parallelcluster-shared/test dependency from other cookbooks

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/test/inspec.yml
+++ b/cookbooks/aws-parallelcluster-awsbatch/test/inspec.yml
@@ -1,7 +1,3 @@
 ---
 maintainer: 'Amazon Web Services'
 license: 'Apache-2.0'
-
-depends:
-  - name: shared
-    path: cookbooks/aws-parallelcluster-shared/test

--- a/cookbooks/aws-parallelcluster-computefleet/test/inspec.yml
+++ b/cookbooks/aws-parallelcluster-computefleet/test/inspec.yml
@@ -1,7 +1,3 @@
 ---
 maintainer: 'Amazon Web Services'
 license: 'Apache-2.0'
-
-depends:
-  - name: shared
-    path: cookbooks/aws-parallelcluster-shared/test

--- a/cookbooks/aws-parallelcluster-entrypoints/test/inspec.yml
+++ b/cookbooks/aws-parallelcluster-entrypoints/test/inspec.yml
@@ -1,7 +1,3 @@
 ---
 maintainer: 'Amazon Web Services'
 license: 'Apache-2.0'
-
-depends:
-  - name: shared
-    path: cookbooks/aws-parallelcluster-shared/test

--- a/cookbooks/aws-parallelcluster-environment/test/inspec.yml
+++ b/cookbooks/aws-parallelcluster-environment/test/inspec.yml
@@ -1,7 +1,3 @@
 ---
 maintainer: 'Amazon Web Services'
 license: 'Apache-2.0'
-
-depends:
-  - name: shared
-    path: cookbooks/aws-parallelcluster-shared/test

--- a/cookbooks/aws-parallelcluster-platform/test/inspec.yml
+++ b/cookbooks/aws-parallelcluster-platform/test/inspec.yml
@@ -1,7 +1,3 @@
 ---
 maintainer: 'Amazon Web Services'
 license: 'Apache-2.0'
-
-depends:
-  - name: shared
-    path: cookbooks/aws-parallelcluster-shared/test

--- a/cookbooks/aws-parallelcluster-slurm/test/inspec.yml
+++ b/cookbooks/aws-parallelcluster-slurm/test/inspec.yml
@@ -1,7 +1,3 @@
 ---
 maintainer: 'Amazon Web Services'
 license: 'Apache-2.0'
-
-depends:
-  - name: shared
-    path: cookbooks/aws-parallelcluster-shared/test


### PR DESCRIPTION
A Chef InSpec profile can bring in the controls and custom resources from another Chef InSpec profile. This dependency is not required because we don't need to execute controls or custom resources from aws-parallelcluster-shared cookbook.

Removing this dependency we should solve the concurrency issue causing random failures with the error:
```
[2023-12-14T23:25:37.069Z] >>>>>>     Failed to complete #verify action: [No such file or directory @ rb_file_s_stat - /var/jenkins_home/jobs/kitchen_tests_3/workspace/pcluster_cookbook/cookbooks/aws-parallelcluster-shared/test/inspec.json] on slurm-config-compute-fleet-arm64-t4gxlarge-alinux2
```

### Tests
* Tried to run a local test: `bash kitchen.docker.sh environment-install test nfs-alinux2`
* Executed full round of kitchen tests in Jenkins
