### PR TITLE
[Dependencies] Overriding the NVIDIA version for Centos7 using node_attributes

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
@@ -23,6 +23,10 @@ action :setup do
   return unless nvidia_driver_enabled?
   return if on_docker?
 
+  # Share nvidia driver version with InSpec tests
+  node.default['cluster']['nvidia']['driver_version'] = _nvidia_driver_version
+  node_attributes "Save Nvidia driver version for Inspec tests"
+
   remote_file tmp_nvidia_run do
     source nvidia_driver_url
     mode '0755'

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
@@ -187,6 +187,10 @@ describe 'nvidia_driver:setup' do
         end
         cached(:node) { chef_run.node }
 
+        it 'dumps nodes attribues' do
+          is_expected.to write_node_attributes('Save Nvidia driver version for Inspec tests')
+        end
+
         it 'sets up nvidia_driver' do
           is_expected.to setup_nvidia_driver('setup')
         end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_spec.rb
@@ -15,11 +15,7 @@ control 'tag:install_expected_versions_of_nvidia_driver_installed' do
       (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
   end
 
-  expected_nvidia_driver_version = if os_properties.centos7?
-                                     '535.129.03'
-                                   else
-                                     node['cluster']['nvidia']['driver_version']
-                                   end
+  expected_nvidia_driver_version = node['cluster']['nvidia']['driver_version']
   expected_nvidia_kernel_license = 'Dual MIT/GPL'
   expected_nvidia_kernel_module = "NVRM version: NVIDIA UNIX Open Kernel Module"
 


### PR DESCRIPTION
Overriding Node Attributes due to failing Centos7 Validation tests in [parallelcluster_validate.yaml]( https://github.com/aws/aws-parallelcluster/blob/ece084c30c66dce5400ef9063aeab9ab736c379c/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml#L150)

Reverting https://github.com/aws/aws-parallelcluster-cookbook/pull/2654/files

### Tests
* Creating AMI and running Validate_tests then ran ` ./kitchen.ec2.sh platform-install test nvidia `

* Unit Test


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
