### PR TITLE
Upload cfn-hup log to CloudWatch

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
@@ -66,6 +66,23 @@
     },
     {
       "timestamp_format_key": "default",
+      "file_path": "/var/log/cfn-hup.log",
+      "log_stream_name": "cfn-hup",
+      "schedulers": [
+        "awsbatch",
+        "slurm"
+      ],
+      "platforms": {{ default_platforms | tojson}},
+      "node_roles": [
+        "HeadNode",
+        "ComputeFleet",
+        "LoginNode",
+        "ExternalSlurmDbd"
+      ],
+      "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "default",
       "file_path": "/var/log/chef-client.log",
       "log_stream_name": "chef-client",
       "schedulers": [


### PR DESCRIPTION
cfn-hup log is useful when debugging cluster update failures. Since https://github.com/aws/aws-parallelcluster-cookbook/pull/2614, all nodes rely on cfn-hup, making have the log on CloudWatch important.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
