### PR TITLE
[github system test] Fix system test on Rocky 8

### DIFF
--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -75,7 +75,7 @@ platforms:
         kernel_release: '4.18.0-477.13.1.el8_7.fake-value' # Use 477 version to match 8.8 kernel version available on docker
   - name: rocky8
     driver:
-      image: <% if ENV['KITCHEN_ROCKY8_IMAGE'] %> <%= ENV['KITCHEN_ROCKY8_IMAGE'] %> <% else %> dokken/rockylinux-8 <% end %>
+      image: <% if ENV['KITCHEN_ROCKY8_IMAGE'] %> <%= ENV['KITCHEN_ROCKY8_IMAGE'] %> <% else %> dokken/rockylinux-8:sha-f885abd <% end %>
     attributes:
       cluster:
         base_os: rocky8


### PR DESCRIPTION
Rocky 8.10 was recently released. Lustre client has not supported the latest kernel. Therefore, we use image of RHEL 8.9 to make system test successful.

### References
* Same fix was done for RHEL 8 https://github.com/aws/aws-parallelcluster-cookbook/pull/2732

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
