### PR TITLE
[ARMPL] Fix ARM PL installation by properly injecting the S3 URL from where gcc dependencies must be downloaded from.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Ubuntu 20.04 is no longer supported.
 
+**BUG FIXES**
+- Fix a bug in the installation of ARM Performance Library that was causing the download of GCC dependencies from 
+  gcc website rather than the ParallelCluster public bucket.
+
 3.13.0
 ------
 **ENHANCEMENTS**

--- a/cookbooks/aws-parallelcluster-platform/resources/arm_pl/partial/_arm_pl_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/arm_pl/partial/_arm_pl_common.rb
@@ -119,14 +119,16 @@ action :setup do
     group 'root'
     cwd new_resource.sources_dir
     code <<-GCC
-        set -e
+        set -ex
 
         # Remove dir if it exists. This happens in case of retries.
         rm -rf gcc-#{gcc_version}
         tar -xf #{gcc_tarball}
         cd gcc-#{gcc_version}
-        # Patch the download_prerequisites script to download over https and not ftp. This works better in China regions.
-        sed -i "s#ftp://gcc\.gnu\.org/pub/gcc/infrastructure##{node['cluster']['artifacts_s3_url']}/dependencies/gcc/prerequisites#g" ./contrib/download_prerequisites
+        # Patch the download_prerequisites script to download GCC dependencies from our public bucket.
+        # This is required to support build image in isolated environments, also HTTPS works better than FTP in China regions. 
+        sed -i "s#\\(ftp\\|http\\|https\\)://gcc\.gnu\.org/pub/gcc/infrastructure##{node['cluster']['artifacts_s3_url']}/dependencies/gcc/prerequisites#g" ./contrib/download_prerequisites
+        cat ./contrib/download_prerequisites | grep 'base_url'
         ./contrib/download_prerequisites
         mkdir build && cd build
         ../configure --prefix=/opt/arm/armpl/gcc/#{gcc_version} --disable-bootstrap --enable-checking=release --enable-languages=c,c++,fortran --disable-multilib


### PR DESCRIPTION
**DONOTMERGE: test failed**

### Description of changes
Fix a bug in the installation of ARM Performance Library that was causing the download of GCC dependencies from gcc website rather than the ParallelCluster public bucket.

This fix is required now because we recently upgraded to GCC 11.3. 
In this version, the script `download_prerequisites` downloads gcc dependencies from http endpoint rather than ftp, invalidating our original replacement command.

### Tests
* ONGOING AMI build succeeded (tested on AL2 arm)
* Verified that gcc dependencies are fetched from S3 bucket
```
2025-04-14 17:16:16.808000	Stdout:     * bash[make install] action run[2025-04-14T17:16:16+00:00] INFO: Processing bash[make install] action run (aws-parallelcluster-platform::install line 117)
2025-04-14 17:16:23.189000	Stdout:
2025-04-14 17:16:23.189000	Stdout:       [execute] 2025-04-14 17:16:23 URL:https://gcc.gnu.org/pub/gcc/infrastructure/gmp-6.1.0.tar.bz2 [2383840/2383840] -> "gmp-6.1.0.tar.bz2" [1]
2025-04-14 17:16:23.439000	Stdout:                 2025-04-14 17:16:23 URL:http://gcc.gnu.org/pub/gcc/infrastructure/mpfr-3.1.6.tar.bz2 [1287202/1287202] -> "mpfr-3.1.6.tar.bz2" [1]
2025-04-14 17:16:23.690000	Stdout:                 2025-04-14 17:16:23 URL:http://gcc.gnu.org/pub/gcc/infrastructure/mpc-1.0.3.tar.gz [669925/669925] -> "mpc-1.0.3.tar.gz" [1]
2025-04-14 17:16:23.960000	Stdout:                 2025-04-14 17:16:23 URL:http://gcc.gnu.org/pub/gcc/infrastructure/isl-0.18.tar.bz2 [1658291/1658291] -> "isl-0.18.tar.bz2" [1]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
