### PR TITLE
[DFSM] Push chef-client.log to CloudWatch Logs in compute nodes.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
@@ -68,7 +68,8 @@
       ],
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "ComputeFleet"
       ],
       "feature_conditions": []
     },

--- a/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
+++ b/cookbooks/aws-parallelcluster-environment/kitchen.environment-config.yml
@@ -24,6 +24,24 @@ suites:
         scheduler: slurm
         cw_logging_enabled: "true"
         log_group_name: test
+  - name: cloudwatch-computenode
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-tests::test_resource]
+    verifier:
+      controls:
+        - /tag:config_cloudwatch/
+        - cloudwatch_logfiles_configuration_computenode
+    attributes:
+      resource: cloudwatch:configure
+      dependencies:
+        - recipe:aws-parallelcluster-platform::cookbook_virtualenv
+        - resource:cloudwatch:setup
+      cluster:
+        node_type: ComputeFleet
+        scheduler: slurm
+        cw_logging_enabled: "true"
+        log_group_name: test
   - name: cloudwatch-loginnode
     run_list:
       - recipe[aws-parallelcluster-tests::setup]


### PR DESCRIPTION
### Description of changes
Push chef-client.log to CloudWatch Logs in compute nodes.
Also added a new kitchen test to cover the configuration in compute nodes.

### Tests
* Manually verified that chef. log is pushed to cw logs after cluster forced update.
* Executed kitchen `cloudwatch-computenode`

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
