### PR TITLE
Allow configuration of custom Slurm accounting port for external slurmdbd

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/external_slurmdbd_config.rb
@@ -40,16 +40,6 @@ elsif platform?('ubuntu')
 end
 # rubocop:enable Lint/DuplicateBranch
 
-# TODO: move this template to a separate recipe
-template '/etc/systemd/system/slurmdbd.service' do
-  cookbook 'aws-parallelcluster-slurm'
-  source 'slurm/head_node/slurmdbd.service.erb'
-  owner 'root'
-  group 'root'
-  mode '0644'
-  action :create
-end
-
 include_recipe 'aws-parallelcluster-slurm::config_head_node_directories'
 
 include_recipe 'aws-parallelcluster-slurm::external_slurmdbd_disable_unrequired_services'

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster.conf
@@ -17,10 +17,11 @@ SelectTypeParameters=CR_CPU
 {#  #}AccountingStorageType=accounting_storage/slurmdbd
 {#  #}{% if scaling_config.Database.Uri is defined %}
 {#      #}AccountingStorageHost={{ head_node_config.head_node_hostname }}
-{#  #}{% elif scaling_config.ExternalSlurmdbd != None  %}
-{#      #}AccountingStorageHost={{ scaling_config.ExternalSlurmdbd }}
+{#      #}AccountingStoragePort=6819
+{#  #}{% elif scaling_config.ExternalSlurmdbd.Host is defined %}
+{#      #}AccountingStorageHost={{ scaling_config.ExternalSlurmdbd.Host }}
+{#      #}AccountingStoragePort={{ scaling_config.ExternalSlurmdbd.Port }}
 {#  #}{% endif %}
-{#  #}AccountingStoragePort=6819
 {#  #}AccountingStorageUser={{ slurmdbd_user }}
 {#  #}JobAcctGatherType=jobacct_gather/cgroup
 {% endif %}

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
@@ -205,14 +205,6 @@ template '/etc/systemd/system/slurmctld.service' do
   action :create
 end
 
-template '/etc/systemd/system/slurmdbd.service' do
-  source 'slurm/head_node/slurmdbd.service.erb'
-  owner 'root'
-  group 'root'
-  mode '0644'
-  action :create
-end
-
 include_recipe 'aws-parallelcluster-slurm::config_health_check'
 
 ruby_block "Configure Slurm Accounting" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
@@ -15,7 +15,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 template '/etc/systemd/system/slurmdbd.service' do
   source 'slurm/head_node/slurmdbd.service.erb'
   owner 'root'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/retrieve_slurmdbd_config_from_s3.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/retrieve_slurmdbd_config_from_s3.rb
@@ -29,9 +29,6 @@ config_files.each do |config_file|
     destination "#{node['cluster']['slurm']['install_dir']}/etc/#{config_file}"
     sensitive true
     ignore_failure true
-  end
-
-  file "#{node['cluster']['slurm']['install_dir']}/etc/#{config_file}" do
     mode '0600'
     owner node['cluster']['slurm']['user']
     group node['cluster']['slurm']['group']

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/external_slurmdbd/slurm_external_slurmdbd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/external_slurmdbd/slurm_external_slurmdbd.conf.erb
@@ -2,6 +2,7 @@
 # Do not modify.
 # Please add user-specific slurmdbd configuration options in slurmdbd.conf
 DbdHost=<%= @dbd_host %>
+DbdPort=<%= @dbd_port %>
 DbdAddr=<%= @dbd_addr %>
 StorageHost=<%= @storage_host %>
 StoragePort=<%= @storage_port %>

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurmdbd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurmdbd.conf.erb
@@ -1,6 +1,8 @@
 AuthType=auth/munge
 LogFile=/var/log/slurmdbd.log
+<% if !node['is_external_slurmdbd'] %>
 DbdPort=6819
+<% end %>
 SlurmUser=<%= node['cluster']['slurm']['user'] %>
 StorageType=accounting_storage/mysql
 

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_partition_nodelist_mapping/sample_input.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_partition_nodelist_mapping/sample_input.yaml
@@ -4,6 +4,7 @@ Scheduling:
     ScaledownIdletime: 10
     EnableMemoryBasedScheduling: false
     Database: null
+    ExternalSlurmdbd: null
   SlurmQueues:
     - Name: queue1
       ComputeResources:

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_externaldbd.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_externaldbd.conf
@@ -9,7 +9,7 @@ ResumeTimeout=1600
 SelectTypeParameters=CR_CPU
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost=test.slurmdbd.host
-AccountingStoragePort=6819
+AccountingStoragePort=12345
 AccountingStorageUser=slurm
 JobAcctGatherType=jobacct_gather/cgroup
 

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/sample_input_externaldbd.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/sample_input_externaldbd.yaml
@@ -23,5 +23,7 @@ Scheduling:
     Scheduler: slurm
     SlurmSettings:
         ScaledownIdletime: 10
-        ExternalSlurmdbd: test.slurmdbd.host
+        ExternalSlurmdbd:
+          Host: test.slurmdbd.host
+          Port: 12345
         Database: null

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_with_custom_settings/sample_input.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_with_custom_settings/sample_input.yaml
@@ -88,3 +88,4 @@ Scheduling:
     ScaledownIdletime: 10
     EnableMemoryBasedScheduling: false
     Database: null
+    ExternalSlurmdbd: null

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_with_job_exc_alloc/cluster_config.yaml
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_with_job_exc_alloc/cluster_config.yaml
@@ -34,3 +34,4 @@ Scheduling:
     ScaledownIdletime: 10
     EnableMemoryBasedScheduling: false
     Database: null
+    ExternalSlurmdbd: null


### PR DESCRIPTION
### Description of changes
* Allow the configuration of the `DbdPort` parameter in the external slurmdbd recipes.
* Improved some internals (moved some actions to common recipes, improved slurm accounting kitchen test, extended `remote_object` Chef resource).
* Allow the configuration of `AccountingStoragePort` in the PC Cluster `slurm_parallelcluster.conf` according to the new `ExternalSlurmdbd/Port` yaml configuration parameter. 

### Tests
* Manually created cluster with new `ExternalSlurmdbd/Host` and `ExternalSlurmdbd/Port` YAML configuration parameters.
* Manually tested creating external slurmdbd instance both with and without slurmdbd configuration files coming from S3 bucket (to check that no empty files got created by the `file` actions in `retrieve_slurmdbd_config_from_s3` recipe).
* Adapted unit tests for the creation of the `slurm_parallelcluster.conf` file.

### References
* https://github.com/aws/aws-parallelcluster/pull/6085

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
