### PR TITLE
Fix logrotate configuration for cloud-init log files on Ubuntu systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Fixed an issue that prevented cluster updates from including EFS filesystems with encryption in transit.
 - Fixed an issue that prevented slurmctld and slurmdbd services from restarting on head node reboot when
   EFS is used for shared internal data. 
+- On Ubuntu systems, remove default logrotate configuration for cloud-init log files that clashed with the
+  configuration coming from Parallelcluster.
 
 3.9.1
 ------

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
@@ -143,6 +143,47 @@ suites:
     attributes:
       cluster:
         node_type: HeadNode
+  - name: log_rotation_head_node
+    run_list:
+      - recipe[aws-parallelcluster-platform::log_rotation]
+    verifier:
+      controls:
+        - /tag:config_log_rotation_all_nodes/
+    attributes:
+      # Add attributes so that all possible logrotate configuration files are generated
+      cluster:
+        log_rotation_enabled: 'true'
+        node_type: 'HeadNode'
+        dcv_enabled: "head_node"
+        directory_service:
+          generate_ssh_keys_for_users: 'true'
+        scheduler: 'slurm'
+  - name: log_rotation_compute_fleet
+    run_list:
+      - recipe[aws-parallelcluster-platform::log_rotation]
+    verifier:
+      controls:
+        - /tag:config_log_rotation_all_nodes/
+    attributes:
+      # Add attributes so that all possible logrotate configuration files are generated
+      cluster:
+        log_rotation_enabled: 'true'
+        node_type: 'ComputeFleet'
+        scheduler: 'slurm'
+  - name: log_rotation_login_node
+    run_list:
+      - recipe[aws-parallelcluster-platform::log_rotation]
+    verifier:
+      controls:
+        - /tag:config_log_rotation_all_nodes/
+    attributes:
+      # Add attributes so that all possible logrotate configuration files are generated
+      cluster:
+        log_rotation_enabled: 'true'
+        node_type: 'LoginNode'
+        directory_service:
+          generate_ssh_keys_for_users: 'true'
+        scheduler: 'slurm'
   - name: networking
     run_list:
       - recipe[aws-parallelcluster-platform::networking]

--- a/cookbooks/aws-parallelcluster-platform/recipes/config/log_rotation.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/log_rotation.rb
@@ -14,6 +14,13 @@
 
 return if node['cluster']['log_rotation_enabled'] != 'true'
 
+if platform?('ubuntu')
+  # Ubuntu recently pushed a default logrotate configuration for cloud-init that clashes with the ParallelCluster one.
+  file '/etc/logrotate.d/cloud-init' do
+    action :delete
+  end
+end
+
 # TODO: move the logrotate configuration of the various services to the corresponding recipes/cookbooks.
 
 case node['cluster']['node_type']

--- a/cookbooks/aws-parallelcluster-platform/test/controls/log_rotation_all_nodes.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/log_rotation_all_nodes.rb
@@ -1,0 +1,24 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+# This control is generic enough to be applied to all types of nodes in ParallelCluster
+control 'tag:config_log_rotation_all_nodes' do
+  title 'Check that log rotation has been properly configured'
+
+  # This should be enough at least to verify that the logrotate overall configuration is valid.
+  # WARNING: do not use the `--force` option, because running multiple times the command with the
+  # `--force` option will cause the command to fail (defeating the purpose of the test)
+  describe "Log rotation command runs successfully" do
+    subject { command("sudo logrotate /etc/logrotate.conf") }
+    its('exit_status') { should eq 0 }
+  end
+
+end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/log_rotation_all_nodes.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/log_rotation_all_nodes.rb
@@ -13,6 +13,9 @@
 control 'tag:config_log_rotation_all_nodes' do
   title 'Check that log rotation has been properly configured'
 
+  # Docker images do not have logrotate
+  only_if { !os_properties.on_docker? }
+
   # This should be enough at least to verify that the logrotate overall configuration is valid.
   # WARNING: do not use the `--force` option, because running multiple times the command with the
   # `--force` option will cause the command to fail (defeating the purpose of the test)

--- a/cookbooks/aws-parallelcluster-platform/test/controls/log_rotation_all_nodes.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/log_rotation_all_nodes.rb
@@ -20,5 +20,4 @@ control 'tag:config_log_rotation_all_nodes' do
     subject { command("sudo logrotate /etc/logrotate.conf") }
     its('exit_status') { should eq 0 }
   end
-
 end


### PR DESCRIPTION
### Description of changes
* On Ubuntu systems, remove the default cloud-init logrotate configuration files coming from the base Ubuntu AMI, which clashed with the one coming from ParallelCluster.

### Tests
* Add basic kitchen test to verify that the overall logrotate configuration created via the logrotate cookbook recipes is functional (run the `logrotate` command to see if it complains about it).
  * I firstly created the kitchen tests, and with them I could catch the issue on the Ubuntu systems;
  * I then fixed the logic in the logrotate recipes and the kitchen tests again, confirming the fix for Ubuntu systems.

### References
* Related to https://github.com/aws/aws-parallelcluster/pull/6264

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
