### PR TITLE
[Bug] Installing Pyxis if nvidia is installed

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pyxis.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pyxis.rb
@@ -15,7 +15,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-return unless nvidia_enabled?
+return unless nvidia_installed?
 return if pyxis_installed?
 
 pyxis_version = node['cluster']['pyxis']['version']

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_pyxis_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_pyxis_spec.rb
@@ -33,7 +33,7 @@ describe 'aws-parallelcluster-slurm::install_pyxis' do
           node.override['cluster']['pyxis']['version'] = pyxis_version
           node.override['cluster']['pyxis']['runtime_path'] = pyxis_runtime_dir
         end
-        allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
+        allow_any_instance_of(Object).to receive(:nvidia_installed?).and_return(true)
         allow_any_instance_of(Object).to receive(:pyxis_installed?).and_return(false)
         runner.converge(described_recipe)
       end
@@ -93,7 +93,7 @@ describe 'aws-parallelcluster-slurm::install_pyxis' do
           runner = runner(platform: platform, version: version) do |_node|
             RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
           end
-          allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
+          allow_any_instance_of(Object).to receive(:nvidia_installed?).and_return(true)
           allow_any_instance_of(Object).to receive(:pyxis_installed?).and_return(true)
           runner.converge(described_recipe)
         end

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/pyxis_spec.rb
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 control 'tag:install_pyxis_installed' do
-  only_if { ['yes', true, 'true'].include?(node['cluster']['nvidia']['enabled']) }
+  only_if { instance.nvidia_installed? }
 
   title 'Checks Pyxis has been installed'
 


### PR DESCRIPTION
### Description of changes
* Pyxis example files are not created when we use a Parent AMI which has NVIDIA already installed as the default value chef attribute is `'{"cluster": {"nvidia": {"enabled": "no" }}}'`

### Tests
* Manual installation + unit test

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
