### PR TITLE
[Bug] Use DomainReadOnlyUser from the input provided in config

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/libraries/directory_service_utils.rb
+++ b/cookbooks/aws-parallelcluster-environment/libraries/directory_service_utils.rb
@@ -21,7 +21,7 @@ end
 def _get_cn_subparam(param)
   tokens = param.split(",") unless param.blank?
   tokens.each do |token|
-    return token if token.include? "cn"
+    return token if token.downcase.start_with? "cn"
   end
   ""
 end


### PR DESCRIPTION
### Description of changes
Use DomainReadOnlyUser from the input provided in config
* Making the function case-sensitive
* making the function stricter as `cn` can be part of username

Current Logs show
```

[2025-05-24T01:14:22+00:00] INFO: Failed to retrieve the ReadOnlyUser from CN=ReadOnlyUser,OU=Users,ou=MICROSOFTAD,DC=microsoftad,DC=kgqvfhzxwz,DC=multiuser,dc=pcluster
--
[2025-05-24T01:14:22+00:00] INFO: Falling back to the default UserName ReadOnlyUser


```
this is a blocker if input is `CN=ReadUser,...`

### Tests
Cluster-creation with AD
Logs
```

[2025-05-27T21:07:00+00:00] INFO: Token is CN=ReadOnlyUser  and condition true ##### Log Line I added for debugging but not part of PR
[2025-05-27T21:07:00+00:00] INFO: UserName for ReadOnly directory service user set to ReadOnlyUser


```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
