### PR TITLE
[release-3.9][DFSM]Using .login_nodes_keys_sync_file  to be used during Init and Update phase of the clusters

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -55,6 +55,7 @@ default['cluster']['head_node_home_path'] = '/home'
 default['cluster']['shared_dir_compute'] = node['cluster']['shared_dir']
 default['cluster']['shared_dir_head'] = node['cluster']['shared_dir']
 default['cluster']['shared_dir_login'] = node['cluster']['shared_dir_login_nodes']
+default['cluster']['shared_login_nodes_keys_sync_file'] = "#{node['cluster']['shared_dir_login_nodes']}/.login_nodes_keys_sync_file"
 # Since this is a shared directory, it needs to be defined here first instead of in the dependent cookbook for slurm
 default['cluster']['slurm']['install_dir'] = '/opt/slurm'
 

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/login_nodes_keys.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/login_nodes_keys.rb
@@ -21,7 +21,7 @@ keys_dir = "#{node['cluster']['shared_dir_login_nodes']}"
 script_dir = "#{keys_dir}/scripts"
 script_path = "#{script_dir}/keys-manager.sh"
 
-sync_file_path = "#{keys_dir}/.login_nodes_keys_sync_file"
+sync_file_path = "#{node['cluster']['shared_login_nodes_keys_sync_file']}"
 
 case node['cluster']['node_type']
 when 'ComputeFleet'

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/login_nodes_keys_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/login_nodes_keys_spec.rb
@@ -93,9 +93,9 @@ describe 'aws-parallelcluster-environment::login_nodes_keys' do
         end
         cached(:node) { chef_run.node }
 
-        it "waits for cluster config version file" do
-          is_expected.to run_bash("Wait for synchronization file at #{SYNC_FILE} to be written for version #{CLUSTER_CONFIG_VERSION}").with(
-            code: "[[ \"$(cat #{SYNC_FILE})\" == \"#{CLUSTER_CONFIG_VERSION}\" ]] || exit 1",
+        it "Wait for sync file to exist" do
+          is_expected.to run_bash("Wait for synchronization file at #{SYNC_FILE} to exist").with(
+            code: "[[ -e #{SYNC_FILE} ]] || exit 1",
             retries: 30,
             retry_delay: 10,
             timeout: 5

--- a/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
@@ -95,13 +95,12 @@ def write_sync_file(path)
 end
 
 def wait_sync_file(path)
-  # Wait for a synchronization file to be written for the current cluster config version.
+  # Wait for a synchronization file to exist.
   # Synchronization files are used as a synchronization point between cluster nodes
   # to signal that a group of actions have been completed.
-  cluster_config_version = node["cluster"]["cluster_config_version"]
   # Wait for the config version file to contain the current cluster config version.
-  bash "Wait for synchronization file at #{path} to be written for version #{cluster_config_version}" do
-    code "[[ \"$(cat #{path})\" == \"#{cluster_config_version}\" ]] || exit 1"
+  bash "Wait for synchronization file at #{path} to exist" do
+    code "[[ -e #{path} ]] || exit 1"
     retries 30
     retry_delay 10
     timeout 5


### PR DESCRIPTION
### Description of changes
[DFSM]Using .login_nodes_keys_sync_file  to be used during Init and Update phase of the clusters


Bug:
Introduced in https://github.com/aws/aws-parallelcluster-cookbook/pull/2671 and https://github.com/aws/aws-parallelcluster-cookbook/pull/2672

The file we create `/opt/parallelcluster/shared_login_nodes/.login_nodes_keys_sync_file` as part of sync during cluster never gets updated when we Stop-Start the Cluster.
This file needs to be updated or any new Login Nodes which are launched after update of the Cluster, goes through the Init phase and wait for the content to be the latest. 

### Tests
* Unit Tests 
* test_create_disable_sudo_access_for_default_user and test_dynamic_file_systems_update [ONGOING]

develop https://github.com/aws/aws-parallelcluster-cookbook/pull/2678

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
