### PR TITLE
[release-3.13] Give `systemctl poweroff --force` the sudoer permission

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/99-parallelcluster-slurm.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/99-parallelcluster-slurm.erb
@@ -1,8 +1,10 @@
 Cmnd_Alias SLURM_COMMANDS = <%= node['cluster']['slurm']['install_dir'] %>/bin/scontrol, <%= node['cluster']['slurm']['install_dir'] %>/bin/sinfo
 Cmnd_Alias SLURM_HOOKS_COMMANDS = <%= node_virtualenv_path %>/bin/slurm_suspend, <%= node_virtualenv_path %>/bin/slurm_resume, <%= node_virtualenv_path %>/bin/slurm_fleet_status_manager
 Cmnd_Alias SHUTDOWN = /usr/sbin/shutdown
+Cmnd_Alias SYSTEMCTL_POWEROFF = /usr/bin/systemctl poweroff --force
 
 <%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SLURM_COMMANDS
 <%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SHUTDOWN
+<%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SYSTEMCTL_POWEROFF
 
 <%= node['cluster']['slurm']['user'] %> ALL = (<%= node['cluster']['cluster_admin_user'] %>) NOPASSWD:SETENV: SLURM_HOOKS_COMMANDS


### PR DESCRIPTION
### Description of changes
* Give `systemctl poweroff --force` the sudoer permission to fix the ubuntu24 self termination issue

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
