### PR TITLE
[Test] Fix kitchen test: `install_pyxis_installed`

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
@@ -14,14 +14,7 @@ control 'tag:install_pyxis_installed' do
 
   title 'Checks Pyxis has been installed'
 
-  describe directory('/opt/slurm/etc') do
-    it { should exist }
-    its('mode') { should cmp '0755' }
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
-  end
-
-  examples_dir = "/opt/parallelcluster/configs/examples"
+  examples_dir = "/opt/parallelcluster/examples"
   dirs = [ examples_dir, "#{examples_dir}/spank", "#{examples_dir}/pyxis" ]
   dirs.each do |path|
     describe directory(path) do


### PR DESCRIPTION
Cherry-picked from https://github.com/aws/aws-parallelcluster-cookbook/pull/2828


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
