### PR TITLE
[AD] Fix the sync of AD data by moving the sync step at the end of the finalize phase with more retries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **BUG FIXES**
 - Fix issue making job fail when submitted as active directory user from login nodes. 
   The issue was caused by an incomplete configuration of the integration with the external Active Directory on the head node.
-  This fix comes with a breaking change: now cluster creation/update would fail if the integration with the Active Directory does not work.
 
 3.8.0
 ------

--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/finalize.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/finalize.rb
@@ -21,6 +21,7 @@ if is_custom_node?
 end
 
 include_recipe "aws-parallelcluster-platform::finalize"
-include_recipe "aws-parallelcluster-environment::finalize"
 
 include_recipe 'aws-parallelcluster-slurm::finalize' if node['cluster']['scheduler'] == 'slurm'
+
+include_recipe "aws-parallelcluster-environment::finalize"

--- a/cookbooks/aws-parallelcluster-environment/recipes/finalize/finalize_directory_service.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/finalize/finalize_directory_service.rb
@@ -22,10 +22,13 @@ if %w(HeadNode LoginNode).include? node['cluster']['node_type']
   read_only_user = domain_service_read_only_user_name(node['cluster']['directory_service']['domain_read_only_user'])
 
   execute 'Fetch user data from remote directory service' do
-    # The switch-user (sudo -u) is necessary to trigger the fetching of AD data
+    # The switch-user (sudo -u) is necessary to trigger the fetching of AD data.
+    # Failures are ignored because we experimentally verified that a MsAD backend
+    # may take long time to become available.
+    # So, we prefer to execute this step in best effort mode.
+    # Once we will reintroduce the failures, we should consider 30 retries with 10 seconds delay.
     command "sudo -u #{default_user} getent passwd #{read_only_user}"
     user 'root'
-    retries 10 # Retries are just a safe guard in case the node is still fetching data from the AD
-    retry_delay 3
+    ignore_failure true
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/finalize_directory_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/finalize_directory_service_spec.rb
@@ -38,8 +38,7 @@ describe 'aws-parallelcluster-environment::finalize_directory_service' do
               is_expected.to run_execute('Fetch user data from remote directory service').with(
                 command: "sudo -u #{cluster_user} getent passwd #{domain_read_only_user}",
                 user: 'root',
-                retries: 10,
-                retry_delay: 3
+                ignore_failure: true
               )
             end
           else


### PR DESCRIPTION
### Description of changes
Fix the sync of AD data by moving the sync step at the end of the finalize phase with more retries.
This makes the change introduced in https://github.com/aws/aws-parallelcluster-cookbook/pull/2655 more robust.
We needed to ignore the failures of this step because we experimentally verifiedf that the mopst we can do is to make it best effort, since MsAD backend may take longer time to become available for SSSD. This approach of ignoring failure is what we adopted in previous release too (see [code](https://github.com/aws/aws-parallelcluster-cookbook/blob/release-3.8/cookbooks/aws-parallelcluster-environment/recipes/config/directory_service.rb#L261)).

### Tests
* Manual creation of a cluster integrated with Ad and checked that job submission from login nodes work; also verified that the sync succeeds in logs.
* Executed test_ad_integration (SimpleAD) and verified that cluster creation succeeds. The test fails cluster update but that is due to other issues.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
