### PR TITLE
[GH Workflows] Add a PR check to prevent the use of recursive deletion

### DIFF
--- a/.github/workflows/security_exclusions_checker.yml
+++ b/.github/workflows/security_exclusions_checker.yml
@@ -13,3 +13,13 @@ jobs:
       with:
         diffDoesNotContainRegex: "\\bnosec\\b|\\bnosemgrep\\b"
         skipLabels: skip-security-exclusions-check
+
+  # Prevent the use of recursive deletion.
+  recursive-deletion-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR
+        uses: francesco-giordano/gh-pr-content-checker@v1.0.0
+        with:
+          diffDoesNotContainRegex: "\\brecursive: true|\\brm -rf\\b"
+          skipLabels: skip-recursive-deletion-check

--- a/.github/workflows/unsafe-patterns-checker.yml
+++ b/.github/workflows/unsafe-patterns-checker.yml
@@ -1,4 +1,4 @@
-name: Security Exclusions Checker
+name: Unsafe Patterns Checker
 on:
   pull_request:
       types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]

--- a/.github/workflows/unsafe-patterns-checker.yml
+++ b/.github/workflows/unsafe-patterns-checker.yml
@@ -18,8 +18,13 @@ jobs:
   recursive-deletion-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR
+      - name: Check PR (recursive true)
         uses: francesco-giordano/gh-pr-content-checker@v1.0.0
         with:
-          diffDoesNotContainRegex: "\\brecursive: true|\\brm -rf\\b"
+          diffDoesNotContainRegex: "recursive true"
+          skipLabels: skip-recursive-deletion-check
+      - name: Check PR (rm -rf)
+        uses: francesco-giordano/gh-pr-content-checker@v1.0.0
+        with:
+          diffDoesNotContainRegex: "rm -rf"
           skipLabels: skip-recursive-deletion-check


### PR DESCRIPTION
### Description of changes
1. Add a PR check to prevent the use of recursive deletion in cookbooks
1. Rename the workflow 'Security Exclusion Checker' to 'Unsafe Patterns Checker' to convey the larger goal of the check.

The check is expected to fail when the following patterns are detected in PR diff:
1. `recursive true`
1. `rm -rf`

We are aware that these patterns may lead to false positive, but that's fine because:
1. when dealing with potential data loss, we are ok with even too sensitive checks
2. we do not expect such patterns to be so frequent
3. false positive can be easily bypassed applying the label `skip-recursive-deletion-check`.

### Tests
* The check fails in this PR because it detects the patterns 'recursive true' and 'rm -rf' in the diff.
* The check is bypassed in this PR by applying the label `skip-recursive-deletion-check`

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
