### PR TITLE
[Security] Disable unused background services: wpa_supplicant and cups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **ENHANCEMENTS**
+- Disable unused background services wpa_supplicant and cups to improve security.
 
 **CHANGES**
 

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/disable_services.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/disable_services.rb
@@ -27,3 +27,13 @@ end unless on_docker?
 service 'log4j-cve-2021-44228-hotpatch' do
   action %i(disable stop mask)
 end unless on_docker?
+
+# Necessary on Ubuntu and Amazon Linux 2
+service 'cups' do
+  action %i(disable stop mask)
+end unless on_docker?
+
+# Necessary on Ubuntu 22
+service 'wpa_supplicant' do
+  action %i(disable stop mask)
+end unless on_docker?

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
@@ -18,6 +18,18 @@ describe 'aws-parallelcluster-platform::disable_services' do
         is_expected.to stop_service('log4j-cve-2021-44228-hotpatch')
         is_expected.to mask_service('log4j-cve-2021-44228-hotpatch')
       end
+
+      it 'disables cups' do
+        is_expected.to disable_service('cups')
+        is_expected.to stop_service('cups')
+        is_expected.to mask_service('cups')
+      end
+
+      it 'disables wpa_supplicant' do
+        is_expected.to disable_service('wpa_supplicant')
+        is_expected.to stop_service('wpa_supplicant')
+        is_expected.to mask_service('wpa_supplicant')
+      end
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
@@ -10,38 +10,46 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 control 'tag:testami_tag:config_services_disabled_on_debian_family' do
-  title 'Test that DLAMI multi eni helper is disabled and masked on debian family'
+  services = %w(aws-ubuntu-eni-helper wpa_supplicant)
+
+  title "Test that #{services.join(',')} are disabled and masked on debian family"
 
   only_if { os_properties.debian_family? && !os_properties.on_docker? }
 
-  describe service('aws-ubuntu-eni-helper') do
-    it { should_not be_enabled }
-    it { should_not be_running }
-  end
+  services.each do |service_name|
+    describe service(service_name) do
+      it { should_not be_enabled }
+      it { should_not be_running }
+    end
 
-  describe bash('systemctl list-unit-files --state=masked --no-legend') do
-    its(:exit_status) { should eq 0 }
-    its(:stdout) { should match /aws-ubuntu-eni-helper.service\s*masked/ }
+    describe bash('systemctl list-unit-files --state=masked --no-legend') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match /#{service_name}.service\s*masked/ }
+    end
   end
 end
 
 control 'tag:testami_tag:config_services_disabled_on_amazon_family' do
-  title 'Test that log4j-cve-2021-44228-hotpatch is disabled and masked on amazon family'
+  services = %w(log4j-cve-2021-44228-hotpatch cups)
+
+  title "Test that #{services.join(',')} are disabled and masked on amazon family"
 
   only_if { os_properties.amazon_family? && !os_properties.on_docker? }
 
-  describe service('log4j-cve-2021-44228-hotpatch') do
-    it { should_not be_enabled }
-    it { should_not be_running }
-  end
+  services.each do |service_name|
+    describe service(service_name) do
+      it { should_not be_enabled }
+      it { should_not be_running }
+    end
 
-  describe bash('systemctl list-unit-files --state=masked --no-legend') do
-    its(:exit_status) { should eq 0 }
-    its(:stdout) { should match /log4j-cve-2021-44228-hotpatch.service\s*masked/ }
-  end
+    describe bash('systemctl list-unit-files --state=masked --no-legend') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match /#{service_name}.service\s*masked/ }
+    end
 
-  describe bash('systemctl show -p LoadState log4j-cve-2021-44228-hotpatch') do
-    its(:exit_status) { should eq 0 }
-    its(:stdout) { should match /LoadState=masked/ }
+    describe bash("systemctl show -p LoadState #{service_name}") do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match /LoadState=masked/ }
+    end
   end
 end


### PR DESCRIPTION
### Description of changes
Disable unused background services: `wpa_supplicant` and `cups`.

### Test
* Spec tests for aws-parallelcluster-platform
* Kitchen tests `./kitchen.ec2.sh platform-install test disable-services`

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
