### PR TITLE
Install enroot + pyxis in AMIs during build process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Allow custom actions on login nodes.
 - Allow DCV connection on login nodes.
 - Add new attribute `efs_access_point_ids` to specify optional EFS access points for the mounts
+- Install enroot and pyxis in official pcluster AMIs
 
 **BUG FIXES**
 - Fix EFA kmod installation with RHEL 8.10 or newer.

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -9,6 +9,10 @@ default['cluster']['sysctl']['ipv4']['gc_thresh3'] = 16_384
 # ArmPL
 default['conditions']['arm_pl_supported'] = arm_instance?
 
+# Enroot + Pyxis
+default['cluster']['enroot']['version'] = '3.4.1'
+default['cluster']['pyxis']['version'] = '0.19.0'
+
 # NVidia
 default['cluster']['nvidia']['enabled'] = 'no'
 default['cluster']['nvidia']['driver_version'] = '535.183.01'

--- a/cookbooks/aws-parallelcluster-platform/recipes/config.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config.rb
@@ -26,3 +26,6 @@ include_recipe 'aws-parallelcluster-platform::dcv'
 include_recipe 'aws-parallelcluster-platform::supervisord_config'
 fetch_config 'Fetch and load cluster configs'
 include_recipe 'aws-parallelcluster-platform::config_login' if node['cluster']['node_type'] == 'LoginNode'
+enroot 'Configure Enroot' do
+  action :configure
+end

--- a/cookbooks/aws-parallelcluster-platform/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install.rb
@@ -36,3 +36,4 @@ include_recipe "aws-parallelcluster-platform::nvidia_install"
 include_recipe "aws-parallelcluster-platform::intel_mpi"
 arm_pl 'Install ARM Performance Library'
 intel_hpc 'Setup Intel HPC'
+enroot 'Setup Enroot'

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/enroot_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/enroot_alinux2023.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :enroot, platform: 'amazon' do |node|
+  node['platform_version'].to_i == 2023
+end
+
+use 'partial/_enroot_common.rb'
+use 'partial/_enroot_rhel.rb'
+
+def prerequisites
+  %w(jq squashfs-tools parallel pigz zstd)
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/enroot_amazon2.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/enroot_amazon2.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :enroot, platform: 'amazon', platform_version: '2'
+
+use 'partial/_enroot_common.rb'
+use 'partial/_enroot_rhel.rb'
+
+def prerequisites
+  %w(jq squashfs-tools parallel pigz squashfuse zstd)
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/enroot_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/enroot_redhat8.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :enroot, platform: 'redhat' do |node|
+  node['platform_version'].to_i >= 8
+end
+
+use 'partial/_enroot_common.rb'
+use 'partial/_enroot_rhel.rb'
+
+def prerequisites
+  %w(jq fuse-overlayfs squashfs-tools parallel pigz squashfuse zstd)
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/enroot_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/enroot_rocky8.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :enroot, platform: 'rocky' do |node|
+  node['platform_version'].to_i >= 8
+end
+
+use 'partial/_enroot_common.rb'
+use 'partial/_enroot_rhel.rb'
+
+def prerequisites
+  %w(jq fuse-overlayfs squashfs-tools parallel pigz squashfuse zstd)
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/enroot_ubuntu20+.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/enroot_ubuntu20+.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+provides :enroot, platform: 'ubuntu' do |node|
+  node['platform_version'].to_i >= 20
+end
+use 'partial/_enroot_common.rb'
+use 'partial/_enroot_debian.rb'

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_common.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+unified_mode true
+default_action :setup
+
+action :setup do
+  action_install_package
+end
+
+action :configure do
+  enroot_installed = ::File.exist?('/usr/bin/enroot')
+  return unless enroot_installed
+
+  bash "Configure enroot" do
+    user 'root'
+    code <<-ENROOT_CONFIGURE
+      set -e
+      ENROOT_CONFIG_RELEASE=pyxis
+      SHARED_DIR=#{node['cluster']['shared_dir']}
+      NONROOT_USER=#{node['cluster']['cluster_user']}
+      wget -O /tmp/enroot.template.conf https://raw.githubusercontent.com/aws-samples/aws-parallelcluster-post-install-scripts/${ENROOT_CONFIG_RELEASE}/pyxis/enroot.template.conf
+      mkdir -p ${SHARED_DIR}/enroot
+      chown ${NONROOT_USER} ${SHARED_DIR}/enroot
+      ENROOT_CACHE_PATH=${SHARED_DIR}/enroot envsubst < /tmp/enroot.template.conf > /tmp/enroot.conf
+      mv /tmp/enroot.conf /etc/enroot/enroot.conf
+      chmod 0644 /etc/enroot/enroot.conf
+  
+      mkdir -p /tmp/enroot
+      chmod 1777 /tmp/enroot
+      mkdir -p /tmp/enroot/data
+      chmod 1777 /tmp/enroot/data
+  
+      chmod 1777 ${SHARED_DIR}/enroot
+  
+      mkdir -p ${SHARED_DIR}/pyxis/
+      chown ${NONROOT_USER} ${SHARED_DIR}/pyxis/
+      sed -i '${s/$/ runtime_path=${SHARED_DIR}\\/pyxis/}' /opt/slurm/etc/plugstack.conf.d/pyxis.conf
+      SHARED_DIR=${SHARED_DIR} envsubst < /opt/slurm/etc/plugstack.conf.d/pyxis.conf > /opt/slurm/etc/plugstack.conf.d/pyxis.tmp.conf
+      mv /opt/slurm/etc/plugstack.conf.d/pyxis.tmp.conf /opt/slurm/etc/plugstack.conf.d/pyxis.conf
+
+    ENROOT_CONFIGURE
+    retries 3
+    retry_delay 5
+  end
+end
+
+def package_version
+  node['cluster']['enroot']['version']
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_common.rb
@@ -16,11 +16,12 @@ unified_mode true
 default_action :setup
 
 action :setup do
+  return if on_docker?
   action_install_package
 end
 
 action :configure do
-  enroot_installed = ::File.exist?('/usr/bin/enroot')
+  return if on_docker?
   return unless enroot_installed
 
   bash "Configure enroot" do
@@ -36,14 +37,14 @@ action :configure do
       ENROOT_CACHE_PATH=${SHARED_DIR}/enroot envsubst < /tmp/enroot.template.conf > /tmp/enroot.conf
       mv /tmp/enroot.conf /etc/enroot/enroot.conf
       chmod 0644 /etc/enroot/enroot.conf
-  
+
       mkdir -p /tmp/enroot
       chmod 1777 /tmp/enroot
       mkdir -p /tmp/enroot/data
       chmod 1777 /tmp/enroot/data
-  
+
       chmod 1777 ${SHARED_DIR}/enroot
-  
+
       mkdir -p ${SHARED_DIR}/pyxis/
       chown ${NONROOT_USER} ${SHARED_DIR}/pyxis/
       sed -i '${s/$/ runtime_path=${SHARED_DIR}\\/pyxis/}' /opt/slurm/etc/plugstack.conf.d/pyxis.conf
@@ -58,4 +59,8 @@ end
 
 def package_version
   node['cluster']['enroot']['version']
+end
+
+def enroot_installed
+  ::File.exist?('/usr/bin/enroot')
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_debian.rb
@@ -24,7 +24,7 @@ action :install_package do
       curl -fSsL -O #{enroot_url}
       curl -fSsL -O #{enroot_caps_url}
       apt install -y ./*.deb
-  
+
       ln -s /usr/share/enroot/hooks.d/50-slurm-pmi.sh /etc/enroot/hooks.d/
       ln -s /usr/share/enroot/hooks.d/50-slurm-pytorch.sh /etc/enroot/hooks.d/
       mkdir -p /etc/sysconfig

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_debian.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+action :install_package do
+  return unless nvidia_enabled?
+
+  bash "Install enroot" do
+    user 'root'
+    cwd node['cluster']['sources_dir']
+    code <<-ENROOT_INSTALL
+      set -e
+      apt-get install -y jq squashfs-tools parallel fuse-overlayfs pigz squashfuse zstd
+      curl -fSsL -O #{enroot_url}
+      curl -fSsL -O #{enroot_caps_url}
+      apt install -y ./*.deb
+  
+      ln -s /usr/share/enroot/hooks.d/50-slurm-pmi.sh /etc/enroot/hooks.d/
+      ln -s /usr/share/enroot/hooks.d/50-slurm-pytorch.sh /etc/enroot/hooks.d/
+      mkdir -p /etc/sysconfig
+      echo "PATH=/opt/slurm/sbin:/opt/slurm/bin:$(bash -c 'source /etc/environment ; echo $PATH')" >> /etc/sysconfig/slurmd
+
+    ENROOT_INSTALL
+    retries 3
+    retry_delay 5
+  end
+end
+
+def enroot_url
+  "https://github.com/NVIDIA/enroot/releases/download/v#{package_version}/enroot_#{package_version}-1_#{arch_suffix}.deb"
+end
+
+def enroot_caps_url
+  "https://github.com/NVIDIA/enroot/releases/download/v#{package_version}/enroot+caps_#{package_version}-1_#{arch_suffix}.deb"
+end
+
+def arch_suffix
+  arm_instance? ? 'arm64' : 'amd64'
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_rhel.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+action :install_package do
+  return unless nvidia_enabled?
+
+  package prerequisites do
+    retries 3
+    retry_delay 5
+  end
+
+  bash "Install enroot" do
+    user 'root'
+    cwd node['cluster']['sources_dir']
+    code <<-ENROOT_INSTALL
+      set -e
+      yum install -y #{enroot_url}
+      yum install -y #{enroot_caps_url}
+    ENROOT_INSTALL
+    retries 3
+    retry_delay 5
+  end
+end
+
+def enroot_url
+  "https://github.com/NVIDIA/enroot/releases/download/v#{package_version}/enroot-#{package_version}-1.el8.#{arch_suffix}.rpm"
+end
+
+def enroot_caps_url
+  "https://github.com/NVIDIA/enroot/releases/download/v#{package_version}/enroot+caps-#{package_version}-1.el8.#{arch_suffix}.rpm"
+end
+
+def arch_suffix
+  arm_instance? ? 'aarch64' : 'x86_64'
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/enroot_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/enroot_spec.rb
@@ -1,0 +1,171 @@
+require 'spec_helper'
+
+package_version = '3.4.1'
+class ConvergeEnroot
+  def self.setup(chef_run)
+    chef_run.converge_dsl('aws-parallelcluster-platform') do
+      enroot 'setup' do
+        action :setup
+      end
+    end
+  end
+
+  def self.configure(chef_run)
+    chef_run.converge_dsl('aws-parallelcluster-platform') do
+      enroot 'configure' do
+        action :configure
+      end
+    end
+  end
+end
+
+describe 'enroot:package_version' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(false)
+        runner = runner(platform: platform, version: version, step_into: ['enroot'])
+        ConvergeEnroot.setup(runner)
+      end
+      cached(:resource) do
+        chef_run.find_resource('enroot', 'setup')
+      end
+
+      it 'returns the expected enroot version' do
+        expected_enroot_version = "3.4.1"
+        expect(resource.package_version).to eq(expected_enroot_version)
+      end
+    end
+  end
+end
+
+describe 'enroot:arch_suffix' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version} - arm" do
+      cached(:chef_run) do
+        allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(false)
+        runner = runner(platform: platform, version: version, step_into: ['enroot'])
+        ConvergeEnroot.setup(runner)
+      end
+      cached(:resource) do
+        chef_run.find_resource('enroot', 'setup')
+      end
+
+      context 'on arm instance' do
+        cached(:expected_arch) do
+          case platform
+          when 'amazon', 'redhat', 'rocky'
+            'aarch64'
+          else
+            'arm64'
+          end
+        end
+
+        it 'returns arch value for arm architecture' do
+          allow_any_instance_of(Object).to receive(:arm_instance?).and_return(true)
+          expect(resource.arch_suffix).to eq(expected_arch)
+        end
+      end
+
+      context 'not on arm instance' do
+        cached(:expected_arch) do
+          platform == 'ubuntu' ? 'amd64' : 'x86_64'
+        end
+
+        it 'returns arch value for arm architecture' do
+          allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+          expect(resource.arch_suffix).to eq(expected_arch)
+        end
+      end
+    end
+  end
+end
+
+describe 'enroot:setup' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      let(:chef_run) do
+        runner(platform: platform, version: version, step_into: ['enroot']) do |node|
+          node.override['cluster']['enroot']['version'] = package_version
+        end
+      end
+
+      context 'when nvidia is enabled' do
+        before do
+          stubs_for_provider('enroot') do |resource|
+            allow(resource).to receive(:nvidia_enabled?).and_return(true)
+          end
+        end
+
+        context 'and enroot is installed' do
+          before do
+            ConvergeEnroot.setup(chef_run)
+          end
+
+          it 'installs Enroot' do
+            is_expected.to run_bash('Install enroot')
+          end
+        end
+      end
+
+      context 'when nvidia is not enabled' do
+        before do
+          stubs_for_provider('enroot') do |resource|
+            allow(resource).to receive(:nvidia_enabled?).and_return(false)
+          end
+        end
+
+        context 'and enroot is installed' do
+          before do
+            ConvergeEnroot.setup(chef_run)
+          end
+
+          it 'does not install Enroot' do
+            is_expected.not_to run_bash('Install enroot')
+          end
+        end
+      end
+    end
+  end
+end
+
+describe 'enroot:configure' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      let(:chef_run) do
+        runner(platform: platform, version: version, step_into: ['enroot'])
+      end
+
+      context 'when enroot is installed' do
+        before do
+          stubs_for_provider('enroot') do |resource|
+            allow(resource).to receive(:enroot_installed).and_return(true)
+          end
+          ConvergeEnroot.configure(chef_run)
+        end
+        it 'run configure enroot script' do
+          is_expected.to run_bash('Configure enroot')
+            .with(retries: 3)
+            .with(retry_delay: 5)
+            .with(user: 'root')
+        end
+      end
+
+      context 'when enroot is not installed' do
+        before do
+          stubs_for_provider('enroot') do |resource|
+            allow(resource).to receive(:enroot_installed).and_return(false)
+          end
+          ConvergeEnroot.configure(chef_run)
+        end
+
+        it 'does not run configure enroot script' do
+          is_expected.not_to run_bash('Configure enroot')
+            .with(retries: 3)
+            .with(retry_delay: 5)
+            .with(user: 'root')
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/enroot_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/enroot_spec.rb
@@ -1,0 +1,47 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'tag:install_expected_version_of_enroot_installed' do
+  only_if { !os_properties.on_docker? && ['yes', true].include?(node['cluster']['nvidia']['enabled']) }
+
+  expected_enroot_version = node['cluster']['enroot']['version']
+
+  describe "gdrcopy version is expected to be #{expected_enroot_version}" do
+    subject { command('enroot version').stdout.strip() }
+    it { should eq expected_enroot_version }
+  end
+end
+
+control 'tag:config_enroot_enabled_on_graphic_instances' do
+  only_if { !os_properties.on_docker? && ['yes', true].include?(node['cluster']['nvidia']['enabled']) }
+
+  describe directory('/usr/bin/enroot') do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end
+
+  describe file("/opt/parallelcluster/shared/enroot") do
+    it { should exist }
+    its('mode') { should cmp '1777' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end unless os_properties.redhat_on_docker?
+end
+
+control 'tag:config_enroot_disabled_on_non_graphic_instances' do
+  only_if { !os_properties.on_docker? && !['yes', true].include?(node['cluster']['nvidia']['enabled']) }
+
+  describe 'enroot service should be disabled' do
+    subject { command("enroot version") }
+    its('exit_status') { should eq 127 }
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install.rb
@@ -23,3 +23,4 @@ munge 'Install munge' do
   action :setup
 end
 include_recipe 'aws-parallelcluster-slurm::install_slurm'
+include_recipe 'aws-parallelcluster-slurm::install_pyxis'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pyxis.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pyxis.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-slurm
+# Recipe:: install_pyxis
+#
+# Copyright:: Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+return unless nvidia_enabled?
+
+pyxis_version = node['cluster']['pyxis']['version']
+pyxis_url = "https://github.com/NVIDIA/pyxis/archive/refs/tags/v#{pyxis_version}.tar.gz"
+pyxis_tarball = "#{node['cluster']['sources_dir']}/pyxis-#{pyxis_version}.tar.gz"
+
+remote_file pyxis_tarball do
+  source pyxis_url
+  mode '0644'
+  retries 3
+  retry_delay 5
+  action :create_if_missing
+end
+
+bash "Install pyxis" do
+  user 'root'
+  code <<-PYXIS_INSTALL
+    set -e
+    tar xf #{pyxis_tarball} -C /tmp
+    cd /tmp/pyxis-#{pyxis_version}
+    CPPFLAGS='-I /opt/slurm/include/' make
+    CPPFLAGS='-I /opt/slurm/include/' make install
+    mkdir -p /opt/slurm/etc/plugstack.conf.d
+    echo -e 'include /opt/slurm/etc/plugstack.conf.d/*' | tee /opt/slurm/etc/plugstack.conf
+    ln -fs /usr/local/share/pyxis/pyxis.conf /opt/slurm/etc/plugstack.conf.d/pyxis.conf
+  PYXIS_INSTALL
+  retries 3
+  retry_delay 5
+end

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
@@ -1,0 +1,25 @@
+# Copyright:: 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'tag:install_pyxis_installed' do
+  only_if { ['yes', true].include?(node['cluster']['nvidia']['enabled']) }
+
+  title 'Checks Pyxis has been installed'
+
+  describe file("/opt/slurm/etc/plugstack.conf.d/pyxis.conf") do
+    it { should exist }
+  end
+
+  describe file("/usr/local/share/pyxis/pyxis.conf") do
+    it { should be_symlink }
+    it { should be_linked_to "/opt/slurm/etc/plugstack.conf.d/pyxis.conf" }
+  end
+end


### PR DESCRIPTION
### Description of changes
* Install enroot + pyxis in AMIs during build process

### Tests
* Built image, created a cluster using the new image, and tested that I could use enroot + pyxis
  * Tested on different OSes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
