### PR TITLE
 [ActiveDirectory] Fix usage of authselect which used to cause node boostrap failures on Rocky 9.5+ when directory service is used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Remove usage of cfn-init for compute node bootstrapping to reduce node scale up time.
 - Fix the execution of overriding aws-parallelcluster-node package only on the head node during update.
 - Fix an issue where containerized jobs executed through Pyxis/Enroot in a multi-user environment (integrated with Active Directory) would fail.
+- Fix usage of authselect causing node bootstrap failures on Rocky 9.5+ when directory service is used.
 
 3.12.0
 ------

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_rocky8.rb
@@ -28,7 +28,7 @@ action :configure do
     user 'root'
     # Tell NSS, PAM to use SSSD for system authentication and identity information
     # authconfig is a compatibility tool, replaced by authselect
-    command "authselect select sssd with-mkhomedir"
+    command "authselect select sssd with-mkhomedir --force"
     sensitive true
     default_env true
   end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/system_authentication_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/system_authentication_spec.rb
@@ -60,6 +60,8 @@ describe 'system_authentication:configure' do
           'authconfig --enablemkhomedir --enablesssdauth --enablesssd --updateall'
         when 'ubuntu'
           'pam-auth-update --enable mkhomedir'
+        when 'rocky'
+          'authselect select sssd with-mkhomedir --force'
         else
           'authselect select sssd with-mkhomedir'
         end


### PR DESCRIPTION
### Description of changes
Fix usage of authselect which used to cause node bootstrap failures on Rocky 9.5+ when directory service is used.

Starting with Rocky 9.5, authselect commands started failing with the error below, which can be fixed by forcing the overwrite of the target files:

```
authselect select sssd with-mkhomedir
[error] File [/etc/pam.d/system-auth] exists but it needs to be overwritten!
[error] File [/etc/pam.d/password-auth] exists but it needs to be overwritten!
[error] File [/etc/pam.d/fingerprint-auth] exists but it needs to be overwritten!
[error] File [/etc/pam.d/smartcard-auth] exists but it needs to be overwritten!
[error] File [/etc/pam.d/postlogin] exists but it needs to be overwritten!
[error] File [/etc/nsswitch.conf] exists but it needs to be overwritten!
[error] File that needs to be overwritten was found
[error] Refusing to activate profile unless this file is removed or overwrite is requested.

Some unexpected changes to the configuration were detected.
Use --force parameter if you want to overwrite these changes.
```

It is safe to force the update because:
1. the --force option implicitly back ups existing configurations, if any. See https://man.linuxreviews.org/man8/authselect.8.html

### Tests
* test_ad_integration

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
