### PR TITLE
Add additional parameters to gpu health check for g6 instances

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_checks/gpu_health_check.sh
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/health_checks/gpu_health_check.sh
@@ -115,7 +115,13 @@ function main() {
 
   ## Run GPUs Health Check test
   log_info "Running GPU Health Check with DCGMI level $DCGMI_LEVEL"
-  dcgmi diag -i $GPU_DEVICE_ORDINAL -r $DCGMI_LEVEL
+
+  parameters=""
+  if [[ $nvidia_smi_out =~ "NVIDIA L4" ]]; then
+    parameters="-p pcie.h2d_d2h_single_pinned.min_pci_width=8;pcie.h2d_d2h_single_unpinned.min_pci_width=8"
+  fi
+
+  dcgmi diag -i $GPU_DEVICE_ORDINAL -r $DCGMI_LEVEL $parameters
   dcgmi_exit_code=$?
 
   if [ $dcgmi_exit_code -ne 0 ]; then


### PR DESCRIPTION
### Description of changes
* Add additional parameters to gpu health check for g6 instances
* NVIDIA L4 GPUs have up to 16 lanes but G6 instances only use 8
* Sets `min_pci_width` to 8 so the gpu health checks do not fail for G6 instances

### Tests
* Ran gpu health check on G6 instance


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
