### PR TITLE
[Sudoers] Restrict permissions for plcuster-admin user to execute systemctl poweroff only on Ubuntu24.04, as this is the only OS where pcluster-admin will shutdown the node using that command.

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/99-parallelcluster-slurm.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/99-parallelcluster-slurm.erb
@@ -1,10 +1,12 @@
 Cmnd_Alias SLURM_COMMANDS = <%= node['cluster']['slurm']['install_dir'] %>/bin/scontrol, <%= node['cluster']['slurm']['install_dir'] %>/bin/sinfo
 Cmnd_Alias SLURM_HOOKS_COMMANDS = <%= node_virtualenv_path %>/bin/slurm_suspend, <%= node_virtualenv_path %>/bin/slurm_resume, <%= node_virtualenv_path %>/bin/slurm_fleet_status_manager
 Cmnd_Alias SHUTDOWN = /usr/sbin/shutdown
-Cmnd_Alias SYSTEMCTL_POWEROFF = /usr/bin/systemctl poweroff --force
-
 <%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SLURM_COMMANDS
 <%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SHUTDOWN
-<%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SYSTEMCTL_POWEROFF
 
 <%= node['cluster']['slurm']['user'] %> ALL = (<%= node['cluster']['cluster_admin_user'] %>) NOPASSWD:SETENV: SLURM_HOOKS_COMMANDS
+
+<% if node['cluster']['os'] == "ubuntu2404" %>
+Cmnd_Alias SYSTEMCTL_POWEROFF = /usr/bin/systemctl poweroff --force
+<%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SYSTEMCTL_POWEROFF
+<% end %>

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_users_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_users_spec.rb
@@ -71,5 +71,9 @@ control 'tag:config_slurm_sudoers_correctly_defined' do
     its('content') { should match %r{Cmnd_Alias SHUTDOWN = /usr/sbin/shutdown} }
     its('content') { should match /#{node['cluster']['slurm']['user']} ALL = \(#{node['cluster']['cluster_admin_user']}\) NOPASSWD:SETENV: SLURM_HOOKS_COMMANDS/ }
     its('content') { should match %r{Cmnd_Alias SLURM_HOOKS_COMMANDS = #{venv_bin}/slurm_suspend, #{venv_bin}/slurm_resume, #{venv_bin}/slurm_fleet_status_manager} } unless redhat_on_docker
+    if os_properties.ubuntu2404?
+      its('content') { should match %r{Cmnd_Alias SYSTEMCTL_POWEROFF = /usr/bin/systemctl poweroff --force} }
+      its('content') { should match /#{node['cluster']['cluster_admin_user']} ALL = \(root\) NOPASSWD: SYSTEMCTL_POWEROFF/ }
+    end
   end
 end


### PR DESCRIPTION
### Description of changes
Restrict permissions for plcuster-admin user to execute systemctl poweroff only on Ubuntu24.04, as this is the only OS where pcluster-admin will shutdown the node using that command.

### Tests
ONGOING

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
