### PR TITLE
Add possibility to disable slurmdbd systemd service and extend timeout

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -15,3 +15,6 @@ default['cluster']['enable_nss_slurm'] = node['cluster']['directory_service']['e
 # PMIX Version and Checksum
 default['cluster']['pmix']['version'] = '4.2.9'
 default['cluster']['pmix']['sha256'] = '00ddb36fb81c31519972079a218c3cdd903510fc3910abaf4d484068fa29e884'
+
+# Slurmdbd
+default['cluster']['slurmdbd_service_enabled'] == "true"

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurm_accounting_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurm_accounting_spec.rb
@@ -3,83 +3,92 @@ require 'spec_helper'
 describe 'aws-parallelcluster-slurm::config_slurm_accounting' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
-      cached(:chef_run) do
-        runner = runner(platform: platform, version: version) do
-          allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
-          allow_any_instance_of(Object).to receive(:dig).and_return(true)
-          RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+      %w(true false).each do |enable_service|
+        context "when service enabled is #{enable_service}" do
+          cached(:chef_run) do
+            runner = runner(platform: platform, version: version) do |node|
+              allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
+              allow_any_instance_of(Object).to receive(:dig).and_return(true)
+              RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+              node.override['cluster']['slurmdbd_service_enabled'] = enable_service
+            end
+            runner.converge(described_recipe)
+          end
+          cached(:node) { chef_run.node }
+
+          it 'creates the service definition for slurmdbd' do
+            is_expected.to create_template('/etc/systemd/system/slurmdbd.service').with(
+              source: 'slurm/head_node/slurmdbd.service.erb',
+              owner: 'root',
+              group: 'root',
+              mode:  '0644'
+            )
+          end
+
+          it 'creates the service definition for slurmdbd with the correct settings' do
+            is_expected.to render_file('/etc/systemd/system/slurmdbd.service')
+              .with_content("After=network-online.target munge.service mysql.service mysqld.service mariadb.service remote-fs.target")
+          end
+
+          it 'creates the slurmdbd configuration files' do
+            slurm_install_dir = "#{node['cluster']['slurm']['install_dir']}"
+            slurm_user  = "#{node['cluster']['slurm']['user']}"
+            slurm_group = "#{node['cluster']['slurm']['group']}"
+            is_expected.to create_template("/etc/systemd/system/slurmdbd.service").with(
+              source: 'slurm/head_node/slurmdbd.service.erb',
+              user: 'root',
+              group: 'root',
+              mode:  '0644'
+            )
+            is_expected.to create_template_if_missing("#{slurm_install_dir}/etc/slurmdbd.conf").with(
+              source: 'slurm/slurmdbd.conf.erb',
+              user: slurm_user,
+              group: slurm_group,
+              mode:  '0600'
+            )
+            is_expected.to create_file("#{slurm_install_dir}/etc/slurm_parallelcluster_slurmdbd.conf").with(
+              user: slurm_user,
+              group: slurm_group,
+              mode:  '0600'
+            )
+          end
+
+          it 'creates the Slurm database password update script' do
+            is_expected.to create_template("#{node['cluster']['scripts_dir']}/slurm/update_slurm_database_password.sh").with(
+              source: 'slurm/head_node/update_slurm_database_password.sh.erb',
+              user: 'root',
+              group: 'root',
+              mode:  '0700'
+            )
+          end
+
+          it 'executes the Slurm database password update scripts' do
+            is_expected.to run_execute("update Slurm database password").with(
+              command: "#{node['cluster']['scripts_dir']}/slurm/update_slurm_database_password.sh",
+              user: "root",
+              group: "root"
+            )
+          end
+          if enable_service == "true"
+            it 'starts the slurm database daemon' do
+              is_expected.to enable_service("slurmdbd")
+              is_expected.to start_service("slurmdbd")
+            end
+            it "waits for the Slurm database to respond" do
+              is_expected.to run_execute("wait for slurm database").with(
+                command: "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn"
+              )
+            end
+
+            it "bootstraps the Slurm database idempotently" do
+              is_expected.to run_bash("bootstrap slurm database")
+            end
+          else
+            it 'disables the slurm database daemon' do
+              is_expected.to disable_service("slurmdbd")
+            end
+          end
         end
-        runner.converge(described_recipe)
-      end
-      cached(:node) { chef_run.node }
-
-      it 'creates the service definition for slurmdbd' do
-        is_expected.to create_template('/etc/systemd/system/slurmdbd.service').with(
-          source: 'slurm/head_node/slurmdbd.service.erb',
-          owner: 'root',
-          group: 'root',
-          mode:  '0644'
-        )
-      end
-
-      it 'creates the service definition for slurmdbd with the correct settings' do
-        is_expected.to render_file('/etc/systemd/system/slurmdbd.service')
-          .with_content("After=network-online.target munge.service mysql.service mysqld.service mariadb.service remote-fs.target")
-      end
-
-      it 'creates the slurmdbd configuration files' do
-        slurm_install_dir = "#{node['cluster']['slurm']['install_dir']}"
-        slurm_user  = "#{node['cluster']['slurm']['user']}"
-        slurm_group = "#{node['cluster']['slurm']['group']}"
-        is_expected.to create_template("/etc/systemd/system/slurmdbd.service").with(
-          source: 'slurm/head_node/slurmdbd.service.erb',
-          user: 'root',
-          group: 'root',
-          mode:  '0644'
-        )
-        is_expected.to create_template_if_missing("#{slurm_install_dir}/etc/slurmdbd.conf").with(
-          source: 'slurm/slurmdbd.conf.erb',
-          user: slurm_user,
-          group: slurm_group,
-          mode:  '0600'
-        )
-        is_expected.to create_file("#{slurm_install_dir}/etc/slurm_parallelcluster_slurmdbd.conf").with(
-          user: slurm_user,
-          group: slurm_group,
-          mode:  '0600'
-        )
-      end
-
-      it 'creates the Slurm database password update script' do
-        is_expected.to create_template("#{node['cluster']['scripts_dir']}/slurm/update_slurm_database_password.sh").with(
-          source: 'slurm/head_node/update_slurm_database_password.sh.erb',
-          user: 'root',
-          group: 'root',
-          mode:  '0700'
-        )
-      end
-
-      it 'executes the Slurm database password update scripts' do
-        is_expected.to run_execute("update Slurm database password").with(
-          command: "#{node['cluster']['scripts_dir']}/slurm/update_slurm_database_password.sh",
-          user: "root",
-          group: "root"
-        )
-      end
-
-      it 'starts the slurm database daemon' do
-        is_expected.to enable_service("slurmdbd")
-        is_expected.to start_service("slurmdbd")
-      end
-
-      it "waits for the Slurm database to respond" do
-        is_expected.to run_execute("wait for slurm database").with(
-          command: "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn"
-        )
-      end
-
-      it "bootstraps the Slurm database idempotently" do
-        is_expected.to run_bash("bootstrap slurm database")
       end
     end
   end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/slurmdbd.service.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/slurmdbd.service.erb
@@ -10,6 +10,7 @@ EnvironmentFile=-/etc/sysconfig/slurmdbd
 ExecStart=<%= node['cluster']['slurm']['install_dir'] %>/sbin/slurmdbd -D -s $SLURMDBD_OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 LimitNOFILE=65536
+TimeoutStartSec=5000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Description of changes
See commits descriptions for details

### Tests
`test_slurm_accounting_external_dbd` has passed

### References
* CLI PR https://github.com/aws/aws-parallelcluster/pull/6226
* Modified unit tests

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
