### PR TITLE
Make -m=kernel-open flag optional to allow for ClosedRM drivers to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.8.1
+------
+
+**ENHANCEMENTS**
+- Add possibility to choose between Open and Closed Source Nvidia Drivers when building an AMI, through the ```['cluster']['nvidia']['kernel_open']``` cookbook node attribute.
+
 3.8.0
 ------
 

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
@@ -68,7 +68,7 @@ action :setup do
     cwd '/tmp'
     code <<-NVIDIA
       set -e
-      #{compiler_version} ./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check -m=kernel-open
+      #{compiler_version} ./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check -m=#{nvidia_kernel_module}
       rm -f /tmp/nvidia.run
     NVIDIA
     creates '/usr/bin/nvidia-smi'
@@ -106,4 +106,12 @@ end
 
 def compiler_version
   ""
+end
+
+def nvidia_kernel_module
+  if node['cluster']['nvidia']['kernel_open'] == "false"
+    "kernel"
+  else
+    "kernel-open"
+  end
 end


### PR DESCRIPTION
### Description of changes
* Cherry pick of https://github.com/aws/aws-parallelcluster-cookbook/pull/2615

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
