### PR TITLE
[Dependencies] Upgrade SLURM to version 24.05.8 (from 24.05.7).

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -1,8 +1,8 @@
 # Slurm
-default['cluster']['slurm']['version'] = '24-05-7-1'
+default['cluster']['slurm']['version'] = '24-05-8-1'
 default['cluster']['slurm']['commit'] = ''
 default['cluster']['slurm']['branch'] = ''
-default['cluster']['slurm']['sha256'] = '297e85853314a0a4d227ca66bb44179c099f0de5d86e83ffe21cb464b9ad3709'
+default['cluster']['slurm']['sha256'] = '06f4b837c3f7ec523a8924a5fee23d8305f20ca8ef3ad6128e128e87986821e4'
 default['cluster']['slurm']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/slurm"
 # Munge
 default['cluster']['munge']['munge_version'] = '0.5.16'


### PR DESCRIPTION
### Description of changes
Cherry-picked from https://github.com/aws/aws-parallelcluster-cookbook/pull/2934

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
