### PR TITLE
Add sync point between head node and login nodes + make DFSM check able to handle missing change-set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **BUG FIXES**
 - Fix issue making job fail when submitted as active directory user from login nodes. 
   The issue was caused by an incomplete configuration of the integration with the external Active Directory on the head node.
+- Fix issue making login nodes fail to bootstrap when the head node takes more time than expected in writing keys. 
 
 3.8.0
 ------

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/login_nodes_keys_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/login_nodes_keys_spec.rb
@@ -1,19 +1,24 @@
 require 'spec_helper'
 
 describe 'aws-parallelcluster-environment::login_nodes_keys' do
+  SHARED_DIR_LOGIN_NODES = "/SHARED_DIR_LOGIN_NODES".freeze
+  SYNC_FILE = "#{SHARED_DIR_LOGIN_NODES}/.login_nodes_keys_sync_file".freeze
+  CLUSTER_CONFIG_VERSION = "CLUSTER_CONFIG_VERSION".freeze
+
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       context "when awsbatch scheduler" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['scheduler'] = 'awsbatch'
+            node.override['cluster']['shared_dir_login_nodes'] = SHARED_DIR_LOGIN_NODES
           end
           runner.converge(described_recipe)
         end
         cached(:node) { chef_run.node }
 
         it 'does not create the script directory' do
-          is_expected.to_not create_directory("#{node['cluster']['shared_dir_login_nodes']}/scripts")
+          is_expected.to_not create_directory("#{SHARED_DIR_LOGIN_NODES}/scripts")
         end
       end
 
@@ -21,13 +26,14 @@ describe 'aws-parallelcluster-environment::login_nodes_keys' do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['node_type'] = 'ComputeFleet'
+            node.override['cluster']['shared_dir_login_nodes'] = SHARED_DIR_LOGIN_NODES
           end
           runner.converge(described_recipe)
         end
         cached(:node) { chef_run.node }
 
         it 'does not create the scripts directory' do
-          is_expected.to_not create_directory("#{node['cluster']['shared_dir_login_nodes']}/scripts")
+          is_expected.to_not create_directory("#{SHARED_DIR_LOGIN_NODES}/scripts")
         end
       end
 
@@ -36,14 +42,15 @@ describe 'aws-parallelcluster-environment::login_nodes_keys' do
           runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['node_type'] = 'HeadNode'
             node.override['cluster']['scheduler'] = 'slurm'
-            node.override['cluster']['shared_dir_login_nodes'] = '/opt/parallelcluster/shared_login_nodes'
+            node.override['cluster']['shared_dir_login_nodes'] = SHARED_DIR_LOGIN_NODES
+            node.override['cluster']['cluster_config_version'] = CLUSTER_CONFIG_VERSION
           end
           runner.converge(described_recipe)
         end
         cached(:node) { chef_run.node }
 
         it 'creates the scripts directory' do
-          is_expected.to create_directory("#{node['cluster']['shared_dir_login_nodes']}/scripts").with(
+          is_expected.to create_directory("#{SHARED_DIR_LOGIN_NODES}/scripts").with(
             owner: 'root',
             group: 'root',
             mode:  '0744'
@@ -51,7 +58,7 @@ describe 'aws-parallelcluster-environment::login_nodes_keys' do
         end
 
         it 'creates keys-manager.sh script' do
-          is_expected.to create_cookbook_file("#{node['cluster']['shared_dir_login_nodes']}/scripts/keys-manager.sh").with(
+          is_expected.to create_cookbook_file("#{SHARED_DIR_LOGIN_NODES}/scripts/keys-manager.sh").with(
             source: 'login_nodes/keys-manager.sh',
             owner: "root",
             group: "root",
@@ -61,7 +68,16 @@ describe 'aws-parallelcluster-environment::login_nodes_keys' do
 
         it "creates login nodes keys" do
           is_expected.to run_execute("Initialize Login Nodes keys")
-            .with(command: "bash #{node['cluster']['shared_dir_login_nodes']}/scripts/keys-manager.sh --create --folder-path #{node['cluster']['shared_dir_login_nodes']}")
+            .with(command: "bash #{SHARED_DIR_LOGIN_NODES}/scripts/keys-manager.sh --create --folder-path #{SHARED_DIR_LOGIN_NODES}")
+        end
+
+        it "writes the synchronization file for login nodes" do
+          is_expected.to create_file(SYNC_FILE).with(
+            content: CLUSTER_CONFIG_VERSION,
+            mode: '0644',
+            owner: 'root',
+            group: 'root'
+          )
         end
       end
 
@@ -70,15 +86,25 @@ describe 'aws-parallelcluster-environment::login_nodes_keys' do
           runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['node_type'] = 'LoginNode'
             node.override['cluster']['scheduler'] = 'slurm'
-            node.override['cluster']['shared_dir_login_nodes'] = '/opt/parallelcluster/shared_login_nodes'
+            node.override['cluster']['shared_dir_login_nodes'] = SHARED_DIR_LOGIN_NODES
+            node.override['cluster']['cluster_config_version'] = CLUSTER_CONFIG_VERSION
           end
           runner.converge(described_recipe)
         end
         cached(:node) { chef_run.node }
 
+        it "waits for cluster config version file" do
+          is_expected.to run_bash("Wait for synchronization file at #{SYNC_FILE} to be written for version #{CLUSTER_CONFIG_VERSION}").with(
+            code: "[[ \"$(cat #{SYNC_FILE})\" == \"#{CLUSTER_CONFIG_VERSION}\" ]] || exit 1",
+            retries: 30,
+            retry_delay: 10,
+            timeout: 5
+          )
+        end
+
         it "imports login nodes keys" do
           is_expected.to run_execute("Import Login Nodes keys")
-            .with(command: "bash #{node['cluster']['shared_dir_login_nodes']}/scripts/keys-manager.sh --import --folder-path #{node['cluster']['shared_dir_login_nodes']}")
+            .with(command: "bash #{SHARED_DIR_LOGIN_NODES}/scripts/keys-manager.sh --import --folder-path #{SHARED_DIR_LOGIN_NODES}")
         end
       end
     end

--- a/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
@@ -80,7 +80,8 @@ action :run do
 
     if new_resource.update
       # Wait for the head node to write the config version file, which is the signal that
-      # all configuration files within the shared folder are aligned with the latest config version.
+      # all configuration files (cluster config, change-set, ...) have been written on the shared folder
+      # and are aligned with the latest config version.
       # This is required only on update because on create it is guaranteed that this recipe is executed on compute node
       # only after it has completed on head node.
       wait_cluster_config_file(sync_file_login_nodes)

--- a/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/update.rb
@@ -36,7 +36,12 @@ end
 
 def are_mount_or_unmount_required?
   require 'json'
-  change_set = JSON.load_file("#{node['cluster']['shared_dir']}/change-set.json")
+
+  change_set_path = node["cluster"]["change_set_path"]
+
+  return false unless ::File.exist?(change_set_path)
+
+  change_set = JSON.load_file(change_set_path)
   change_set["changeSet"].each do |change|
     next unless change["updatePolicy"] == "SHARED_STORAGE_UPDATE_POLICY"
 

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/libraries/update_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/libraries/update_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe "aws-parallelcluster-slurm:libraries:are_mount_unmount_required" do
-  CHANGE_SET_PATH = "/CHANGE_SET_PATH"
+describe "aws-parallelcluster-slurm:libraries:are_mount_or_unmount_required" do
+  CHANGE_SET_PATH = "/CHANGE_SET_PATH".freeze
 
   let(:node) do
     {

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/libraries/update_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/libraries/update_spec.rb
@@ -1,18 +1,31 @@
 require 'spec_helper'
 
 describe "aws-parallelcluster-slurm:libraries:are_mount_unmount_required" do
+  CHANGE_SET_PATH = "/CHANGE_SET_PATH"
+
   let(:node) do
     {
-      "cluster" => { "shared_dir" => "/SHARED_DIR" },
+      "cluster" => { "change_set_path" => CHANGE_SET_PATH },
     }
   end
 
   shared_examples "the correct method" do |changeset, expected_result|
     it "returns #{expected_result}" do
-      allow(File).to receive(:read).with("/SHARED_DIR/change-set.json").and_return(JSON.dump(changeset))
+      if changeset.nil?
+        allow(File).to receive(:exist?).with(CHANGE_SET_PATH).and_return(false)
+        allow(File).to receive(:read).with(CHANGE_SET_PATH).and_call_original
+      else
+        allow(File).to receive(:exist?).with(CHANGE_SET_PATH).and_return(true)
+        allow(File).to receive(:read).with(CHANGE_SET_PATH).and_return(JSON.dump(changeset))
+      end
       result = are_mount_or_unmount_required?
       expect(result).to eq(expected_result)
     end
+  end
+
+  context "when changeset does not exist" do
+    changeset = nil
+    include_examples "the correct method", changeset, false
   end
 
   context "when changeset is empty" do


### PR DESCRIPTION
### Description of changes
1. Add a syncronization point between head node and login nodes, so that login nodes wait for the head node to write the keys before attempting to import them. The lack of dependency is the source of sporadic bootstrap failures in login nodes.
2.  Make DFSM check able to handle missing change-set: when a change-set file is missing then for sure mount/unmount is not required.
3. Clarify a comment describing the role of a syncronization file
4. Add tests

### Tests
* Spec test
* Kitchen: ./kitchen.ec2.sh environment-config test login-nodes-keys-configuration-alinux2
* `test_shared_home` succeeded; it used to show login nodes bootstrap failures before this change.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
