### PR TITLE
Extend Amazon DCV support to Ubuntu2204 on ARM instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 3.12.0
 ------
 
+**ENHANCEMENTS**
+- Extend Amazon DCV support to Ubuntu2204 on ARM instances.
+
 **CHANGES**
 - Upgrade mysql-community-client to version 8.0.39. 
 - Upgrade Amazon DCV to version `2024.0-18131`.

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/dcv_ubuntu20.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/dcv_ubuntu20.rb
@@ -23,3 +23,7 @@ def dcv_sha256sum
   # Ubuntu20 supports DCV on x86
   'cf63d51a5bb7ac82569d747215c0118a7468a32c753c0b0fa9c1cf47513c0a0c'
 end
+
+def dcv_supported?
+  !arm_instance?
+end

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/dcv_ubuntu22.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/dcv_ubuntu22.rb
@@ -20,6 +20,9 @@ use 'partial/_dcv_common'
 use 'partial/_ubuntu_common'
 
 def dcv_sha256sum
-  # Ubuntu22 supports DCV on x86
-  'b30a57f5029b9d8acb59db9fc72f1dbc7c6a33d76dbbfe02017cec553c5b86f9'
+  if arm_instance?
+    '48bb605dbb5f28af79b94de9239a8c3e7811e9e47078d8985d036915f2a34217'
+  else
+    'b30a57f5029b9d8acb59db9fc72f1dbc7c6a33d76dbbfe02017cec553c5b86f9'
+  end
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_ubuntu_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_ubuntu_common.rb
@@ -33,10 +33,6 @@ def dcv_gl
   "/nice-dcv-gl_#{node['cluster']['dcv']['gl']['version']}_#{dcv_pkg_arch}.#{node['cluster']['base_os']}.deb"
 end
 
-def dcv_supported?
-  !arm_instance?
-end
-
 action_class do
   def pre_install
     apt_update

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -42,7 +42,7 @@ describe 'dcv:dcv_supported?' do
           allow_any_instance_of(Object).to receive(:arm_instance?).and_return(true)
         end
 
-        if platform == 'ubuntu' && version.to_i >= 20
+        if platform == 'ubuntu' && version.to_i == 20
           it "is false" do
             expect(resource.dcv_supported?).to eq(false)
           end


### PR DESCRIPTION
### Tests
* Manual testing is successful
* The following integration test is successful
```
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["m6g.xlarge"]
          oss: ["alinux2", "rhel8", "alinux2023", "ubuntu2204"]
          schedulers: ["slurm"]
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
