### PR TITLE
[DFSM] Fix major gaps in the update workflow

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
@@ -108,7 +108,7 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
         logger.info("Found batch of %s cluster node(s): %s", n_instance_ids, instance_ids)
 
         items = get_cluster_config_records(table_name, instance_ids, region)
-        logger.info("Retrieved %s DDB item(s): %s", len(items), items)
+        logger.info("Retrieved %s DDB item(s):\n\t%s", len(items), "\n\t".join([str(i) for i in items]))
 
         missing, incomplete, wrong = _check_cluster_config_items(instance_ids, items, expected_config_version)
 

--- a/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
@@ -16,7 +16,15 @@
 # This is done to understand what is the deployed cluster config in each node, for example, during a CFN Stack update.
 
 DDB_CONFIG_STATUS = {
+  # The node successfully deployed the cluster configuration.
   DEPLOYED: "DEPLOYED",
+
+  # The node evaluated the cluster configuration and concluded that a live update should be skipped because:
+  #   1. not supported: the changeset contains changes that cannot be applied with a live update
+  #                   and may instead require a node replacement.
+  #                   Example: mounting a managed EBS.
+  #   2. not required:  the changeset contains changes that could lead to an empty live update.
+  #                   Example: changing the number of static nodes.
   SKIPPED_LIVE_UPDATE: "SKIPPED_LIVE_UPDATE",
 }.freeze
 

--- a/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
@@ -15,11 +15,10 @@
 # the instance id and the cluster config version deployed on that instance.
 # This is done to understand what is the deployed cluster config in each node, for example, during a CFN Stack update.
 
-
 DDB_CONFIG_STATUS = {
   DEPLOYED: "DEPLOYED",
-  SKIPPED_LIVE_UPDATE: "SKIPPED_LIVE_UPDATE"
-}
+  SKIPPED_LIVE_UPDATE: "SKIPPED_LIVE_UPDATE",
+}.freeze
 
 def save_instance_config_version_to_dynamodb(status)
   unless on_docker? || kitchen_test? && !node['interact_with_ddb']

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -173,8 +173,8 @@ def wait_cluster_ready
               " --config-version #{node['cluster']['cluster_config_version']}" \
               " --region #{node['cluster']['region']}"
     timeout 30
-    retries 5
-    retry_delay 180
+    retries 10
+    retry_delay 90
   end
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/libraries/storage.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/storage.rb
@@ -104,7 +104,7 @@ def storage_change_supports_live_update?(changes)
 
   if storage_changes.empty?
     Chef::Log.info("No shared storage change found: assuming live update is supported")
-    return true
+    return false
   end
 
   storage_changes.each do |change|

--- a/cookbooks/aws-parallelcluster-slurm/libraries/storage.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/storage.rb
@@ -96,15 +96,15 @@ end
 # @return [Boolean] true if the change supports live updates; false, otherwise.
 def storage_change_supports_live_update?(changes)
   if changes.nil? || changes.empty?
-    Chef::Log.info("No change found: assuming live update is supported")
+    Chef::Log.info("No change found: live update is supported")
     return true
   end
 
   storage_changes = changes.select { |change| change["parameter"] == "SharedStorage" }
 
   if storage_changes.empty?
-    Chef::Log.info("No shared storage change found: assuming live update is supported")
-    return false
+    Chef::Log.info("No shared storage change found: live update is supported")
+    return true
   end
 
   storage_changes.each do |change|

--- a/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
@@ -114,16 +114,16 @@ def is_live_update_required?
   Chef::Log.info("Changeset found: evaluating changes #{changes}")
 
   outcome = case node["cluster"]["node_type"]
-  when 'HeadNode'
-    # The head node supports live updates regardless the content of the changeset.
-    true
-  when 'ComputeFleet','LoginNode'
-    # The compute and login nodes support live updates only in specific cases:
-    #   * changeset  contains only shared storage changes that support live updates
-    storage_change_supports_live_update?(changes)
-  else
-    raise "node_type must be HeadNode, LoginNode or ComputeFleet"
-  end
+            when 'HeadNode'
+              # The head node supports live updates regardless the content of the changeset.
+              true
+            when 'ComputeFleet', 'LoginNode'
+              # The compute and login nodes support live updates only in specific cases:
+              #   * changeset  contains only shared storage changes that support live updates
+              storage_change_supports_live_update?(changes)
+            else
+              raise "node_type must be HeadNode, LoginNode or ComputeFleet"
+            end
 
   Chef::Log.info("Live update required: #{outcome}")
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_compute.rb
@@ -60,4 +60,4 @@ execute 'resume_node' do
   only_if { is_static_node?(node.run_state['slurm_compute_nodename']) }
 end
 
-save_instance_config_version_to_dynamodb
+save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED])

--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_login_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_login_node.rb
@@ -15,4 +15,4 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-save_instance_config_version_to_dynamodb
+save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED])

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_compute.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-unless lambda { is_live_update_required? }.call
+unless -> { is_live_update_required? }.call
   save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:SKIPPED_LIVE_UPDATE])
   return
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_compute.rb
@@ -15,8 +15,13 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+unless lambda { is_live_update_required? }.call
+  save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:SKIPPED_LIVE_UPDATE])
+  return
+end
+
 # TODO: Move the only_if decision to the update_shared_storage recipe for better definition of responsibilities
-# and to facilitate unit testing.
+#  and to facilitate unit testing.
 ruby_block "update_shared_storages" do
   block do
     run_context.include_recipe 'aws-parallelcluster-environment::update_shared_storages'
@@ -24,4 +29,4 @@ ruby_block "update_shared_storages" do
   only_if { are_mount_or_unmount_required? }
 end
 
-save_instance_config_version_to_dynamodb
+save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED])

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_login_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_login_node.rb
@@ -15,6 +15,11 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+unless lambda { is_live_update_required? }.call
+  save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:SKIPPED_LIVE_UPDATE])
+  return
+end
+
 # TODO: Move the only_if decision to the update_shared_storage recipe for better definition of responsibilities
 #  and to facilitate unit testing.
 ruby_block "update_shared_storages" do
@@ -24,4 +29,4 @@ ruby_block "update_shared_storages" do
   only_if { are_mount_or_unmount_required? }
 end
 
-save_instance_config_version_to_dynamodb
+save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED])

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_login_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_login_node.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-unless lambda { is_live_update_required? }.call
+unless -> { is_live_update_required? }.call
   save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:SKIPPED_LIVE_UPDATE])
   return
 end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_compute_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_compute_spec.rb
@@ -15,6 +15,7 @@ require 'spec_helper'
 
 describe 'aws-parallelcluster-slurm::finalize_compute' do
   for_all_oses do |platform, version|
+    node_type = "ComputeFleet"
     cookbook_venv_path = "MOCK_COOKBOOK_VENV_PATH"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
@@ -32,8 +33,7 @@ describe 'aws-parallelcluster-slurm::finalize_compute' do
           allow(Time).to receive(:now).and_return(Time.parse(time_now))
           RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-          node.override['cluster']['node_type'] = 'ComputeFleet'
-          node.override['interact_with_ddb'] = true
+          node.override['cluster']['node_type'] = node_type
           node.override['cluster']['cluster_name'] = cluster_name
           node.override['cluster']['region'] = region
           node.override['ec2']['instance_id'] = instance_id
@@ -42,10 +42,11 @@ describe 'aws-parallelcluster-slurm::finalize_compute' do
         runner.converge(described_recipe)
       end
 
-      it 'saves the cluster config version to dynamodb' do
+      status = "DEPLOYED"
+      it "saves the cluster config version to dynamodb with status #{status}" do
         expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
           " --table-name parallelcluster-#{cluster_name}"\
-          " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
+          " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"status\": {\"S\": \"#{status}\"}, \"node_type\": {\"S\": \"#{node_type}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
           " --region #{region}"
         is_expected.to run_execute("Save cluster config version to DynamoDB").with(
           command: expected_command,
@@ -62,11 +63,8 @@ describe 'aws-parallelcluster-slurm::finalize_compute' do
             allow_any_instance_of(Object).to receive(:is_static_node?).and_return(false)
             RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-            node.override['cluster']['node_type'] = 'ComputeFleet'
             node.override['kitchen'] = true
             node.override['interact_with_ddb'] = false
-            node.override['ec2']['instance_id'] = instance_id
-            node.override['cluster']['cluster_config_version'] = cluster_config_version
           end
           runner.converge(described_recipe)
         end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_head_node_spec.rb
@@ -48,8 +48,8 @@ describe 'aws-parallelcluster-slurm::finalize_head_node' do
         is_expected.to run_execute("Check cluster readiness").with(
           command: expected_command,
           timeout: 30,
-          retries: 5,
-          retry_delay: 180
+          retries: 10,
+          retry_delay: 90
         )
       end
     end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_login_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_login_node_spec.rb
@@ -15,6 +15,7 @@ require 'spec_helper'
 
 describe 'aws-parallelcluster-slurm::finalize_login_node' do
   for_all_oses do |platform, version|
+    node_type = "LoginNode"
     cookbook_venv_path = "MOCK_COOKBOOK_VENV_PATH"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
@@ -32,8 +33,7 @@ describe 'aws-parallelcluster-slurm::finalize_login_node' do
           allow(Time).to receive(:now).and_return(Time.parse(time_now))
           RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-          node.override['cluster']['node_type'] = 'LoginNode'
-          node.override['interact_with_ddb'] = true
+          node.override['cluster']['node_type'] = node_type
           node.override['cluster']['cluster_name'] = cluster_name
           node.override['cluster']['region'] = region
           node.override['ec2']['instance_id'] = instance_id
@@ -42,10 +42,11 @@ describe 'aws-parallelcluster-slurm::finalize_login_node' do
         runner.converge(described_recipe)
       end
 
-      it 'saves the cluster config version to dynamodb' do
+      status = "DEPLOYED"
+      it "saves the cluster config version to dynamodb with status #{status}" do
         expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
           " --table-name parallelcluster-#{cluster_name}"\
-          " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
+          " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"status\": {\"S\": \"#{status}\"}, \"node_type\": {\"S\": \"#{node_type}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
           " --region #{region}"
         is_expected.to run_execute("Save cluster config version to DynamoDB").with(
           command: expected_command,
@@ -62,11 +63,8 @@ describe 'aws-parallelcluster-slurm::finalize_login_node' do
             allow_any_instance_of(Object).to receive(:is_static_node?).and_return(false)
             RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-            node.override['cluster']['node_type'] = 'LoginNode'
             node.override['kitchen'] = true
             node.override['interact_with_ddb'] = false
-            node.override['ec2']['instance_id'] = instance_id
-            node.override['cluster']['cluster_config_version'] = cluster_config_version
           end
           runner.converge(described_recipe)
         end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_compute_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_compute_spec.rb
@@ -15,6 +15,7 @@ require 'spec_helper'
 
 describe 'aws-parallelcluster-slurm::update_compute' do
   for_all_oses do |platform, version|
+    node_type = "ComputeFleet"
     cookbook_venv_path = "MOCK_COOKBOOK_VENV_PATH"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
@@ -25,14 +26,14 @@ describe 'aws-parallelcluster-slurm::update_compute' do
     context "on #{platform}#{version}" do
       cached(:chef_run) do
         runner = runner(platform: platform, version: version) do |node|
+          allow_any_instance_of(Object).to receive(:is_live_update_required?).and_return(false)
           allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
           allow_any_instance_of(Object).to receive(:dig).and_return(true)
           allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
           allow(Time).to receive(:now).and_return(Time.parse(time_now))
           RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-          node.override['cluster']['node_type'] = 'ComputeFleet'
-          node.override['interact_with_ddb'] = true
+          node.override['cluster']['node_type'] = node_type
           node.override['cluster']['cluster_name'] = cluster_name
           node.override['cluster']['region'] = region
           node.override['ec2']['instance_id'] = instance_id
@@ -41,16 +42,19 @@ describe 'aws-parallelcluster-slurm::update_compute' do
         runner.converge(described_recipe)
       end
 
-      context "when mount/unmount is not required" do
+      context "when live update is not required" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:is_live_update_required?).and_return(false)
             allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
             allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
+            allow(Time).to receive(:now).and_return(Time.parse(time_now))
             RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-            node.override['cluster']['node_type'] = 'ComputeFleet'
-            # node.override['kitchen'] = true
-            # node.override['interact_with_ddb'] = false
+            node.override['cluster']['node_type'] = node_type
+            node.override['cluster']['cluster_name'] = cluster_name
+            node.override['cluster']['region'] = region
             node.override['ec2']['instance_id'] = instance_id
             node.override['cluster']['cluster_config_version'] = cluster_config_version
           end
@@ -58,21 +62,37 @@ describe 'aws-parallelcluster-slurm::update_compute' do
         end
         cached(:node) { chef_run.node }
 
+        status = "SKIPPED_LIVE_UPDATE"
+        it "saves the cluster config version to dynamodb with status #{status}" do
+          expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
+            " --table-name parallelcluster-#{cluster_name}"\
+            " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"status\": {\"S\": \"#{status}\"}, \"node_type\": {\"S\": \"#{node_type}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
+            " --region #{region}"
+          is_expected.to run_execute("Save cluster config version to DynamoDB").with(
+            command: expected_command,
+            retries: 3,
+            retry_delay: 5
+          )
+        end
+
         it 'does not update the shared storage' do
           is_expected.not_to run_ruby_block("update_shared_storages")
         end
       end
 
-      context "when mount/unmount is required" do
+      context "when live update is required" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:is_live_update_required?).and_return(true)
             allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(true)
             allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
+            allow(Time).to receive(:now).and_return(Time.parse(time_now))
             RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-            node.override['cluster']['node_type'] = 'ComputeFleet'
-            # node.override['kitchen'] = true
-            # node.override['interact_with_ddb'] = false
+            node.override['cluster']['node_type'] = node_type
+            node.override['cluster']['cluster_name'] = cluster_name
+            node.override['cluster']['region'] = region
             node.override['ec2']['instance_id'] = instance_id
             node.override['cluster']['cluster_config_version'] = cluster_config_version
           end
@@ -83,32 +103,31 @@ describe 'aws-parallelcluster-slurm::update_compute' do
         it 'updates the shared storage' do
           is_expected.to run_ruby_block("update_shared_storages")
         end
-      end
 
-      it 'saves the cluster config version to dynamodb' do
-        expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
-          " --table-name parallelcluster-#{cluster_name}"\
-          " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
-          " --region #{region}"
-        is_expected.to run_execute("Save cluster config version to DynamoDB").with(
-          command: expected_command,
-          retries: 3,
-          retry_delay: 5
-        )
+        status = "DEPLOYED"
+        it "saves the cluster config version to dynamodb with status #{status}" do
+          expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
+            " --table-name parallelcluster-#{cluster_name}"\
+            " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"status\": {\"S\": \"#{status}\"}, \"node_type\": {\"S\": \"#{node_type}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
+            " --region #{region}"
+          is_expected.to run_execute("Save cluster config version to DynamoDB").with(
+            command: expected_command,
+            retries: 3,
+            retry_delay: 5
+          )
+        end
       end
 
       context "when interaction with ddb is disabled during kitchen tests" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
-            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+            allow_any_instance_of(Object).to receive(:is_live_update_required?).and_return(true)
+            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(true)
             allow_any_instance_of(Object).to receive(:dig).and_return(true)
             RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-            node.override['cluster']['node_type'] = 'ComputeFleet'
             node.override['kitchen'] = true
             node.override['interact_with_ddb'] = false
-            node.override['ec2']['instance_id'] = instance_id
-            node.override['cluster']['cluster_config_version'] = cluster_config_version
           end
           runner.converge(described_recipe)
         end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
@@ -41,8 +41,8 @@ describe 'aws-parallelcluster-slurm::update_head_node' do
         is_expected.to run_execute("Check cluster readiness").with(
           command: expected_command,
           timeout: 30,
-          retries: 5,
-          retry_delay: 180
+          retries: 10,
+          retry_delay: 90
         )
       end
     end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_login_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_login_node_spec.rb
@@ -15,6 +15,7 @@ require 'spec_helper'
 
 describe 'aws-parallelcluster-slurm::update_login_node' do
   for_all_oses do |platform, version|
+    node_type = "LoginNode"
     cookbook_venv_path = "MOCK_COOKBOOK_VENV_PATH"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
@@ -25,15 +26,14 @@ describe 'aws-parallelcluster-slurm::update_login_node' do
     context "on #{platform}#{version}" do
       cached(:chef_run) do
         runner = runner(platform: platform, version: version) do |node|
+          allow_any_instance_of(Object).to receive(:is_live_update_required?).and_return(false)
           allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
           allow_any_instance_of(Object).to receive(:dig).and_return(true)
           allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
-          allow_any_instance_of(Object).to receive(:is_static_node?).and_return(false)
           allow(Time).to receive(:now).and_return(Time.parse(time_now))
           RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-          node.override['cluster']['node_type'] = 'LoginNode'
-          node.override['interact_with_ddb'] = true
+          node.override['cluster']['node_type'] = node_type
           node.override['cluster']['cluster_name'] = cluster_name
           node.override['cluster']['region'] = region
           node.override['ec2']['instance_id'] = instance_id
@@ -42,14 +42,19 @@ describe 'aws-parallelcluster-slurm::update_login_node' do
         runner.converge(described_recipe)
       end
 
-      context "when mount/unmount is not required" do
+      context "when live update is not required" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:is_live_update_required?).and_return(false)
             allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
             allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
+            allow(Time).to receive(:now).and_return(Time.parse(time_now))
             RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-            node.override['cluster']['node_type'] = 'LoginNode'
+            node.override['cluster']['node_type'] = node_type
+            node.override['cluster']['cluster_name'] = cluster_name
+            node.override['cluster']['region'] = region
             node.override['ec2']['instance_id'] = instance_id
             node.override['cluster']['cluster_config_version'] = cluster_config_version
           end
@@ -57,19 +62,37 @@ describe 'aws-parallelcluster-slurm::update_login_node' do
         end
         cached(:node) { chef_run.node }
 
+        status = "SKIPPED_LIVE_UPDATE"
+        it "saves the cluster config version to dynamodb with status #{status}" do
+          expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
+            " --table-name parallelcluster-#{cluster_name}"\
+            " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"status\": {\"S\": \"#{status}\"}, \"node_type\": {\"S\": \"#{node_type}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
+            " --region #{region}"
+          is_expected.to run_execute("Save cluster config version to DynamoDB").with(
+            command: expected_command,
+            retries: 3,
+            retry_delay: 5
+          )
+        end
+
         it 'does not update the shared storage' do
           is_expected.not_to run_ruby_block("update_shared_storages")
         end
       end
 
-      context "when mount/unmount is required" do
+      context "when live update is required" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:is_live_update_required?).and_return(true)
             allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(true)
             allow_any_instance_of(Object).to receive(:dig).and_return(true)
+            allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
+            allow(Time).to receive(:now).and_return(Time.parse(time_now))
             RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-            node.override['cluster']['node_type'] = 'LoginNode'
+            node.override['cluster']['node_type'] = node_type
+            node.override['cluster']['cluster_name'] = cluster_name
+            node.override['cluster']['region'] = region
             node.override['ec2']['instance_id'] = instance_id
             node.override['cluster']['cluster_config_version'] = cluster_config_version
           end
@@ -80,39 +103,37 @@ describe 'aws-parallelcluster-slurm::update_login_node' do
         it 'updates the shared storage' do
           is_expected.to run_ruby_block("update_shared_storages")
         end
-      end
 
-      it 'saves the cluster config version to dynamodb' do
-        expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
-          " --table-name parallelcluster-#{cluster_name}"\
-          " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
-          " --region #{region}"
-        is_expected.to run_execute("Save cluster config version to DynamoDB").with(
-          command: expected_command,
-          retries: 3,
-          retry_delay: 5
-        )
+        status = "DEPLOYED"
+        it "saves the cluster config version to dynamodb with status #{status}" do
+          expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
+            " --table-name parallelcluster-#{cluster_name}"\
+            " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"status\": {\"S\": \"#{status}\"}, \"node_type\": {\"S\": \"#{node_type}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
+            " --region #{region}"
+          is_expected.to run_execute("Save cluster config version to DynamoDB").with(
+            command: expected_command,
+            retries: 3,
+            retry_delay: 5
+          )
+        end
       end
 
       context "when interaction with ddb is disabled during kitchen tests" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
-            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+            allow_any_instance_of(Object).to receive(:is_live_update_required?).and_return(true)
+            allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(true)
             allow_any_instance_of(Object).to receive(:dig).and_return(true)
-            allow_any_instance_of(Object).to receive(:is_static_node?).and_return(false)
             RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-            node.override['cluster']['node_type'] = 'LoginNode'
             node.override['kitchen'] = true
             node.override['interact_with_ddb'] = false
-            node.override['ec2']['instance_id'] = instance_id
-            node.override['cluster']['cluster_config_version'] = cluster_config_version
           end
           runner.converge(described_recipe)
         end
         cached(:node) { chef_run.node }
 
-        it 'does not saves the cluster config version to dynamodb' do
+        it 'does not save the cluster config version to dynamodb' do
           is_expected.not_to run_execute("Save cluster config version to DynamoDB")
         end
       end


### PR DESCRIPTION
### Description of changes
This change addresses the major gaps in the update workflows. In particular:
1. If the change-set does not require a live update on compute and login nodes, they save a DDB record with status SKIPPED_LIVE_UPDATE and exists from the update without performing and storage change.
2. If the change-set requires a live update on compute and login nodes, they perform the storage change and save a DDB record with status DEPLOYED.
3. The cluster readiness check performed by the head node considers successful all nodes having either status DEPLOYED or SKIPPED_LIVE_UPDATE.
4. Cluster readiness check now emits a more readable log about retrieved DDB items.


### Tests
* Manual tests: 
  * created a cluster without shared storage
  * updated it with external storage supporting live updates
  * updated it with external storage supporting live updates and adding more static nodes (to increase noise)
  * updated it with shared storage not supporting live updates
  * updated with a mix of shared storage changes that support and des not support live updates
  * updated shared storage with a change also in static fleet capacity. 
* Integ tests: `test_update_slurm` (with the fixes to the test code made in https://github.com/aws/aws-parallelcluster/pull/6110)
* Integ test `test_update_instance_list`

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
