### PR TITLE
Clean resolv.conf at the end of AMI build

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/ami_cleanup.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/ami_cleanup.sh
@@ -22,7 +22,7 @@ fi
 
 # Clean resolv.conf if it's not managed by system
 if [ ! -L "/etc/resolv.conf" ]; then
-    echo -n > /etc/resolv.conf
+    sed -i '/^nameserver/d' /etc/resolv.conf
 fi
 
 find /var/log -type f -exec /bin/rm -v {} \;

--- a/cookbooks/aws-parallelcluster-platform/files/ami_cleanup.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/ami_cleanup.sh
@@ -20,5 +20,10 @@ if [ "${ID}${VERSION_ID}" == "centos7" ]; then
     rm -f /etc/sysconfig/network-scripts/ifcfg-eth0
 fi
 
+# Clean resolv.conf if it's not managed by system
+if [ ! -L "/etc/resolv.conf" ]; then
+    echo -n > /etc/resolv.conf
+fi
+
 find /var/log -type f -exec /bin/rm -v {} \;
 touch /var/log/lastlog


### PR DESCRIPTION
The conditional statement avoids cleaning if the `/etc/resolv.conf` is a symbolic link. It is a symbolic link when it is managed by other systems.

Cleaning the `/etc/resolv.conf` speeds up instance launch because it wouldn't try to use name server from the AMI creation environment. The delay was shown in `/var/log/cloud-init.log`:
```
2025-03-19 16:00:07,721 - util.py[DEBUG]: Resolving URL: http://169.254.169.254 took 40.099 seconds
2025-03-19 16:00:07,721 - util.py[DEBUG]: Resolving URL: http://[fd00:ec2::254] took 0.000 seconds
2025-03-19 16:00:17,731 - util.py[DEBUG]: Resolving URL: http://instance-data.:8773 took 10.010 seconds
```

Example content of `/etc/resolv.conf`:
```
cat /etc/resolv.conf
# Generated by NetworkManager
search ec2.internal
nameserver 192.168.0.2
```

### Tests
* Manually made change to the AMI. Cluster creation time with static compute nodes on RHEL 9 was 19:00. Now it is 16:00

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
