### PR TITLE
Auto-restart slurmctld on failure after 1 second.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - xdcv: `2024.0.631-1`
   - gl: `2024.0.1078-1`
   - web_viewer: `2024.0-18131-1`
+- Auto-restart slurmctld on failure.
 
 **BUG FIXES**
 - Fix an issue in the way we get region when manage volumes so that it can correctly handle local zone.

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurmctld_systemd_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurmctld_systemd_service_spec.rb
@@ -32,6 +32,8 @@ describe 'aws-parallelcluster-slurm::config_slurmctld_systemd_service' do
       it 'creates the service definition for slurmctld with the correct settings' do
         is_expected.to render_file('/etc/systemd/system/slurmctld.service')
           .with_content("After=network-online.target munge.service remote-fs.target")
+          .with_content("Restart=on-failure")
+          .with_content("RestartSec=1s")
       end
     end
   end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/slurmctld.service.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/slurmctld.service.erb
@@ -12,6 +12,8 @@ ExecReload=/bin/kill -HUP $MAINPID
 LimitNOFILE=562930
 LimitMEMLOCK=infinity
 LimitSTACK=infinity
+Restart=on-failure
+RestartSec=1s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Description of changes
Auto-restart slurmctld on failure after 1 second.

### Tests
* Verified that slurmctl is auto-restarted after a forced crash (kill) and job info are restored
* Spec test

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
