### PR TITLE
[develop] Fix an issue where users cannot SSH into LoginNodes with LoginNode-specific keys when different keys are specified for HeadNode and LoginNodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Ubuntu 20.04 is no longer supported.
 
+**BUG FIXES**
+- Fix an issue where users cannot SSH into LoginNodes with LoginNode-specific keys when different keys are specified for HeadNode and LoginNodes.
+
 3.13.1
 ------
 

--- a/cookbooks/aws-parallelcluster-platform/recipes/config/cluster_user.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/cluster_user.rb
@@ -89,6 +89,40 @@ when 'LoginNode'
     shell '/bin/bash'
   end
 
+  directory node['cluster']['login_authorized_keys_dir'] do
+    owner 'root'
+    group 'root'
+    mode '0755'
+  end
+
+  directory "#{node['cluster']['login_authorized_keys_dir']}/#{node['cluster']['cluster_user']}" do
+    owner node['cluster']['cluster_user']
+    group node['cluster']['cluster_user']
+    mode '0700'
+  end
+
+  bash 'populate_login_node_local_key' do
+    code <<-PERMS
+      set -e
+      cp #{node['cluster']['shared_dir_login_nodes']}/authorized_keys \
+         #{node['cluster']['login_authorized_keys_dir']}/#{node['cluster']['cluster_user']}/authorized_keys
+      chown #{node['cluster']['cluster_user']}:#{node['cluster']['cluster_user']} \
+         #{node['cluster']['login_authorized_keys_dir']}/#{node['cluster']['cluster_user']}/authorized_keys
+      chmod 0600 #{node['cluster']['login_authorized_keys_dir']}/#{node['cluster']['cluster_user']}/authorized_keys
+    PERMS
+    not_if { ::File.exist?("#{node['cluster']['login_authorized_keys_dir']}/#{node['cluster']['cluster_user']}/authorized_keys") }
+  end
+
+  bash 'patch_sshd_config_for_login_nodes' do
+    code <<-CONF
+      set -e
+      AUTH_DIR="#{node['cluster']['login_authorized_keys_dir']}/#{node['cluster']['cluster_user']}"
+      LINE='AuthorizedKeysFile /etc/ssh/login_nodes_authorized_keys.d/%u/authorized_keys .ssh/authorized_keys'
+      grep -q "${AUTH_DIR}/authorized_keys" /etc/ssh/sshd_config || echo "${LINE}" >> /etc/ssh/sshd_config
+    CONF
+  end
+
+  # keep the existing copy into /home for backward compatibility
   bash "copy_auth_file" do
     code <<-PERMS
       set -e

--- a/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
@@ -23,6 +23,7 @@ default['cluster']['cluster_config_path'] = "#{node['cluster']['shared_dir']}/cl
 default['cluster']['previous_cluster_config_path'] = "#{node['cluster']['shared_dir']}/previous-cluster-config.yaml"
 default['cluster']['login_cluster_config_path'] = "#{node['cluster']['shared_dir_login_nodes']}/cluster-config.yaml"
 default['cluster']['login_previous_cluster_config_path'] = "#{node['cluster']['shared_dir_login_nodes']}/previous-cluster-config.yaml"
+default['cluster']['login_authorized_keys_dir'] = '/etc/ssh/login_nodes_authorized_keys.d'
 default['cluster']['change_set_path'] = "#{node['cluster']['shared_dir']}/change-set.json"
 default['cluster']['instance_types_data_path'] = "#{node['cluster']['shared_dir']}/instance-types-data.json"
 default['cluster']['previous_instance_types_data_path'] = "#{node['cluster']['shared_dir']}/previous-instance-types-data.json"


### PR DESCRIPTION
### Description of changes
* During Login Node bootstrap before mounting `/home`:
  * Create a local folder to store the key pair for LoginNodes:
      *  `/etc/ssh/login_nodes_authorized_keys.d` (0755 root:root)
      * `/etc/ssh/login_nodes_authorized_keys.d/$DEFAULT_USER/` (0700 $DEFAULT_USER:$DEFAULT_USER)
  * Copy the Login Node key to `/etc/ssh/login_nodes_authorized_keys.d/$DEFAULT_USER/authorized_keys` (0600 $DEFAULT_USER:$DEFAULT_USER).
  * Append in `/etc/ssh/sshd_config`:
  ```
  AuthorizedKeysFile /etc/ssh/login_nodes_authorized_keys.d/%u/authorized_keys .ssh/authorized_keys
  ```


### Tests
* I am on the manually testing

### References
* https://github.com/aws/aws-parallelcluster/issues/6811

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
