### PR TITLE
Add recipe to disable not required services in ExternalSlurmdbd

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
@@ -52,6 +52,8 @@ end
 
 include_recipe 'aws-parallelcluster-slurm::config_head_node_directories'
 
+include_recipe 'aws-parallelcluster-slurm::external_slurmdbd_disable_unrequired_services'
+
 # TODO: move this template to a separate recipe
 # TODO: add a logic in update_munge_key.sh.erb to skip sharing munge key to shared dir
 template "#{node['cluster']['scripts_dir']}/slurm/update_munge_key.sh" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/external_slurmdbd_disable_unrequired_services.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/external_slurmdbd_disable_unrequired_services.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-slurm
+# Recipe:: external_slurmdbd_disable_unrequired_services
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Most ParallelCluster AMI are configured for Desktop use and so have some active service that is not required
+# This recipe will disable some that are certainly unused, like { apache2, cups, ...,  wpa_supplicant }
+
+# The list depends on the base OS
+# This was tested on Ubuntu 20.04, Alinux2 and Rocky8
+# Others OS should be checked and added
+
+serviceList = %w()
+if platform_family?('debian')
+  serviceList = %w(apache2 avahi-daemon cups.service ModemManager wpa_supplicant stunnel whoopsie)
+elsif platform?('amazon') && node['platform_version'] == "2"
+  serviceList = %w(cups.service)
+elsif platform?('rocky') && node['platform_version'].to_i == 8
+  serviceList = %w(avahi-daemon cups.service ModemManager mlocate-updatedb)
+end
+
+# NOTE: we first tried to use the chef `service` resource as follows
+#
+# service 'example_service' do
+#   action [ :stop, :disable ]
+#   user 'root'
+# end
+#
+# however it reported "up to date - nothing to do" but the services where still running.
+# So we falled back to a direct invocation of systemctl
+# we also added `ignore_failure` because if the service is stopped or disabled the return code will be != 0 and
+# the command will be considered as failed
+
+serviceList.each do |service_name|
+  execute "Stop service #{service_name}" do
+    command "systemctl stop #{service_name}"
+    user 'root'
+    ignore_failure true
+  end
+
+  execute "Disable service #{service_name}" do
+    command "systemctl disable #{service_name}"
+    user 'root'
+    ignore_failure true
+  end
+end


### PR DESCRIPTION
### Description of changes
Add recipe to disable not required services in ExternalSlurmdbd

ParallelCluster AMI are configured for Desktop use and so may have some active services that are not required and are certainly unused like { apache2, cups, ...,  wpa_supplicant }
For this we created a recipe with a (os-dependent) list of services that will be stopped and disable at launch time.

### Tests
* An ExternalSlurmDbd instance was launched with Ubuntu 20.04, Alinux2 and Rocky8.
* For each of them 
  * the list of Running and Enabled service was checked before applying the recipe to identify the services that should be stopped
  * then, after populating the list, a new instance was launched and we manually verified that all listed services were actually stopped and disabled 
  
We also checked that Slurm Accounting still worked as expected.

### References
N/A

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
