### PR TITLE
Upgrade Intel MPI Library to 2021.12.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Open MPI: `openmpi40-aws-4.1.6-3` and `openmpi50-aws-5.0.2-12`
 - Upgrade NVIDIA driver to version 535.183.01 (from 535.154.05).
 - Upgrade Python to 3.9.19 (from 3.9.17).
+- Upgrade Intel MPI Library to 2021.12.1.8 (from 2021.9.0.43482).
 
 **BUG FIXES**
 - Fixed an issue that prevented cluster updates from including EFS filesystems with encryption in transit.

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/intel_mpi.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/intel_mpi.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 intelmpi_supported = !arm_instance?
-intelmpi_version = '2021.9.0'
+intelmpi_version = '2021.12'
 
 node.default['conditions']['intel_mpi_supported'] = intelmpi_supported
 node.default['cluster']['intelmpi']['version'] = intelmpi_version
@@ -25,12 +25,12 @@ node_attributes "dump node attributes"
 
 return unless intelmpi_supported
 
-intelmpi_full_version = "#{intelmpi_version}.43482"
+intelmpi_full_version = "#{intelmpi_version}.1.8"
 intelmpi_installation_path = "/opt/intel/mpi/#{intelmpi_version}"
 intelmpi_installer = "l_mpi_oneapi_p_#{intelmpi_full_version}_offline.sh"
 intelmpi_installer_path = "#{node['cluster']['sources_dir']}/#{intelmpi_installer}"
 intelmpi_installer_url = "#{node['cluster']['artifacts_s3_url']}/impi/#{intelmpi_installer}"
-intelmpi_qt_version = '6.4.2'
+intelmpi_qt_version = '6.5.3'
 
 # Prerequisite for module install
 modules 'Prerequisite: Environment modules'
@@ -59,12 +59,12 @@ bash "install intel mpi" do
 end
 
 modules 'append intel modules file dir to modules conf' do
-  line "#{intelmpi_installation_path}/modulefiles/"
+  line "#{intelmpi_installation_path}/etc/modulefiles/"
   action :append_to_config
 end
 
-intelmpi_modulefile_from = "#{intelmpi_installation_path}/modulefiles/mpi"
-intelmpi_modulefile_to   = "#{intelmpi_installation_path}/modulefiles/intelmpi"
+intelmpi_modulefile_from = "#{intelmpi_installation_path}/etc/modulefiles/mpi"
+intelmpi_modulefile_to   = "#{intelmpi_installation_path}/etc/modulefiles/intelmpi"
 
 execute "rename intel mpi modules file name" do
   command "mv #{intelmpi_modulefile_from} #{intelmpi_modulefile_to}"

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/intel_mpi_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/intel_mpi_spec.rb
@@ -20,8 +20,8 @@ describe 'aws-parallelcluster-platform::intel_mpi' do
   end
 
   it 'fetches intel mpi installer script' do
-    is_expected.to create_remote_file("#{source_dir}/l_mpi_oneapi_p_2021.9.0.43482_offline.sh").with(
-      source: "https://#{aws_region}-aws-parallelcluster.s3.#{aws_region}.test_aws_domain/archives/impi/l_mpi_oneapi_p_2021.9.0.43482_offline.sh",
+    is_expected.to create_remote_file("#{source_dir}/l_mpi_oneapi_p_2021.12.1.8_offline.sh").with(
+      source: "https://#{aws_region}-aws-parallelcluster.s3.#{aws_region}.test_aws_domain/archives/impi/l_mpi_oneapi_p_2021.12.1.8_offline.sh",
       mode: '0744',
       retries: 3,
       retry_delay: 5
@@ -31,25 +31,25 @@ describe 'aws-parallelcluster-platform::intel_mpi' do
   it 'installs intel mpi' do
     is_expected.to run_bash('install intel mpi').with(
       cwd: source_dir,
-      creates: '/opt/intel/mpi/2021.9.0'
-    ).with_code(%r{chmod +x l_mpi_oneapi_p_2021.9.0.43482_offline.sh --remove-extracted-files yes -a --silent --eula accept --install-dir /opt/intel})
-                                                .with_code(/rm -f l_mpi_oneapi_p_2021.9.0.43482_offline.sh/)
+      creates: '/opt/intel/mpi/2021.12'
+    ).with_code(%r{chmod +x l_mpi_oneapi_p_2021.12.1.8_offline.sh --remove-extracted-files yes -a --silent --eula accept --install-dir /opt/intel})
+                                                .with_code(/rm -f l_mpi_oneapi_p_2021.12.1.8_offline.sh/)
   end
 
   it 'appends intel module file dir to modules config' do
     is_expected.to append_to_config_modules('append intel modules file dir to modules conf')
-      .with_line('/opt/intel/mpi/2021.9.0/modulefiles/')
+      .with_line('/opt/intel/mpi/2021.12/etc/modulefiles/')
   end
 
   it 'renames intel mpi module' do
     is_expected.to run_execute('rename intel mpi modules file name').with(
-      command: "mv /opt/intel/mpi/2021.9.0/modulefiles/mpi /opt/intel/mpi/2021.9.0/modulefiles/intelmpi",
-      creates: '/opt/intel/mpi/2021.9.0/modulefiles/intelmpi'
+      command: "mv /opt/intel/mpi/2021.12/etc/modulefiles/mpi /opt/intel/mpi/2021.12/etc/modulefiles/intelmpi",
+      creates: '/opt/intel/mpi/2021.12/etc/modulefiles/intelmpi'
     )
   end
 
   it 'adds Qt source file' do
-    is_expected.to create_template("/opt/intel/mpi/2021.9.0/qt_source_code.txt").with(
+    is_expected.to create_template("/opt/intel/mpi/2021.12/qt_source_code.txt").with(
       source: 'intel_mpi/qt_source_code.erb',
       owner: 'root',
       group: 'root',
@@ -57,7 +57,7 @@ describe 'aws-parallelcluster-platform::intel_mpi' do
       variables: {
         aws_region: aws_region,
         aws_domain: 'test_aws_domain',
-        intelmpi_qt_version: '6.4.2',
+        intelmpi_qt_version: '6.5.3',
       }
     )
   end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/intel_mpi_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/intel_mpi_spec.rb
@@ -21,7 +21,7 @@ control 'tag:install_intel_mpi_modules_file_dir_is_appended_to_modules_conf' do
 
   describe file(modulepath_config_file) do
     it { should exist }
-    its('content') { should match %r{/opt/intel/mpi/#{node['cluster']['intelmpi']['version']}/modulefiles/} }
+    its('content') { should match %r{/opt/intel/oneapi/mpi/#{node['cluster']['intelmpi']['version']}/etc/modulefiles/} }
   end
 end
 
@@ -34,6 +34,6 @@ control 'tag:install_tag:config_intel_mpi_installed' do
 
   describe bash("unset MODULEPATH && source /etc/profile.d/modules.sh && module load intelmpi && mpirun --help") do
     its('exit_status') { should eq(0) }
-    its('stdout') { should match(/Version #{node['cluster']['intelmpi']['version'].split('.')[0..1].join(".")}/) }
+    its('stdout') { should match(/Version #{node['cluster']['intelmpi']['version']}/) }
   end
 end


### PR DESCRIPTION
### Description of changes
* The new version of Intel MPI has a bit different installation directory structure. Therefore, in addition to upgrade the version, this PR changes the path references accordingly

### Tests
* AMIs build are good on all OSes except CentOS7. We are going to ignore failures on CentOS7 because we are going to remove support for CentOS7

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
