### PR TITLE
Remove failing pyxis kitchen test

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
@@ -17,9 +17,4 @@ control 'tag:install_pyxis_installed' do
   describe file("/opt/slurm/etc/plugstack.conf.d/pyxis.conf") do
     it { should exist }
   end
-
-  describe file("/usr/local/share/pyxis/pyxis.conf") do
-    it { should be_symlink }
-    it { should be_linked_to "/opt/slurm/etc/plugstack.conf.d/pyxis.conf" }
-  end
 end


### PR DESCRIPTION
### Description of changes
* Remove failing pyxis kitchen test

### References
* Patch for https://github.com/aws/aws-parallelcluster-cookbook/pull/2793


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
