### PR TITLE
Remove temporary slurm resume file at the end of resume_program

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/resume_program.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/resume_program.erb
@@ -13,3 +13,5 @@ chgrp <%= node['cluster']['cluster_admin_slurm_share_group'] %> ${SLURM_RESUME_F
 chmod g+r ${SLURM_RESUME_FILE_TMP}
 
 sudo -u <%= node['cluster']['cluster_admin_user'] %> SLURM_RESUME_FILE=${SLURM_RESUME_FILE_TMP} <%= node_virtualenv_path %>/bin/slurm_resume  "$@"
+
+rm -f ${SLURM_RESUME_FILE_TMP}


### PR DESCRIPTION
Prior this commit, the code only had `trap "rm -f ${SLURM_RESUME_FILE_TMP}" EXIT`, which works fine for the script until the `sudo -u` happens. When using `sudo -u` to run a command, it creates a new process with a different user context. The trap that was set in the parent shell does not carry over to this new process. Therefore, when the script ends through the sudo command, the EXIT trap in the original shell never gets executed.

Therefore, this commit add another removal of temporary file at the end of the script

### Tests
* Manually tested job submissions. The temporary files are cleaned up properly.

### References
* This issue is reported by https://github.com/aws/aws-parallelcluster/issues/6572

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
