### PR TITLE
[test] Reeenable install_munge_folders_created check

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/test/controls/munge_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/munge_spec.rb
@@ -35,25 +35,19 @@ control 'tag:install_munge_user_and_group_created' do
   end
 end unless os_properties.redhat_on_docker?
 
-# FIXME: Re-enabled the following check and fix failures
-# control 'tag:install_munge_folders_created' do
-#   title 'Munge folder have been created'
-#
-#   describe file('/var/log/munge') do
-#     it { should exist }
-#     it { should be_directory }
-#   end
-#
-#   describe file('/etc/munge') do
-#     it { should exist }
-#     it { should be_directory }
-#   end
-#
-#   describe file('/var/run/munge') do
-#     it { should exist }
-#     it { should be_directory }
-#   end
-# end unless os_properties.redhat_on_docker?
+control 'tag:install_munge_folders_created' do
+  title 'Munge folder have been created'
+
+  describe file('/var/log/munge') do
+    it { should exist }
+    it { should be_directory }
+  end
+
+  describe file('/etc/munge') do
+    it { should exist }
+    it { should be_directory }
+  end
+end unless os_properties.redhat_on_docker?
 
 control 'tag:config_munge_service_enabled' do
   only_if { node['cluster']['scheduler'] == 'slurm' && !os_properties.redhat_on_docker? }


### PR DESCRIPTION
Among the original three folders checked, this commit removes the check on `/var/run/munge`. `/var/run` content changes across reboots. The check was successful on validate phase because there was no reboot between validate phase and build phase. The check fails on test phase because build and test are running on different instances

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
