### PR TITLE
[release-3.9][DFSM]Using cluster-config-version file to be used during Init and Update phase of cluster

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/recipes/init/login_nodes_keys.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/init/login_nodes_keys.rb
@@ -21,7 +21,7 @@ keys_dir = "#{node['cluster']['shared_dir_login_nodes']}"
 script_dir = "#{keys_dir}/scripts"
 script_path = "#{script_dir}/keys-manager.sh"
 
-sync_file_path = "#{keys_dir}/.login_nodes_keys_sync_file"
+sync_file_path = "#{keys_dir}/cluster-config-version"
 
 case node['cluster']['node_type']
 when 'ComputeFleet'
@@ -46,11 +46,11 @@ when 'HeadNode'
     user 'root'
   end
 
-  write_sync_file(sync_file_path)
+  write_config_version_file(sync_file_path)
 
 when 'LoginNode'
 
-  wait_sync_file(sync_file_path)
+  wait_cluster_config_file(sync_file_path)
 
   execute 'Import Login Nodes keys' do
     command "bash #{script_path} --import --folder-path #{keys_dir}"

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/login_nodes_keys_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/login_nodes_keys_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'aws-parallelcluster-environment::login_nodes_keys' do
   SHARED_DIR_LOGIN_NODES = "/SHARED_DIR_LOGIN_NODES".freeze
-  SYNC_FILE = "#{SHARED_DIR_LOGIN_NODES}/.login_nodes_keys_sync_file".freeze
+  SYNC_FILE = "#{SHARED_DIR_LOGIN_NODES}/cluster-config-version".freeze
   CLUSTER_CONFIG_VERSION = "CLUSTER_CONFIG_VERSION".freeze
 
   for_all_oses do |platform, version|
@@ -94,10 +94,10 @@ describe 'aws-parallelcluster-environment::login_nodes_keys' do
         cached(:node) { chef_run.node }
 
         it "waits for cluster config version file" do
-          is_expected.to run_bash("Wait for synchronization file at #{SYNC_FILE} to be written for version #{CLUSTER_CONFIG_VERSION}").with(
+          is_expected.to run_bash("Wait for file at #{SYNC_FILE} to be updated by the head node").with(
             code: "[[ \"$(cat #{SYNC_FILE})\" == \"#{CLUSTER_CONFIG_VERSION}\" ]] || exit 1",
             retries: 30,
-            retry_delay: 10,
+            retry_delay: 15,
             timeout: 5
           )
         end

--- a/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
@@ -162,27 +162,4 @@ action_class do # rubocop:disable Metrics/BlockLength
       fetch_s3_object("copy_instance_type_data_from_s3", node['cluster']['instance_types_data_s3_key'], node['cluster']['instance_types_data_path'], instance_version_id)
     end
   end
-
-  def write_config_version_file(path)
-    # Write the cluster config version into the specified file.
-    # This file is used as a synchronization point between the head node and the other cluster nodes.
-    # In particular, the head node uses this file to signal to other cluster nodes that all files
-    # in the shared folder related to the cluster config have been updated with the current config version.
-    file path do
-      content node['cluster']['cluster_config_version']
-      mode '0644'
-      owner 'root'
-      group 'root'
-    end
-  end
-
-  def wait_cluster_config_file(path)
-    # Wait for the config version file to contain the current cluster config version.
-    bash "Wait cluster config files to be updated by the head node" do
-      code "[[ \"$(cat #{path})\" == \"#{node['cluster']['cluster_config_version']}\" ]] || exit 1"
-      retries 30
-      retry_delay 15
-      timeout 5
-    end
-  end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
@@ -59,7 +59,7 @@ describe 'fetch_config:run' do
     end
 
     it "does not wait for cluster config version file" do
-      is_expected.not_to run_execute("Wait cluster config files to be updated by the head node")
+      is_expected.not_to run_execute("Wait for file at /shared_dir_login_nodes/cluster-config-version to be updated by the head node")
     end
   end
 
@@ -90,7 +90,7 @@ describe 'fetch_config:run' do
       end
 
       it "does not wait for cluster config version file" do
-        is_expected.not_to run_execute("Wait cluster config files to be updated by the head node")
+        is_expected.not_to run_execute("Wait for file at #{cluster_config_path} to be updated by the head node")
       end
 
       it "reads config from shared folder" do
@@ -146,7 +146,7 @@ describe 'fetch_config:run' do
                               else
                                 raise "Unsupported node_type #{node_type}"
                               end
-        is_expected.to run_bash("Wait cluster config files to be updated by the head node").with(
+        is_expected.to run_bash("Wait for file at #{config_version_file} to be updated by the head node").with(
           code: "[[ \"$(cat #{config_version_file})\" == \"cluster_config_version\" ]] || exit 1",
           retries: 30,
           retry_delay: 15,

--- a/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
@@ -82,28 +82,28 @@ def is_custom_node?
   !custom_node_package.nil? && !custom_node_package.empty?
 end
 
-def write_sync_file(path)
-  # Write a synchronization file containing the current cluster config version.
-  # Synchronization files are used as a synchronization point between cluster nodes
-  # to signal that a group of actions have been completed.
+def write_config_version_file(path)
+  # Write the cluster config version into the specified file.
+  # This file is used as a synchronization point between the head node and the other cluster nodes.
+  # In particular, the head node uses this file to signal to other cluster nodes that all files
+  # in the shared folder related to the cluster config have been updated with the current config version.
   file path do
-    content node["cluster"]["cluster_config_version"]
-    mode "0644"
-    owner "root"
-    group "root"
+    content node['cluster']['cluster_config_version']
+    mode '0644'
+    owner 'root'
+    group 'root'
   end
 end
 
-def wait_sync_file(path)
+def wait_cluster_config_file(path)
   # Wait for a synchronization file to be written for the current cluster config version.
   # Synchronization files are used as a synchronization point between cluster nodes
   # to signal that a group of actions have been completed.
-  cluster_config_version = node["cluster"]["cluster_config_version"]
   # Wait for the config version file to contain the current cluster config version.
-  bash "Wait for synchronization file at #{path} to be written for version #{cluster_config_version}" do
-    code "[[ \"$(cat #{path})\" == \"#{cluster_config_version}\" ]] || exit 1"
+  bash "Wait for file at #{path} to be updated by the head node" do
+    code "[[ \"$(cat #{path})\" == \"#{node['cluster']['cluster_config_version']}\" ]] || exit 1"
     retries 30
-    retry_delay 10
+    retry_delay 15
     timeout 5
   end
 end


### PR DESCRIPTION
### Description of changes
[DFSM]Using cluster-config-version file to be used during Init and Update phase of cluster

Moving login_nodes_keys.rb in init folder as its invoked during init phase of cluster creation and removing `/opt/parallelcluster/shared_login_nodes/.login_nodes_keys_sync_file`


Bug:
Introduced in https://github.com/aws/aws-parallelcluster-cookbook/pull/2671

The file we create `/opt/parallelcluster/shared_login_nodes/.login_nodes_keys_sync_file` or `/opt/parallelcluster/shared_login_nodes/cluster-config-version`  as part of sync during cluster never gets updated when we Stop-Start the Cluster.
This file needs to be updated or any new Login Nodes which are launched after update of the Cluster, goes through the Init phase and wait for the content to be the latest. 

### Tests
* Unit Tests 
* test_create_disable_sudo_access_for_default_user and test_dynamic_file_systems_update [ONGOING]

develop https://github.com/aws/aws-parallelcluster-cookbook/pull/2676

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
