### PR TITLE
Avoid /opt/intel when backing up, restoring, and mounting fs mount points on arm instances

### DIFF
--- a/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
+++ b/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
@@ -156,11 +156,11 @@ class ComputeFleetStatus(Enum):
     @staticmethod
     def _transform_compute_fleet_data(compute_fleet_data):
         try:
-            compute_fleet_data[
-                ComputeFleetStatusManager.COMPUTE_FLEET_STATUS_ATTRIBUTE
-            ] = ComputeFleetStatus.EVENT_HANDLER_STATUS_MAPPING.value.get(
-                compute_fleet_data.get(ComputeFleetStatusManager.COMPUTE_FLEET_STATUS_ATTRIBUTE),
-                str(ComputeFleetStatus.UNKNOWN),
+            compute_fleet_data[ComputeFleetStatusManager.COMPUTE_FLEET_STATUS_ATTRIBUTE] = (
+                ComputeFleetStatus.EVENT_HANDLER_STATUS_MAPPING.value.get(
+                    compute_fleet_data.get(ComputeFleetStatusManager.COMPUTE_FLEET_STATUS_ATTRIBUTE),
+                    str(ComputeFleetStatus.UNKNOWN),
+                )
             )
             return compute_fleet_data
         except AttributeError as e:

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -58,7 +58,12 @@ default['cluster']['shared_dir_login'] = node['cluster']['shared_dir_login_nodes
 # Since this is a shared directory, it needs to be defined here first instead of in the dependent cookbook for slurm
 default['cluster']['slurm']['install_dir'] = '/opt/slurm'
 
-default['cluster']['internal_shared_dirs'] = [node['cluster']['shared_dir'], node['cluster']['shared_dir_login_nodes'], node['cluster']['slurm']['install_dir'], "/opt/intel"]
+default['cluster']['internal_shared_dirs'] = if x86_instance?
+                                               [node['cluster']['shared_dir'], node['cluster']['shared_dir_login_nodes'], node['cluster']['slurm']['install_dir'], "/opt/intel"]
+                                             else
+                                               [node['cluster']['shared_dir'], node['cluster']['shared_dir_login_nodes'], node['cluster']['slurm']['install_dir']]
+                                             end
+
 default['cluster']['internal_initial_shared_dir'] = "#{node['cluster']['base_dir']}/init_shared"
 
 default['cluster']['head_node_private_ip'] = nil

--- a/cookbooks/aws-parallelcluster-environment/recipes/init/backup_internal_use_shared_data.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/init/backup_internal_use_shared_data.rb
@@ -19,6 +19,7 @@ if node['cluster']['node_type'] == 'HeadNode'
   # This is necessary to preserve any data in these directories that was
   # generated during the build of ParallelCluster AMIs after converting to
   # shared storage
+  Chef::Log.info("Backup internal dirs #{node['cluster']['internal_shared_dirs']}")
   node['cluster']['internal_shared_dirs'].each do |dir|
     bash "Backup #{dir}" do
       user 'root'


### PR DESCRIPTION
### Tests
* Ran updated integration tests, `test_internal_efs`, on both x86 and arm instance types.  The integ test now includes both and arm and an intel instance type

### References
* https://github.com/aws/aws-parallelcluster/pull/6231

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
