### PR TITLE
[Dependencies] Upgrade ARMPL to 24.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - yum-7.4.20 (from yum-7.4.13)
   - yum-epel-5.0.8 (from yum-epel-5.0.2)
 - Upgrade Pmix to 5.0.6 (from 5.0.3).
+- Upgrade ARM PL to version 24.10 (from 23.10).
 
 3.12.0
 ------

--- a/cookbooks/aws-parallelcluster-platform/resources/arm_pl/partial/_arm_pl_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/arm_pl/partial/_arm_pl_common.rb
@@ -27,12 +27,8 @@ property :aws_domain, String
 # We upload ArmPL to a ParallelCluster bucket (account for it in scope of the upgrade) and download it from there
 # to install ArmPL on the AMI.
 # We download gcc directly from gnu.org repository to install correct gcc version on the AMI.
-property :armpl_major_minor_version, String, default: '23.10'
+property :armpl_major_minor_version, String, default: '24.10'
 property :gcc_patch_version, String, default: '0'
-
-action :arm_pl_prerequisite do
-  # Do nothing
-end
 
 action :setup do
   return unless node['conditions']['arm_pl_supported']
@@ -49,10 +45,8 @@ action :setup do
   build_tools 'Prerequisite: build tools'
   package %w(wget bzip2)
 
-  action_arm_pl_prerequisite
-
   armpl_version = "#{new_resource.armpl_major_minor_version}"
-  armpl_tarball_name = "arm-performance-libraries_#{armpl_version}_#{armpl_platform}_gcc-#{gcc_major_minor_version}.tar"
+  armpl_tarball_name = "arm-performance-libraries_#{armpl_version}_#{package_manager}_gcc.tar"
 
   armpl_url = %W(
     #{node['cluster']['artifacts_s3_url']}
@@ -62,7 +56,7 @@ action :setup do
 
   armpl_installer = "#{new_resource.sources_dir}/#{armpl_tarball_name}"
 
-  armpl_name = "arm-performance-libraries_#{armpl_version}_#{armpl_platform}"
+  armpl_name = "arm-performance-libraries_#{armpl_version}_#{package_manager}"
 
   # download ArmPL tarball
   remote_file armpl_installer do
@@ -89,11 +83,7 @@ action :setup do
   # create armpl module directory
   directory "#{modulefile_dir}/armpl"
 
-  armpl_license_dir = if new_resource.armpl_major_minor_version == "21.0"
-                        "/opt/arm/armpl/#{armpl_version}/arm-performance-libraries_#{new_resource.armpl_major_minor_version}_gcc-#{gcc_major_minor_version}/license_terms"
-                      else
-                        "/opt/arm/armpl/#{armpl_version}/arm-performance-libraries_#{armpl_version}_gcc-#{gcc_major_minor_version}/license_terms"
-                      end
+  armpl_license_dir = "/opt/arm/armpl/#{armpl_version}/arm-performance-libraries_#{armpl_version}_gcc/license_terms"
 
   # arm performance library modulefile configuration
   template "#{modulefile_dir}/armpl/#{armpl_version}" do
@@ -104,7 +94,6 @@ action :setup do
     mode '0755'
     variables(
       armpl_version: armpl_version,
-      armpl_major_minor_version: new_resource.armpl_major_minor_version,
       armpl_license_dir: armpl_license_dir,
       gcc_major_minor_version: gcc_major_minor_version
     )
@@ -167,7 +156,6 @@ action :setup do
   # save ArmPL and gcc versions on the node environment so that they will be available
   # to dependencies (for instance, test code)
   # Complete versions are intentionally redundant.
-  node.default['cluster']['armpl']['major_minor_version'] = new_resource.armpl_major_minor_version
   node.default['cluster']['armpl']['version'] = armpl_version
   node.default['cluster']['armpl']['gcc']['major_minor_version'] = gcc_major_minor_version
   node.default['cluster']['armpl']['gcc']['patch_version'] = new_resource.gcc_patch_version
@@ -179,5 +167,13 @@ end
 action_class do
   def modulefile_dir
     '/usr/share/Modules/modulefiles'
+  end
+
+  def package_manager
+    if platform_family?('debian')
+      'deb'
+    else
+      'rpm'
+    end
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/arm_pl_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/arm_pl_spec.rb
@@ -16,7 +16,7 @@ describe 'arm_pl:setup' do
       cached(:aws_region) { 'test_region' }
       cached(:aws_domain) { 'test_domain' }
       cached(:armpl_major_minor_version) do
-        '23.10'
+        '24.10'
       end
 
       cached(:armpl_platform) do
@@ -43,11 +43,12 @@ describe 'arm_pl:setup' do
       cached(:gcc_patch_version) { '0' }
       cached(:sources_dir) { 'sources_test_dir' }
       cached(:modulefile_dir) { platform == 'ubuntu' ? '/usr/share/modules/modulefiles' : '/usr/share/Modules/modulefiles' }
+      cached(:package_manager) { platform == 'ubuntu' ? 'deb' : 'rpm' }
       cached(:armpl_version) { "#{armpl_major_minor_version}" }
-      cached(:armpl_tarball_name) { "arm-performance-libraries_#{armpl_version}_#{armpl_platform}_gcc-#{gcc_major_minor_version}.tar" }
+      cached(:armpl_tarball_name) { "arm-performance-libraries_#{armpl_version}_#{package_manager}_gcc.tar" }
       cached(:armpl_url) { "https://bucket.s3.amazonaws.com/archives/armpl/#{armpl_platform}/#{armpl_tarball_name}" }
       cached(:armpl_installer) { "#{sources_dir}/#{armpl_tarball_name}" }
-      cached(:armpl_name) { "arm-performance-libraries_#{armpl_version}_#{armpl_platform}" }
+      cached(:armpl_name) { "arm-performance-libraries_#{armpl_version}_#{package_manager}" }
       cached(:gcc_version) { "#{gcc_major_minor_version}.#{gcc_patch_version}" }
       cached(:gcc_url) { "https://bucket.s3.amazonaws.com/archives/dependencies/gcc/gcc-#{gcc_version}.tar.gz" }
       cached(:gcc_tarball) { "#{sources_dir}/gcc-#{gcc_version}.tar.gz" }
@@ -128,11 +129,7 @@ describe 'arm_pl:setup' do
         end
 
         it 'creates arm performance library modulefile configuration' do
-          armpl_license_dir = if armpl_major_minor_version == "21.0"
-                                "/opt/arm/armpl/#{armpl_version}/arm-performance-libraries_#{armpl_major_minor_version}_gcc-#{gcc_major_minor_version}/license_terms"
-                              else
-                                "/opt/arm/armpl/#{armpl_version}/arm-performance-libraries_#{armpl_version}_gcc-#{gcc_major_minor_version}/license_terms"
-                              end
+          armpl_license_dir = "/opt/arm/armpl/#{armpl_version}/arm-performance-libraries_#{armpl_version}_gcc/license_terms"
           is_expected.to create_template("#{modulefile_dir}/armpl/#{armpl_version}").with(
             source: 'arm_pl/armpl_modulefile.erb',
             user: 'root',
@@ -140,7 +137,6 @@ describe 'arm_pl:setup' do
             mode: '0755',
             variables: {
               armpl_version: armpl_version,
-              armpl_major_minor_version: armpl_major_minor_version,
               armpl_license_dir: armpl_license_dir,
               gcc_major_minor_version: gcc_major_minor_version,
             }
@@ -179,7 +175,6 @@ describe 'arm_pl:setup' do
         end
 
         it 'sets node attributes' do
-          expect(node['cluster']['armpl']['major_minor_version']).to eq(armpl_major_minor_version)
           expect(node['cluster']['armpl']['version']).to eq(armpl_version)
           expect(node['cluster']['armpl']['gcc']['major_minor_version']).to eq(gcc_major_minor_version)
           expect(node['cluster']['armpl']['gcc']['patch_version']).to eq(gcc_patch_version)

--- a/cookbooks/aws-parallelcluster-platform/templates/arm_pl/armpl_modulefile.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/arm_pl/armpl_modulefile.erb
@@ -4,7 +4,7 @@
 set category arm
 set name     armpl
 set version  <%= @armpl_version %>
-set major_minor_version  <%= @armpl_major_minor_version %>
+set major_minor_version  <%= @armpl_version %>
 set gcc_version <%= @gcc_major_minor_version %>
 set root     /opt/$category/$name/$version
 
@@ -40,7 +40,7 @@ puts stderr "At compile time add '-I<armpl_include>' and at link time"
   }
 
   # Load the pre-installed armpl module
-  module load $root/modulefiles/armpl/${full_version}_gcc-${gcc_version}
+  module load $root/modulefiles/armpl/${full_version}_gcc
 
   # EULA
   if [ module-info mode load ] {

--- a/cookbooks/aws-parallelcluster-platform/test/controls/arm_pl_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/arm_pl_spec.rb
@@ -13,21 +13,15 @@ control 'tag:install_arm_pl_installed' do
   title "Check ARM Performance libraries installation"
   only_if { os_properties.arm? && !os_properties.on_docker? }
 
-  armpl_major_minor_version = node['cluster']['armpl']['major_minor_version']
   armpl_version = node['cluster']['armpl']['version']
   gcc_major_minor_version = node['cluster']['armpl']['gcc']['major_minor_version']
 
   armpl_module_general_name = "armpl/#{armpl_version}"
-  armpl_module_name = "armpl/#{armpl_version}.0_gcc-#{gcc_major_minor_version}"
+  armpl_module_name = "armpl/#{armpl_version}.0_gcc"
   gcc_module_name = "armpl/gcc-#{gcc_major_minor_version}"
 
-  if os_properties.ubuntu2204?
-    armpl_script_dir = "/opt/arm/#{armpl_module_general_name}/arm-performance-libraries_#{armpl_version}_gcc-#{gcc_major_minor_version}"
-    armpl_install_dir = "/opt/arm/#{armpl_module_general_name}/armpl_#{armpl_version}_gcc-#{gcc_major_minor_version}"
-  else
-    armpl_script_dir = "/opt/arm/#{armpl_module_general_name}/arm-performance-libraries_#{armpl_major_minor_version}_gcc-#{gcc_major_minor_version}"
-    armpl_install_dir = "/opt/arm/#{armpl_module_general_name}/armpl_#{armpl_major_minor_version}_gcc-#{gcc_major_minor_version}"
-  end
+  armpl_script_dir = "/opt/arm/#{armpl_module_general_name}/arm-performance-libraries_#{armpl_version}_gcc"
+  armpl_install_dir = "/opt/arm/#{armpl_module_general_name}/armpl_#{armpl_version}_gcc"
 
   setup = "unset MODULEPATH && source /etc/profile.d/modules.sh"
 
@@ -50,14 +44,14 @@ control 'tag:install_arm_pl_installed' do
   scl_centos7 = "scl enable devtoolset-8" if os_properties.centos?
 
   describe bash("#{setup} && module load #{armpl_module_general_name} && "\
-                "cd #{armpl_install_dir}/examples && "\
+                "cd #{armpl_install_dir}/examples_lp64 && "\
                 "make clean && #{scl_centos7} make") do
     its('exit_status') { should eq(0) }
     its('stdout') { should match /testing: no example difference files were generated/i }
     its('stdout') { should match /test passed ok/i }
   end
 
-  describe bash("sudo bash -c 'unset MODULEPATH && source /etc/profile.d/modules.sh && module load armpl && cd #{armpl_install_dir}/examples &&  \
+  describe bash("sudo bash -c 'unset MODULEPATH && source /etc/profile.d/modules.sh && module load armpl && cd #{armpl_install_dir}/examples_lp64 &&  \
     gcc -c -I#{armpl_install_dir}/include #{test_software}.c -o #{test_software}.o && \
     gcc #{test_software}.o -L#{armpl_install_dir}/lib -o #{test_software}.exe -larmpl_lp64 -lm && \
     ./#{test_software}.exe'") do


### PR DESCRIPTION
### Description of changes
Upgrade ARMPL to 24.10

* Renaming armpl files and location as per the latest naming convention used.
* Update armpl Kitchen test
* Removing duplicate use of armpl_version and armpl_major_minor_version
* Remove unwanted arm_pl_prerequisite action which does nothing
* Remove usage of if condition for ARMPL 21.0 which is no longer used
* Changing Path to examples directory as it gives error `No such file or directory` error and documentation mentions its a symlink to the directory examples_lp64

### Tests
* AMI Creation and running armpl kitchen test

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
