### PR TITLE
[CodeStyle] Address Shellcheck finding 'SC2155 in iso-ca-bundle-config.sh'

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/isolated/iso-ca-bundle-config.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/isolated/iso-ca-bundle-config.sh
@@ -2,7 +2,8 @@
 set -ex
 
 function get_instance_region {
-  local _token=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 3600")
+  local _token
+  _token=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 3600")
   curl -H "X-aws-ec2-metadata-token: $_token" -v "http://169.254.169.254/latest/meta-data/placement/region" 2> /dev/null
 }
 


### PR DESCRIPTION
### Description of changes
Address Shellcheck finding 'SC2155 in iso-ca-bundle-config.sh':  _token variable is now declared and assigned separately to avoid masking return values.

### Tests
Shellcheck success.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
