### PR TITLE
[kitchen tests] Fix pinning NVIDIA version for Centos7 to 535.129.03

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_spec.rb
@@ -15,7 +15,11 @@ control 'tag:install_expected_versions_of_nvidia_driver_installed' do
       (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
   end
 
-  expected_nvidia_driver_version = node['cluster']['nvidia']['driver_version']
+  expected_nvidia_driver_version = if os_properties.centos7?
+                                     '535.129.03'
+                                   else
+                                     node['cluster']['nvidia']['driver_version']
+                                   end
   expected_nvidia_kernel_license = 'Dual MIT/GPL'
   expected_nvidia_kernel_module = "NVRM version: NVIDIA UNIX Open Kernel Module"
 


### PR DESCRIPTION
This PR fixes a miss in https://github.com/aws/aws-parallelcluster-cookbook/pull/2648

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
