### PR TITLE
[AD] Fix a bug that was preventing the script 'update_directory_service_password.sh' from updating the AD password due to lack of permissions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Open MPI: openmpi40-aws-4.1.7-2 and openmpi50-aws-5.0.6
 - Upgrade amazon-efs-utils to version 2.3.1 (from v2.1.0) for non-Amazon Linux AMI's.
 
-
 **BUG FIXES**
 - Fix an issue where we were not installing Pyxis if NVIDIA is already installed.
+- Fix a bug that was preventing the script 'update_directory_service_password.sh' from updating the AD password.
 
 3.13.0
 ------

--- a/cookbooks/aws-parallelcluster-environment/templates/directory_service/update_directory_service_password.sh.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/directory_service/update_directory_service_password.sh.erb
@@ -27,9 +27,8 @@ echo "[INFO] Reading password from AWS: ${SECRET_ARN}"
 service=$(echo "${SECRET_ARN}" | cut -d ':' -f 3)
 resource=$(echo "${SECRET_ARN}" | cut -d ':' -f 6-)
 if [ "$service" == "secretsmanager" ]; then
-  secret_name=$(echo "$resource" | cut -d ':' -f 2)
-  echo "[INFO] Reading password as a secret from AWS Secrets Manager: ${secret_name}"
-  password_from_secret_store=$(aws secretsmanager get-secret-value --secret-id "${secret_name}" --region "${REGION}" --query "SecretString" --output text)
+  echo "[INFO] Reading password as a secret from AWS Secrets Manager: ${SECRET_ARN}"
+  password_from_secret_store=$(aws secretsmanager get-secret-value --secret-id "${SECRET_ARN}" --region "${REGION}" --query "SecretString" --output text)
 elif [ "$service" == "ssm" ]; then
   parameter_name=$(echo "$resource" | cut -d '/' -f 2)
   echo "[INFO] Reading password as a parameter from AWS SSM: ${SECRET_ARN}"


### PR DESCRIPTION
### Description of changes
Cherry-pick https://github.com/aws/aws-parallelcluster-cookbook/pull/2970

### Tests
Tested in source PR.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
