### PR TITLE
Upgrade efa installer from 1.34.0 to 1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - xdcv: `2024.0.631-1`
   - gl: `2024.0.1078-1`
   - web_viewer: `2024.0-18131-1`
+- Upgrade EFA installer to `1.36.0`.
+  - Efa-driver: `efa-2.13.0-1`
+  - Efa-config: `efa-config-1.17-1`
+  - Efa-profile: `efa-profile-1.7-1`
+  - Libfabric-aws: `libfabric-aws-1.22.0-1`
+  - Rdma-core: `rdma-core-54.0-1`
+  - Open MPI: `openmpi40-aws-4.1.7-1` and `openmpi50-aws-5.0.5`
 - Auto-restart slurmctld on failure.
 
 **BUG FIXES**

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -70,8 +70,8 @@ default['cluster']['internal_initial_shared_dir'] = "#{node['cluster']['base_dir
 
 default['cluster']['head_node_private_ip'] = nil
 
-default['cluster']['efa']['version'] = '1.34.0'
-default['cluster']['efa']['sha256'] = 'bd68839e741b0afd3ec2e37d50603803cfa7a279c120f0a736cc57c2ff2d7fdc'
+default['cluster']['efa']['version'] = '1.36.0'
+default['cluster']['efa']['sha256'] = 'de183f333cfb58aeb7908a67bf9106985ba3ccb7f8638b851d2a0d8dbfacaec4'
 
 # TODO: Move to platform cookbook
 default['cluster']['spack_shared_dir'] = "#{node['cluster']['shared_dir']}/spack"

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 # parallelcluster default source dir defined in attributes
 source_dir = '/opt/parallelcluster/sources'
-efa_version = '1.34.0'
-efa_checksum = 'bd68839e741b0afd3ec2e37d50603803cfa7a279c120f0a736cc57c2ff2d7fdc'
+efa_version = '1.36.0'
+efa_checksum = 'de183f333cfb58aeb7908a67bf9106985ba3ccb7f8638b851d2a0d8dbfacaec4'
 
 class ConvergeEfa
   def self.setup(chef_run, efa_version: nil, efa_checksum: nil)


### PR DESCRIPTION
### Description of changes
* Upgrade efa installer from 1.34.0 to 1.36.0

### Tests
* Built an AMI with updated efa version and ran test_efa integ test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
