### PR TITLE
[ARMPL] Download GCC dependencies from our public bucket rather than GCC website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Upgrade Slurm to version 24.05.8.
 
+**BUG FIXES**
+- Fix a bug in the installation of ARM Performance Library that was causing the build image fail in isolated environments 
+due to cookbook retrieving GCC dependencies from GCC website rather than ParallelCluster bucket.
+
 3.13.0
 ------
 **ENHANCEMENTS**

--- a/cookbooks/aws-parallelcluster-platform/resources/arm_pl/partial/_arm_pl_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/arm_pl/partial/_arm_pl_common.rb
@@ -125,8 +125,9 @@ action :setup do
         rm -rf gcc-#{gcc_version}
         tar -xf #{gcc_tarball}
         cd gcc-#{gcc_version}
-        # Patch the download_prerequisites script to download over https and not ftp. This works better in China regions.
-        sed -i "s#ftp://gcc\.gnu\.org/pub/gcc/infrastructure##{node['cluster']['artifacts_s3_url']}/dependencies/gcc/prerequisites#g" ./contrib/download_prerequisites
+        # Patch the download_prerequisites script to download GCC dependencies from our public bucket.
+        # This is required to support build image in isolated environments.
+        sed -i "s#http://gcc\.gnu\.org/pub/gcc/infrastructure##{node['cluster']['artifacts_s3_url']}/dependencies/gcc/prerequisites#g" ./contrib/download_prerequisites
         ./contrib/download_prerequisites
         mkdir build && cd build
         ../configure --prefix=/opt/arm/armpl/gcc/#{gcc_version} --disable-bootstrap --enable-checking=release --enable-languages=c,c++,fortran --disable-multilib


### PR DESCRIPTION
### Description of changes
Fix a bug in the installation of ARM Performance Library that was causing the build image fail in isolated environments due to cookbook retrieving GCC dependencies from GCC website rather than ParallelCluster bucket.

### Tests
Build images succeeded (tested in AL2 arm)

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
