### PR TITLE
Shortening RHEL/Rock boot time by deprioritizing ipv6 and disable internet check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Remove generation of DSA keys for login nodes as DSA, which became unsupported in OpenSSH 9.7+.
 - Set instance ID and instance type information in Slurm upon compute nodes launch.
 - Install NVIDIA drivers without the option 'no-cc-version-check', which is now deprecated in the NVIDIA installer.
+- Reduce RHEL/Rocky Linux boot time by the following network customization:
+  - Configuring higher priority to IPv4 than IPv6
+  - Disabling Internet connectivity check
+  - Configuring only IPv4 IMDS endpoint to cloud-init
 
 **BUG FIXES**
 - Remove usage of cfn-init for compute node bootstrapping to reduce node scale-up time.

--- a/cookbooks/aws-parallelcluster-slurm/files/redhat/dns_domain/99-disable-ipv6-metadata.cfg
+++ b/cookbooks/aws-parallelcluster-slurm/files/redhat/dns_domain/99-disable-ipv6-metadata.cfg
@@ -1,0 +1,3 @@
+datasource:
+  Ec2:
+    metadata_urls: [ 'http://169.254.169.254' ]

--- a/cookbooks/aws-parallelcluster-slurm/files/redhat/dns_domain/NetworkManager.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/redhat/dns_domain/NetworkManager.conf
@@ -23,6 +23,13 @@
 plugins = ifcfg-rh,
 dhcp = dhclient
 
+[connection]
+ipv4.route-metric=100
+ipv6.route-metric=200
+
+[connectivity]
+enabled=false
+
 [logging]
 # When debugging NetworkManager, enabling debug logging is of great help.
 #

--- a/cookbooks/aws-parallelcluster-slurm/files/rocky/dns_domain/99-disable-ipv6-metadata.cfg
+++ b/cookbooks/aws-parallelcluster-slurm/files/rocky/dns_domain/99-disable-ipv6-metadata.cfg
@@ -1,0 +1,3 @@
+datasource:
+  Ec2:
+    metadata_urls: [ 'http://169.254.169.254' ]

--- a/cookbooks/aws-parallelcluster-slurm/files/rocky/dns_domain/NetworkManager.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/rocky/dns_domain/NetworkManager.conf
@@ -23,6 +23,13 @@
 plugins = ifcfg-rh,
 dhcp = dhclient
 
+[connection]
+ipv4.route-metric=100
+ipv6.route-metric=200
+
+[connectivity]
+enabled=false
+
 [logging]
 # When debugging NetworkManager, enabling debug logging is of great help.
 #

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_redhat8.rb
@@ -33,6 +33,16 @@ action :configure do
     mode '0644'
   end
 
+  # Disable ipv6 IMDS in cloud init to speed up
+  cookbook_file '99-disable-ipv6-metadata.cfg' do
+    path '/etc/cloud/cloud.cfg.d/99-disable-ipv6-metadata.cfg'
+    source 'dns_domain/99-disable-ipv6-metadata.cfg'
+    cookbook 'aws-parallelcluster-slurm'
+    user 'root'
+    group 'root'
+    mode '0644'
+  end
+
   action_update_search_domain
   network_service 'Restart network service'
 end

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/dns_domain_rocky8.rb
@@ -33,6 +33,16 @@ action :configure do
     mode '0644'
   end
 
+  # Disable ipv6 IMDS in cloud init to speed up
+  cookbook_file '99-disable-ipv6-metadata.cfg' do
+    path '/etc/cloud/cloud.cfg.d/99-disable-ipv6-metadata.cfg'
+    source 'dns_domain/99-disable-ipv6-metadata.cfg'
+    cookbook 'aws-parallelcluster-slurm'
+    user 'root'
+    group 'root'
+    mode '0644'
+  end
+
   action_update_search_domain
   network_service 'Restart network service'
 end


### PR DESCRIPTION
This commit saves time because the os won't retry on unsupported ipv6 and optional Internet connection

Job start time on Rocky is shorten from 8.5 mins to 7 mins

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
