### PR TITLE
[Storage] Fix method used to get the AWS domain for FSx.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/libraries/fsx.rb
+++ b/cookbooks/aws-parallelcluster-environment/libraries/fsx.rb
@@ -1,4 +1,10 @@
 def aws_domain_for_fsx(region)
   # DNS names have the default AWS domain (amazonaws.com) also in China and GovCloud.
-  region.start_with?("us-iso") ? aws_domain : CLASSIC_AWS_DOMAIN
+  if region.start_with?("us-iso-")
+    US_ISO_AWS_DOMAIN
+  elsif region.start_with?("us-isob-")
+    US_ISOB_AWS_DOMAIN
+  else
+    CLASSIC_AWS_DOMAIN
+  end
 end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/libraries/fsx_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/libraries/fsx_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-environment:libraries:aws_domain_for_fsx' do
+  shared_examples 'a valid aws_domain_for_fsx function' do |region, expected_aws_domain|
+    it 'returns the correct AWS domain' do
+      result = aws_domain_for_fsx(region)
+      expect(result).to eq(expected_aws_domain)
+    end
+  end
+
+  context 'when in US-ISO region' do
+    include_examples 'a valid aws_domain_for_fsx function', 'us-iso-WHATEVER', 'c2s.ic.gov'
+  end
+
+  context 'when in US-ISOB region' do
+    include_examples 'a valid aws_domain_for_fsx function', 'us-isob-', 'sc2s.sgov.gov'
+  end
+
+  context 'when in CN region' do
+    include_examples 'a valid aws_domain_for_fsx function', 'cn-WHATEVER', 'amazonaws.com'
+  end
+
+  context 'when in GovCloud region' do
+    include_examples 'a valid aws_domain_for_fsx function', 'us-gov-WHATEVER', 'amazonaws.com'
+  end
+
+  context 'when in whatever else region' do
+    include_examples 'a valid aws_domain_for_fsx function', 'WHATEVER-ELSE', 'amazonaws.com'
+  end
+end


### PR DESCRIPTION
### Description of changes
Fix method used to get the AWS domain for FSx.
In particular, now it does not need anymore to access the undefined node attribute in US ISO regions.
The method is called from a resource and it causes errors in US ISO because in these regions the method invokes aws_domain, which internally relies on  node attributes, which are not accessible from within a resource.

This comes with a cost of code duplication: reuse the domain constants for US ISO domain rather than calling the aws_domain, but it's acceptable to unblock the use case case.

### Tests
* SUCCEEDED test_fsx_lustre commercial

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
