### PR TITLE
[DFSM] Add head node checks and storage updates for login nodes + prevent drain/terminate when live updates are supported 

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/recipes/config/update_fs_mapping.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/update_fs_mapping.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 case node['cluster']['node_type']
-when 'HeadNode', 'ComputeFleet'
+when 'HeadNode', 'ComputeFleet', 'LoginNode'
   # generate the shared storages mapping file
   template node['cluster']['shared_storages_mapping_path'] do
     source 'shared_storages/shared_storages_data.erb'

--- a/cookbooks/aws-parallelcluster-environment/recipes/init/mount_internal_use_ebs.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/init/mount_internal_use_ebs.rb
@@ -30,6 +30,17 @@ when 'ComputeFleet'
   end
 
 when 'LoginNode'
+  # Mount /opt/parallelcluster/shared over NFS
+  volume "mount #{node['cluster']['shared_dir']}" do
+    action :mount
+    shared_dir node['cluster']['shared_dir']
+    device(lazy { "#{node['cluster']['head_node_private_ip']}:#{node['cluster']['shared_dir_head']}" })
+    fstype 'nfs'
+    options node['cluster']['nfs']['hard_mount_options']
+    retries 10
+    retry_delay 6
+  end
+
   # Mount /opt/parallelcluster/shared_login_nodes over NFS
   volume "mount #{node['cluster']['shared_dir_login']}" do
     action :mount

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/mount_internal_use_ebs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/mount_internal_use_ebs_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-environment::mount_internal_use_ebs' do
+  SHARED_DIR = "/opt/parallelcluster/shared"
+  SHARED_DIR_HEAD = "/opt/parallelcluster/shared"
+  SHARED_DIR_COMPUTE = "/opt/parallelcluster/shared"
+  SHARED_DIR_LOGIN = "/opt/parallelcluster/shared_login"
+  HEAD_NODE_PRIVATE_IP = "0.0.0.0"
+  HARD_MOUNT_OPTIONS = "HARD_MOUNT_OPTIONS"
+
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      %w(HeadNode ComputeFleet LoginNode).each do |node_type|
+        context "on #{node_type}" do
+          cached(:chef_run) do
+            runner = runner(platform: platform, version: version) do |node|
+              node.override['cluster']['node_type'] = node_type
+              node.override['cluster']['shared_dir'] = SHARED_DIR
+              node.override['cluster']['shared_dir_head'] = SHARED_DIR_HEAD
+              node.override['cluster']['shared_dir_compute'] = SHARED_DIR_COMPUTE
+              node.override['cluster']['shared_dir_login'] = SHARED_DIR_LOGIN
+              node.override['cluster']['head_node_private_ip'] = HEAD_NODE_PRIVATE_IP
+              node.override['cluster']['nfs']['hard_mount_options'] = HARD_MOUNT_OPTIONS
+            end
+            runner.converge(described_recipe)
+          end
+          cached(:node) { chef_run.node }
+
+          case node_type
+          when "HeadNode"
+            it 'does not mount the internal EBS volume shared with all cluster nodes' do
+              is_expected.not_to mount_volume("mount #{SHARED_DIR}")
+            end
+            it 'does not mount the internal EBS volume shared with login nodes' do
+              is_expected.not_to mount_volume("mount #{SHARED_DIR_LOGIN}")
+            end
+
+          when "ComputeFleet"
+            it 'mounts the internal EBS volume shared with all cluster nodes' do
+              is_expected.to mount_volume("mount #{SHARED_DIR}").with(
+                shared_dir: SHARED_DIR,
+                device: "#{HEAD_NODE_PRIVATE_IP}:#{SHARED_DIR_HEAD}",
+                fstype: "nfs",
+                options: HARD_MOUNT_OPTIONS,
+                retries: 10,
+                retry_delay: 6
+              )
+            end
+
+            it 'does not mount the internal EBS volume shared with login nodes' do
+              is_expected.not_to mount_volume("mount #{SHARED_DIR_LOGIN}")
+            end
+
+          when "LoginNode"
+            it 'mounts the internal EBS volume shared with all cluster nodes' do
+              is_expected.to mount_volume("mount #{SHARED_DIR}").with(
+                shared_dir: SHARED_DIR,
+                device: "#{HEAD_NODE_PRIVATE_IP}:#{SHARED_DIR_HEAD}",
+                fstype: "nfs",
+                options: HARD_MOUNT_OPTIONS,
+                retries: 10,
+                retry_delay: 6
+              )
+            end
+            it 'mounts the internal EBS volume shared with login nodes' do
+              is_expected.to mount_volume("mount #{SHARED_DIR_LOGIN}").with(
+                shared_dir: SHARED_DIR_LOGIN,
+                device: "#{HEAD_NODE_PRIVATE_IP}:#{SHARED_DIR_LOGIN}",
+                fstype: "nfs",
+                options: HARD_MOUNT_OPTIONS,
+                retries: 10,
+                retry_delay: 6
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/update_fs_mapping_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/update_fs_mapping_spec.rb
@@ -63,8 +63,13 @@ describe 'aws-parallelcluster-environment::update_fs_mapping' do
         end
         cached(:node) { chef_run.node }
 
-        it 'does nothing' do
-          is_expected.not_to create_template("#{node['cluster']['etc_dir']}/shared_storages_data.yaml")
+        it 'generates the file shared_storages_data' do
+          is_expected.to create_template("#{node['cluster']['etc_dir']}/shared_storages_data.yaml").with(
+            source: "shared_storages/shared_storages_data.erb",
+            owner: 'root',
+            group: 'root',
+            mode: '0644'
+          )
         end
       end
     end

--- a/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
@@ -22,11 +22,14 @@ action :run do
       Chef::Log.info("Backing up old configuration from (#{node['cluster']['cluster_config_path']}) to (#{node['cluster']['previous_cluster_config_path']})")
       ::FileUtils.cp_r(node['cluster']['cluster_config_path'], node['cluster']['previous_cluster_config_path'], remove_destination: true)
       fetch_cluster_config(node['cluster']['cluster_config_path'])
+      Chef::Log.info("Cluster config is:\n#{::File.read(node['cluster']['cluster_config_path'])}")
 
       Chef::Log.info("Backing up old instance types data from (#{node['cluster']['instance_types_data_path']}) to (#{node['cluster']['previous_instance_types_data_path']})")
       ::FileUtils.cp_r(node['cluster']['instance_types_data_path'], node['cluster']['previous_instance_types_data_path'], remove_destination: true)
 
       fetch_change_set
+      Chef::Log.info("Changeset is:\n#{::File.read(node['cluster']['change_set_path'])}")
+
       fetch_instance_type_data unless ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path'])
       Chef::Log.info("Backing up old shared storages data from (#{node['cluster']['shared_storages_mapping_path']}) to (#{node['cluster']['previous_shared_storages_mapping_path']})")
       ::FileUtils.cp_r(node['cluster']['shared_storages_mapping_path'], node['cluster']['previous_shared_storages_mapping_path'], remove_destination: true)

--- a/cookbooks/aws-parallelcluster-slurm/libraries/storage.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/storage.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+# rubocop:disable Style/SingleArgumentDig
+
+STORAGE_TYPES_SUPPORTING_LIVE_UPDATES = %w(Efs FsxLustre FsxOntap FsxOpenZfs FileCache).freeze
+EXTERNAL_STORAGE_KEYS = %w(VolumeId FileSystemId FileCacheId).freeze
+
+class SharedStorageChangeInfo
+  attr_reader :is_mount, :is_unmount, :storage_type, :storage_settings, :is_external
+
+  # Creates a new instance of SharedStorageChangeInfo capturing the relevant information out of the given
+  # shared storage change of a change-set.
+  #
+  # @param [any] change a change provided by a change-set. Example of a change:
+  #                     {
+  #                       "parameter": "SharedStorage",
+  #                       "requestedValue": {
+  #                         "MountDir": "/opt/shared/efs/managed/1",
+  #                         "Name": "shared-efs-managed-1",
+  #                         "StorageType": "Efs",
+  #                         "EfsSettings": {
+  #                           "FileSystemId": "fs-123456789"
+  #                         },
+  #                       "currentValue": "-"
+  #                      }
+  def initialize(change)
+    old_value = change["currentValue"]
+    new_value = change["requestedValue"]
+
+    storage_item = new_value.nil? ? old_value : new_value
+
+    # Storage Action
+    @is_mount = (old_value.nil? and !new_value.nil?)
+    @is_unmount = (!old_value.nil? and new_value.nil?)
+
+    @storage_type = storage_item["StorageType"]
+    @storage_settings = storage_item["#{@storage_type}Settings"] || {}
+
+    # Storage Ownership
+    @is_external = @storage_settings.keys.any? { |k| EXTERNAL_STORAGE_KEYS.include?(k) }
+  end
+
+  # Checks if a given shared storage change within a changeset supports live updates.
+  # With live updates we refer to in-place updates that do not required node replacement.
+  # Currently, a live update is supported only in the following cases:
+  #   1. mount/unmount of external EFS
+  #   1. mount/unmount of external FSx
+  #
+  # @return [Boolean] true if the change supports live updates; false, otherwise.
+  def support_live_updates?
+    @is_external and STORAGE_TYPES_SUPPORTING_LIVE_UPDATES.include?(@storage_type)
+  end
+
+  # Returns the string representation of the object.
+  #
+  # @return [String] the string representation of the object.
+  def to_s
+    attributes = instance_variables.reduce [] do |list, attribute|
+      list.append "#{attribute}=#{instance_variable_get(attribute).inspect}"
+    end
+
+    "{#{attributes.join(', ')}}"
+  end
+end
+
+# Checks if the given changes provided by a change-set support live updates.
+# With live updates we refer to in-place updates that do not required node replacement.
+# The decision on the support is demanded to SharedStorageChangeInfo.
+# If the changes are nil, empty or they do not contain any shared storage change,
+# we assume that a live update is supported.
+# Example of a change:
+#   {
+#     "parameter": "SharedStorage",
+#     "requestedValue": {
+#       "MountDir": "/opt/shared/efs/managed/1",
+#       "Name": "shared-efs-managed-1",
+#       "StorageType": "Efs",
+#       "EfsSettings": {
+#         "FileSystemId": "fs-123456789"
+#       },
+#     "currentValue": "-"
+#    }
+#
+# @param [List[change]] changes the list fo changes provided by a change-set.
+# @return [Boolean] true if the change supports live updates; false, otherwise.
+def storage_change_supports_live_update?(changes)
+  if changes.nil? || changes.empty?
+    Chef::Log.info("No change found: assuming live update is supported")
+    return true
+  end
+
+  storage_changes = changes.select { |change| change["parameter"] == "SharedStorage" }
+
+  if storage_changes.empty?
+    Chef::Log.info("No shared storage change found: assuming live update is supported")
+    return true
+  end
+
+  storage_changes.each do |change|
+    Chef::Log.info("Analyzing shared storage change: #{change}")
+    change_info = SharedStorageChangeInfo.new(change)
+    Chef::Log.info("Generated shared storage change info: #{change_info}")
+    supported = change_info.support_live_updates?
+    Chef::Log.info("Change #{change} #{'does not ' unless supported}support live updates")
+    return false unless supported
+  end
+  Chef::Log.info("All shared storage changes support live update.")
+  true
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_login_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_login_node.rb
@@ -15,4 +15,13 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: Move the only_if decision to the update_shared_storage recipe for better definition of responsibilities
+#  and to facilitate unit testing.
+ruby_block "update_shared_storages" do
+  block do
+    run_context.include_recipe 'aws-parallelcluster-environment::update_shared_storages'
+  end
+  only_if { are_mount_or_unmount_required? }
+end
+
 save_instance_config_version_to_dynamodb


### PR DESCRIPTION
### Description of changes
1. Include login nodes in cluster readiness checks done by head node before signaling update completion
2. Include storage update as part of the update of login nodes.
3. Prevent drain/terminate when live updates are supported
4. Mount internal EBS volume `/opt/parallelcluster/shared` also in login nodes as it contain files that are useful, such as cluster config, change-set and so on. 
5. Added spec tests to cover the above changes.
6. Added log lines to facilitate troubleshooting of the update workflow.


### Tests
* Manual testing: created a cluster without shared storage, updated by adding and removing external EFS in draining mode (no node replacement occur, as expected), updated by adding and removing a managed EFS in draining mode (node replacement occur as expected).
* Unit testing (both existing and new ones)
* Integ test `test_update_slurm`

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
