### PR TITLE
Bump gdr copy version up from 2.4 to 2.4.4

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 def gdrcopy_version
-  '2.4'
+  '2.4.4'
 end
 
 def gdrcopy_checksum
-  '39e74d505ca16160567f109cc23478580d157da897f134989df1d563e55f7a5b'
+  '8802f7bc4a589a610118023bdcdd83c10a56dea399acf6eeaac32e8cc10739a8'
 end
 
 unified_mode true

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
@@ -136,7 +136,7 @@ describe 'gdrcopy:gdrcopy_version' do
         expected_gdrcopy_version = if platform == "centos"
                                      "2.3.1"
                                    else
-                                     "2.4"
+                                     "2.4.4"
                                    end
         expect(resource.gdrcopy_version).to eq(expected_gdrcopy_version)
       end
@@ -186,7 +186,7 @@ describe 'gdrcopy:setup' do
 
     context "on #{platform}#{version} when gdrcopy enabled" do
       cached(:sources_dir) { 'sources_dir' }
-      cached(:gdrcopy_version) { platform == 'centos' ? '2.3.1' : '2.4' }
+      cached(:gdrcopy_version) { platform == 'centos' ? '2.3.1' : '2.4.4' }
       cached(:gdrcopy_checksum) do
         if platform == 'centos'
           '59b3cc97a4fc6008a5407506d9e67ecc4144cfad61c261217fabcb671cd30ca8'

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
@@ -160,7 +160,7 @@ describe 'gdrcopy:gdrcopy_checksum' do
         expected_gdrcopy_checksum = if platform == "centos"
                                       "59b3cc97a4fc6008a5407506d9e67ecc4144cfad61c261217fabcb671cd30ca8"
                                     else
-                                      "39e74d505ca16160567f109cc23478580d157da897f134989df1d563e55f7a5b"
+                                      "8802f7bc4a589a610118023bdcdd83c10a56dea399acf6eeaac32e8cc10739a8"
                                     end
         expect(resource.gdrcopy_checksum).to eq(expected_gdrcopy_checksum)
       end
@@ -191,7 +191,7 @@ describe 'gdrcopy:setup' do
         if platform == 'centos'
           '59b3cc97a4fc6008a5407506d9e67ecc4144cfad61c261217fabcb671cd30ca8'
         else
-          '39e74d505ca16160567f109cc23478580d157da897f134989df1d563e55f7a5b'
+          '8802f7bc4a589a610118023bdcdd83c10a56dea399acf6eeaac32e8cc10739a8'
         end
       end
       cached(:gdrcopy_service) { platform == 'ubuntu' ? 'gdrdrv' : 'gdrcopy' }

--- a/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_gdrcopy_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_gdrcopy_spec.rb
@@ -15,7 +15,7 @@ control 'tag:install_expected_versions_of_nvidia_gdrcopy_installed' do
       (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
   end
 
-  expected_gdrcopy_version = node['cluster']['nvidia']['gdrcopy']['version']
+  expected_gdrcopy_version = "2.4"
 
   describe "gdrcopy version is expected to be #{expected_gdrcopy_version}" do
     subject { command('modinfo -F version gdrdrv').stdout.strip() }


### PR DESCRIPTION
### Description of changes
* Bump gdr copy version up from 2.4 to 2.4.4

### Tests
* Ran `second_stage_build` for rhel9 and rocky9

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
