### PR TITLE
Remove creation of SSH keys of type DSA to prevent cluster creation failure when the OS ships a version of OpenSSH that does not support DSA keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ aws-parallelcluster-cookbook CHANGELOG
 ======================================
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
+
 3.13.0
 ------
 
@@ -18,6 +19,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - yum-epel-5.0.8 (from yum-epel-5.0.2)
 - Upgrade Pmix to 5.0.6 (from 5.0.3).
 - Upgrade ARM PL to version 24.10 (from 23.10).
+- Remove generation of DSA keys for login nodes as DSA, which became unsupported in OpenSSH 9.7+.
 
 3.12.0
 ------

--- a/cookbooks/aws-parallelcluster-environment/files/login_nodes/keys-manager.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/login_nodes/keys-manager.sh
@@ -38,9 +38,6 @@ function create_keys() {
   ssh-keygen -t ecdsa -f "$FOLDER_PATH/ssh_host_ecdsa_key" -q -P ""
   ssh-keygen -t ed25519 -f "$FOLDER_PATH/ssh_host_ed25519_key" -q -P ""
   ssh-keygen -t rsa -f "$FOLDER_PATH/ssh_host_rsa_key" -q -P ""
-  if is_ubuntu; then
-    ssh-keygen -t dsa -f "$FOLDER_PATH/ssh_host_dsa_key" -q -P ""
-  fi
 }
 
 function import_keys() {
@@ -50,7 +47,6 @@ function import_keys() {
   cp "$FOLDER_PATH/ssh_host_ed25519"* /etc/ssh/
   cp "$FOLDER_PATH/ssh_host_rsa"* /etc/ssh/
   if is_ubuntu; then
-    cp "$FOLDER_PATH/ssh_host_dsa"* /etc/ssh/
     chown root:root /etc/ssh/ssh_host_*
     chmod 600 /etc/ssh/ssh_host_*_key
   else

--- a/cookbooks/aws-parallelcluster-environment/test/controls/login_nodes_keys_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/login_nodes_keys_spec.rb
@@ -11,9 +11,6 @@
 
 key_types = %w(ecdsa ed25519 rsa)
 is_ubuntu = os_properties.ubuntu?
-if is_ubuntu
-  key_types << 'dsa'
-end
 
 control 'head_node_directory_initialized' do
   only_if { instance.head_node? && node['cluster']['scheduler'] != 'awsbatch' }


### PR DESCRIPTION
### Description of changes
Remove creation of SSH keys of type DSA to prevent cluster creation failure when the OS ships a version of OpenSSH that does not support DSA keys.

### Tests
Cluster creation with login nodes succeeded.
Can SSH into the login nodes and submit jobs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
