### PR TITLE
Stop the sshd service and close connections before moving the default user home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Add support for RHEL9.
 - Add support for Rocky Linux 9 as `CustomAmi` created through `build-image` process. No public official ParallelCluster Rocky9 Linux AMI is made available at this time.
 - Add the configuration parameter `DeploymentSettings/DefaultUserHome` to allow users to move the default user's home directory to `/local/home` instead of `/home` (default).
+  - SSH connections will be closed and rejected while the user's home directory is being moved during the bootstrapping process.
 - Add possibility to choose between Open and Closed Source Nvidia Drivers when building an AMI, through the ```['cluster']['nvidia']['kernel_open']``` cookbook node attribute.
 
 **CHANGES**

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/config_default_user_home_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/config_default_user_home_spec.rb
@@ -15,9 +15,12 @@ describe 'aws-parallelcluster-environment::config_default_user_home' do
         cached(:node) { chef_run.node }
 
         it 'runs the recipe' do
+          is_expected.to stop_service("sshd")
+          is_expected.to run_bash("Close ssh connections to perform a default user move")
           is_expected.to run_bash("Backup /home/user")
           is_expected.to run_bash("Move /home/user")
           expect(chef_run.node['cluster']['cluster_user_home']).to eq('/local/home/user')
+          is_expected.to start_service("sshd")
         end
       end
       context 'when shared' do


### PR DESCRIPTION
### Tests
* Created clusters locally and ssh'd into the head node to see the connection closed and the default user home move succeed

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
