### PR TITLE
[DFSM] Make compute nodes update shared storage as part of the update workflow.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/recipes/config/update_fs_mapping.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/update_fs_mapping.rb
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 case node['cluster']['node_type']
-when 'HeadNode'
+when 'HeadNode', 'ComputeFleet'
   # generate the shared storages mapping file
   template node['cluster']['shared_storages_mapping_path'] do
     source 'shared_storages/shared_storages_data.erb'
+    owner 'root'
+    group 'root'
     mode '0644'
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/update_fs_mapping_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/update_fs_mapping_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-environment::update_fs_mapping' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      context "when head node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['node_type'] = 'HeadNode'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'generates the file shared_storages_data' do
+          is_expected.to create_template("#{node['cluster']['etc_dir']}/shared_storages_data.yaml").with(
+            source: "shared_storages/shared_storages_data.erb",
+            owner: 'root',
+            group: 'root',
+            mode: '0644'
+          )
+        end
+      end
+
+      context "when compute node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['node_type'] = 'HeadNode'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'generates the file shared_storages_data' do
+          is_expected.to create_template("#{node['cluster']['etc_dir']}/shared_storages_data.yaml").with(
+            source: "shared_storages/shared_storages_data.erb",
+            owner: 'root',
+            group: 'root',
+            mode: '0644'
+          )
+        end
+      end
+
+      context "when login node" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['node_type'] = 'LoginNode'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'does nothing' do
+          is_expected.not_to create_template("#{node['cluster']['etc_dir']}/shared_storages_data.yaml")
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
@@ -2,8 +2,10 @@ require 'spec_helper'
 
 describe 'fetch_config:run' do
   context "when running a HeadNode from kitchen" do
+    cached(:cluster_shared_dir) { '/cluster_shared_dir' }
     cached(:cluster_config_path) { 'cluster_config_path' }
     cached(:previous_cluster_config_path) { 'previous_cluster_config_path' }
+    cached(:cluster_config_version) { 'cluster_config_version' }
     cached(:instance_types_data_path) { 'instance_types_data_path' }
     cached(:previous_instance_types_data_path) { 'previous_instance_types_data_path' }
     cached(:chef_run) do
@@ -11,8 +13,10 @@ describe 'fetch_config:run' do
         platform: 'ubuntu', step_into: %w(fetch_config)
       ) do |node|
         node.override['kitchen'] = true
+        node.override['cluster']['shared_dir'] = cluster_shared_dir
         node.override['cluster']['cluster_config_path'] = cluster_config_path
         node.override['cluster']['previous_cluster_config_path'] = previous_cluster_config_path
+        node.override['cluster']['cluster_config_version'] = cluster_config_version
         node.override['cluster']['instance_types_data_path'] = instance_types_data_path
         node.override['cluster']['previous_instance_types_data_path'] = previous_instance_types_data_path
         node.override['cluster']['node_type'] = 'HeadNode'
@@ -33,10 +37,23 @@ describe 'fetch_config:run' do
         .with(path: instance_types_data_path)
         .with(source: "file://#{kitchen_instance_types_data_path}")
     end
+
+    it "writes the cluster config version file" do
+      is_expected.to create_file("/cluster_shared_dir/cluster-config-version").with(
+        content: cluster_config_version,
+        mode: '0644',
+        owner: 'root',
+        group: 'root'
+      )
+    end
+
+    it "does not wait for cluster config version file" do
+      is_expected.not_to run_execute("Wait cluster config files to be updated by the head node")
+    end
   end
 
   %w(ComputeFleet LoginNode).each do |node_type|
-    context "when running a #{node_type} from kitchen" do
+    context "when running a #{node_type} from kitchen on create" do
       cached(:cluster_config_path) { 'cluster_config_path' }
       cached(:previous_cluster_config_path) { 'previous_cluster_config_path' }
       cached(:instance_types_data_path) { 'instance_types_data_path' }
@@ -54,7 +71,68 @@ describe 'fetch_config:run' do
         runner.converge_dsl do
           fetch_config 'run' do
             action :run
+            update false
           end
+        end
+      end
+
+      it "does not wait for cluster config version file" do
+        is_expected.not_to run_execute("Wait cluster config files to be updated by the head node")
+      end
+
+      it "reads config from shared folder" do
+        is_expected.to run_ruby_block("load cluster configuration")
+      end
+    end
+  end
+
+  %w(ComputeFleet LoginNode).each do |node_type|
+    context "when running a #{node_type} from kitchen on update" do
+      cached(:cluster_shared_dir) { '/cluster_shared_dir' }
+      cached(:cluster_config_path) { 'cluster_config_path' }
+      cached(:previous_cluster_config_path) { 'previous_cluster_config_path' }
+      cached(:cluster_config_version) { 'cluster_config_version' }
+      cached(:cluster_shared_storages_mapping_path) { '/cluster_shared_storages_mapping_path' }
+      cached(:cluster_previous_shared_storages_mapping_path) { '/cluster_previous_shared_storages_mapping_path' }
+      cached(:instance_types_data_path) { 'instance_types_data_path' }
+      cached(:previous_instance_types_data_path) { 'previous_instance_types_data_path' }
+      cached(:chef_run) do
+        runner = ChefSpec::Runner.new(
+          platform: 'ubuntu', step_into: %w(fetch_config)
+        ) do |node|
+          node.override['kitchen'] = true
+          node.override['cluster']['shared_dir'] = cluster_shared_dir
+          node.override['cluster']['cluster_config_path'] = cluster_config_path
+          node.override['cluster']['cluster_config_version'] = cluster_config_version
+          node.override['cluster']['shared_storages_mapping_path'] = cluster_shared_storages_mapping_path
+          node.override['cluster']['previous_shared_storages_mapping_path'] = cluster_previous_shared_storages_mapping_path
+          node.override['cluster']['login_cluster_config_path'] = cluster_config_path
+          node.override['cluster']['node_type'] = node_type
+        end
+        allow(File).to receive(:exist?).with(cluster_config_path).and_return(true)
+        allow(FileUtils).to receive(:cp_r).with(
+          cluster_shared_storages_mapping_path, cluster_previous_shared_storages_mapping_path, remove_destination: true
+        ).and_return(true)
+        runner.converge_dsl do
+          fetch_config 'run' do
+            action :run
+            update true
+          end
+        end
+      end
+
+      if node_type == "ComputeFleet"
+        it "waits for cluster config version file" do
+          is_expected.to run_execute("Wait cluster config files to be updated by the head node").with(
+            command: "[[ \"$(cat /cluster_shared_dir/cluster-config-version)\" == \"cluster_config_version\" ]]",
+            retries: 30,
+            retry_delay: 10,
+            timeout: 5
+          )
+        end
+      else
+        it "does not wait for cluster config version file" do
+          is_expected.not_to run_execute("Wait cluster config files to be updated by the head node")
         end
       end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_compute.rb
@@ -15,4 +15,13 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: Move the only_if decision to the update_shared_storage recipe for better definition of responsibilities
+# and to facilitate unit testing.
+ruby_block "update_shared_storages" do
+  block do
+    run_context.include_recipe 'aws-parallelcluster-environment::update_shared_storages'
+  end
+  only_if { are_mount_or_unmount_required? }
+end
+
 save_instance_config_version_to_dynamodb


### PR DESCRIPTION
### Description of changes
Make compute nodes update shared storage as part of the update workflow.
In order for compute nodes to be able to execute the recipe to update shared storage, we also needed a mechanism (implemented in this PR) to make compute nodes retrieve the required config files generated by the head node in the shared storage.

Notes: 
1. the commit that adds chef logs is part of https://github.com/aws/aws-parallelcluster-cookbook/pull/2627 and will be removed once rebase.
2. we are skipping the changelog update in this PR because we will add it for the feature only once it will be complete,

### Tests
* Executed existing spec tests for cookbooks: aws-parallelcluster-platform, aws-parallelcluster-environment, aws-parallelcluster-slurm
* Executed newly introduced spec tests.
* Manual create/update adding/removing external EFs/FSx

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
