### PR TITLE
[ADC] Configure certificates for login nodes in ADC

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/isolated/iso-ca-bundle-config.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/isolated/iso-ca-bundle-config.sh
@@ -12,6 +12,10 @@ echo "export AWS_CA_BUNDLE=/etc/pki/${REGION}/certs/ca-bundle.pem" >> /etc/profi
 
 echo "export AWS_DEFAULT_REGION=${REGION}" >> /etc/profile.d/aws-cli-default-config.sh
 
-echo "Defaults env_keep += \"AWS_DEFAULT_REGION AWS_CA_BUNDLE\"" > /etc/sudoers.d/pcluster-aws-cli-envkeep
+echo "export REQUESTS_CA_BUNDLE=${AWS_CA_BUNDLE}" >> /etc/profile.d/aws-cli-default-config.sh
+
+echo "export SSL_CERT_FILE=${AWS_CA_BUNDLE}" >> /etc/profile.d/aws-cli-default-config.sh
+
+echo "Defaults env_keep += \"AWS_DEFAULT_REGION AWS_CA_BUNDLE REQUESTS_CA_BUNDLE SSL_CERT_FILE\"" > /etc/sudoers.d/pcluster-aws-cli-envkeep
 
 source /etc/profile.d/aws-cli-default-config.sh

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/resume_program.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/resume_program.erb
@@ -2,6 +2,8 @@
 # ResumeProgram should read SLURM_RESUME_FILE within ten seconds of starting to guarantee that it still exists.
 # ref https://slurm.schedmd.com/power_save.html#tolerance
 
+source /etc/profile.d/aws-cli-default-config.sh
+
 trap "rm -f ${SLURM_RESUME_FILE_TMP}" EXIT
 
 SLURM_RESUME_FILE_TMP=$(mktemp)


### PR DESCRIPTION
### Description of changes
* Add `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` environment variables to allow LoginNodes to communicate with the NLB in ADC
* Source environment variables in the slurm resume program to allow dynamic nodes to have the correct certificates in ADC

### Tests
* Built an AMI with these changes 
* Created a cluster with login nodes
* Test cluster scaling


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
