### PR TITLE
[DFSM] Make compute nodes save cluster config version to DynamoDB.

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
@@ -19,11 +19,6 @@ end
 # generate the updated shared storages mapping file
 include_recipe 'aws-parallelcluster-environment::update_fs_mapping'
 
-if node["cluster"]["node_type"] == "ComputeFleet"
-  Chef::Log.info("Dummy log line to prove that update is triggered on compute node")
-  return
-end
-
 include_recipe 'aws-parallelcluster-environment::directory_service'
 include_recipe 'aws-parallelcluster-slurm::update' if node['cluster']['scheduler'] == 'slurm'
 

--- a/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Saves on the DynamoDB table 'parallelcluster-$CLUSTERNAME' the correspondence between
+# the instance id and the cluster config version deployed on that instance.
+# This is done to understand what is the deployed cluster config in each node, for example, during a CFN Stack update.
+def save_instance_config_version_to_dynamodb
+  unless on_docker? || kitchen_test? && !node['interact_with_ddb']
+    # TODO: the table name should be read from a dedicated node attribute,
+    #   but it is currently missing in the dna.json for compute nodes.
+    table_name = "parallelcluster-#{node['cluster']['cluster_name']}"
+    item_id = "CLUSTER_CONFIG.#{node['ec2']['instance_id']}"
+    item_data = "{\"cluster_config_version\": {\"S\": \"#{node['cluster']['cluster_config_version']}\"}, \"lastUpdateTime\": {\"S\": \"#{Time.now.utc}\"}}"
+    item = "{\"Id\": {\"S\": \"#{item_id}\"}, \"Data\": {\"M\": #{item_data}}}"
+
+    execute "Save cluster config version to DynamoDB" do
+      command "#{cookbook_virtualenv_path}/bin/aws dynamodb put-item" \
+                " --table-name #{table_name}"\
+                " --item '#{item}'" \
+                " --region #{node['cluster']['region']}"
+      retries 3
+      retry_delay 5
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize.rb
@@ -4,7 +4,7 @@
 # Cookbook:: aws-parallelcluster-slurm
 # Recipe:: finalize
 #
-# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2013-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at

--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_compute.rb
@@ -4,7 +4,7 @@
 # Cookbook:: aws-parallelcluster-slurm
 # Recipe:: finalize_compute
 #
-# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2013-2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -59,3 +59,5 @@ execute 'resume_node' do
   # Only resume static nodes
   only_if { is_static_node?(node.run_state['slurm_compute_nodename']) }
 end
+
+save_instance_config_version_to_dynamodb

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_compute.rb
@@ -2,9 +2,9 @@
 
 #
 # Cookbook:: aws-parallelcluster-slurm
-# Recipe:: update
+# Recipe:: update_compute
 #
-# Copyright:: 2013-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -15,11 +15,4 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-case node['cluster']['node_type']
-when 'HeadNode'
-  include_recipe 'aws-parallelcluster-slurm::update_head_node'
-when 'ComputeFleet'
-  include_recipe 'aws-parallelcluster-slurm::update_compute'
-else
-  raise "node_type must be HeadNode or ComputeFleet"
-end
+save_instance_config_version_to_dynamodb

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_compute_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_compute_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::finalize_compute' do
+  for_all_oses do |platform, version|
+    cookbook_venv_path = "MOCK_COOKBOOK_VENV_PATH"
+    cluster_name = "MOCK_CLUSTER_NAME"
+    region = "MOCK_REGION"
+    instance_id = "MOCK_INSTANCE_ID"
+    cluster_config_version = "MOCK_CLUSTER_CONFIG_VERSION"
+    time_now = "2024-01-16 15:30:45 UTC"
+
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner = runner(platform: platform, version: version) do |node|
+          allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+          allow_any_instance_of(Object).to receive(:dig).and_return(true)
+          allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
+          allow_any_instance_of(Object).to receive(:is_static_node?).and_return(false)
+          allow(Time).to receive(:now).and_return(Time.parse(time_now))
+          RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+          node.override['cluster']['node_type'] = 'ComputeFleet'
+          node.override['interact_with_ddb'] = true
+          node.override['cluster']['cluster_name'] = cluster_name
+          node.override['cluster']['region'] = region
+          node.override['ec2']['instance_id'] = instance_id
+          node.override['cluster']['cluster_config_version'] = cluster_config_version
+        end
+        runner.converge(described_recipe)
+      end
+
+      it 'saves the cluster config version to dynamodb' do
+        expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
+          " --table-name parallelcluster-#{cluster_name}"\
+          " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
+          " --region #{region}"
+        is_expected.to run_execute("Save cluster config version to DynamoDB").with(
+          command: expected_command,
+          retries: 3,
+          retry_delay: 5
+        )
+      end
+
+      context "when interaction with ddb is disabled during kitchen tests" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+            allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            allow_any_instance_of(Object).to receive(:is_static_node?).and_return(false)
+            RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+            node.override['cluster']['node_type'] = 'ComputeFleet'
+            node.override['kitchen'] = true
+            node.override['interact_with_ddb'] = false
+            node.override['ec2']['instance_id'] = instance_id
+            node.override['cluster']['cluster_config_version'] = cluster_config_version
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'does not saves the cluster config version to dynamodb' do
+          is_expected.not_to run_execute("Save cluster config version to DynamoDB")
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::finalize' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      context "when head node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+            allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+            node.override['cluster']['node_type'] = 'HeadNode'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'includes the recipe to finalize the head node' do
+          is_expected.to include_recipe('aws-parallelcluster-slurm::finalize_head_node')
+        end
+      end
+
+      context "when compute node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+            allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            allow_any_instance_of(Object).to receive(:is_static_node?).and_return(false)
+            RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+            node.override['cluster']['node_type'] = 'ComputeFleet'
+            node.override['interact_with_ddb'] = true
+            node.override['ec2']['instance_id'] = "MOCK_INSTANCE_ID"
+            node.override['cluster']['cluster_config_version'] = "MOCK_CLUSTER_CONFIG_VERSION"
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'includes the recipe to update the compute node' do
+          is_expected.to include_recipe('aws-parallelcluster-slurm::finalize_compute')
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_compute_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_compute_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::update_compute' do
+  for_all_oses do |platform, version|
+    cookbook_venv_path = "MOCK_COOKBOOK_VENV_PATH"
+    cluster_name = "MOCK_CLUSTER_NAME"
+    region = "MOCK_REGION"
+    instance_id = "MOCK_INSTANCE_ID"
+    cluster_config_version = "MOCK_CLUSTER_CONFIG_VERSION"
+    time_now = "2024-01-16 15:30:45 UTC"
+
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner = runner(platform: platform, version: version) do |node|
+          allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+          allow_any_instance_of(Object).to receive(:dig).and_return(true)
+          allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
+          allow(Time).to receive(:now).and_return(Time.parse(time_now))
+          RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+          node.override['cluster']['node_type'] = 'ComputeFleet'
+          node.override['interact_with_ddb'] = true
+          node.override['cluster']['cluster_name'] = cluster_name
+          node.override['cluster']['region'] = region
+          node.override['ec2']['instance_id'] = instance_id
+          node.override['cluster']['cluster_config_version'] = cluster_config_version
+        end
+        runner.converge(described_recipe)
+      end
+
+      it 'saves the cluster config version to dynamodb' do
+        expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
+          " --table-name parallelcluster-#{cluster_name}"\
+          " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
+          " --region #{region}"
+        is_expected.to run_execute("Save cluster config version to DynamoDB").with(
+          command: expected_command,
+          retries: 3,
+          retry_delay: 5
+        )
+      end
+
+      context "when interaction with ddb is disabled during kitchen tests" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+            allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+            node.override['cluster']['node_type'] = 'ComputeFleet'
+            node.override['kitchen'] = true
+            node.override['interact_with_ddb'] = false
+            node.override['ec2']['instance_id'] = instance_id
+            node.override['cluster']['cluster_config_version'] = cluster_config_version
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'does not saves the cluster config version to dynamodb' do
+          is_expected.not_to run_execute("Save cluster config version to DynamoDB")
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::update' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      context "when head node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+            allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+            node.override['cluster']['node_type'] = 'HeadNode'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'includes the recipe to update the head node' do
+          is_expected.to include_recipe('aws-parallelcluster-slurm::update_head_node')
+        end
+      end
+
+      context "when compute node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+            allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+            node.override['cluster']['node_type'] = 'ComputeFleet'
+            node.override['interact_with_ddb'] = true
+            node.override['ec2']['instance_id'] = "MOCK_INSTANCE_ID"
+            node.override['cluster']['cluster_config_version'] = "MOCK_CLUSTER_CONFIG_VERSION"
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'includes the recipe to update the compute node' do
+          is_expected.to include_recipe('aws-parallelcluster-slurm::update_compute')
+        end
+      end
+
+      context "when login node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+            allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+            node.override['cluster']['node_type'] = 'LoginNode'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'raises an error' do
+          expect { chef_run }.to raise_error(RuntimeError).with_message('node_type must be HeadNode or ComputeFleet')
+        end
+      end
+
+      context "when other type of node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+            allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+            node.override['cluster']['node_type'] = 'AnotherTypeOfNode'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'raises an error' do
+          expect { chef_run }.to raise_error(RuntimeError).with_message('node_type must be HeadNode or ComputeFleet')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
Make compute nodes save cluster config version to DynamoDB during create (`finalize` recipe) and update (`update_compute` recipe).

In particular every compute node stores the following record on the cluster main DDB table (`parallelcluster-$CLUSTERNAME`):

```
{
  "Id": {
    "S": "CLUSTER_CONFIG.i-0ae39403fd72e34e4"
  },
  "Data": {
    "M": {
      "cluster_config_version": {
        "S": "HoqyEZYBkMig3gSxaMARUv0NGcG0rrso"
      },
      "lastUpdateTime": {
        "S": "2024-01-16 18:59:18 UTC"
      }
    }
  }
}
```

Also:
1. Added new spec tests to cover changed/new recipes.
1. Removed the dummy log line that was emitted in the initial PR for DFSM to prove updates are triggered.

Note: we derive the DDB table name on the fly from clustername (parallelcluster-$CLUSTERNAME) rather than reading it from dna.json. This is because compute node are currently missing such info in their dna.json. We will add it as part of another iteration.

### Tests
Executed the below manual tests and verified that every compute node stores the correct cluster config version and the last update time in the main DDB table.
1. Created a cluster
1. Updated the same cluster
1. Updated the same cluster with injected error causing rollback (forced update adding a non existing external EBS volume): compute nodes update the cluster config version with the faulty one, then the previous one is restored on the DB as consequence of the rollback. Notice that the version reported in S3 is the faulty one as it is the last one being submitted by the user.

Unit Tests:
1. Executed all existing spec tests on the aws-parallelcluster-slurm cookbook
3. Executed all new spec tests.

Integ Tests:
1. Test `test_update_slurm` succeeded

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
