### PR TITLE
Revert "Give systemctl poweroff --force the sudoer permission to fix ubuntu24 self termination issue (#2959)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Open MPI: openmpi40-aws-4.1.7-2 and openmpi50-aws-5.0.6
 
 **BUG FIXES**
-- Fix a bug in the installation of ARM Performance Library that was causing the build image fail in isolated environments.
 - Upgrade amazon-efs-utils to version 2.3.1 (from v2.1.0) for non-Amazon Linux AMI's.
 
 3.13.0

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/99-parallelcluster-slurm.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/99-parallelcluster-slurm.erb
@@ -1,10 +1,8 @@
 Cmnd_Alias SLURM_COMMANDS = <%= node['cluster']['slurm']['install_dir'] %>/bin/scontrol, <%= node['cluster']['slurm']['install_dir'] %>/bin/sinfo
 Cmnd_Alias SLURM_HOOKS_COMMANDS = <%= node_virtualenv_path %>/bin/slurm_suspend, <%= node_virtualenv_path %>/bin/slurm_resume, <%= node_virtualenv_path %>/bin/slurm_fleet_status_manager
 Cmnd_Alias SHUTDOWN = /usr/sbin/shutdown
-Cmnd_Alias SYSTEMCTL_POWEROFF = /usr/bin/systemctl poweroff --force
 
 <%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SLURM_COMMANDS
 <%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SHUTDOWN
-<%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: SYSTEMCTL_POWEROFF
 
 <%= node['cluster']['slurm']['user'] %> ALL = (<%= node['cluster']['cluster_admin_user'] %>) NOPASSWD:SETENV: SLURM_HOOKS_COMMANDS


### PR DESCRIPTION
### Description of changes
This reverts commit cc2aeb212248a0ae6f00cfa81fc85fbb3aedd73a.
We verified that this fix does not solve the issue. even if compute node uses the systemctl poweroff --force with the sudo permissions, there are still cases where the compute node with broken network interface is unable to self terminate.

This bug fix was a nice to have for the patch release, so better to revert.

### Tests
* schedulers.test_slurm.test_error_handling failed due to compute node being stuck in self termination.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
