### PR TITLE
[Bug] Adding different values for `kernel-open` option

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
@@ -113,7 +113,7 @@ def compiler_version
 end
 
 def nvidia_kernel_module
-  if node['cluster']['nvidia']['kernel_open'] == "false"
+  if ['false', 'no', false].include?(node['cluster']['nvidia']['kernel_open'])
     "kernel"
   else
     "kernel-open"

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
@@ -96,7 +96,7 @@ describe 'nvidia_driver:nvidia_driver_enabled?' do
 end
 
 describe 'nvidia_driver:nvidia_kernel_module' do
-  [%w(false kernel), %w(true kernel-open)].each do |kernel_open, kernel_module|
+  [%w(false kernel), [false, 'kernel'], %w(no kernel), %w(true kernel-open), [true, 'kernel-open'], %w(yes kernel-open)].each do |kernel_open, kernel_module|
     context "node['cluster']['nvidia']['kernel_open'] is #{kernel_open}" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(step_into: ['nvidia_driver']) do |node|


### PR DESCRIPTION
### Description of changes
* Adding different options when we dont want to install Open Sourced Nvidia Drivers

release-3.9 https://github.com/aws/aws-parallelcluster-cookbook/pull/2733



### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
