### PR TITLE
[ARMPL] Fix a bug in the installation of GCC required by ARM Performance Library to cover both gcc 9.3 and gcc 11.3. In particular gcc 9.3.0 requires ftp endpoint, whereas gcc 11.3.0 requires http endpoint.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/arm_pl/partial/_arm_pl_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/arm_pl/partial/_arm_pl_common.rb
@@ -127,7 +127,8 @@ action :setup do
         cd gcc-#{gcc_version}
         # Patch the download_prerequisites script to download GCC dependencies from our public bucket.
         # This is required to support build image in isolated environments.
-        sed -i "s#http://gcc\.gnu\.org/pub/gcc/infrastructure##{node['cluster']['artifacts_s3_url']}/dependencies/gcc/prerequisites#g" ./contrib/download_prerequisites
+        # Note: gcc 9.3 uses ftp, whereas gcc 11.3 uses http.
+        sed -i "s#\\(ftp\\|http\\)://gcc\.gnu\.org/pub/gcc/infrastructure##{node['cluster']['artifacts_s3_url']}/dependencies/gcc/prerequisites#g" ./contrib/download_prerequisites
         ./contrib/download_prerequisites
         mkdir build && cd build
         ../configure --prefix=/opt/arm/armpl/gcc/#{gcc_version} --disable-bootstrap --enable-checking=release --enable-languages=c,c++,fortran --disable-multilib


### PR DESCRIPTION
### Description of changes
Fix a bug in the installation of GCC required by ARM Performance Library to cover both gcc 9.3 and gcc 11.3. 
In particular gcc 9.3.0 requires ftp endpoint, whereas gcc 11.3.0 requires http endpoint.

The regression was introduced by https://github.com/aws/aws-parallelcluster-cookbook/pull/2942, where we replace only http endpoint (gcc-11.3), while we should cover both ftp (gcc-9.3) and http (gcc-11.3).

### Tests
Build image succeeded on both AL2 (using gcc9.3) and AL23 (using gcc11.3)
ARMPL installation succeeds on both AL2 and AL23 and verified from logs that gcc dependencioes are fetched from our public buckets both when using gcc9.3 and gcc11.3.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
