### PR TITLE
[Dependencies] Upgrade SLURM to version 24.05.8 (from 24.05.7).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.13.1
+------
+
+**CHANGES**
+- Upgrade Slurm to version 24.05.8.
+
 3.13.0
 ------
 **ENHANCEMENTS**

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -1,8 +1,8 @@
 # Slurm
-default['cluster']['slurm']['version'] = '24-05-7-1'
+default['cluster']['slurm']['version'] = '24-05-8-1'
 default['cluster']['slurm']['commit'] = ''
 default['cluster']['slurm']['branch'] = ''
-default['cluster']['slurm']['sha256'] = '297e85853314a0a4d227ca66bb44179c099f0de5d86e83ffe21cb464b9ad3709'
+default['cluster']['slurm']['sha256'] = '06f4b837c3f7ec523a8924a5fee23d8305f20ca8ef3ad6128e128e87986821e4'
 default['cluster']['slurm']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/slurm"
 # Munge
 default['cluster']['munge']['munge_version'] = '0.5.16'


### PR DESCRIPTION
### Description of changes
Upgrade SLURM to version 24.05.8 (from 24.05.7).

### Tests
1. Version manually tested by upgrading to it from 24.05.7 on a running cluster
2. Checksum manually verified

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
