### PR TITLE
Change Shellcheck severity level to warning and make fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:
-          severity: error
+          severity: warning
           ignore_paths: cookbooks/third-party
   rspec:
     name: ChefSpec

--- a/cookbooks/aws-parallelcluster-environment/files/imds/imds-access.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/imds/imds-access.sh
@@ -19,7 +19,8 @@ function info() {
 }
 
 function help() {
-  local -- cmd=$(basename "$0")
+  local -- cmd
+  cmd=$(basename "$0")
   cat <<EOF
 
   Usage: ${cmd} [OPTION]...

--- a/cookbooks/aws-parallelcluster-environment/files/login_nodes/keys-manager.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/login_nodes/keys-manager.sh
@@ -18,7 +18,8 @@ function info() {
 }
 
 function help() {
-  local -- cmd=$(basename "$0")
+  local -- cmd
+  cmd=$(basename "$0")
   cat <<EOF
 
   Usage: ${cmd} [OPTION]...

--- a/cookbooks/aws-parallelcluster-environment/files/setup-ephemeral-drives.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/setup-ephemeral-drives.sh
@@ -17,11 +17,10 @@ LVM_PATH="/dev/${LVM_VG_NAME}/${LVM_NAME}"
 LVM_ACTIVE_STATE="a"
 FS_TYPE="ext4"
 MOUNT_OPTIONS="noatime,nodiratime"
-# cfn_ephemeral_dir is set in the environment by cfnconfig sourcing
+# shellcheck disable=SC2154 # cfn_ephemeral_dir is set in the environment by cfnconfig sourcing
 INPUT_MOUNTPOINT="${cfn_ephemeral_dir}"
 
 function log {
-  SCRIPT=$(basename "$0")
   MESSAGE="$1"
   echo "ParallelCluster - ${MESSAGE}"
 }
@@ -73,7 +72,7 @@ function print_block_device_mapping {
 function check_instance_store {
   if ls /dev/nvme* >& /dev/null; then
     IS_NVME=1
-    MAPPINGS=$(realpath --relative-to=/dev/ -P /dev/disk/by-id/nvme*Instance_Storage* | grep -v "*Instance_Storage*" | uniq)
+    MAPPINGS=$(realpath --relative-to=/dev/ -P /dev/disk/by-id/nvme*Instance_Storage* | grep -v "Instance_Storage" | uniq)
   else
     IS_NVME=0
     set_imds_token

--- a/cookbooks/aws-parallelcluster-environment/files/setup-ephemeral-drives.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/setup-ephemeral-drives.sh
@@ -72,7 +72,7 @@ function print_block_device_mapping {
 function check_instance_store {
   if ls /dev/nvme* >& /dev/null; then
     IS_NVME=1
-    MAPPINGS=$(realpath --relative-to=/dev/ -P /dev/disk/by-id/nvme*Instance_Storage* | grep -v "Instance_Storage" | uniq)
+    MAPPINGS=$(realpath --relative-to=/dev/ -P /dev/disk/by-id/nvme*Instance_Storage* | grep -v "\*Instance_Storage\*" | uniq)
   else
     IS_NVME=0
     set_imds_token

--- a/cookbooks/aws-parallelcluster-platform/files/dcv/pcluster_dcv_connect.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/dcv/pcluster_dcv_connect.sh
@@ -53,7 +53,7 @@ _validate_json() {
   if [[ -z "${json_param}" ]]; then
       _fail "${message}. Empty JSON."
   fi
-  if ! $(jq -e . >/dev/null 2>&1 <<<"${json_param}"); then
+  if ! jq -e . >/dev/null 2>&1 <<<"${json_param}"; then
       _fail "${message}. Wrong JSON."
   fi
 }

--- a/util/bump-version.sh
+++ b/util/bump-version.sh
@@ -8,7 +8,7 @@ if [ "$(uname)" == "Darwin" ]; then
   PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
 fi
 
-if [ -z "$1" -o -z "$2" ]; then
+if [ -z "$1" ] || [ -z "$2" ]; then
     echo "New version not specified. Usage: bump-version.sh NEW_PCLUSTER_VERSION NEW_AWSBATCH_CLI_VERSION"
     exit 1
 fi
@@ -35,13 +35,13 @@ for cookbook in "${COOKBOOKS[@]}"; do
 done
 
 # Update version in specific cookbook metadata
-sed -i "s/version '${CURRENT_PCLUSTER_VERSION_SHORT}'/version '${NEW_PCLUSTER_VERSION_SHORT}'/g" ${METADATA_FILES[*]}
+sed -i "s/version '${CURRENT_PCLUSTER_VERSION_SHORT}'/version '${NEW_PCLUSTER_VERSION_SHORT}'/g" "${METADATA_FILES[@]}"
 
-for COOKBOOK in ${COOKBOOKS[*]}; do
+for COOKBOOK in "${COOKBOOKS[@]}"; do
   # Update dependencies version in main cookbook metadata
   sed -i "s/depends '${COOKBOOK}', '~> ${CURRENT_PCLUSTER_VERSION_SHORT}'/depends '${COOKBOOK}', '~> ${NEW_PCLUSTER_VERSION_SHORT}'/g" metadata.rb
   # Update dependencies version in specific cookbook metadata
-  sed -i "s/depends '${COOKBOOK}', '~> ${CURRENT_PCLUSTER_VERSION_SHORT}'/depends '${COOKBOOK}', '~> ${NEW_PCLUSTER_VERSION_SHORT}'/g" ${METADATA_FILES[*]}
+  sed -i "s/depends '${COOKBOOK}', '~> ${CURRENT_PCLUSTER_VERSION_SHORT}'/depends '${COOKBOOK}', '~> ${NEW_PCLUSTER_VERSION_SHORT}'/g" "${METADATA_FILES[@]}"
 done
 
 # Update AWS Batch CLI version

--- a/util/cinc-install.sh
+++ b/util/cinc-install.sh
@@ -75,6 +75,7 @@ checksum_mismatch() {
 unable_to_retrieve_package() {
   echo "Unable to retrieve a valid package!"
   report_bug
+  # shellcheck disable=SC2154
   echo "Metadata URL: $metadata_url"
   if test "x$download_url" != "x"; then
     echo "Download URL: $download_url"
@@ -132,7 +133,7 @@ do_wget() {
   wget --user-agent="User-Agent: mixlib-install/3.12.27" -O "$2" "$1" 2>$tmp_dir/stderr
   rc=$?
   # check for 404
-  grep "ERROR 404" $tmp_dir/stderr 2>&1 >/dev/null
+  grep "ERROR 404" $tmp_dir/stderr >/dev/null 2>&1
   if test $? -eq 0; then
     echo "ERROR 404"
     http_404_error
@@ -153,7 +154,7 @@ do_curl() {
   curl -A "User-Agent: mixlib-install/3.12.27" --retry 5 -sL -D $tmp_dir/stderr "$1" > "$2"
   rc=$?
   # check for 404
-  grep "404 Not Found" $tmp_dir/stderr 2>&1 >/dev/null
+  grep "404 Not Found" $tmp_dir/stderr >/dev/null 2>&1
   if test $? -eq 0; then
     echo "ERROR 404"
     http_404_error
@@ -183,7 +184,7 @@ do_perl() {
   perl -e 'use LWP::Simple; getprint($ARGV[0]);' "$1" > "$2" 2>$tmp_dir/stderr
   rc=$?
   # check for 404
-  grep "404 Not Found" $tmp_dir/stderr 2>&1 >/dev/null
+  grep "404 Not Found" $tmp_dir/stderr >/dev/null 2>&1
   if test $? -eq 0; then
     echo "ERROR 404"
     http_404_error
@@ -204,7 +205,7 @@ do_python() {
   python -c "import sys,urllib2; sys.stdout.write(urllib2.urlopen(urllib2.Request(sys.argv[1], headers={ 'User-Agent': 'mixlib-install/3.12.27' })).read())" "$1" > "$2" 2>$tmp_dir/stderr
   rc=$?
   # check for 404
-  grep "HTTP Error 404" $tmp_dir/stderr 2>&1 >/dev/null
+  grep "HTTP Error 404" $tmp_dir/stderr >/dev/null 2>&1
   if test $? -eq 0; then
     echo "ERROR 404"
     http_404_error
@@ -222,12 +223,12 @@ do_python() {
 do_checksum() {
   if exists sha256sum; then
     echo "Comparing checksum with sha256sum..."
-    checksum=`sha256sum $1 | awk '{ print $1 }'`
-    return `test "x$checksum" = "x$2"`
+    checksum=$(sha256sum $1 | awk '{ print $1 }')
+    return "$(test "x$checksum" = "x$2")"
   elif exists shasum; then
     echo "Comparing checksum with shasum..."
-    checksum=`shasum -a 256 $1 | awk '{ print $1 }'`
-    return `test "x$checksum" = "x$2"`
+    checksum=$(shasum -a 256 $1 | awk '{ print $1 }')
+    return "$(test "x$checksum" = "x$2")"
   else
     echo "WARNING: could not find a valid checksum program, pre-install shasum or sha256sum in your O/S image to get validation..."
     return 0
@@ -311,7 +312,7 @@ install_file() {
     "deb")
       echo "installing with dpkg..."
       # WARNING: Custom fix to avoid hangs when another installation is running
-      flock $(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)'$/\1/")daily_lock dpkg -i "$2"
+      flock "$(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)'$/\1/")daily_lock" dpkg -i "$2"
       ;;
     "bff")
       echo "installing with installp..."
@@ -333,7 +334,7 @@ install_file() {
       echo "installing dmg file..."
       hdiutil detach "/Volumes/cinc_project" >/dev/null 2>&1 || true
       hdiutil attach "$2" -mountpoint "/Volumes/cinc_project"
-      cd / && /usr/sbin/installer -pkg `find "/Volumes/cinc_project" -name \*.pkg` -target /
+      cd / && /usr/sbin/installer -pkg "$(find "/Volumes/cinc_project" -name \*.pkg)" -target /
       hdiutil detach "/Volumes/cinc_project"
       ;;
     "sh" )
@@ -408,7 +409,7 @@ do
   esac
 done
 
-shift `expr $OPTIND - 1`
+shift "$(expr $OPTIND - 1)"
 
 
 if test -d "/opt/$project" && test "x$install_strategy" = "xonce"; then
@@ -530,6 +531,7 @@ elif test "x$os" = "xAIX"; then
 elif test -f "/etc/os-release"; then
   . /etc/os-release
   if test "x$CISCO_RELEASE_INFO" != "x"; then
+    # shellcheck source=/dev/null
     . $CISCO_RELEASE_INFO
   fi
 
@@ -633,6 +635,7 @@ if test "x$platform" = "xsolaris2"; then
 fi
 
 # WARNING: Custom code to detect AWS Region
+# shellcheck disable=SC2034 # instance_metadata_file is used below
 instance_metadata_file=$tmp_dir/instance_metadata
 get_region instance_metadata_file
 

--- a/util/cinc-install.sh
+++ b/util/cinc-install.sh
@@ -75,8 +75,6 @@ checksum_mismatch() {
 unable_to_retrieve_package() {
   echo "Unable to retrieve a valid package!"
   report_bug
-  # shellcheck disable=SC2154
-  echo "Metadata URL: $metadata_url"
   if test "x$download_url" != "x"; then
     echo "Download URL: $download_url"
   fi
@@ -108,7 +106,6 @@ http_404_error() {
   echo "that $platform is not supported."
   echo ""
   # deliberately do not call report_bug to suppress bug report noise.
-  echo "Metadata URL: $metadata_url"
   if test "x$download_url" != "x"; then
     echo "Download URL: $download_url"
   fi

--- a/util/upload-cookbook.sh
+++ b/util/upload-cookbook.sh
@@ -10,7 +10,8 @@ _info() {
 }
 
 _help() {
-    local -- _cmd=$(basename "$0")
+    local -- _cmd
+    _cmd=$(basename "$0")
 
     cat <<EOF
 
@@ -84,11 +85,11 @@ main() {
 
     # Create archive and md5
     _cwd=$(pwd)
-    pushd "${_srcdir}" > /dev/null
+    pushd "${_srcdir}" > /dev/null || exit
     _stashName=$(git stash create)
     git archive --format tar --prefix="aws-parallelcluster-cookbook-${_version}/" "${_stashName:-HEAD}" | gzip > "${_cwd}/aws-parallelcluster-cookbook-${_version}.tgz"
     #tar zcvf "${_cwd}/aws-parallelcluster-cookbook-${_version}.tgz" --transform "s,^aws-parallelcluster-cookbook/,aws-parallelcluster-cookbook-${_version}/," ../aws-parallelcluster-cookbook
-    popd > /dev/null
+    popd > /dev/null || exit
     md5sum aws-parallelcluster-cookbook-${_version}.tgz > aws-parallelcluster-cookbook-${_version}.md5
 
     # upload packages


### PR DESCRIPTION
### Description of changes
* Changed the shellcheck severity level to warning to discover potential problems earlier
* Fixed the warnings, the warnings are in this check in my [fork](https://github.com/judysng/aws-parallelcluster-cookbook/actions/runs/7414056129/job/20174303506)

### Tests
* Tested the bash line changes locally
* Ran bump-version.sh

### References
* Also changed severity level to warning in the [CLI](https://github.com/aws/aws-parallelcluster/pull/5996) and [node](https://github.com/aws/aws-parallelcluster-node/pull/610)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
