### PR TITLE
[Storage] Delete the shared directory only if the directory exists and it is empty.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_mount_umount.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_mount_umount.rb
@@ -120,7 +120,7 @@ action :unmount do
       mode '1777'
       recursive false
       action :delete
-      only_if { Dir.empty?(efs_shared_dir.to_s) }
+      only_if { Dir.exist?(efs_shared_dir.to_s) && Dir.empty?(efs_shared_dir.to_s) }
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_mount_unmount.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_mount_unmount.rb
@@ -92,7 +92,7 @@ action :unmount do
       mode '1777'
       recursive false
       action :delete
-      only_if { Dir.empty?(fsx.shared_dir) }
+      only_if { Dir.exist?(fsx.shared_dir) && Dir.empty?(fsx.shared_dir) }
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/volume.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/volume.rb
@@ -114,7 +114,7 @@ action :unmount do
   directory shared_dir do
     recursive false
     action :delete
-    only_if { Dir.empty?(shared_dir) }
+    only_if { Dir.exist?(shared_dir) && Dir.empty?(shared_dir) }
   end
 end
 

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efs_spec.rb
@@ -355,7 +355,9 @@ describe 'efs:unmount' do
       before do
         stub_command("mount | grep ' /shared_dir_1 '").and_return(false)
         stub_command("mount | grep ' /shared_dir_2 '").and_return(true)
+        allow(Dir).to receive(:exist?).with("/shared_dir_1").and_return(true)
         allow(Dir).to receive(:empty?).with("/shared_dir_1").and_return(true)
+        allow(Dir).to receive(:exist?).with("/shared_dir_2").and_return(true)
         allow(Dir).to receive(:empty?).with("/shared_dir_2").and_return(false)
       end
 
@@ -382,7 +384,7 @@ describe 'efs:unmount' do
         end
       end
 
-      it "deletes shared dir only if empty" do
+      it "deletes shared dir only if it exists and it is empty" do
         is_expected.to delete_directory('/shared_dir_1')
           .with(recursive: false)
 

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_mount_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_mount_spec.rb
@@ -362,7 +362,9 @@ describe 'lustre:unmount' do
         before do
           stub_command("mount | grep ' /shared_dir_1 '").and_return(false)
           stub_command("mount | grep ' /shared_dir_2 '").and_return(true)
+          allow(Dir).to receive(:exist?).with("/shared_dir_1").and_return(true)
           allow(Dir).to receive(:empty?).with("/shared_dir_1").and_return(true)
+          allow(Dir).to receive(:exist?).with("/shared_dir_2").and_return(true)
           allow(Dir).to receive(:empty?).with("/shared_dir_2").and_return(false)
         end
 
@@ -386,7 +388,7 @@ describe 'lustre:unmount' do
             .with(pattern: "lustre_id_2.fsx.REGION.amazonaws.com@tcp:/mount_name_2 *")
         end
 
-        it 'deletes shared dir only if empty' do
+        it 'deletes shared dir only if it exists and it is empty' do
           is_expected.to delete_directory('/shared_dir_1')
             .with(recursive: false)
           is_expected.not_to delete_directory('/shared_dir_2')
@@ -417,7 +419,9 @@ describe 'lustre:unmount' do
         before do
           stub_command("mount | grep ' /shared_dir_1 '").and_return(false)
           stub_command("mount | grep ' /shared_dir_2 '").and_return(true)
+          allow(Dir).to receive(:exist?).with("/shared_dir_1").and_return(true)
           allow(Dir).to receive(:empty?).with("/shared_dir_1").and_return(true)
+          allow(Dir).to receive(:exist?).with("/shared_dir_2").and_return(true)
           allow(Dir).to receive(:empty?).with("/shared_dir_2").and_return(false)
         end
 
@@ -441,7 +445,7 @@ describe 'lustre:unmount' do
             .with(pattern: "ontap_id_2.fsx.REGION.amazonaws.com:/junction_path_2 *")
         end
 
-        it 'deletes shared dir only if empty' do
+        it 'deletes shared dir only if it exists and it is empty' do
           is_expected.to delete_directory('/shared_dir_1')
             .with(recursive: false)
           is_expected.not_to delete_directory('/shared_dir_2')
@@ -472,7 +476,9 @@ describe 'lustre:unmount' do
         before do
           stub_command("mount | grep ' /filecache_dir_1 '").and_return(false)
           stub_command("mount | grep ' /filecache_dir_2 '").and_return(true)
+          allow(Dir).to receive(:exist?).with("/filecache_dir_1").and_return(true)
           allow(Dir).to receive(:empty?).with("/filecache_dir_1").and_return(true)
+          allow(Dir).to receive(:exist?).with("/filecache_dir_2").and_return(true)
           allow(Dir).to receive(:empty?).with("/filecache_dir_2").and_return(false)
         end
 
@@ -496,7 +502,7 @@ describe 'lustre:unmount' do
             .with(pattern: "filecache_dns_name_2@tcp:/filecache_mount_name_2 *")
         end
 
-        it 'deletes shared dir only if empty' do
+        it 'deletes shared dir only if it exists and it is empty' do
           is_expected.to delete_directory('/filecache_dir_1')
             .with(recursive: false)
           is_expected.not_to delete_directory('/filecache_dir_2')

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/volume_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/volume_spec.rb
@@ -134,6 +134,7 @@ describe 'volume:unmount' do
 
             before do
               stub_command("mount | grep ' /SHARED_DIR '").and_return(false)
+              allow(Dir).to receive(:exist?).with("/SHARED_DIR").and_return(true)
               allow(Dir).to receive(:empty?).with("/SHARED_DIR").and_return(is_dir_empty)
             end
 
@@ -147,7 +148,7 @@ describe 'volume:unmount' do
                 .with(pattern: " /SHARED_DIR ")
             end
 
-            it "deletes shared dir only if empty" do
+            it "deletes shared dir only if it exists and it is empty" do
               if is_dir_empty
                 is_expected.to delete_directory('/SHARED_DIR')
                   .with(recursive: false)
@@ -174,6 +175,7 @@ describe 'volume:unmount' do
 
             before do
               stub_command("mount | grep ' /SHARED_DIR '").and_return(true)
+              allow(Dir).to receive(:exist?).with("/SHARED_DIR").and_return(true)
               allow(Dir).to receive(:empty?).with("/SHARED_DIR").and_return(is_dir_empty)
             end
 
@@ -189,7 +191,7 @@ describe 'volume:unmount' do
                 .with(pattern: " /SHARED_DIR ")
             end
 
-            it "deletes shared dir only if empty" do
+            it "deletes shared dir only if it exists and it is empty" do
               if is_dir_empty
                 is_expected.to delete_directory('/SHARED_DIR')
                   .with(recursive: false)


### PR DESCRIPTION
### Description of changes
Delete the shared directory only if the directory exists and it is empty.
this change completes the change in https://github.com/aws/aws-parallelcluster-cookbook/pull/2696, where we introduced the emptiness condition. 
We introduce in this PR the condition of existence because otherwise, the empty condition may fail when the directory does not exist.

### Tests
* Spec test covering the change
* [PENDING] Verified that the rollback path is fixed doing what the DFSM integ test does.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
