### PR TITLE
[DRAFT] Configure Enroot and Pyxis only on HeadNode

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/recipes/config.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config.rb
@@ -26,6 +26,3 @@ include_recipe 'aws-parallelcluster-platform::dcv'
 include_recipe 'aws-parallelcluster-platform::supervisord_config'
 fetch_config 'Fetch and load cluster configs'
 include_recipe 'aws-parallelcluster-platform::config_login' if node['cluster']['node_type'] == 'LoginNode'
-enroot 'Configure Enroot' do
-  action :configure
-end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/enroot_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/enroot_spec.rb
@@ -9,14 +9,6 @@ class ConvergeEnroot
       end
     end
   end
-
-  def self.configure(chef_run)
-    chef_run.converge_dsl('aws-parallelcluster-platform') do
-      enroot 'configure' do
-        action :configure
-      end
-    end
-  end
 end
 
 describe 'enroot:package_version' do
@@ -123,47 +115,6 @@ describe 'enroot:setup' do
           it 'does not install Enroot' do
             is_expected.not_to run_bash('Install enroot')
           end
-        end
-      end
-    end
-  end
-end
-
-describe 'enroot:configure' do
-  for_all_oses do |platform, version|
-    context "on #{platform}#{version}" do
-      let(:chef_run) do
-        runner(platform: platform, version: version, step_into: ['enroot'])
-      end
-
-      context 'when enroot is installed' do
-        before do
-          stubs_for_provider('enroot') do |resource|
-            allow(resource).to receive(:enroot_installed).and_return(true)
-          end
-          ConvergeEnroot.configure(chef_run)
-        end
-        it 'run configure enroot script' do
-          is_expected.to run_bash('Configure enroot')
-            .with(retries: 3)
-            .with(retry_delay: 5)
-            .with(user: 'root')
-        end
-      end
-
-      context 'when enroot is not installed' do
-        before do
-          stubs_for_provider('enroot') do |resource|
-            allow(resource).to receive(:enroot_installed).and_return(false)
-          end
-          ConvergeEnroot.configure(chef_run)
-        end
-
-        it 'does not run configure enroot script' do
-          is_expected.not_to run_bash('Configure enroot')
-            .with(retries: 3)
-            .with(retry_delay: 5)
-            .with(user: 'root')
         end
       end
     end

--- a/cookbooks/aws-parallelcluster-platform/templates/enroot/enroot.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/enroot/enroot.conf.erb
@@ -1,9 +1,9 @@
 #ENROOT_LIBRARY_PATH        /usr/lib/enroot
 #ENROOT_SYSCONF_PATH        /etc/enroot
-ENROOT_RUNTIME_PATH        /tmp/enroot/user-$(id -u)
-ENROOT_CONFIG_PATH         ${ENROOT_CONFIG_PATH}
-ENROOT_CACHE_PATH          ${ENROOT_CACHE_PATH}
-ENROOT_DATA_PATH           /tmp/enroot/data/user-$(id -u)
+ENROOT_RUNTIME_PATH        /run/enroot/user-$(id -u)
+ENROOT_CONFIG_PATH         
+ENROOT_CACHE_PATH          <%= node['cluster']['enroot_cache_path'] %>
+ENROOT_DATA_PATH           /run/enroot/data/user-$(id -u)
 #ENROOT_TEMP_PATH           ${TMPDIR:-/tmp}
 
 # Gzip program used to uncompress digest layers.

--- a/cookbooks/aws-parallelcluster-platform/templates/pyxis/pyxis.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/pyxis/pyxis.conf.erb
@@ -1,0 +1,3 @@
+# THIS IS AN EXAMPLE OF pyxis.conf file
+# When you want to enable please move this to /opt/slurm/etc/plugstack.conf.d/
+required /usr/local/lib/slurm/spank_pyxis.so runtime_path=<%= @pyxis_persistent_runtime_path %>

--- a/cookbooks/aws-parallelcluster-platform/test/controls/enroot_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/enroot_spec.rb
@@ -14,16 +14,37 @@ control 'tag:install_expected_version_of_enroot_installed' do
 
   expected_enroot_version = node['cluster']['enroot']['version']
 
-  describe "gdrcopy version is expected to be #{expected_enroot_version}" do
+  describe "enroot version is expected to be #{expected_enroot_version}" do
     subject { command('enroot version').stdout.strip() }
     it { should eq expected_enroot_version }
+  end
+
+  base_dir1 = "/etc/enroot"
+  etc_dirs = [ base_dir1, "#{base_dir1}/enroot-cache"]
+
+  etc_dirs.each do |path|
+    describe directory(path) do
+      it { should exist }
+      its('mode') { should cmp '01777' }
+      its('owner') { should eq 'root' }
+      its('group') { should eq 'root' }
+    end
+  end
+
+  base_dir2 = "/run/enroot"
+  tmp_dirs = [ base_dir2, "#{base_dir2}/data" ]
+  tmp_dirs.each do |path|
+    describe directory(path) do
+      it { should exist }
+      its('mode') { should cmp '01777' }
+    end
   end
 end
 
 control 'tag:config_enroot_enabled_on_graphic_instances' do
   only_if { !os_properties.on_docker? && ['yes', true].include?(node['cluster']['nvidia']['enabled']) }
 
-  describe file("/opt/parallelcluster/shared/enroot") do
+  describe file("/etc/enroot/enroot-cache") do
     it { should exist }
     its('group') { should eq 'root' }
   end unless os_properties.redhat_on_docker?

--- a/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
@@ -33,3 +33,8 @@ default['cluster']["directory_service"]["enabled"] = 'false'
 
 # Default NFS mount options
 default['cluster']['nfs']['hard_mount_options'] = 'hard,_netdev,noatime'
+
+# Pyxis+Enroot Exmaple Config files
+default['cluster']['config_examples_dir'] = "#{node['cluster']['configs_dir']}/examples"
+default['cluster']['enroot_dir'] = "/etc/enroot"
+default['cluster']['enroot_cache_path'] = "#{node['cluster']['enroot_dir']}/enroot-cache"

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/pyxis/plugstack.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/pyxis/plugstack.conf.erb
@@ -1,0 +1,1 @@
+include <%= node['cluster']['slurm']['install_dir'] %>/etc/plugstack.conf.d/*

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
@@ -14,7 +14,37 @@ control 'tag:install_pyxis_installed' do
 
   title 'Checks Pyxis has been installed'
 
-  describe file("/opt/slurm/etc/plugstack.conf.d/pyxis.conf") do
+  describe directory('/opt/slurm/etc') do
+    it { should exist }
+    its('mode') { should cmp '0755' }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end
+
+  base_dir = "/opt/parallelcluster/configs/examples"
+  dirs = [ base_dir, "#{base_dir}/spank", "#{base_dir}/pyxis" ]
+  dirs.each do |path|
+    describe directory(path) do
+      it { should exist }
+    end
+  end
+
+  describe directory('/run/pyxis') do
+    it { should exist }
+    its('owner') { should eq "#{node['cluster']['cluster_user']}" }
+  end
+
+  describe directory('/opt/slurm/etc/plugstack.conf.d') do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end
+
+  describe file("#{base_dir}/pyxis/pyxis.conf") do
+    it { should exist }
+  end
+
+  describe file("#{base_dir}/spank/plugstack.conf") do
     it { should exist }
   end
 end


### PR DESCRIPTION
### Description of changes
* Running Config Phase of Enroot and Pyxis only on HeadNode
* Replacing sed commands with templates

### Tests
* Create ParallelCluster AMI
* Test scaling of 200 nodes
    * [ONGOIN}Created a cluster with   SharedStorageType: Efs
        * Tested with ExtarChefAttributes `{"cluster":{"pyxis":{"enabled":true},"enroot":{"enabled":true}}}`
    * [SUCCESS]Created  a cluster with   SharedStorageType: Efs
        * Without Configuring pyxis and enroot
   

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
