### PR TITLE
[DFSM] On cluster update, remove the check on static fleet and move the cluster readiness check before clustermgtd is restarted.

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -278,6 +278,8 @@ end
 
 chef_sleep '15'
 
+wait_cluster_ready
+
 execute 'start clustermgtd' do
   command "#{cookbook_virtualenv_path}/bin/supervisorctl start clustermgtd"
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && !are_bulk_custom_slurm_settings_updated? }
@@ -289,7 +291,3 @@ template "#{node['cluster']['etc_dir']}/cfnconfig" do
   cookbook 'aws-parallelcluster-environment'
   mode '0644'
 end
-
-wait_static_fleet_running
-
-wait_cluster_ready

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
@@ -32,10 +32,6 @@ describe 'aws-parallelcluster-slurm::update_head_node' do
         )
       end
 
-      it 'checks that the static fleet is running' do
-        is_expected.to run_ruby_block("wait for static fleet capacity")
-      end
-
       it 'checks cluster readiness' do
         expected_command = "#{cookbook_venv_path}/bin/python #{scripts_dir}/head_node_checks/check_cluster_ready.py" \
           " --cluster-name #{cluster_name}" \


### PR DESCRIPTION
### Description of changes
On cluster update, remove the check on static fleet and move the cluster readiness check before clustermgtd is restarted.

**Background**
In https://github.com/aws/aws-parallelcluster-cookbook/pull/2634, we introduced some checks at the end of the update recipe for the head node to verify that in-place updates where successful on compute fleet. Among these checks there was the `wait_static_fleet_running`. This check was added before the `wait_cluster_ready` check to ensure that the second check is running on a stable static fleet.

**Problem**
Having the `wait_static_fleet_running` may cause cluster update failures due to time out in all the scenarios where it is ok for the static fleet to stabilize after the cluster update (eg: draining update on static nodes with job running).

**Solution**
Remove the check `wait_static_fleet_running` from the update workflow and move the check `wait_cluster_ready` before the restart of clustermgtd, so that the check evaluates in-place updates on a stable fleet (before clustermgtd starts doing replacements).


### Tests
* Spec test
* est `test_update_instance_list`, that was failing before this change due to cluster update failure.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
