### PR TITLE
[Dependencies] Pinning NVIDIA version for Centos7 to 535.129.03

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/nvidia_driver_centos7.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/nvidia_driver_centos7.rb
@@ -21,3 +21,8 @@ use 'partial/_nvidia_driver_common.rb'
 def nvidia_driver_enabled?
   !arm_instance? && nvidia_enabled?
 end
+
+# Pinning the Nvidia Driver version for centos7 due to incompatibility with Gdrcopy 2.3.1
+def _nvidia_driver_version
+  '535.129.03'
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
@@ -163,11 +163,12 @@ describe 'nvidia_driver:setup' do
 
     [%w(false kernel), %w(true kernel-open)].each do |kernel_open, kernel_module|
       context "on #{platform}#{version} when nvidia_driver enabled and node['cluster']['nvidia']['kernel_open'] is #{kernel_open}" do
-        cached(:nvidia_arch) { 'nvidia_arch' }
-        cached(:nvidia_driver_version) { 'nvidia_driver_version' }
-        cached(:nvidia_kernel_module) { 'nvidia_kernel_module' }
+        if platform == 'centos'
+          cached(:nvidia_driver_version) { '535.129.03' }
+        else
+          cached(:nvidia_driver_version) { 'nvidia_driver_version' }
+        end
         cached(:nvidia_driver_url) { "https://us.download.nvidia.com/tesla/#{nvidia_driver_version}/NVIDIA-Linux-#{nvidia_arch}-#{nvidia_driver_version}.run" }
-
         cached(:chef_run) do
           stubs_for_resource('nvidia_driver') do |res|
             allow(res).to receive(:nvidia_driver_enabled?).and_return(true)


### PR DESCRIPTION
### Description of changes
* Pinning NVIDIA version for Centos7 to 535.129.03

### Tests
* Created an AMI for centos7 and Alinux2 then ran 
*  ` ./kitchen.ec2.sh platform-config test nvidia-gdrcopy-centos7` 
* ` ./kitchen.ec2.sh platform-config test nvidia-gdrcopy-alinux2`
 

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
