### PR TITLE
[LoginNodes] Add DCV support for login nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **ENHANCEMENTS**
-- Allow custom actions on Login Nodes.
+- Allow custom actions on login nodes.
+- Allow DCV connection on login nodes.
 
 **BUG FIXES**
 - Fix EFA kmod installation with RHEL 8.10 or newer.

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -16,7 +16,7 @@ default['cluster']['log_group_name'] = "NONE"
 # IMDS
 default['cluster']['head_node_imds_secured'] = 'true'
 default['cluster']['head_node_imds_allowed_users'] = ['root', node['cluster']['cluster_admin_user'], node['cluster']['cluster_user'] ]
-default['cluster']['head_node_imds_allowed_users'].append('dcv') if node['cluster']['dcv_enabled'] == 'head_node' && dcv_installed?
+default['cluster']['head_node_imds_allowed_users'].append('dcv') if (node['cluster']['dcv_enabled'] == 'head_node' || node['cluster']['dcv_enabled'] == 'login_node') && dcv_installed?
 
 # ParallelCluster internal variables to configure active directory service
 default['cluster']["directory_service"]["domain_name"] = nil

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
@@ -296,12 +296,13 @@
       ],
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "LoginNode"
       ],
       "feature_conditions": [
         {
           "dna_key": "dcv_enabled",
-          "satisfying_values": ["head_node"]
+          "satisfying_values": ["head_node", "login_node"]
         }
       ]
     },
@@ -379,12 +380,13 @@
       ],
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "LoginNode"
       ],
       "feature_conditions": [
         {
           "dna_key": "dcv_enabled",
-          "satisfying_values": ["head_node"]
+          "satisfying_values": ["head_node", "login_node"]
         }
       ]
     },
@@ -398,12 +400,13 @@
       ],
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "LoginNode"
       ],
       "feature_conditions": [
         {
           "dna_key": "dcv_enabled",
-          "satisfying_values": ["head_node"]
+          "satisfying_values": ["head_node", "login_node"]
         }
       ]
     },
@@ -417,12 +420,13 @@
       ],
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "LoginNode"
       ],
       "feature_conditions": [
         {
           "dna_key": "dcv_enabled",
-          "satisfying_values": ["head_node"]
+          "satisfying_values": ["head_node", "login_node"]
         }
       ]
     },
@@ -436,12 +440,13 @@
       ],
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "LoginNode"
       ],
       "feature_conditions": [
         {
           "dna_key": "dcv_enabled",
-          "satisfying_values": ["head_node"]
+          "satisfying_values": ["head_node", "login_node"]
         }
       ]
     },
@@ -455,12 +460,13 @@
       ],
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "LoginNode"
       ],
       "feature_conditions": [
         {
           "dna_key": "dcv_enabled",
-          "satisfying_values": ["head_node"]
+          "satisfying_values": ["head_node", "login_node"]
         }
       ]
     },
@@ -474,12 +480,13 @@
       ],
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
-        "HeadNode"
+        "HeadNode",
+        "LoginNode"
       ],
       "feature_conditions": [
         {
           "dna_key": "dcv_enabled",
-          "satisfying_values": ["head_node"]
+          "satisfying_values": ["head_node", "login_node"]
         }
       ]
     },

--- a/cookbooks/aws-parallelcluster-platform/files/dcv/pcluster_dcv_connect.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/dcv/pcluster_dcv_connect.sh
@@ -122,7 +122,7 @@ main() {
 
     # Create a session with session storage enabled.
     mkdir -p "${DCV_SESSION_FOLDER}"
-    dcv_session_file="${DCV_SESSION_FOLDER}/dcv_session"
+    dcv_session_file="${DCV_SESSION_FOLDER}/dcv_session_$(hostname)"
     if [[ ! -e ${dcv_session_file} ]]; then
         sessionid=$(_create_dcv_session "${dcv_session_file}" "${shared_folder_path}")
     else

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-config.yml
@@ -181,6 +181,7 @@ suites:
       cluster:
         log_rotation_enabled: 'true'
         node_type: 'LoginNode'
+        dcv_enabled: "login_node"
         directory_service:
           generate_ssh_keys_for_users: 'true'
         scheduler: 'slurm'

--- a/cookbooks/aws-parallelcluster-platform/recipes/config/dcv.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/dcv.rb
@@ -20,4 +20,11 @@ when 'HeadNode'
       action :configure
     end
   end unless on_docker?
+when 'LoginNode'
+  if node['cluster']['dcv_enabled'] == "login_node"
+    # Activate DCV on login node
+    dcv "Configure DCV" do
+      action :configure
+    end
+  end unless on_docker?
 end

--- a/cookbooks/aws-parallelcluster-platform/recipes/config/log_rotation_login_node.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/log_rotation_login_node.rb
@@ -22,6 +22,12 @@ config_files = %w(
   parallelcluster_supervisord_log_rotation
 )
 
+if node['cluster']['dcv_enabled'] == "login_node" && dcv_installed?
+  config_files += %w(
+    parallelcluster_dcv_log_rotation
+  )
+end
+
 if node['cluster']["directory_service"]["generate_ssh_keys_for_users"] == 'true'
   config_files += %w(
     parallelcluster_pam_ssh_key_generator_log_rotation

--- a/cookbooks/aws-parallelcluster-platform/recipes/config/supervisord_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/supervisord_config.rb
@@ -24,7 +24,9 @@ template "#{node['cluster']['etc_dir']}/parallelcluster_supervisord.conf" do
   variables(
     region: region,
     aws_ca_bundle: region.start_with?('us-iso') ? "/etc/pki/#{region}/certs/ca-bundle.pem" : '',
-    dcv_configured: node['cluster']['dcv_enabled'] == "head_node" && dcv_installed?,
+    dcv_configured: (node['cluster']['dcv_enabled'] == "head_node" ||
+                    node['cluster']['dcv_enabled'] == "login_node") &&
+                    dcv_installed?,
     dcv_auth_virtualenv_path: node['cluster']['dcv']['authenticator']['virtualenv_path'],
     dcv_auth_user_home: node['cluster']['dcv']['authenticator']['user_home'],
     dcv_port: node['cluster']['dcv_port'],

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
@@ -183,7 +183,7 @@ action :setup do
 end
 
 action :configure do
-  if dcv_supported? && node['cluster']['node_type'] == "HeadNode"
+  if dcv_supported? && (node['cluster']['node_type'] == "HeadNode" || node['cluster']['node_type'] == "LoginNode")
     if dcv_gpu_accel_supported?
       # Enable graphic acceleration in dcv conf file for graphic instances.
       allow_gpu_acceleration

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/log_rotation_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/log_rotation_spec.rb
@@ -218,13 +218,15 @@ describe 'aws-parallelcluster-platform::log_rotation' do
         end
       end
 
-      context "in the login node when log_rotation enabled and pam ssh key generation is enabled" do
+      context "in the login node when log_rotation, pam ssh key generation, and dcv are enabled" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['node_type'] = "LoginNode"
             node.override['cluster']['log_rotation_enabled'] = 'true'
+            node.override['cluster']['dcv_enabled'] = "login_node"
             node.override['cluster']["directory_service"]["generate_ssh_keys_for_users"] = 'true'
             node.override['cluster']["scheduler"] = 'slurm'
+            allow_any_instance_of(Object).to receive(:dcv_installed?).and_return(true)
           end
           runner.converge(described_recipe)
         end
@@ -235,12 +237,12 @@ describe 'aws-parallelcluster-platform::log_rotation' do
           parallelcluster_supervisord_log_rotation
           parallelcluster_cloud_init_output_log_rotation
           parallelcluster_pam_ssh_key_generator_log_rotation
+          parallelcluster_dcv_log_rotation
         )
         unexpected_config_files = %w(
           parallelcluster_bootstrap_error_msg_log_rotation
           parallelcluster_cfn_init_log_rotation
           parallelcluster_chef_client_log_rotation
-          parallelcluster_dcv_log_rotation
           parallelcluster_clustermgtd_log_rotation
           parallelcluster_clusterstatusmgtd_log_rotation
           parallelcluster_slurm_fleet_status_manager_log_rotation

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/supervisord_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/supervisord_config_spec.rb
@@ -77,12 +77,12 @@ describe 'aws-parallelcluster-platform::supervisord_config' do
             .with_content("[program:pcluster_dcv_authenticator]")
         end
       end
-      context "when login node" do
+      context "when login node and dcv configured" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['node_type'] = 'LoginNode'
-            node.override['cluster']['dcv_enabled'] = 'head_node'
-            allow_any_instance_of(Object).to receive(:dcv_installed?).and_return(false)
+            node.override['cluster']['dcv_enabled'] = 'login_node'
+            allow_any_instance_of(Object).to receive(:dcv_installed?).and_return(true)
           end
           runner.converge(described_recipe)
         end
@@ -92,11 +92,30 @@ describe 'aws-parallelcluster-platform::supervisord_config' do
           is_expected.to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
             .with_content("[program:cfn-hup]")
             .with_content("[program:loginmgtd]")
-
-          is_expected.not_to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
             .with_content("[program:pcluster_dcv_authenticator]")
+            .with_content("--port 8444")
+        end
+
+        context "when login node and dcv not configured" do
+          cached(:chef_run) do
+            runner = runner(platform: platform, version: version) do |node|
+              node.override['cluster']['node_type'] = 'LoginNode'
+              node.override['cluster']['dcv_enabled'] = 'NONE'
+              allow_any_instance_of(Object).to receive(:dcv_installed?).and_return(true)
+            end
+            runner.converge(described_recipe)
+          end
+          cached(:node) { chef_run.node }
+
+          it 'has the correct content' do
+            is_expected.to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
+                             .with_content("[program:loginmgtd]")
+
+            is_expected.not_to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
+                                 .with_content("[program:pcluster_dcv_authenticator]")
+            end
+          end
         end
       end
     end
-  end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/supervisord_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/supervisord_config_spec.rb
@@ -109,13 +109,13 @@ describe 'aws-parallelcluster-platform::supervisord_config' do
 
           it 'has the correct content' do
             is_expected.to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
-                             .with_content("[program:loginmgtd]")
+              .with_content("[program:loginmgtd]")
 
             is_expected.not_to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
-                                 .with_content("[program:pcluster_dcv_authenticator]")
-            end
+              .with_content("[program:pcluster_dcv_authenticator]")
           end
         end
       end
     end
+  end
 end

--- a/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
@@ -68,7 +68,8 @@ exitcodes = 0
 redirect_stderr = true
 stdout_logfile = /var/log/parallelcluster/loginmgtd.log
 stdout_logfile_maxbytes = 1MB
-<% if @dcv_configured -%>[program:pcluster_dcv_authenticator]
+<% if @dcv_configured -%>
+[program:pcluster_dcv_authenticator]
 command = <%= @dcv_auth_virtualenv_path %>/bin/python <%= @dcv_auth_user_home %>/pcluster_dcv_authenticator.py
       --port <%= Integer(@dcv_port) + 1 %>
       --certificate <%= @dcv_auth_certificate %>

--- a/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
@@ -68,4 +68,12 @@ exitcodes = 0
 redirect_stderr = true
 stdout_logfile = /var/log/parallelcluster/loginmgtd.log
 stdout_logfile_maxbytes = 1MB
+<% if @dcv_configured -%>[program:pcluster_dcv_authenticator]
+command = <%= @dcv_auth_virtualenv_path %>/bin/python <%= @dcv_auth_user_home %>/pcluster_dcv_authenticator.py
+      --port <%= Integer(@dcv_port) + 1 %>
+      --certificate <%= @dcv_auth_certificate %>
+      --key <%= @dcv_auth_private_key %>
+user = <%= @dcv_auth_user %>
+environment = HOME="<%= @dcv_auth_user_home %>",USER="<%= @dcv_auth_user %>"<% if @region.start_with?('us-iso') -%>,AWS_CA_BUNDLE="<%= @aws_ca_bundle %>"<% end -%>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
### Description of changes

These changes enable DCV on login nodes. A user can now connect to a login node with DCV using `dcv-connect` and `--login-node-ip` parameter.

* Allow DCV instance metadata access when enabled on login nodes.
* Change dcv sessionID filename to include the hostname of the instance. This is to enable multiple sessionID files within the shared directory.
* Update `dcv.rb` to configure dcv when enabled on login nodes.
* Update supervisord to include `pcluster_dcv_authenticator` on login nodes.
* Support DCV cloudwatch logs:
  * Update `cloudwatch_agent_config.json` with login node `dcv_enabled` dna key.
  * Add dcv logs to login node log rotation.
* Update CHANGELOG

### Tests

Manual tests:

* Verified able to connect to login node with DCV only when enabled.
* Verified DCV cloudwatch logging.
* Verified DCV authenticator.

ChefSpec + Kitchen

* Update `supervisord_config_spec` to test proper supervisord configuration when dcv is enabled on login nodes.
* Update `log_rotation_spec` to test proper log configuration when dcv enabled on login nodes.
* Update `kitchen.platform-config` log rotation resource.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
