### PR TITLE
[Storage][Isolated Regions] Add support for FSx Lustre in US isolated regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **ENHANCEMENTS**
 - Add support for external Slurmdbd.
+- Add support for FSx Lustre in US isolated regions.
 
 **CHANGES**
 - Upgrade Cinc Client to version to 18.4.12 from 18.2.7.

--- a/cookbooks/aws-parallelcluster-environment/libraries/fsx.rb
+++ b/cookbooks/aws-parallelcluster-environment/libraries/fsx.rb
@@ -1,0 +1,4 @@
+def aws_domain_for_fsx(region)
+  # DNS names have the default AWS domain (amazonaws.com) also in China and GovCloud.
+  region.start_with?("us-iso") ? aws_domain : CLASSIC_AWS_DOMAIN
+end

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_mount_unmount.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_mount_unmount.rb
@@ -112,8 +112,8 @@ action_class do
       @volume_junction_path = self.class.make_absolute(resource.fsx_volume_junction_path_array[index])
 
       if @dns_name.blank?
-        # Region Building Note: DNS names have the default AWS domain (amazonaws.com) also in China and GovCloud.
-        @dns_name = "#{@id}.fsx.#{node['cluster']['region']}.amazonaws.com"
+        region = node['cluster']['region']
+        @dns_name = "#{@id}.fsx.#{region}.#{aws_domain_for_fsx(region)}"
       end
 
       @mount_name = resource.fsx_mount_name_array[index]

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_mount_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/lustre_mount_spec.rb
@@ -29,6 +29,7 @@ describe 'lustre:mount' do
           before do
             stub_command("mount | grep ' /lustre_shared_dir_with_no_mount '").and_return(false)
             stub_command("mount | grep ' /lustre_shared_dir_with_mount '").and_return(true)
+            allow_any_instance_of(Object).to receive(:aws_domain_for_fsx).and_return("AWS_DOMAIN_FOR_FSX")
           end
 
           it 'creates_shared_dir' do
@@ -58,7 +59,7 @@ describe 'lustre:mount' do
 
           it 'enables shared dir mount if already mounted' do
             is_expected.to enable_mount('/lustre_shared_dir_with_mount')
-              .with(device: 'lustre_id_2.fsx.REGION.amazonaws.com@tcp:/lustre_mount_name_2')
+              .with(device: 'lustre_id_2.fsx.REGION.AWS_DOMAIN_FOR_FSX@tcp:/lustre_mount_name_2')
               .with(fstype: 'lustre')
               .with(dump: 0)
               .with(pass: 0)
@@ -113,6 +114,7 @@ describe 'lustre:mount' do
           before do
             stub_command("mount | grep ' /filecache_shared_dir_1 '").and_return(false)
             stub_command("mount | grep ' /filecache_shared_dir_2 '").and_return(true)
+            allow_any_instance_of(Object).to receive(:aws_domain_for_fsx).and_return("AWS_DOMAIN_FOR_FSX")
           end
 
           it 'creates_shared_dir' do
@@ -196,6 +198,7 @@ describe 'lustre:mount' do
           before do
             stub_command("mount | grep ' /openzfs_shared_dir_1 '").and_return(false)
             stub_command("mount | grep ' /openzfs_shared_dir_2 '").and_return(true)
+            allow_any_instance_of(Object).to receive(:aws_domain_for_fsx).and_return("AWS_DOMAIN_FOR_FSX")
           end
 
           it 'creates_shared_dir' do
@@ -225,7 +228,7 @@ describe 'lustre:mount' do
 
           it 'enables shared dir mount if already mounted' do
             is_expected.to enable_mount('/openzfs_shared_dir_2')
-              .with(device: 'openzfs_id_2.fsx.REGION.amazonaws.com:/junction_path_2')
+              .with(device: 'openzfs_id_2.fsx.REGION.AWS_DOMAIN_FOR_FSX:/junction_path_2')
               .with(fstype: 'nfs')
               .with(dump: 0)
               .with(pass: 0)
@@ -272,6 +275,7 @@ describe 'lustre:mount' do
           before do
             stub_command("mount | grep ' /ontap_shared_dir_1 '").and_return(false)
             stub_command("mount | grep ' /ontap_shared_dir_2 '").and_return(true)
+            allow_any_instance_of(Object).to receive(:aws_domain_for_fsx).and_return("AWS_DOMAIN_FOR_FSX")
           end
 
           it 'creates_shared_dir' do
@@ -301,7 +305,7 @@ describe 'lustre:mount' do
 
           it 'enables shared dir mount if already mounted' do
             is_expected.to enable_mount('/ontap_shared_dir_2')
-              .with(device: 'ontap_id_2.fsx.REGION.amazonaws.com:/junction_path_2')
+              .with(device: 'ontap_id_2.fsx.REGION.AWS_DOMAIN_FOR_FSX:/junction_path_2')
               .with(fstype: 'nfs')
               .with(dump: 0)
               .with(pass: 0)
@@ -366,6 +370,7 @@ describe 'lustre:unmount' do
           allow(Dir).to receive(:empty?).with("/shared_dir_1").and_return(true)
           allow(Dir).to receive(:exist?).with("/shared_dir_2").and_return(true)
           allow(Dir).to receive(:empty?).with("/shared_dir_2").and_return(false)
+          allow_any_instance_of(Object).to receive(:aws_domain_for_fsx).and_return("AWS_DOMAIN_FOR_FSX")
         end
 
         it 'unmounts fsx only if mounted' do
@@ -385,9 +390,9 @@ describe 'lustre:unmount' do
             .with(path: "/etc/fstab")
             .with(pattern: "dns_name@tcp:/mount_name_1 *")
 
-          is_expected.to edit_delete_lines('remove volume lustre_id_2.fsx.REGION.amazonaws.com@tcp:/mount_name_2 from /etc/fstab')
+          is_expected.to edit_delete_lines('remove volume lustre_id_2.fsx.REGION.AWS_DOMAIN_FOR_FSX@tcp:/mount_name_2 from /etc/fstab')
             .with(path: "/etc/fstab")
-            .with(pattern: "lustre_id_2.fsx.REGION.amazonaws.com@tcp:/mount_name_2 *")
+            .with(pattern: "lustre_id_2.fsx.REGION.AWS_DOMAIN_FOR_FSX@tcp:/mount_name_2 *")
         end
 
         it 'deletes shared dir only if it exists and it is empty' do
@@ -425,6 +430,7 @@ describe 'lustre:unmount' do
           allow(Dir).to receive(:empty?).with("/shared_dir_1").and_return(true)
           allow(Dir).to receive(:exist?).with("/shared_dir_2").and_return(true)
           allow(Dir).to receive(:empty?).with("/shared_dir_2").and_return(false)
+          allow_any_instance_of(Object).to receive(:aws_domain_for_fsx).and_return("AWS_DOMAIN_FOR_FSX")
         end
 
         it 'unmounts fsx only if mounted' do
@@ -442,9 +448,9 @@ describe 'lustre:unmount' do
             .with(path: "/etc/fstab")
             .with(pattern: "dns_name:/junction_path_1 *")
 
-          is_expected.to edit_delete_lines('remove volume ontap_id_2.fsx.REGION.amazonaws.com:/junction_path_2 from /etc/fstab')
+          is_expected.to edit_delete_lines('remove volume ontap_id_2.fsx.REGION.AWS_DOMAIN_FOR_FSX:/junction_path_2 from /etc/fstab')
             .with(path: "/etc/fstab")
-            .with(pattern: "ontap_id_2.fsx.REGION.amazonaws.com:/junction_path_2 *")
+            .with(pattern: "ontap_id_2.fsx.REGION.AWS_DOMAIN_FOR_FSX:/junction_path_2 *")
         end
 
         it 'deletes shared dir only if it exists and it is empty' do
@@ -482,6 +488,7 @@ describe 'lustre:unmount' do
           allow(Dir).to receive(:empty?).with("/filecache_dir_1").and_return(true)
           allow(Dir).to receive(:exist?).with("/filecache_dir_2").and_return(true)
           allow(Dir).to receive(:empty?).with("/filecache_dir_2").and_return(false)
+          allow_any_instance_of(Object).to receive(:aws_domain_for_fsx).and_return("AWS_DOMAIN_FOR_FSX")
         end
 
         it 'unmounts fsx only if mounted' do

--- a/cookbooks/aws-parallelcluster-shared/libraries/environment.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/environment.rb
@@ -2,17 +2,22 @@ def aws_region
   node['cluster']['region']
 end
 
+CLASSIC_AWS_DOMAIN = "amazonaws.com".freeze
+CHINA_AWS_DOMAIN = "amazonaws.com.cn".freeze
+US_ISO_AWS_DOMAIN = "c2s.ic.gov".freeze
+US_ISOB_AWS_DOMAIN = "sc2s.sgov.gov".freeze
+
 def aws_domain
   # Get the aws domain name
   region = aws_region
   if region.start_with?("cn-")
-    "amazonaws.com.cn"
+    CHINA_AWS_DOMAIN
   elsif region.start_with?("us-iso-")
-    "c2s.ic.gov"
+    US_ISO_AWS_DOMAIN
   elsif region.start_with?("us-isob-")
-    "sc2s.sgov.gov"
+    US_ISOB_AWS_DOMAIN
   else
-    "amazonaws.com"
+    CLASSIC_AWS_DOMAIN
   end
 end
 

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/libraries/environment_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/libraries/environment_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../../../libraries/environment'
+require 'spec_helper'
+
+describe 'aws_domain' do
+  shared_examples 'a valid aws_domain function' do |region, expected_aws_domain|
+    it 'returns the correct AWS domain' do
+      allow_any_instance_of(Object).to receive(:aws_region).and_return(region)
+      # We must force aws_domain to call the original function because
+      # the spec_helper configures aws_domain to return a mocked value for all rspec tests.
+      allow_any_instance_of(Object).to receive(:aws_domain).and_call_original
+
+      expect(aws_domain).to eq(expected_aws_domain)
+    end
+  end
+
+  context 'when in CN region' do
+    include_examples 'a valid aws_domain function', 'cn-WHATEVER', 'amazonaws.com.cn'
+  end
+
+  context 'when in US-ISO region' do
+    include_examples 'a valid aws_domain function', 'us-iso-WHATEVER', 'c2s.ic.gov'
+  end
+
+  context 'when in US-ISOB region' do
+    include_examples 'a valid aws_domain function', 'us-isob-', 'sc2s.sgov.gov'
+  end
+
+  context 'when in GovCloud region' do
+    include_examples 'a valid aws_domain function', 'us-gov-WHATEVER', 'amazonaws.com'
+  end
+
+  context 'when in whatever else region' do
+    include_examples 'a valid aws_domain function', 'WHATEVER-ELSE', 'amazonaws.com'
+  end
+end


### PR DESCRIPTION
### Description of changes
Add support for FSx Lustre in US isolated regions.
In particular:
1. Adapted the FSxLustre DNS name for US isolated regions.
2. Defined AWS domains as constants and added a test to validate that the correct domain is returned for a given region.

### Tests
* Spec tests
* Cluster creation successful with FSxLustre in Commercial and in us-iso-east-1
* integ test test_fsx_lustre succeeded


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
