### PR TITLE
Changing the PATH order we set for using the cfnbootstrap script we have installed in virtualenv rather than using default scripts

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/pcluster.sh.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/pcluster.sh.erb
@@ -2,7 +2,6 @@
 # pcluster.sh:
 #   Setup ParallelCluster environment variables
 #
-
-PATH=$PATH:<%= @cfn_bootstrap_virtualenv_path %>/bin
+PATH=<%= @cfn_bootstrap_virtualenv_path %>/bin:$PATH
 
 export PATH

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cfn_bootstrap_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cfn_bootstrap_spec.rb
@@ -36,6 +36,12 @@ control 'tag:install_cfnbootstrap_virtualenv_created' do
     its('mode') { should cmp '0644' }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
-    its('content') { should match "PATH=\\$PATH:#{pyenv_dir}/versions/#{cfn_python_version}/envs/cfn_bootstrap_virtualenv/bin" }
+    its('content') { should match "PATH=#{pyenv_dir}/versions/#{cfn_python_version}/envs/cfn_bootstrap_virtualenv/bin:\\$PATH" }
   end
+
+  desc "cfn-init needs to be from the cfnbootstrap virtualenv"
+  describe bash("sudo -u #{node['cluster']['cluster_user']} -i which cfn-init") do
+    its('exit_status') { should eq(0) }
+    its('stdout') { should match("#{pyenv_dir}/versions/#{cfn_python_version}/envs/cfn_bootstrap_virtualenv/bin/cfn-init") }
+  end unless os_properties.on_docker?
 end


### PR DESCRIPTION
### Description of changes
Changing the PATH order we set for using the cfnbootstrap script we have installed in virtualenv rather than using default scripts

* Adding Kitchen test

### Tests
Locally 
```
./kitchen.ec2.sh environment-install test cfn-bootstrap -c 7

```


release-3.9 -> https://github.com/aws/aws-parallelcluster-cookbook/pull/2730

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
