### PR TITLE
[Slurm] Make slurmctld and slurmdbd services wait for remote file systems to be mounted before being started.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Fixed an issue that prevented cluster updates from including EFS filesystems with encryption in transit.
+- Fixed an issue that prevented slurmctld and slurmdbd services from restarting on head node reboot when
+  EFS is used for shared internal data. 
 
 3.9.1
 ------

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/slurmctld.service.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/slurmctld.service.erb
@@ -1,6 +1,6 @@
 [Unit]
 Description=Slurm controller daemon
-After=network-online.target munge.service
+After=network-online.target munge.service remote-fs.target
 Wants=network-online.target
 ConditionPathExists=<%= node['cluster']['slurm']['install_dir'] %>/etc/slurm.conf
 

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/slurmdbd.service.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/slurmdbd.service.erb
@@ -1,6 +1,6 @@
 [Unit]
 Description=Slurm DBD accounting daemon
-After=network-online.target munge.service mysql.service mysqld.service mariadb.service
+After=network-online.target munge.service mysql.service mysqld.service mariadb.service remote-fs.target
 Wants=network-online.target
 ConditionPathExists=<%= node['cluster']['slurm']['install_dir'] %>/etc/slurmdbd.conf
 


### PR DESCRIPTION
### Description of changes
Make slurmctld and slurmdbd services wait for remote file systems to be mounted before being started.

### Tests
* Before this change, slurmctld fails to restart on head node reboot.
* After this change, slurmctld succeeds the restart on head node reboot.
* The same change was already applied to slurmd
* We can safely assume that the same applies to slurmdbd

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
