### PR TITLE
Allow overriding of node package only on HeadNode during an Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Remove usage of cfn-init for compute node bootstrapping to reduce node scale up time.
-
+- Fix the execution of overriding aws-parallelcluster-node package only on the head node during update.
 
 3.12.0
 ------

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/config/update_parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/config/update_parallelcluster_node.rb
@@ -17,6 +17,8 @@
 
 # REMINDER: the update recipe runs only on the head node and the only supervisord daemon provided by the
 # aws-parallelcluster-node package on the head node is clustermgtd. Therefore, only this daemon is restarted.
+return unless node['cluster']['node_type'] == 'HeadNode'
+
 execute 'stop clustermgtd' do
   command "#{cookbook_virtualenv_path}/bin/supervisorctl stop clustermgtd"
 end


### PR DESCRIPTION
### Description of changes
* Allow overriding of node package only on HeadNode during an Update
* Introduced in 3.7.0 https://github.com/aws/aws-parallelcluster-cookbook/releases/tag/v3.7.0 but did not add the condition where it runs only on HeadNode



### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
