### PR TITLE
Clean Resolv.conf in official AMI build

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/ami_cleanup.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/ami_cleanup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+IS_OFFICIAL_AMI_BUILD=${1:-"false"}
+
 # clean up cloud init artifacts https://cloudinit.readthedocs.io/en/latest/topics/cli.html#clean
 cloud-init clean -s
 
@@ -21,8 +23,10 @@ if [ "${ID}${VERSION_ID}" == "centos7" ]; then
 fi
 
 # Clean resolv.conf if it's not managed by system
-if [ ! -L "/etc/resolv.conf" ]; then
-    sed -i '/^nameserver/d' /etc/resolv.conf
+if [ "${IS_OFFICIAL_AMI_BUILD}" == "true" ]; then
+    echo "Clean resolv.conf for official AMIs"
+    echo -n > /etc/resolv.conf
+    rm -f /run/systemd/resolve/resolv.conf
 fi
 
 find /var/log -type f -exec /bin/rm -v {} \;


### PR DESCRIPTION
This PR is a followup of https://github.com/aws/aws-parallelcluster-cookbook/pull/2919

1. Only cleanup resolv conf during official AMI build. In the future, we will evaluate to apply this improvement to all AMI builds.
2. Also clean up `/run/systemd/resolve/resolv.conf `. This file exists on Ubuntu

### Tests
* AMI builds are successful

### References
* CLI https://github.com/aws/aws-parallelcluster/pull/6759

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
