### PR TITLE
[AD] Fix a bug that was preventing the script 'update_directory_service_password.sh' from updating the AD password due to lack of permissions.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/templates/directory_service/update_directory_service_password.sh.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/directory_service/update_directory_service_password.sh.erb
@@ -27,9 +27,8 @@ echo "[INFO] Reading password from AWS: ${SECRET_ARN}"
 service=$(echo "${SECRET_ARN}" | cut -d ':' -f 3)
 resource=$(echo "${SECRET_ARN}" | cut -d ':' -f 6-)
 if [ "$service" == "secretsmanager" ]; then
-  secret_name=$(echo "$resource" | cut -d ':' -f 2)
-  echo "[INFO] Reading password as a secret from AWS Secrets Manager: ${secret_name}"
-  password_from_secret_store=$(aws secretsmanager get-secret-value --secret-id "${secret_name}" --region "${REGION}" --query "SecretString" --output text)
+  echo "[INFO] Reading password as a secret from AWS Secrets Manager: ${SECRET_ARN}"
+  password_from_secret_store=$(aws secretsmanager get-secret-value --secret-id "${SECRET_ARN}" --region "${REGION}" --query "SecretString" --output text)
 elif [ "$service" == "ssm" ]; then
   parameter_name=$(echo "$resource" | cut -d '/' -f 2)
   echo "[INFO] Reading password as a parameter from AWS SSM: ${SECRET_ARN}"


### PR DESCRIPTION
### Description of changes
Fix a bug that was preventing the script 'update_directory_service_password.sh' from updating the AD password due to lack of permissions.

Doc: https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3-multi-user.html#troubleshooting-v3-multi-user-reset-passwd

Before this change the script failed with error:

```
[root@ip-27-6-36-135 ~]# /opt/parallelcluster/scripts/directory_service/update_directory_service_password.sh
...
An error occurred (AccessDeniedException) when calling the GetSecretValue operation: User: arn:aws:sts::OBFUSCATED:assumed-role/ad-3130-2-RoleHeadNode-OBFUSCATED/i-OBFUSCATED is not authorized to perform: secretsmanager:GetSecretValue on resource: OBFUSCATED because no identity-based policy allows the secretsmanager:GetSecretValue action
```

This is because our script retrieves the secret by secret name whereas the HN permissions allow to retrieve the secret by ARN.

After this fix:

```
[root@ip-27-6-36-135 ~]# /opt/parallelcluster/scripts/directory_service/update_directory_service_password.sh
[INFO] Reading password from /etc/sssd/sssd.conf[INFO] Reading password from AWS: arn:aws:secretsmanager:us-east-1:OBFUSCATED:secret:OBFUSCATED
[INFO] Reading password as a secret from AWS Secrets Manager: arn:aws:secretsmanager:us-east-1:OBFUSCATED:secret:OBFUSCATED
[WARN] Password match, skipping update
```

Skipping changelog update b/c need to decide whether to include in 3.13.1 or 3.14.0

### Tests
See manual test above.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
