### PR TITLE
Get kernel-devel package for rocky based on installed kernel version

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
@@ -25,7 +25,7 @@ action :install_kernel_source do
   bash "Install kernel source" do
     user 'root'
     code <<-INSTALL_KERNEL_SOURCE
-    package="#{kernel_source_package}-$#{node['platform_version']}"
+    package="#{kernel_source_package}"
 
     # try to install kernel source for a specific release version
     dnf install -y #{kernel_source_package} --releasever #{node['platform_version']}

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
@@ -25,10 +25,10 @@ action :install_kernel_source do
   bash "Install kernel source" do
     user 'root'
     code <<-INSTALL_KERNEL_SOURCE
-    package="#{kernel_source_package}-$(uname -r)"
+    package="#{kernel_source_package}-$#{node['platform_version']}"
 
     # try to install kernel source for a specific release version
-    dnf install -y ${package} --releasever #{node['platform_version']}
+    dnf install -y #{kernel_source_package} --releasever #{node['platform_version']}
     if [ $? -ne 0 ]; then
       # Previous releases are moved into a vault area once a new minor release version is available for at least a week.
       # https://wiki.rockylinux.org/rocky/repo/#notes-on-devel

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
@@ -25,7 +25,7 @@ action :install_kernel_source do
   bash "Install kernel source" do
     user 'root'
     code <<-INSTALL_KERNEL_SOURCE
-    package="#{kernel_source_package}-#{kernel_source_package_version}"
+    package="#{kernel_source_package}-$(uname -r)"
 
     # try to install kernel source for a specific release version
     dnf install -y ${package} --releasever #{node['platform_version']}


### PR DESCRIPTION
### Description of changes
* Get kernel-devel package for rocky based on installed kernel version
* If `UpdateOsPackage` was enabled, `kernel_source_package_version` was still set to the old kernel version, so it attempted to download the kernel-devel package for the old kernel version.

### Tests
* Ran the following integ test:
```
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
        - regions: ["eu-west-3"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          schedulers: [ "slurm" ]
          oss: ["rocky8"]
```

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
