### PR TITLE
Remove minor version pinning at the end of the second_stage_build

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/ami_cleanup.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/ami_cleanup.sh
@@ -9,6 +9,11 @@ rm -f /etc/udev/rules.d/70-persistent-net.rules
 grep -l "Created by cloud-init on instance boot automatically" /etc/sysconfig/network-scripts/ifcfg-* | xargs rm -f
 rm -rf /var/crash/*
 
+if [ -f /opt/parallelcluster/pin_releasesever ]; then
+  rm -f /opt/parallelcluster/pin_releasesever
+  rm -f /etc/yum/vars/releasever
+fi
+
 # https://bugs.centos.org/view.php?id=13836#c33128
 source /etc/os-release
 if [ "${ID}${VERSION_ID}" == "centos7" ]; then


### PR DESCRIPTION
### Description of changes
* Remove minor version pinning at the end of the second_stage_build

### Tests
* Ran second-stage build for both RHEL9 and Rocky9
  * checked that kernel version was correct but was no longer pinned

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
