### PR TITLE
Relax inspec test for cstate to accept "no idle states"

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/c_states_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/c_states_spec.rb
@@ -4,8 +4,8 @@ control 'tag:install_c_states_kernel_configured' do
   only_if { !os_properties.on_docker? && os_properties.x86? }
   ## cpupower is installed for Ubuntu >=22
   describe bash('cpupower idle-info') do
-    its('stdout') { should match(/Number of idle states: 2/) }
-    its('stdout') { should match(/Available idle states: POLL C1/) }
+    its('stdout') { should match(/Number of idle states: 2|No idle states/) }
+    its('stdout') { should match(/Available idle states: POLL C1|No idle states/) }
   end
 end
 


### PR DESCRIPTION
The recent update of AL2023 totally disabled idle states, which could give even better performance.

ParallelCluster has been restricting idle state to maximum level 1 for performance reason. ToDo: ParallelCluster should improve the configuration to totally disable idle state for all OS.


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
