### PR TITLE
Configure CloudWatch agent for External Slurm Dbd

### DIFF
--- a/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
+++ b/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
@@ -156,11 +156,11 @@ class ComputeFleetStatus(Enum):
     @staticmethod
     def _transform_compute_fleet_data(compute_fleet_data):
         try:
-            compute_fleet_data[
-                ComputeFleetStatusManager.COMPUTE_FLEET_STATUS_ATTRIBUTE
-            ] = ComputeFleetStatus.EVENT_HANDLER_STATUS_MAPPING.value.get(
-                compute_fleet_data.get(ComputeFleetStatusManager.COMPUTE_FLEET_STATUS_ATTRIBUTE),
-                str(ComputeFleetStatus.UNKNOWN),
+            compute_fleet_data[ComputeFleetStatusManager.COMPUTE_FLEET_STATUS_ATTRIBUTE] = (
+                ComputeFleetStatus.EVENT_HANDLER_STATUS_MAPPING.value.get(
+                    compute_fleet_data.get(ComputeFleetStatusManager.COMPUTE_FLEET_STATUS_ATTRIBUTE),
+                    str(ComputeFleetStatus.UNKNOWN),
+                )
             )
             return compute_fleet_data
         except AttributeError as e:

--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
@@ -22,6 +22,9 @@ node.default['cluster']['slurmdbd_response_retries'] = 30
 node.default['cluster']['stack_name'] = node['stack_name']
 node.default['cluster']['munge']['user'] = 'munge'
 node.default['cluster']['munge']['group'] = node['cluster']['munge']['user']
+node.default['cluster']['node_type'] = 'ExternalSlurmDbd' # force node_type to ExternalSlurmDbd to configure CW agent
+node.default['cluster']['cw_logging_enabled'] = 'true' # enable CW agent logging
+node.default['cluster']['log_group_name'] = node['log_group_name'] # map the `log_group_name` coming from the dna.json to the proper variable expected by the recipes
 
 # rubocop:disable Lint/DuplicateBranch
 if platform?('amazon') && node['platform_version'] == "2"
@@ -66,6 +69,10 @@ template "#{node['cluster']['scripts_dir']}/slurm/update_munge_key.sh" do
     shared_directory_compute: node['cluster']['shared_dir'],
     shared_directory_login: node['cluster']['shared_dir_login_nodes']
   )
+end
+
+cloudwatch "Configure CloudWatch" do
+  action :configure
 end
 
 # TODO: add a logic in munge_key_manager to skip sharing munge key to shared dir

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
@@ -23,7 +23,8 @@
       ],
       "node_roles": [
         "ComputeFleet",
-        "HeadNode"
+        "HeadNode",
+        "ExternalSlurmDbd"
       ],
       "feature_conditions": []
     },
@@ -54,7 +55,8 @@
       ],
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "ExternalSlurmDbd"
       ],
       "feature_conditions": []
     },
@@ -68,7 +70,8 @@
       ],
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "ExternalSlurmDbd"
       ],
       "feature_conditions": []
     },
@@ -97,7 +100,8 @@
       "node_roles": [
         "ComputeFleet",
         "HeadNode",
-        "LoginNode"
+        "LoginNode",
+        "ExternalSlurmDbd"
       ],
       "feature_conditions": []
     },
@@ -111,7 +115,8 @@
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
         "ComputeFleet",
-        "LoginNode"
+        "LoginNode",
+        "ExternalSlurmDbd"
       ],
       "feature_conditions": []
     },
@@ -270,7 +275,8 @@
       ],
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "ExternalSlurmDbd"
       ],
       "feature_conditions": []
     },

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config_schema.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config_schema.json
@@ -20,7 +20,7 @@
           },
           "node_roles": {
             "type": "array",
-            "items": {"type": "string", "enum": ["HeadNode", "ComputeFleet", "LoginNode"]}
+            "items": {"type": "string", "enum": ["HeadNode", "ComputeFleet", "LoginNode", "ExternalSlurmDbd"]}
           },
           "feature_conditions": {
             "type": "array",

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/write_cloudwatch_agent_json.py
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/write_cloudwatch_agent_json.py
@@ -31,7 +31,7 @@ def parse_args():
     parser.add_argument(
         "--node-role",
         required=True,
-        choices=["HeadNode", "ComputeFleet", "LoginNode"],
+        choices=["HeadNode", "ComputeFleet", "LoginNode", "ExternalSlurmDbd"],
         help="Role this node plays in the cluster (i.e., is it a compute node or the head node?)",
     )
     parser.add_argument("--scheduler", required=True, choices=["slurm", "awsbatch"], help="Scheduler")

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
@@ -40,7 +40,7 @@ control 'tag:config_cloudwatch_configured' do
 
   describe file('/usr/local/bin/write_cloudwatch_agent_json.py') do
     it { should exist }
-    its('sha256sum') { should eq '29ac1f73e0403095f40a4217e737d58d3786962a2c5427eb9c690627841ae17a' }
+    its('sha256sum') { should eq '92f89faed070182ba2d1c700b84243175f7f80ae81dc6629bdce28358b92146b' }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0755' }
@@ -56,7 +56,7 @@ control 'tag:config_cloudwatch_configured' do
 
   describe file('/usr/local/etc/cloudwatch_agent_config_schema.json') do
     it { should exist }
-    its('sha256sum') { should eq '902aab6974f296b6da757159edf4210b3e4674ba4aea96c9cd1662bcbc987cb4' }
+    its('sha256sum') { should eq '021809afad563292c78b139c0c2de7072b90d161e0bfab77a084d0ffa689ff43' }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0644' }


### PR DESCRIPTION
### Description of changes
Configure CW Agent in the External Slurm Ddb instance to retrieve useful logs and post them on CloudWatch.

To do so add a dedicated NodeType `ExternalSlurmDbd`.
This is required by to trigger the right behavior in CW resource logic (that is driven by NodeType).
Also mocks some required config parameters in the external dbd entrypoint recipe.
This logs will be exported
* slurmdbd
* cloud-init-output
* chef-client
* cloud-init
* cfn-init

### Tests
* CDK app synthesized in my personal account.
* Logs emitted in the SlurmDbdInstances where visible in CloudWatch

### References
* [CLI changes](https://github.com/aws/aws-parallelcluster/pull/6061)
  * the log_group_name is defined in the Stack so it has to be provided trough the dna.json

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
