### PR TITLE
Using correct path of the profile created with CFN_BOOTSTRAP_VIRTUALENV_PATH

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/cfn-hook-update.conf.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/cfn-hook-update.conf.erb
@@ -1,5 +1,5 @@
 [parallelcluster-update]
 triggers=post.update
 path=Resources.<%= @launch_template_resource_id %>.Metadata.AWS::CloudFormation::Init
-action=PATH=/usr/local/bin:/bin:/usr/bin:/opt/aws/bin; . /etc/profile.d/pcluster_cookbook_environment.sh; $CFN_BOOTSTRAP_VIRTUALENV_PATH/cfn-init -v --stack <%= @stack_id %> --resource <%= @launch_template_resource_id %> --configsets update --region <%= @region %> --url <%= @cloudformation_url %> --role <%= @cfn_init_role %>
+action=PATH=/usr/local/bin:/bin:/usr/bin:/opt/aws/bin; . /etc/parallelcluster/pcluster_cookbook_environment.sh; $CFN_BOOTSTRAP_VIRTUALENV_PATH/cfn-init -v --stack <%= @stack_id %> --resource <%= @launch_template_resource_id %> --configsets update --region <%= @region %> --url <%= @cloudformation_url %> --role <%= @cfn_init_role %>
 runas=root


### PR DESCRIPTION
### Description of changes
* Using correct path of the profile created with CFN_BOOTSTRAP_VIRTUALENV_PATH

### Tests
* ONGOING
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  create:
    test_create.py::test_create_disable_sudo_access_for_default_user:
      dimensions:
        - regions: [ "us-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          schedulers: [ "slurm" ]
          oss: [ "rocky8" ]

```


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
