### PR TITLE
[DFSM] Fix method that determines if a live update is required.

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
@@ -134,4 +134,6 @@ def is_live_update_required?
             end
 
   Chef::Log.info("Live update required: #{outcome}")
+
+  outcome
 end


### PR DESCRIPTION
### Description of changes
Fix method that determines if a live update is required.
We wrongly removed the returned value during an iteration in https://github.com/aws/aws-parallelcluster-cookbook/pull/2661

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
