### PR TITLE
Use noninteractive mode when using pam-auth-update for debian

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_debian.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_debian.rb
@@ -15,6 +15,7 @@
 action :configure do
   execute 'Configure Directory Service' do
     user 'root'
+    environment 'DEBIAN_FRONTEND' => 'noninteractive'
     # Enable PAM mkhomedir module
     command "pam-auth-update --enable mkhomedir"
     default_env true


### PR DESCRIPTION
### Description of changes
* Patch fixes the PAM configuration step when you are on Debian based distro. By default pam-auth-update command creates an interactive popup window (with ncurses) which blocks the chef flow.

### Tests
* Manual testing is done. With DEBIAN_FRONTEND=noninteractive set pam-auth-update uses non interactive way of working and doesn't block execution.

### References
* https://stackoverflow.com/questions/44389362/how-to-configure-pam-auth-update-in-non-interactive-mode 

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
