### PR TITLE
[Test] Fix Python version in kitchen tests related to AWS Batch and CFN Boostrap scripts. In particular, we expect all Oses to use Python 3.12.8, except for AL2 which uses 3.9.20.

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_virtualenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_virtualenv_spec.rb
@@ -9,11 +9,11 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-python_version = '3.12.8'
 base_dir = "/opt/parallelcluster"
 pyenv_dir = "#{base_dir}/pyenv"
 
 control 'tag:install_awsbatch_virtualenv_created' do
+  python_version = os_properties.alinux2? ? '3.9.20' : '3.12.8'
   title "awsbatch virtualenv should be created on #{python_version}"
   only_if { !os_properties.redhat? }
 

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cfn_bootstrap_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cfn_bootstrap_spec.rb
@@ -9,11 +9,11 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-cfn_python_version = '3.12.8'
 base_dir = "/opt/parallelcluster"
 pyenv_dir = "#{base_dir}/pyenv"
 
 control 'tag:install_cfnbootstrap_virtualenv_created' do
+  cfn_python_version = os_properties.alinux2? ? '3.9.20' : '3.12.8'
   title "cfnbootstrap virtualenv should be created on #{cfn_python_version}"
   only_if { !os_properties.redhat_on_docker? }
 


### PR DESCRIPTION
### Description of changes
In https://github.com/aws/aws-parallelcluster-cookbook/pull/2869 we upgrade Phython from version 3.9.20 to 3.12.8 for all OSes but AL2. The current PR reflects this expectation into tests related to AWS Batch and CFN Bootstrap scripts.

### Tests
ONGOING

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
