### PR TITLE
[Dependencies] Rename Enroot+Caps object URL from enroot+caps to enroot-caps to prevent URL encoding issues on RHEL and Debian.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_debian.rb
@@ -41,7 +41,7 @@ def enroot_url
 end
 
 def enroot_caps_url
-  "#{node['cluster']['artifacts_s3_url']}/dependencies/enroot/enroot%2Bcaps_#{package_version}-1_#{arch_suffix}.deb"
+  "#{node['cluster']['artifacts_s3_url']}/dependencies/enroot/enroot-caps_#{package_version}-1_#{arch_suffix}.deb"
 end
 
 def arch_suffix

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_rhel.rb
@@ -38,7 +38,7 @@ def enroot_url
 end
 
 def enroot_caps_url
-  "#{node['cluster']['artifacts_s3_url']}/dependencies/enroot/enroot%2Bcaps-#{package_version}-1.el8.#{arch_suffix}.rpm"
+  "#{node['cluster']['artifacts_s3_url']}/dependencies/enroot/enroot-caps-#{package_version}-1.el8.#{arch_suffix}.rpm"
 end
 
 def arch_suffix


### PR DESCRIPTION
### Description of changes
Rename Enroot+Caps object URL from enroot+caps (encoded is enroot%2Bcaps) to enroot-caps to prevent URL encoding issues on RHEL and Debian.

In fact we observed the following URL encoding issue:
* on RHEL9 enroot%2Bcaps is interpreted as it should be, i.e. enrott+caps
* on RHEL8 enroot%2Bcaps is translated into enroot%252Bcaps.

To prevent this behaviour we decided to resolve by avoid the use of special characters in the object URL.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
