### PR TITLE
Refactored config recipe for the head node to make it easier to unit test definition of slurm services and added tests.

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
@@ -192,14 +192,7 @@ template "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/
   mode '0644'
 end
 
-template '/etc/systemd/system/slurmctld.service' do
-  source 'slurm/head_node/slurmctld.service.erb'
-  owner 'root'
-  group 'root'
-  mode '0644'
-  action :create
-end
-
+include_recipe 'aws-parallelcluster-slurm::config_slurmctld_systemd_service'
 include_recipe 'aws-parallelcluster-slurm::config_health_check'
 
 ruby_block "Configure Slurm Accounting" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurmctld_systemd_service.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurmctld_systemd_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-slurm
+# Recipe:: config_slurmctld_systemd_service.rb
+#
+# Copyright:: 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create systemd service file for slurmctld
+template '/etc/systemd/system/slurmctld.service' do
+  source 'slurm/head_node/slurmctld.service.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_head_node_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::config_head_node' do
+  before do
+    @included_recipes = []
+    %w(
+      aws-parallelcluster-slurm::config_head_node_directories
+      aws-parallelcluster-slurm::config_check_login_stopped_script
+      aws-parallelcluster-slurm::config_munge_key
+      aws-parallelcluster-slurm::config_slurm_resume
+      aws-parallelcluster-slurm::config_slurmctld_systemd_service
+      aws-parallelcluster-slurm::config_health_check
+    ).each do |recipe_name|
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with(recipe_name) do
+        @included_recipes << recipe_name
+      end
+    end
+  end
+
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner = runner(platform: platform, version: version) do |node|
+          allow_any_instance_of(Object).to receive(:nvidia_installed?).and_return(false)
+
+          node.override['cluster']['node_type'] = 'HeadNode'
+          node.override['cluster']['scheduler'] = 'slurm'
+          node.override['cluster']['config'] = {}
+        end
+        runner.converge(described_recipe)
+      end
+      cached(:node) { chef_run.node }
+
+      expected_recipes = %w(
+          aws-parallelcluster-slurm::config_head_node_directories
+          aws-parallelcluster-slurm::config_check_login_stopped_script
+          aws-parallelcluster-slurm::config_munge_key
+          aws-parallelcluster-slurm::config_slurm_resume
+          aws-parallelcluster-slurm::config_slurmctld_systemd_service
+          aws-parallelcluster-slurm::config_health_check
+                                 )
+
+      it "includes the recipes in the right order" do
+        chef_run
+        expect(@included_recipes).to eq(expected_recipes)
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurm_accounting_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurm_accounting_spec.rb
@@ -13,6 +13,20 @@ describe 'aws-parallelcluster-slurm::config_slurm_accounting' do
       end
       cached(:node) { chef_run.node }
 
+      it 'creates the service definition for slurmdbd' do
+        is_expected.to create_template('/etc/systemd/system/slurmdbd.service').with(
+          source: 'slurm/head_node/slurmdbd.service.erb',
+          owner: 'root',
+          group: 'root',
+          mode:  '0644'
+        )
+      end
+
+      it 'creates the service definition for slurmdbd with the correct settings' do
+        is_expected.to render_file('/etc/systemd/system/slurmdbd.service')
+          .with_content("After=network-online.target munge.service mysql.service mysqld.service mariadb.service remote-fs.target")
+      end
+
       it 'creates the slurmdbd configuration files' do
         slurm_install_dir = "#{node['cluster']['slurm']['install_dir']}"
         slurm_user  = "#{node['cluster']['slurm']['user']}"

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurmctld_systemd_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurmctld_systemd_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::config_slurmctld_systemd_service' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner(platform: platform, version: version).converge(described_recipe)
+      end
+
+      it 'creates the service definition for slurmctld' do
+        is_expected.to create_template('/etc/systemd/system/slurmctld.service').with(
+          source: 'slurm/head_node/slurmctld.service.erb',
+          owner: 'root',
+          group: 'root',
+          mode:  '0644'
+        )
+      end
+
+      it 'creates the service definition for slurmctld with the correct settings' do
+        is_expected.to render_file('/etc/systemd/system/slurmctld.service')
+          .with_content("After=network-online.target munge.service remote-fs.target")
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurmd_systemd_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurmd_systemd_service_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::config_slurmd_systemd_service' do
+  before do
+    allow_any_instance_of(Object).to receive(:graphic_instance?).and_return(false)
+    allow_any_instance_of(Object).to receive(:nvidia_installed?).and_return(false)
+  end
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner(platform: platform, version: version).converge(described_recipe)
+      end
+
+      it 'creates the service definition for slurmd' do
+        is_expected.to create_template('/etc/systemd/system/slurmd.service').with(
+          source: 'slurm/compute/slurmd.service.erb',
+          owner: 'root',
+          group: 'root',
+          mode:  '0644'
+        )
+      end
+
+      it 'creates the service definition for slurmd with the correct settings' do
+        is_expected.to render_file('/etc/systemd/system/slurmd.service')
+          .with_content("After=munge.service network-online.target remote-fs.target")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
Refactored config recipe for the head node to make it easier to unit test definition of slurm services and added tests.
Added spec tests covering the definitions of slurmctld, slurmd and slurmdbd.

### Tests
* Spec tests
* ONGOING cluster creation with Slurm Accounting enabled

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
