### PR TITLE
[github system test] Fix system test on RHEL8

### DIFF
--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -64,7 +64,7 @@ platforms:
         kernel_release: '5.15.0-1028-aws'
   - name: rhel8
     driver:
-      image: <% if ENV['KITCHEN_RHEL8_IMAGE'] %> <%= ENV['KITCHEN_RHEL8_IMAGE'] %> <% else %> registry.access.redhat.com/ubi8/ubi <% end %>
+      image: <% if ENV['KITCHEN_RHEL8_IMAGE'] %> <%= ENV['KITCHEN_RHEL8_IMAGE'] %> <% else %> registry.access.redhat.com/ubi8/ubi:8.9 <% end %>
       intermediate_instructions:
         - RUN chmod +t /tmp
     attributes:


### PR DESCRIPTION
### Description of changes
* RHEL 8.10 was recently released. Lustre client has not supported the latest kernel. Therefore, we use image of RHEL 8.9 to make system test successful.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
