### PR TITLE
[DFSM] Increase the frequency of cfn-hup loop.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/cfn-hup-runner.sh.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/cfn-hup-runner.sh.erb
@@ -10,5 +10,5 @@ set -ex
 
 while true; do
   <%= @cfn_bootstrap_virtualenv_path %>/bin/cfn-hup --no-daemon --verbose
-  sleep 120
+  sleep 60
 done


### PR DESCRIPTION
### Description of changes
Increase the frequency of cfn-hup loop for every cluster node.
In particular, we set one iteration per minute, rather than one every 2 minutes.

In this way we reduce the risk for login/compute nodes to miss pending in-place updates.

### Tests
* Manual: cluster creation + in-place updates adding EFS storage. Verified that head node starts the update ~1m10sec after the stack update and login/compute nodes start their update workflow ~1m:40sec after.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
