### PR TITLE
Upgrade tj-actions/changed-files to version 41 to fix dependabot alert

### DIFF
--- a/.github/workflows/dokken-system-tests.yml
+++ b/.github/workflows/dokken-system-tests.yml
@@ -62,7 +62,7 @@ jobs:
           df -h /
       - name: Get changed files
         id: changed-files-excluding-tests
-        uses: tj-actions/changed-files@v35.6.0
+        uses: tj-actions/changed-files@v41.0.0
         with:
           files_ignore: |
             !.*


### PR DESCRIPTION
### Description of changes
* Upgrade tj-actions/changed-files to version 41 to fix dependabot alert

### References
* Dependabot alert: https://github.com/aws/aws-parallelcluster-cookbook/security/dependabot/1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
