### PR TITLE
[Kitchen test] Simplify cstate check

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/c_states_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/c_states_spec.rb
@@ -3,26 +3,21 @@ control 'tag:install_c_states_kernel_configured' do
   title 'Check the configuration to disable c states'
   only_if { !os_properties.on_docker? && os_properties.x86? }
 
-  describe file('/etc/default/grub') do
-    it { should exist }
-    its('content') { should match(/processor.max_cstate=1/) }
-    its('content') { should match(/intel_idle.max_cstate=1/) }
-  end
-
-  if os_properties.redhat8? || os_properties.alinux2? || os_properties.centos7? || os_properties.rocky8?
-
-    describe file('/boot/grub2/grub.cfg') do
+  if os_properties.ubuntu2004?
+    describe file('/etc/default/grub') do
       it { should exist }
       its('content') { should match(/processor.max_cstate=1/) }
       its('content') { should match(/intel_idle.max_cstate=1/) }
     end
-
-  elsif os.debian?
-
     describe file('/boot/grub/grub.cfg') do
       it { should exist }
       its('content') { should match(/processor.max_cstate=1/) }
       its('content') { should match(/intel_idle.max_cstate=1/) }
+    end
+  else
+    describe bash('cpupower idle-info') do
+      its('stdout') { should match(/Number of idle states: 2/) }
+      its('stdout') { should match(/Available idle states: POLL C1/) }
     end
   end
 end


### PR DESCRIPTION
`grubby` command on Rocky 9.5 no longer writes to `/etc/default/grub`. It uses another file. To avoid too many branches based on operating system, this commit use `cpupower` command to check CPU cstate. `cpupower` doesn't work on Ubuntu20, for which this commit keeps the old checks.

### Tests
* Build image on all operating systems is successful.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
