### PR TITLE
Restarting cfn-hup if it hangs using supervisorctl

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/recipes/install/cfn_bootstrap.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/install/cfn_bootstrap.rb
@@ -98,5 +98,6 @@ template "#{node['cluster']['scripts_dir']}/cfn-hup-runner.sh" do
   owner 'root'
   group 'root'
   mode '0744'
-  variables(cfn_bootstrap_virtualenv_path: virtualenv_path)
+  variables(cfn_bootstrap_virtualenv_path: virtualenv_path,
+            node_bootstrap_timeout: node['cluster']['compute_node_bootstrap_timeout'] || node['cluster']['Timeout'])
 end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/cfn_bootstrap_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/cfn_bootstrap_spec.rb
@@ -8,12 +8,14 @@ describe 'aws-parallelcluster-environment::cfn_bootstrap' do
       cached(:python_version) { '3.9.20' }
       cached(:system_pyenv_root) { 'system_pyenv_root' }
       cached(:virtualenv_path) { "system_pyenv_root/versions/#{python_version}/envs/cfn_bootstrap_virtualenv" }
+      cached(:timeout) { 1800 }
 
       context "when cfn_bootstrap virtualenv not installed yet" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['region'] = 'non_china'
+            node.override['cluster']['compute_node_bootstrap_timeout'] = timeout
           end
           runner.converge(described_recipe)
         end
@@ -79,7 +81,7 @@ describe 'aws-parallelcluster-environment::cfn_bootstrap' do
             owner: 'root',
             group: 'root',
             mode: '0744',
-            variables: { cfn_bootstrap_virtualenv_path: virtualenv_path }
+            variables: { cfn_bootstrap_virtualenv_path: virtualenv_path, node_bootstrap_timeout: timeout }
           )
         end
       end

--- a/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/cfn-hup-runner.sh.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/cfn_bootstrap/cfn-hup-runner.sh.erb
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -x
 
 # This script is used to run cfn-hup is a way that is suitable to be managed by supervisord.
 # In particular, cfn-hup is executed in no-daemon mode.
@@ -9,6 +9,6 @@ set -ex
 [ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh
 
 while true; do
-  <%= @cfn_bootstrap_virtualenv_path %>/bin/cfn-hup --no-daemon --verbose
+  timeout <%= @node_bootstrap_timeout %> <%= @cfn_bootstrap_virtualenv_path %>/bin/cfn-hup --no-daemon --verbose
   sleep 60
 done


### PR DESCRIPTION
### Description of changes
* Restarting cfn-hup if it hangs using supervisorctl

### Tests
```
  update:
    test_update.py::test_dynamic_file_systems_update:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
