### PR TITLE
[AD] Execute the directory service config recipe during the update only on the head node.

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-entrypoints::update' do
+  before do
+    @included_recipes = []
+    %w(
+      aws-parallelcluster-platform::update
+      aws-parallelcluster-environment::update
+      aws-parallelcluster-slurm::update
+      aws-parallelcluster-computefleet::update_parallelcluster_node
+    ).each do |recipe_name|
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with(recipe_name) do
+        @included_recipes << recipe_name
+      end
+    end
+  end
+
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      for_all_node_types do |node_type|
+        context "when #{node_type}" do
+          [true, false].each do |is_custom_node|
+            context "and does #{'not ' unless is_custom_node}use a custom node package" do
+              cached(:chef_run) do
+                runner = runner(platform: platform, version: version) do |node|
+                  allow_any_instance_of(Object).to receive(:fetch_config).and_return(OpenStruct.new)
+
+                  node.override['cluster']['node_type'] = node_type
+                  node.override['cluster']['scheduler'] = 'slurm'
+                  node.override['cluster']['custom_node_package'] = "CUSTOM_NODE_PACKAGE" if is_custom_node
+                end
+                runner.converge(described_recipe)
+              end
+              cached(:node) { chef_run.node }
+
+              expected_recipes = %w(
+                                  aws-parallelcluster-platform::update
+                                  aws-parallelcluster-environment::update
+                                  aws-parallelcluster-slurm::update
+                                )
+
+              if is_custom_node
+                expected_recipes = expected_recipes.append("aws-parallelcluster-computefleet::update_parallelcluster_node")
+              end
+
+              it "includes the recipes in the right order" do
+                chef_run
+                expect(@included_recipes).to eq(expected_recipes)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-environment/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/update.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-#
-# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -12,14 +11,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Fetch and load cluster configs
-include_recipe 'aws-parallelcluster-platform::update'
+# generate the updated shared storages mapping file
+include_recipe "aws-parallelcluster-environment::update_fs_mapping"
 
-include_recipe 'aws-parallelcluster-environment::update'
-
-include_recipe 'aws-parallelcluster-slurm::update' if node['cluster']['scheduler'] == 'slurm'
-
-# Update node package - useful for development purposes only
-if is_custom_node?
-  include_recipe 'aws-parallelcluster-computefleet::update_parallelcluster_node'
-end
+include_recipe "aws-parallelcluster-environment::directory_service" if node["cluster"]["node_type"] == "HeadNode"

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/update_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/update_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-environment::update' do
+  before do
+    @included_recipes = []
+    %w(
+      aws-parallelcluster-environment::update_fs_mapping
+      aws-parallelcluster-environment::directory_service
+    ).each do |recipe_name|
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with(recipe_name) do
+        @included_recipes << recipe_name
+      end
+    end
+  end
+
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      for_all_node_types do |node_type|
+        context "when #{node_type}" do
+          cached(:chef_run) do
+            runner = runner(platform: platform, version: version) do |node|
+              node.override['cluster']['node_type'] = node_type
+            end
+            runner.converge(described_recipe)
+          end
+          cached(:node) { chef_run.node }
+
+          expected_recipes = %w(aws-parallelcluster-environment::update_fs_mapping)
+
+          if node_type == "HeadNode"
+            expected_recipes = expected_recipes.append("aws-parallelcluster-environment::directory_service")
+          end
+
+          it "includes the recipes in the right order" do
+            chef_run
+            expect(@included_recipes).to eq(expected_recipes)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
Allow only the head node to execute the directory service config recipe during an update.

Adding this restriction became necessary in 3.9.0 with the introduction of the live updates for compute/login fleet, as part of DFSMv2 feature.

Before 3.9.0, the update recipes were executed only on the head node, so it was not necessary to specify any restriction.

### Tests
* Spec tests
* Integ test `test_ad_integration` now succeeds.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
