### PR TITLE
Add possibility to skip Lustre installation

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -77,3 +77,5 @@ default['cluster']['efa']['sha256'] = 'bd68839e741b0afd3ec2e37d50603803cfa7a279c
 default['cluster']['spack_shared_dir'] = "#{node['cluster']['shared_dir']}/spack"
 default['cluster']['spack']['version'] = '0.20.2'
 default['cluster']['spack']['sha256'] = '62f87ab6ca332118f2812a255edcf4be4977623d067b9396251ce8c44b158e49'
+
+default['cluster']['lustre']['enabled'] = 'yes'

--- a/cookbooks/aws-parallelcluster-environment/libraries/fsx.rb
+++ b/cookbooks/aws-parallelcluster-environment/libraries/fsx.rb
@@ -8,3 +8,7 @@ def aws_domain_for_fsx(region)
     CLASSIC_AWS_DOMAIN
   end
 end
+
+def lustre_enabled?
+  ['yes', true].include?(node['cluster']['lustre']['enabled'])
+end

--- a/cookbooks/aws-parallelcluster-environment/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/install.rb
@@ -19,7 +19,9 @@ ec2_udev_rules 'configure udev'
 cloudwatch 'Install amazon-cloudwatch-agent'
 efa 'Install EFA'
 raid 'Install RAID prerequisite packages'
-lustre 'Install FSx options'
+if lustre_enabled?
+  lustre 'Install FSx options'
+end
 efs 'Install efs-utils'
 stunnel 'Install stunnel'
 system_authentication "Install packages required for directory service integration"


### PR DESCRIPTION
### Tests
Build AMIs with/without Lustre. The builds were successful. The output AMIs have proper software installed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
