### PR TITLE
[Disable Sudo] Invoking sudo_access from Platform cookbook when updating cluster

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
@@ -12,9 +12,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-fetch_config 'Fetch and load cluster configs' do
-  update true
-end
+# Fetch and load cluster configs
+include_recipe 'aws-parallelcluster-platform::update'
 
 # generate the updated shared storages mapping file
 include_recipe 'aws-parallelcluster-environment::update_fs_mapping'
@@ -26,5 +25,3 @@ include_recipe 'aws-parallelcluster-slurm::update' if node['cluster']['scheduler
 if is_custom_node?
   include_recipe 'aws-parallelcluster-computefleet::update_parallelcluster_node'
 end
-
-sudo_access "Update Sudo Access" if node['cluster']['scheduler'] == 'slurm'

--- a/cookbooks/aws-parallelcluster-platform/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/update.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-platform
+# Recipe:: update
+#
+# Copyright:: 2013-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+fetch_config 'Fetch and load cluster configs' do
+  update true
+end
+
+sudo_access "Update Sudo Access" if node['cluster']['scheduler'] == 'slurm'

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/update_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/update_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-platform::update' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      context "when scheduler is slurm" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['scheduler'] = 'slurm'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'it fetches and updates cluster configs' do
+          is_expected.to run_fetch_config('Fetch and load cluster configs')
+        end
+        it 'it updates sudo access' do
+          is_expected.to setup_sudo_access('Update Sudo Access')
+        end
+      end
+
+      context "when scheduler is awsbatch" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['scheduler'] = 'awsbatch'
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'it fetches and updates cluster configs' do
+          is_expected.to run_fetch_config('Fetch and load cluster configs')
+        end
+        it 'it doesnt update sudo access' do
+          is_expected.not_to setup_sudo_access('Update Sudo Access')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
* Invoking sudo_access from Platform cookbook when updating cluster

### Tests

* Passed Integ tests
      * create:test_create.py::test_create_disable_sudo_access_for_default_user
      * test_build_image ( failure for Stack deletion unrelated to this commit)

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
