### PR TITLE
Configure S3 mountpoint for external slurmdbd

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
@@ -52,6 +52,8 @@ end
 
 include_recipe 'aws-parallelcluster-slurm::config_head_node_directories'
 
+include_recipe 'aws-parallelcluster-slurm::config_external_slurmdbd_s3_mountpoint'
+
 # TODO: move this template to a separate recipe
 # TODO: add a logic in update_munge_key.sh.erb to skip sharing munge key to shared dir
 template "#{node['cluster']['scripts_dir']}/slurm/update_munge_key.sh" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_external_slurmdbd_s3_mountpoint.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_external_slurmdbd_s3_mountpoint.rb
@@ -2,7 +2,7 @@
 
 #
 # Cookbook:: aws-parallelcluster-slurm
-# Recipe:: config_head_node
+# Recipe:: config_external_slurmdbd_s3_mountpoint
 #
 # Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_external_slurmdbd_s3_mountpoint.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_external_slurmdbd_s3_mountpoint.rb
@@ -15,6 +15,11 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# WARNING: Mountpoint for Amazon S3 is a tool that allows you to mount an S3 bucket as a file system.
+# This is now GA, but it is still hosted on the AWS Labs repositories (https://github.com/awslabs/mountpoint-s3).
+# This is considered fine for the external slurmdbd stack.
+# A deeper evaluation would be required for further uses of this tool in AWS ParallelCluster.
+
 ext = platform?('ubuntu') ? "deb" : "rpm"
 subtree = arm? ? "arm64" : "x86_64"
 mount_s3_url = "https://s3.amazonaws.com/mountpoint-s3-release/latest/#{subtree}/mount-s3.#{ext}"

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_external_slurmdbd_s3_mountpoint.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_external_slurmdbd_s3_mountpoint.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-slurm
+# Recipe:: config_head_node
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+ext = platform?('ubuntu') ? "deb" : "rpm"
+subtree = arm? ? "arm64" : "x86_64"
+mount_s3_url = "https://s3.amazonaws.com/mountpoint-s3-release/latest/#{subtree}/mount-s3.#{ext}"
+download_path = "/tmp/mount-s3.#{ext}"
+
+remote_file 'download mountpoint-s3' do
+  source mount_s3_url
+  path download_path
+  retries 3
+  retry_delay 5
+  action :create_if_missing
+end
+
+if platform?('ubuntu')
+  # The Chef apt_package resource does not support the source attribute, so we use the dpkg_package resource instead.
+  dpkg_package "Install mountpoint-s3" do
+    source download_path
+  end
+else
+  package "Install mountpoint-s3" do
+    source download_path
+  end
+end
+
+execute 'mount slurmdbd configuration via S3' do
+  command "mount-s3 --allow-delete --uid $(id -u slurm) --gid $(id -g slurm) --dir-mode 0755 --file-mode 0600 #{node['slurmdbd_conf_bucket']} /opt/slurm/etc/"
+  user 'root'
+end


### PR DESCRIPTION
### Description of changes
* Install mountpoint-s3 and mount the S3 bucket of the external slurmdbd stack on `/opt/slurm/etc`.
  * The slurmdbd configuration files are already generated from a template with a `:create_if_missing` action, meaning that if the files are already present in the bucket they will not be overwritten.

### Tests
* Manually tested the changes in my POC stack (with multiple OSs, once with Ubuntu and once with Rocky).
* Skipping system tests because the changes would not be covered currently.

### References
* https://github.com/aws/aws-parallelcluster/pull/6067

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
