### PR TITLE
[Supervisord] Remove extra tab added for ADC regions only, compromising the bootstrap of supervisord.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
@@ -10,7 +10,7 @@ redirect_stderr = true
 stdout_logfile = /var/log/parallelcluster/cfn-hup-runner.log
 stdout_logfile_maxbytes = 1MB
 <% if @region.start_with?('us-iso') -%>
-  environment = AWS_CA_BUNDLE="<%= @aws_ca_bundle %>"
+environment = AWS_CA_BUNDLE="<%= @aws_ca_bundle %>"
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
### Description of changes
Remove extra tab added for ADC regions only, compromising the bootstrap of supervisord.

### Tests
Expected to fix ADc deployment according to supervisord error logs.
No impact outside ADC since the environment block is included only for ADc regions.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
