### PR TITLE
Use node.override to set node package for ADC

### DIFF
--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/parallelcluster_node.rb
@@ -36,7 +36,7 @@ end
 if aws_region.start_with?("us-iso") && !is_custom_node?
   node_package = "aws-parallelcluster-node-#{node['cluster']['parallelcluster-node-version']}.tgz"
 
-  node.default['cluster']['custom_node_package'] = "#{node['cluster']['s3_url']}/parallelcluster/#{node['cluster']['parallelcluster-node-version']}/node/#{node_package}"
+  node.override['cluster']['custom_node_package'] = "#{node['cluster']['s3_url']}/parallelcluster/#{node['cluster']['parallelcluster-node-version']}/node/#{node_package}"
 end
 
 if is_custom_node?


### PR DESCRIPTION
### Description of changes
* Use node.override to set node package for ADC

### Tests
* Tested that build image used custom node package when node.override was used

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
