### PR TITLE
[Nvidia] Remove 'no-cc-version-check' from installation of nvidia driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade ARM PL to version 24.10 (from 23.10).
 - Remove generation of DSA keys for login nodes as DSA, which became unsupported in OpenSSH 9.7+.
 - Set instance ID and instance type information in Slurm upon compute nodes launch.
+- Install NVIDIA drivers without the option 'no-cc-version-check', which is now deprecated in the NVIDIA installer.
 
 3.12.0
 ------

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
@@ -73,14 +73,13 @@ action :setup do
   end
 
   # Install driver
-  # TODO remove --no-cc-version-check when we can update ubuntu 22 images
   bash 'nvidia.run advanced' do
     user 'root'
     group 'root'
     cwd '/tmp'
     code <<-NVIDIA
       set -e
-      #{compiler_path} ./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check -m=#{nvidia_kernel_module}
+      #{compiler_path} ./nvidia.run --silent --dkms --disable-nouveau -m=#{nvidia_kernel_module}
       rm -f /tmp/nvidia.run
     NVIDIA
     creates '/usr/bin/nvidia-smi'

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
@@ -244,7 +244,7 @@ describe 'nvidia_driver:setup' do
                 cwd: '/tmp',
                 creates: '/usr/bin/nvidia-smi'
               )
-              .with_code(%r{CC=/usr/bin/gcc10-gcc ./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check -m=#{kernel_module}})
+              .with_code(%r{CC=/usr/bin/gcc10-gcc ./nvidia.run --silent --dkms --disable-nouveau -m=#{kernel_module}})
               .with_code(%r{rm -f /tmp/nvidia.run})
           end
         elsif platform == 'ubuntu' && version == '22.04'
@@ -272,7 +272,7 @@ describe 'nvidia_driver:setup' do
                                cwd: '/tmp',
                                creates: '/usr/bin/nvidia-smi'
                              )
-              .with_code(%r{#{compiler_path} ./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check -m=#{kernel_module}})
+              .with_code(%r{#{compiler_path} ./nvidia.run --silent --dkms --disable-nouveau -m=#{kernel_module}})
           end
         else
           it "doesn't install gcc10" do
@@ -286,7 +286,7 @@ describe 'nvidia_driver:setup' do
                 cwd: '/tmp',
                 creates: '/usr/bin/nvidia-smi'
               )
-              .with_code(%r{./nvidia.run --silent --dkms --disable-nouveau --no-cc-version-check -m=#{kernel_module}})
+              .with_code(%r{./nvidia.run --silent --dkms --disable-nouveau -m=#{kernel_module}})
               .with_code(%r{rm -f /tmp/nvidia.run})
           end
         end


### PR DESCRIPTION
### Description of changes
Remove 'no-cc-version-check' from installation of nvidia driver
We remove it because:
  1/ it is not supported anymore by the NVIDIA installer.
  2/ it was an unsafe workaround introduced in 3.8.0 (https://github.com/aws/aws-parallelcluster-cookbook/pull/2404), which was supposed to be there only in the short term and in ended be there for long time.
  3/ we introduced in 3.12.0 a logic to install NVIDIA drivers using the gcc version used to compile the kernel https://github.com/aws/aws-parallelcluster-cookbook/pull/2852.

### Tests
AMI build succeeded on all supported OSes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
