### PR TITLE
Prevent pcluster from changing default permissions on /home directory

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/recipes/config/mount_home.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/mount_home.rb
@@ -62,6 +62,7 @@ else
         efs_iam_authorization_array [node['cluster']['efs_iam_authorizations'].split(',')[index]]
         efs_mount_point_array ['/home']
         efs_access_point_id_array [node['cluster']['efs_access_point_ids'].split(',')[index]]
+        mode '755'
         action :mount
       end
       break
@@ -75,6 +76,7 @@ else
         efs_encryption_in_transit_array [node['cluster']['efs_encryption_in_transits'].split(',')[index]]
         efs_iam_authorization_array [node['cluster']['efs_iam_authorizations'].split(',')[index]]
         efs_access_point_id_array [node['cluster']['efs_access_point_ids'].split(',')[index]]
+        mode '755'
         action :mount
       end
       break
@@ -89,6 +91,7 @@ else
         fsx_dns_name_array [node['cluster']['fsx_dns_names'].split(',')[index]]
         fsx_mount_name_array [node['cluster']['fsx_mount_names'].split(',')[index]]
         fsx_volume_junction_path_array [node['cluster']['fsx_volume_junction_paths'].split(',')[index]]
+        mode '755'
         action :mount
       end
       break
@@ -101,6 +104,7 @@ else
         manage_ebs "add ebs /home" do
           shared_dir_array [dir]
           vol_array [node['cluster']['volume'].split(',')[index]]
+          mode '755'
           action %i(mount export)
         end
         break
@@ -111,6 +115,7 @@ else
         shared_dir '/home'
         device(lazy { "#{node['cluster']['head_node_private_ip']}:#{format_directory('/home')}" })
         fstype 'nfs'
+        mode '755'
         options node['cluster']['nfs']['hard_mount_options']
         retries 10
         retry_delay 6
@@ -123,6 +128,7 @@ else
         raid_shared_dir '/home'
         raid_type node['cluster']['raid_type']
         raid_vol_array node['cluster']['raid_vol_ids'].split(',')
+        mode '755'
         action %i(mount export)
       end
     when 'ComputeFleet', 'LoginNode'
@@ -131,6 +137,7 @@ else
         shared_dir '/home'
         device(lazy { "#{node['cluster']['head_node_private_ip']}:/home" })
         fstype 'nfs'
+        mode '755'
         options node['cluster']['nfs']['hard_mount_options']
         retries 10
         retry_delay 6

--- a/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_mount_umount.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_mount_umount.rb
@@ -22,6 +22,7 @@ property :efs_access_point_id_array, Array, required: false
 # This is the mount point on the EFS itself, as opposed to the local system directory, defaults to "/"
 property :efs_mount_point_array, Array, required: false
 property :efs_unmount_forced_array, Array, required: false
+property :mode, String, default: "1777"
 
 action :mount do
   return if on_docker?
@@ -61,7 +62,7 @@ action :mount do
     directory efs_shared_dir do
       owner 'root'
       group 'root'
-      mode '1777'
+      mode new_resource.mode
       recursive true
       action :create
     end unless ::File.directory?(efs_shared_dir)
@@ -97,7 +98,7 @@ action :mount do
       path efs_shared_dir
       owner 'root'
       group 'root'
-      mode '1777'
+      mode new_resource.mode
       only_if { node['cluster']['node_type'] == "HeadNode" }
     end
   end
@@ -130,7 +131,7 @@ action :unmount do
     directory efs_shared_dir do
       owner 'root'
       group 'root'
-      mode '1777'
+      mode new_resource.mode
       recursive false
       action :delete
       only_if { Dir.exist?(efs_shared_dir.to_s) && Dir.empty?(efs_shared_dir.to_s) }

--- a/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_mount_unmount.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/lustre/partial/_mount_unmount.rb
@@ -15,6 +15,7 @@ property :fsx_shared_dir_array, Array, required: %i(mount unmount)
 property :fsx_dns_name_array, Array, required: %i(mount unmount)
 property :fsx_mount_name_array, Array, required: %i(mount unmount)
 property :fsx_volume_junction_path_array, Array, required: %i(mount unmount)
+property :mode, String, default: "1777"
 
 action :mount do
   return if on_docker?
@@ -25,7 +26,7 @@ action :mount do
     directory fsx.shared_dir do
       owner 'root'
       group 'root'
-      mode '1777'
+      mode new_resource.mode
       recursive true
       action :create
     end
@@ -61,7 +62,7 @@ action :mount do
       path fsx.shared_dir
       owner 'root'
       group 'root'
-      mode '1777'
+      mode new_resource.mode
       only_if { fsx.can_change_shared_dir_permissions && node['cluster']['node_type'] == "HeadNode" }
     end
   end
@@ -92,7 +93,7 @@ action :unmount do
     directory fsx.shared_dir do
       owner 'root'
       group 'root'
-      mode '1777'
+      mode new_resource.mode
       recursive false
       action :delete
       only_if { Dir.exist?(fsx.shared_dir) && Dir.empty?(fsx.shared_dir) }

--- a/cookbooks/aws-parallelcluster-environment/resources/manage_ebs.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/manage_ebs.rb
@@ -13,6 +13,7 @@ unified_mode true
 
 property :shared_dir_array, Array, required: %i(mount export unmount unexport)
 property :vol_array, Array, required: %i(mount unmount)
+property :mode, String, default: "1777"
 
 default_action :mount
 
@@ -43,6 +44,7 @@ action :mount do
 
     volume "mount volume #{index}" do
       action :mount
+      mode new_resource.mode
       shared_dir shared_dir_array[index]
       device(lazy_uuid(dev_path[index]))
       fstype(DelayedEvaluator.new { node['cluster']['volume_fs_type'] })

--- a/cookbooks/aws-parallelcluster-environment/resources/raid/partial/_raid_common.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/raid/partial/_raid_common.rb
@@ -15,6 +15,7 @@ default_action :setup
 property :raid_shared_dir, String, required: %i(mount unmount export unexport)
 property :raid_type, [String, Integer], required: %i(mount)
 property :raid_vol_array, Array, required: %i(mount unmount)
+property :mode, String, default: "1777"
 
 action :setup do
   package 'mdadm' do
@@ -79,6 +80,7 @@ action :mount do
     device raid_dev
     fstype "ext4"
     options "defaults,nofail,_netdev"
+    mode new_resource.mode
     retries 10
     retry_delay 6
   end

--- a/cookbooks/aws-parallelcluster-environment/resources/volume.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/volume.rb
@@ -7,6 +7,7 @@ property :fstype, String, required: %i(mount)
 property :options, [Array, String], required: %i(mount)
 property :device_type, [String, Symbol], default: :device
 property :volume_id, String, required: %i(attach detach)
+property :mode, String, default: "1777"
 
 action :attach do
   volume_id = new_resource.volume_id.strip
@@ -42,7 +43,7 @@ action :mount do
   directory shared_dir do
     owner 'root'
     group 'root'
-    mode '1777'
+    mode new_resource.mode
     recursive true
     action :create
   end
@@ -78,7 +79,7 @@ action :mount do
   directory shared_dir do
     owner 'root'
     group 'root'
-    mode '1777'
+    mode new_resource.mode
     only_if { node['cluster']['node_type'] == "HeadNode" }
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/volume.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/volume.rb
@@ -79,6 +79,7 @@ action :mount do
     owner 'root'
     group 'root'
     mode '1777'
+    only_if { node['cluster']['node_type'] == "HeadNode" }
   end
 end
 


### PR DESCRIPTION
### Description of changes
* Prevents the permissions of the `/home` directory from being reset every time a compute node or login node is launched
* The old behavior works as follows:
  * When a cluster is launched with 0 static nodes, the `/home` directory on the head node has permission 755
    * When a dynamic node is launched, the `/home` directory on the head node has its permissions changed to 1777
  * When a cluster with at least 1 static node is launched, the `/home` directory on the head node has permission 1777 because the launching of the static node changes the permissions
  * When the permissions of the `/home` directory is changed, and a dynamic node is launched, the permission of `/home` is changed back to 1777
* The new behavior works as follows:
  * When a cluster is launched with 0 or more static nodes, the `/home` directory on the head node has permission 755
  * When a dynamic node is launched, the permissions of `/home` does not change
  * When the permissions of the `/home` directory is changed, and a dynamic node is launched, the permission of `/home` is not changed

### Tests
* Tried all the cases mentioned in the description
* Ran an integration test with the following test configuration:
```
test-suites:
  storage:
    test_shared_home.py::test_shared_home:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5.xlarge"]
          oss: ["alinux2023"]
          schedulers: ["slurm"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
