### PR TITLE
[DFSM] Add head node checks and storage updates for login nodes

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/recipes/config/update_fs_mapping.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/update_fs_mapping.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 case node['cluster']['node_type']
-when 'HeadNode', 'ComputeFleet'
+when 'HeadNode', 'ComputeFleet', 'LoginNode'
   # generate the shared storages mapping file
   template node['cluster']['shared_storages_mapping_path'] do
     source 'shared_storages/shared_storages_data.erb'

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/update_fs_mapping_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/update_fs_mapping_spec.rb
@@ -63,8 +63,13 @@ describe 'aws-parallelcluster-environment::update_fs_mapping' do
         end
         cached(:node) { chef_run.node }
 
-        it 'does nothing' do
-          is_expected.not_to create_template("#{node['cluster']['etc_dir']}/shared_storages_data.yaml")
+        it 'generates the file shared_storages_data' do
+          is_expected.to create_template("#{node['cluster']['etc_dir']}/shared_storages_data.yaml").with(
+            source: "shared_storages/shared_storages_data.erb",
+            owner: 'root',
+            group: 'root',
+            mode: '0644'
+          )
         end
       end
     end

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
@@ -95,7 +95,7 @@ def check_compute_nodes_config_version(cluster_name: str, table_name: str, expec
 
     for instance_ids in list_cluster_instance_ids_iterator(
         cluster_name=cluster_name,
-        node_type=["Compute"],
+        node_type=["Compute", "LoginNode"],
         instance_state=["running"],
         region=region,
     ):

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_login_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_login_node.rb
@@ -15,4 +15,13 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: Move the only_if decision to the update_shared_storage recipe for better definition of responsibilities
+#  and to facilitate unit testing.
+ruby_block "update_shared_storages" do
+  block do
+    run_context.include_recipe 'aws-parallelcluster-environment::update_shared_storages'
+  end
+  only_if { are_mount_or_unmount_required? }
+end
+
 save_instance_config_version_to_dynamodb


### PR DESCRIPTION
### Description of changes
1. Make head node check that all login nodes have deployed the expected cluster config version, on create and update.
2. Make login nodes update shared storage as part of the update workflow.

Observations:
1. This PR is the equivalent of https://github.com/aws/aws-parallelcluster-cookbook/pull/2629 and https://github.com/aws/aws-parallelcluster-cookbook/pull/2634 for login nodes.
2. This PR depends on https://github.com/aws/aws-parallelcluster-cookbook/pull/2640 and https://github.com/aws/aws-parallelcluster/pull/6080


### Tests
* Manual testing verifying that with a forces update we can add/remove external EFS/FSx from a running cluster without login nodes replacement.
* Executed `test_update_slurm`
* [PENDING] Executed `test_dynamic_file_systems_mounting`

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
