### PR TITLE
Remove UnkillableStepTimeout as slurm sets this value by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.14.0
+------
+
+**ENHANCEMENTS**
+- Remove UnkillableStepTimeout from slurm.conf and let slurm set this value.
+
 3.13.0
 ------
 **ENHANCEMENTS**

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -50,7 +50,6 @@ BatchStartTimeout=180
 # TIMERS
 SlurmctldTimeout=300
 SlurmdTimeout=180
-UnkillableStepTimeout=180
 InactiveLimit=0
 MinJobAge=300
 KillWait=30


### PR DESCRIPTION
### Description of changes
* Remove UnkillableStepTimeout as slurm sets this value as 5 *MessageTimeout


### Tests
* Simple cluster creation and a job submission

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
