### PR TITLE
[DFSM] Make command that waits for cluster config version file OS independent.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
@@ -153,8 +153,8 @@ action_class do # rubocop:disable Metrics/BlockLength
 
   def wait_cluster_config_file(path)
     # Wait for the config version file to contain the current cluster config version.
-    execute "Wait cluster config files to be updated by the head node" do
-      command "[[ \"$(cat #{path})\" == \"#{node['cluster']['cluster_config_version']}\" ]]"
+    bash "Wait cluster config files to be updated by the head node" do
+      code "[[ \"$(cat #{path})\" == \"#{node['cluster']['cluster_config_version']}\" ]] || exit 1"
       retries 30
       retry_delay 10
       timeout 5

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
@@ -55,6 +55,7 @@ describe 'fetch_config:run' do
   %w(ComputeFleet LoginNode).each do |node_type|
     context "when running a #{node_type} from kitchen on create" do
       cached(:cluster_config_path) { 'cluster_config_path' }
+      cached(:login_cluster_config_path) { 'login_cluster_config_path' }
       cached(:previous_cluster_config_path) { 'previous_cluster_config_path' }
       cached(:instance_types_data_path) { 'instance_types_data_path' }
       cached(:previous_instance_types_data_path) { 'previous_instance_types_data_path' }
@@ -123,8 +124,8 @@ describe 'fetch_config:run' do
 
       if node_type == "ComputeFleet"
         it "waits for cluster config version file" do
-          is_expected.to run_execute("Wait cluster config files to be updated by the head node").with(
-            command: "[[ \"$(cat /cluster_shared_dir/cluster-config-version)\" == \"cluster_config_version\" ]]",
+          is_expected.to run_bash("Wait cluster config files to be updated by the head node").with(
+            code: "[[ \"$(cat /cluster_shared_dir/cluster-config-version)\" == \"cluster_config_version\" ]] || exit 1",
             retries: 30,
             retry_delay: 10,
             timeout: 5
@@ -132,7 +133,7 @@ describe 'fetch_config:run' do
         end
       else
         it "does not wait for cluster config version file" do
-          is_expected.not_to run_execute("Wait cluster config files to be updated by the head node")
+          is_expected.not_to run_bash("Wait cluster config files to be updated by the head node")
         end
       end
 


### PR DESCRIPTION
### Description of changes
Make command that waits for cluster config version file OS independent.

### Tests
Spec tests `fetch_config_spec.rb`

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
