### PR TITLE
[DFSM] Add Python dependencies to cookbook virtual env: click and retrying.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 line_length=120
-known_third_party=assertpy,boto3,botocore,dcv,gnupg,jinja2,jsonschema,pytest,requests,slurm
+known_third_party=assertpy,boto3,botocore,dcv,gnupg,jinja2,jsonschema,pytest,requests,slurm,retrying,click
 # 3 - Vertical Hanging Indent
 # from third_party import (
 #     lib1,

--- a/cookbooks/aws-parallelcluster-platform/files/cookbook_virtualenv/requirements.txt
+++ b/cookbooks/aws-parallelcluster-platform/files/cookbook_virtualenv/requirements.txt
@@ -6,3 +6,5 @@ jsonschema
 jinja2
 requests
 PyYAML
+retrying
+click

--- a/test/unit/requirements.txt
+++ b/test/unit/requirements.txt
@@ -9,3 +9,5 @@ jinja2
 PyYAML
 requests
 boto3
+retrying
+click


### PR DESCRIPTION
### Description of changes
Add Python dependencies to cookbook virtual env: click and retrying.
These dependencies are required by the script used by the head node to check cluster readiness.

### Tests
Tested as part of https://github.com/aws/aws-parallelcluster-cookbook/pull/2634

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
