### PR TITLE
[ADC] Set default node package for build image command

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 return if platform?('redhat')
+return if aws_region.start_with?("us-iso")
 
 include_recipe "::awsbatch_virtualenv"
 
@@ -28,9 +29,6 @@ end
 
 # Check whether install a custom aws-parallelcluster-awsbatch-cli package or the standard one
 # Install awsbatch cli into awsbatch virtual env
-if aws_region.start_with?("us-iso") && !node['cluster']['custom_awsbatchcli_package'].empty?
-  node.default['cluster']['custom_awsbatchcli_package'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/awsbatch/aws-parallelcluster.tgz"
-end
 if !node['cluster']['custom_awsbatchcli_package'].nil? && !node['cluster']['custom_awsbatchcli_package'].empty?
   # Install custom aws-parallelcluster package
   bash "install aws-parallelcluster-awsbatch-cli" do

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/parallelcluster_node.rb
@@ -34,7 +34,9 @@ activate_virtual_env node_virtualenv_name do
 end
 
 if aws_region.start_with?("us-iso") && !is_custom_node?
-  node.default['cluster']['custom_node_package'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/node/aws-parallelcluster-node.tgz"
+  node_package = "aws-parallelcluster-node-#{node['cluster']['parallelcluster-node-version']}.tgz"
+
+  node.default['cluster']['custom_node_package'] = "#{node['cluster']['s3_url']}/parallelcluster/#{node['cluster']['parallelcluster-node-version']}/node/#{node_package}"
 end
 
 if is_custom_node?

--- a/cookbooks/aws-parallelcluster-shared/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/environment.rb
@@ -5,4 +5,5 @@ default['cluster']['aws_domain'] = aws_domain
 
 # URL for ParallelCluster Artifacts stored in public S3 buckets
 # ['cluster']['region'] will need to be defined by image_dna.json during AMI build.
-default['cluster']['artifacts_s3_url'] = "https://#{node['cluster']['region']}-aws-parallelcluster.s3.#{node['cluster']['region']}.#{node['cluster']['aws_domain']}/archives"
+default['cluster']['s3_url'] = "https://#{node['cluster']['region']}-aws-parallelcluster.s3.#{node['cluster']['region']}.#{node['cluster']['aws_domain']}"
+default['cluster']['artifacts_s3_url'] = "#{node['cluster']['s3_url']}/archives"


### PR DESCRIPTION
### Description of changes
* Set default node package for build image command
* So that `build-image` command can be run without having to specify custom packages in ADC

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
