### PR TITLE
Fetch slurmdbd configuration from S3 if available

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
@@ -52,8 +52,6 @@ end
 
 include_recipe 'aws-parallelcluster-slurm::config_head_node_directories'
 
-include_recipe 'aws-parallelcluster-slurm::config_external_slurmdbd_s3_mountpoint'
-
 # TODO: move this template to a separate recipe
 # TODO: add a logic in update_munge_key.sh.erb to skip sharing munge key to shared dir
 template "#{node['cluster']['scripts_dir']}/slurm/update_munge_key.sh" do
@@ -79,5 +77,7 @@ end
 
 # TODO: add a logic in munge_key_manager to skip sharing munge key to shared dir
 include_recipe 'aws-parallelcluster-slurm::config_munge_key'
+
+include_recipe 'aws-parallelcluster-slurm::retrieve_slurmdbd_config_from_s3'
 
 include_recipe "aws-parallelcluster-slurm::config_slurm_accounting"


### PR DESCRIPTION
### Description of changes
* Fetch slurmdbd configuration from the stack S3 bucket if available
* Remove previously implemented logic to configur s3 mountpoint for the configuration of the external slurmdbd

### Tests
* manually tested in my POC stack

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
