### PR TITLE
Use private IP for DbdAddr in external slurmdbd

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
@@ -49,8 +49,6 @@ end
 
 include_recipe 'aws-parallelcluster-slurm::config_head_node_directories'
 
-# TODO: configuration of munge systemd service;
-
 # TODO: move this template to a separate recipe
 # TODO: add a logic in update_munge_key.sh.erb to skip sharing munge key to shared dir
 template "#{node['cluster']['scripts_dir']}/slurm/update_munge_key.sh" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
@@ -32,6 +32,7 @@ template "#{node['cluster']['slurm']['install_dir']}/etc/slurm_external_slurmdbd
   action :create_if_missing
   variables(
     dbd_host: "localhost",
+    dbd_addr: node['slurmdbd_ip'],
     storage_host: node['dbms_uri'],
     # TODO: expose additional CFN Parameter in template
     storage_port: 3306,
@@ -73,6 +74,8 @@ end unless on_docker?
 # After starting slurmdbd the database may not be fully responsive yet and
 # its bootstrapping may fail. We need to wait for sacctmgr to successfully
 # query the database before proceeding.
+# In case of an external slurmdbd the Slurm commands do not work, so this
+# check cannot be executed.
 execute "wait for slurm database" do
   command "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn"
   retries node['cluster']['slurmdbd_response_retries']

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/external_slurmdbd/slurm_external_slurmdbd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/external_slurmdbd/slurm_external_slurmdbd.conf.erb
@@ -7,3 +7,5 @@ StoragePort=<%= @storage_port %>
 StorageLoc=<%= @storage_loc %>
 StorageUser=<%= @storage_user %>
 StoragePass=dummy
+DebugLevel=verbose
+DebugFlags=Network

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/external_slurmdbd/slurm_external_slurmdbd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/external_slurmdbd/slurm_external_slurmdbd.conf.erb
@@ -2,6 +2,7 @@
 # Do not modify.
 # Please add user-specific slurmdbd configuration options in slurmdbd.conf
 DbdHost=<%= @dbd_host %>
+DbdAddr=<%= @dbd_addr %>
 StorageHost=<%= @storage_host %>
 StoragePort=<%= @storage_port %>
 StorageLoc=<%= @storage_loc %>

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -32,7 +32,6 @@ TreeWidth=65533
 SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,cloud_dns,node_reg_mem_percent=<%= node['cluster']['slurm_node_reg_mem_percent'] %>
 TreeWidth=30
 <% end -%>
-CommunicationParameters=NoAddrCache
 SuspendProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_suspend
 ResumeProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_resume
 ResumeFailProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_suspend


### PR DESCRIPTION
### Description of changes
* Use private IP for DbdAddr in external slurmdbd
* Increase debug level for slurmdbd daemon and add the `Network` debug flag in case of external slurmdbd.

### Tests
* Manually tested the changes on my POC stack.

### References
* https://github.com/aws/aws-parallelcluster/pull/6044

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
