### PR TITLE
[AL2023]Changing the syntax for the command as it gives error for a numercial error

### DIFF
--- a/util/cinc-install.sh
+++ b/util/cinc-install.sh
@@ -220,12 +220,14 @@ do_python() {
 do_checksum() {
   if exists sha256sum; then
     echo "Comparing checksum with sha256sum..."
-    checksum=$(sha256sum $1 | awk '{ print $1 }')
-    return "$(test "x$checksum" = "x$2")"
+    checksum=`sha256sum $1 | awk '{ print $1 }'`
+    # shellcheck disable=SC2046
+    return `test "x$checksum" = "x$2"`
   elif exists shasum; then
     echo "Comparing checksum with shasum..."
-    checksum=$(shasum -a 256 $1 | awk '{ print $1 }')
-    return "$(test "x$checksum" = "x$2")"
+    checksum=`shasum -a 256 $1 | awk '{ print $1 }'`
+    # shellcheck disable=SC2046
+    return `test "x$checksum" = "x$2"`
   else
     echo "WARNING: could not find a valid checksum program, pre-install shasum or sha256sum in your O/S image to get validation..."
     return 0
@@ -331,7 +333,8 @@ install_file() {
       echo "installing dmg file..."
       hdiutil detach "/Volumes/cinc_project" >/dev/null 2>&1 || true
       hdiutil attach "$2" -mountpoint "/Volumes/cinc_project"
-      cd / && /usr/sbin/installer -pkg "$(find "/Volumes/cinc_project" -name \*.pkg)" -target /
+      # shellcheck disable=SC2046
+      cd / && /usr/sbin/installer -pkg `find "/Volumes/cinc_project" -name \*.pkg` -target /
       hdiutil detach "/Volumes/cinc_project"
       ;;
     "sh" )


### PR DESCRIPTION
I see below error during Checksum Match which is same but due to the syntax it shows a mismatch

```
cinc-install.sh: line 225: return: : numeric argument required
Package checksum mismatch!
```

Took the syntax from https://cinc.sh/download/

### Tests
* Manually tested on an Ec2 instance
* Integ Tests 
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_COMMERCIAL_X86 }}
          schedulers: [ "slurm" ]

```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
