### PR TITLE
[Dependencies] Fix Enroot+Caps URL used for RHEL.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_rhel.rb
@@ -38,7 +38,7 @@ def enroot_url
 end
 
 def enroot_caps_url
-  "#{node['cluster']['artifacts_s3_url']}/dependencies/enroot/enroot+caps-#{package_version}-1.el8.#{arch_suffix}.rpm"
+  "#{node['cluster']['artifacts_s3_url']}/dependencies/enroot/enroot%2Bcaps-#{package_version}-1.el8.#{arch_suffix}.rpm"
 end
 
 def arch_suffix


### PR DESCRIPTION
### Description of changes
Fix Enroot+Caps URL used for RHEL.
The malformed URL is causing build image failures for RHEL AMIs.
The artifacts name is `enroot+caps` that, as URL, is translated into `enroot%2Bcaps`.

### Tests
* Manually verified on S3 that the URL is now correct.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
