### PR TITLE
[Bug Fix] Fix permission error when running Pyxis+Enroot jobs with multi-user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **BUG FIXES**
 - Remove usage of cfn-init for compute node bootstrapping to reduce node scale up time.
 - Fix the execution of overriding aws-parallelcluster-node package only on the head node during update.
+- Fix an issue where containerized jobs executed through Pyxis/Enroot in a multi-user environment (integrated with Active Directory) would fail.
 
 3.12.0
 ------

--- a/cookbooks/aws-parallelcluster-platform/templates/enroot/enroot.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/enroot/enroot.conf.erb
@@ -1,9 +1,9 @@
 #ENROOT_LIBRARY_PATH        /usr/lib/enroot
 #ENROOT_SYSCONF_PATH        /etc/enroot
-ENROOT_RUNTIME_PATH         <%= node['cluster']['enroot']['temporary_dir'] %>/runtime/user-$(id -u)
-ENROOT_DATA_PATH            <%= node['cluster']['enroot']['temporary_dir'] %>/data/user-$(id -u)
-ENROOT_CONFIG_PATH          <%= node['cluster']['enroot']['persistent_dir'] %>/config/user-$(id -u)
-ENROOT_CACHE_PATH           <%= node['cluster']['enroot']['persistent_dir'] %>/cache/group-$(id -g)
+ENROOT_RUNTIME_PATH         <%= node['cluster']['enroot']['temporary_dir'] %>/user-$(id -u)/runtime
+ENROOT_DATA_PATH            <%= node['cluster']['enroot']['temporary_dir'] %>/user-$(id -u)/data
+ENROOT_CONFIG_PATH          <%= node['cluster']['enroot']['persistent_dir'] %>/user-$(id -u)/config
+ENROOT_CACHE_PATH           <%= node['cluster']['enroot']['persistent_dir'] %>/user-$(id -u)/cache
 #ENROOT_TEMP_PATH           ${TMPDIR:-/tmp}
 
 # Gzip program used to uncompress digest layers.


### PR DESCRIPTION
### Description of changes
* Fix an issue where containerized jobs executed through Pyxis/Enroot in a multi-user environment (integrated with Active Directory) would fail due to permission error like below.
```
slurmstepd-hades: error: pyxis:     mkdir: cannot create directory ‘/raid’: Permission denied
slurmstepd-hades: error: pyxis:     mkdir: cannot create directory ‘/tmp/enroot-data’: Permission denied
slurmstepd-hades: error: pyxis:     mkdir: cannot create directory ‘/run/enroot’: Permission denied
```

### Tests
- Manually tests done, I tried below tests in Ubuntu Os ParallelCluster and all of them succeeded:
  1. User A submit Pyxis job
  2. User B submit Pyxis job
  3. User C submit Pyxis job
  4. User ubuntu submit Pyxis job
  5. User A submit Pyxis job again

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
