### PR TITLE
Get instances from DynamoDB in batches of 100

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/common/constants.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/common/constants.py
@@ -12,7 +12,7 @@ from botocore.config import Config
 
 # BOTO
 BOTO_CONFIG = Config(retries={"max_attempts": 60})
-BOTO_PAGINATION_CONFIG = {"PageSize": 500}
+BOTO_PAGINATION_CONFIG = {"PageSize": 100}
 
 # TAGS
 CLUSTER_NAME_TAG = "parallelcluster:cluster-name"

--- a/test/unit/head_node_checks/test_check_cluster_ready.py
+++ b/test/unit/head_node_checks/test_check_cluster_ready.py
@@ -41,7 +41,7 @@ def _mocked_request_describe_instances(cluster_name: str, node_types: [str], com
                 {"Name": "tag:parallelcluster:node-type", "Values": node_types},
                 {"Name": "instance-state-name", "Values": ["running"]},
             ],
-            "MaxResults": 500,
+            "MaxResults": 100,
         },
         generate_error=False,
         error_code=None,


### PR DESCRIPTION
DynamoDB batch_get_item API limit the number of input to 100. This change fixes cluster creation with >100 compute nodes

### Tests
Manually tested cluster creation and update with 1000 compute nodes

### References
* This PR fixes a bug from https://github.com/aws/aws-parallelcluster-cookbook/pull/2634

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
