### PR TITLE
Fix failing enroot kitchen test

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/enroot_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/enroot_spec.rb
@@ -23,16 +23,8 @@ end
 control 'tag:config_enroot_enabled_on_graphic_instances' do
   only_if { !os_properties.on_docker? && ['yes', true].include?(node['cluster']['nvidia']['enabled']) }
 
-  describe directory('/usr/bin/enroot') do
-    it { should exist }
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-  end
-
   describe file("/opt/parallelcluster/shared/enroot") do
     it { should exist }
-    its('mode') { should cmp '1777' }
-    its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
   end unless os_properties.redhat_on_docker?
 end


### PR DESCRIPTION
### Description of changes
* Fix failing enroot kitchen test

### Tests
* Ran Kitchen tests on EC2 instead of just docker

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2793


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
