### PR TITLE
Append pcluster CloudWatch config when CW agent is running

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/partial/_cloudwatch_common.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/partial/_cloudwatch_common.rb
@@ -182,7 +182,6 @@ action :configure do
   execute "cloudwatch-agent-start" do
     user 'root'
     timeout 300
-    command "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
-    not_if "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status | grep status | grep running"
+    command "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
   end unless node['cluster']['cw_logging_enabled'] != 'true' || on_docker?
 end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/cloudwatch_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/cloudwatch_spec.rb
@@ -255,7 +255,7 @@ describe 'cloudwatch:configure' do
           is_expected.to run_execute("cloudwatch-agent-start").with(
             user: 'root',
             timeout: 300,
-            command: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
+            command: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
           )
         end
       end
@@ -309,8 +309,12 @@ describe 'cloudwatch:configure' do
           ConvergeCloudWatch.configure(runner)
         end
 
-        it 'does not start cloudwatch' do
-          is_expected.not_to run_execute("cloudwatch-agent-start")
+        it 'starts cloudwatch agent' do
+          is_expected.to run_execute("cloudwatch-agent-start").with(
+            user: 'root',
+            timeout: 300,
+            command: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
+          )
         end
       end
     end


### PR DESCRIPTION
Before this commit, pcluster CW config is not loaded when CW agent is running on the custom AMI, causing the lack of logs on CloudWatch.

This commit appends pcluster CW config regardless of whether the CW agent is running. Therefore, CW config in the custom AMI will be preserved in addition to pcluster CW config. If there are conflicting parameters, the parameters in pcluster CW config overwrites the config from custom AMI.

### Tests
* Manually tested cluster creation with official AMI and custom AMI. Verified pcluster logs were uploaded to CloudWatch

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
