### PR TITLE
Renaming pcluster.sh profile to cookbook_environment.sh profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   EFS is used for shared internal data. 
 - On Ubuntu systems, remove default logrotate configuration for cloud-init log files that clashed with the
   configuration coming from Parallelcluster.
+- Removing `/etc/profile.d/pcluster.sh` so that it's not executed at every user login and 
+  `cfn_bootstrap_virtualenv` is not added in PATH environment variable.
 
 3.9.1
 ------

--- a/cookbooks/aws-parallelcluster-environment/recipes/install/cfn_bootstrap.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/install/cfn_bootstrap.rb
@@ -53,9 +53,9 @@ bash "Install CloudFormation helpers from #{cfnbootstrap_package}" do
   creates "#{virtualenv_path}/bin/cfn-hup"
 end
 
-# Add cfn_bootstrap virtualenv to default path
-template "/etc/profile.d/pcluster.sh" do
-  source "cfn_bootstrap/pcluster.sh.erb"
+# Add cfn_bootstrap virtualenv to a profile to be used only for cookbook
+template "#{node['cluster']['etc_dir']}/pcluster_cookbook_environment.sh" do
+  source "cfn_bootstrap/pcluster_cookbook_environment.sh.erb"
   owner 'root'
   group 'root'
   mode '0644'

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/cfn_bootstrap_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/cfn_bootstrap_spec.rb
@@ -51,9 +51,9 @@ describe 'aws-parallelcluster-environment::cfn_bootstrap' do
           )
         end
 
-        it 'adds cfn_bootstrap virtualenv to default path' do
-          is_expected.to create_template("/etc/profile.d/pcluster.sh").with(
-            source: "cfn_bootstrap/pcluster.sh.erb",
+        it 'adds cfn_bootstrap virtualenv to a cookbook profile' do
+          is_expected.to create_template("#{node['cluster']['etc_dir']}/pcluster_cookbook_environment.sh").with(
+            source: "cfn_bootstrap/pcluster_cookbook_environment.sh.erb",
             owner: 'root',
             group: 'root',
             mode: '0644',

--- a/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/cfn-hook-update.conf.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/cfn-hook-update.conf.erb
@@ -1,5 +1,5 @@
 [parallelcluster-update]
 triggers=post.update
 path=Resources.<%= @launch_template_resource_id %>.Metadata.AWS::CloudFormation::Init
-action=PATH=/usr/local/bin:/bin:/usr/bin:/opt/aws/bin; . /etc/profile.d/pcluster.sh; cfn-init -v --stack <%= @stack_id %> --resource <%= @launch_template_resource_id %> --configsets update --region <%= @region %> --url <%= @cloudformation_url %> --role <%= @cfn_init_role %>
+action=PATH=/usr/local/bin:/bin:/usr/bin:/opt/aws/bin; . /etc/profile.d/pcluster_cookbook_environment.sh; cfn-init -v --stack <%= @stack_id %> --resource <%= @launch_template_resource_id %> --configsets update --region <%= @region %> --url <%= @cloudformation_url %> --role <%= @cfn_init_role %>
 runas=root

--- a/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/pcluster.sh.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/pcluster.sh.erb
@@ -1,8 +1,0 @@
-#
-# pcluster.sh:
-#   Setup ParallelCluster environment variables
-#
-
-PATH=$PATH:<%= @cfn_bootstrap_virtualenv_path %>/bin
-
-export PATH

--- a/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/pcluster_cookbook_environment.sh.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/pcluster_cookbook_environment.sh.erb
@@ -1,0 +1,8 @@
+#
+# pcluster_cookbook_environment.sh:
+#   Setup ParallelCluster cookbook environment variables
+#
+
+CFN_BOOTSTRAP_VIRTUALENV_PATH=<%= @cfn_bootstrap_virtualenv_path %>/bin
+
+export CFN_BOOTSTRAP_VIRTUALENV_PATH

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cfn_bootstrap_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cfn_bootstrap_spec.rb
@@ -30,12 +30,12 @@ control 'tag:install_cfnbootstrap_virtualenv_created' do
     its('stdout')      { should match('aws-cfn-bootstrap') }
   end
 
-  desc "cfnbootstrap virtualenv bin dir should be added to the PATH"
-  describe file('/etc/profile.d/pcluster.sh') do
+  desc "cfnbootstrap virtualenv bin dir should be added to cookbook PATH"
+  describe file('/etc/parallelcluster/pcluster_cookbook_environment.sh') do
     it { should exist }
     its('mode') { should cmp '0644' }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
-    its('content') { should match "PATH=\\$PATH:#{pyenv_dir}/versions/#{cfn_python_version}/envs/cfn_bootstrap_virtualenv/bin" }
+    its('content') { should match "CFN_BOOTSTRAP_VIRTUALENV_PATH=\\#{pyenv_dir}/versions/#{cfn_python_version}/envs/cfn_bootstrap_virtualenv/bin" }
   end
 end


### PR DESCRIPTION
### Description of changes
* Renaming pcluster.sh profile to cookbook_environment.sh profile which will be using cfn_bootstrap_virtualenv_path for all cfn-init, cfn-signal, cfn-hup commands

* This is not to pollute the default PATH


CLI https://github.com/aws/aws-parallelcluster/pull/6266

### Tests
* Created AMI's
* tests
```
  update:
    test_update.py::test_update_slurm:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2004"]
    test_update.py::test_dynamic_file_systems_update:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
    test_update.py::test_dynamic_file_systems_update_rollback:
      dimensions:
        - regions: [ "eu-west-2" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "centos7" ]
          schedulers: [ "slurm" ]
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
