### PR TITLE
[EFA] Upgrade EFA to version 1.38.1 (from 1.38.0) to address issue on Rocky9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Python to 3.12.8 for all OSs except AL2 (from 3.9.20).
 - On Ubuntu 22.04, install the Nvidia driver with the same compiler version used to compile the kernel.
 - Upgrade aws-cfn-bootstrap to version 2.0-33.
-- Upgrade EFA installer to 1.38.0 (from 1.36.0).
+- Upgrade EFA installer to 1.38.1 (from 1.36.0).
   - Efa-driver: efa-2.13.0-1
   - Efa-config: efa-config-1.17-1
   - Efa-profile: efa-profile-1.7-1

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -70,8 +70,8 @@ default['cluster']['internal_initial_shared_dir'] = "#{node['cluster']['base_dir
 
 default['cluster']['head_node_private_ip'] = nil
 
-default['cluster']['efa']['version'] = '1.38.0'
-default['cluster']['efa']['sha256'] = '4f436954f35ad53754b4d005fd8d0be63de3b4184de41a695b504bdce0fecb22'
+default['cluster']['efa']['version'] = '1.38.1'
+default['cluster']['efa']['sha256'] = '83923374afd388b1cfcf4b3a21a2b1ba7cf46a01a587f7b519b8386cb95e4f81'
 
 # TODO: Move to platform cookbook
 default['cluster']['spack_shared_dir'] = "#{node['cluster']['shared_dir']}/spack"

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 # parallelcluster default source dir defined in attributes
 source_dir = '/opt/parallelcluster/sources'
-efa_version = '1.38.0'
-efa_checksum = '4f436954f35ad53754b4d005fd8d0be63de3b4184de41a695b504bdce0fecb22'
+efa_version = '1.38.1'
+efa_checksum = '83923374afd388b1cfcf4b3a21a2b1ba7cf46a01a587f7b519b8386cb95e4f81'
 
 class ConvergeEfa
   def self.setup(chef_run, efa_version: nil, efa_checksum: nil)


### PR DESCRIPTION
cherry-picked from https://github.com/aws/aws-parallelcluster-cookbook/pull/2906

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
