### PR TITLE
[Directories] Set /etc permissions to 0755.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/recipes/install/directories.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/directories.rb
@@ -29,3 +29,13 @@ directory node['cluster']['log_base_dir'] do
   mode '1777'
   recursive true
 end
+
+# The default permission for directory /etc is 0755.
+# However, in Rocky9.4 it was unintentionally changed to 0777,
+# causing issues with Munge, that fails to start if /etc has group-writable permission without sticky bit.
+# See https://forums.rockylinux.org/t/changed-permissions-on-etc-in-rl9-4-genericcloud-image/14449
+directory '/etc' do
+  owner 'root'
+  mode '0755'
+  recursive false
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/directories_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/directories_spec.rb
@@ -43,6 +43,14 @@ describe 'aws-parallelcluster-platform::directories' do
           recursive: true
         )
       end
+
+      it 'sets permission 0755 for /etc' do
+        is_expected.to create_directory('/etc').with(
+          owner: 'root',
+          mode: '0755',
+          recursive: false
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of changes
Set /etc permissions to 0755.
This is the default permission in Linux, but it was unintentionally changed in Rocky9.4 (https://forums.rockylinux.org/t/changed-permissions-on-etc-in-rl9-4-genericcloud-image/14449) breaking Munge, which requires the folder to be 0755.

### Tests
* Spec test `cookbooks/aws-parallelcluster-platform/spec/unit/recipes/directories_spec.rb`
* [ONGOING] Build image in Rocky9.4
* [PENDING] integ test `createami.test_createami.test_build_image`

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
