### PR TITLE
[Test] Fix kitchen test: `install_pyxis_installed`

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
@@ -14,14 +14,7 @@ control 'tag:install_pyxis_installed' do
 
   title 'Checks Pyxis has been installed'
 
-  describe directory('/opt/slurm/etc') do
-    it { should exist }
-    its('mode') { should cmp '0755' }
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-  end
-
-  examples_dir = "/opt/parallelcluster/configs/examples"
+  examples_dir = "/opt/parallelcluster/examples"
   dirs = [ examples_dir, "#{examples_dir}/spank", "#{examples_dir}/pyxis" ]
   dirs.each do |path|
     describe directory(path) do


### PR DESCRIPTION
### Description of changes
Fix kitchen test: `install_pyxis_installed`.
The test was not reflecting the most recent changes made in https://github.com/aws/aws-parallelcluster-cookbook/pull/2820.

In particular, we are not creating the folder /opt/slurm/etc and we changed the examples directory to `/opt/parallelcluster/examples`.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
