### PR TITLE
Use separate commands when copying files and preserving permissions

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/recipes/config/cluster_user.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/cluster_user.rb
@@ -73,7 +73,9 @@ when 'ComputeFleet'
   bash "copy_auth_file" do
     code <<-PERMS
       set -e
-      cp -p #{node['cluster']['shared_dir']}/authorized_keys #{node['cluster']['cluster_user_home']}/.ssh/authorized_keys
+      cp #{node['cluster']['shared_dir']}/authorized_keys #{node['cluster']['cluster_user_home']}/.ssh/authorized_keys
+      chmod --reference=#{node['cluster']['shared_dir']}/authorized_keys #{node['cluster']['cluster_user_home']}/.ssh/authorized_keys
+      chown --reference=#{node['cluster']['shared_dir']}/authorized_keys #{node['cluster']['cluster_user_home']}/.ssh/authorized_keys
     PERMS
     only_if { node['cluster']['default_user_home'] == 'local' }
   end
@@ -90,7 +92,9 @@ when 'LoginNode'
   bash "copy_auth_file" do
     code <<-PERMS
       set -e
-      cp -p #{node['cluster']['shared_dir_login_nodes']}/authorized_keys #{node['cluster']['cluster_user_home']}/.ssh/authorized_keys
+      cp #{node['cluster']['shared_dir_login_nodes']}/authorized_keys #{node['cluster']['cluster_user_home']}/.ssh/authorized_keys
+      chmod --reference=#{node['cluster']['shared_dir_login_nodes']}/authorized_keys #{node['cluster']['cluster_user_home']}/.ssh/authorized_keys
+      chown --reference=#{node['cluster']['shared_dir_login_nodes']}/authorized_keys #{node['cluster']['cluster_user_home']}/.ssh/authorized_keys
     PERMS
     only_if { node['cluster']['default_user_home'] == 'local' }
   end


### PR DESCRIPTION
`cp -p` fails with the following error on Ubuntu 24:
```
STDERR: cp: preserving permissions for ‘/local/home/ubuntu/.ssh/authorized_keys’: Operation not supported
```

### Tests
* test_default_user_local_home on Ubuntu24 has been passed

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
