### PR TITLE
[develop] Remove start from service "supervisord"

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/recipes/finalize.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/finalize.rb
@@ -14,5 +14,5 @@
 # Restart supervisord
 service "supervisord" do
   supports restart: true
-  action %i(enable start restart)
+  action %i(enable restart)
 end unless on_docker?


### PR DESCRIPTION
### Description of changes
Since there is already a restart added in https://github.com/aws/aws-parallelcluster-cookbook/pull/2570, there is no need to waste time doing a start before the restart. This to avoid the following
```
Recipe: aws-parallelcluster-platform::finalize
  * service[supervisord] action enable[2024-01-24T10:26:09+00:00] INFO: Processing service[supervisord] action enable (aws-parallelcluster-platform::finalize line 15)
[2024-01-24T10:26:10+00:00] INFO: service[supervisord] enabled

    - enable service service[supervisord]
  * service[supervisord] action start[2024-01-24T10:26:10+00:00] INFO: Processing service[supervisord] action start (aws-parallelcluster-platform::finalize line 15)
[2024-01-24T10:26:10+00:00] INFO: service[supervisord] started

    - start service service[supervisord]
  * service[supervisord] action restart[2024-01-24T10:26:10+00:00] INFO: Processing service[supervisord] action restart (aws-parallelcluster-platform::finalize line 15)
[2024-01-24T10:26:24+00:00] INFO: service[supervisord] restarted

    - restart service service[supervisord]
```

### Tests
* n/a

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2570

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
