### PR TITLE
Force a string `true` in the update_shared_storages to match the expectations of  _mount_unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.10.0
+------
+
+**ENHANCEMENTS**
+
+**CHANGES**
+
+**BUG FIXES**
+- Fixed an issue that prevented cluster updates from including EFS filesystems with encryption in transit.
+
 3.9.0
 ------
 

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/update_shared_storages.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/update_shared_storages.rb
@@ -83,8 +83,9 @@ ruby_block "get storage to mount and unmount" do
         next unless not_in_shared_storages_mapping["efs"].nil? || !not_in_shared_storages_mapping["efs"].include?(storage)
         shared_dir_array.push(storage["mount_dir"])
         efs_fs_id_array.push(storage["efs_fs_id"])
-        efs_encryption_in_transit_array.push(storage["efs_encryption_in_transit"])
-        efs_iam_authorization_array.push(storage["efs_iam_authorization"])
+        # The EFS resource expects strings for these attributes, not booleans
+        efs_encryption_in_transit_array.push(String(storage["efs_encryption_in_transit"]))
+        efs_iam_authorization_array.push(String(storage["efs_iam_authorization"]))
       end
     end
     [shared_dir_array, efs_fs_id_array, efs_encryption_in_transit_array, efs_iam_authorization_array]


### PR DESCRIPTION
… in the efs resource

Updates to a cluster result in boolean values for the iam_authorization and efs_encryption_in_transit objects.

### Tests
* Tested the change locally with an update to a cluster with an EFS fs with encryption in transit.  Adding the boolean check allows the cookbook to use TLS for the fs.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
