### PR TITLE
[Subnet Prioritization] Add EnableSingleAvailabilityZone to Fleet Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **CHANGES**
 - Ubuntu 20.04 is no longer supported.
+- Add SingleAvailabilityZone parameter to fleet_config.json
 
 3.13.1
 ------

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
@@ -99,7 +99,9 @@ def generate_fleet_config_file(output_file: str, input_file: str):
                     queue_capacity_reservation=queue_capacity_reservation,
                     queue_capacity_type=queue_capacity_type,
                     queue_subnets=queue_config["Networking"]["SubnetIds"],
-                    queue_single_availability_zone=queue_config["Networking"]["EnableSingleAvailabilityZone"],
+                    queue_single_availability_zone=queue_config.get("Networking", {}).get(
+                        "EnableSingleAvailabilityZone", None
+                    ),
                 )
                 fleet_config[queue_name][compute_resource_name] = config_for_fleet
 

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
@@ -99,6 +99,7 @@ def generate_fleet_config_file(output_file: str, input_file: str):
                     queue_capacity_reservation=queue_capacity_reservation,
                     queue_capacity_type=queue_capacity_type,
                     queue_subnets=queue_config["Networking"]["SubnetIds"],
+                    queue_single_availability_zone=queue_config["Networking"]["EnableSingleAvailabilityZone"],
                 )
                 fleet_config[queue_name][compute_resource_name] = config_for_fleet
 
@@ -125,6 +126,7 @@ def _generate_compute_resource_fleet_config(
     queue_capacity_reservation: str,
     queue_capacity_type: str,
     queue_subnets: List,
+    queue_single_availability_zone: bool,
 ):
     """
     Generate compute resource config to add in the fleet-config.json, overriding values from the queue.
@@ -156,7 +158,10 @@ def _generate_compute_resource_fleet_config(
                 {
                     "Api": "create-fleet",
                     "Instances": copy.deepcopy(compute_resource_config["Instances"]),
-                    "Networking": {"SubnetIds": queue_subnets},
+                    "Networking": {
+                        "SubnetIds": queue_subnets,
+                        "SingleAvailabilityZone": queue_single_availability_zone
+                    },
                 }
             )
             allocation_strategy = compute_resource_config.get("AllocationStrategy", queue_allocation_strategy)

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_fleet_config_generator.py
@@ -160,7 +160,7 @@ def _generate_compute_resource_fleet_config(
                     "Instances": copy.deepcopy(compute_resource_config["Instances"]),
                     "Networking": {
                         "SubnetIds": queue_subnets,
-                        "SingleAvailabilityZone": queue_single_availability_zone
+                        "SingleAvailabilityZone": queue_single_availability_zone,
                     },
                 }
             )

--- a/test/unit/slurm/test_fleet_config_generator.py
+++ b/test/unit/slurm/test_fleet_config_generator.py
@@ -60,7 +60,7 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
                 }
             },
             CriticalError,
-            "Unable to find key 'EnableSingleAvailabilityZone' in the configuration file. Queue: q1",
+            "Unable to find key 'Name' in the configuration file. Queue: q1",
         ),
         (
             {
@@ -239,8 +239,8 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
                     ]
                 }
             },
-            CriticalError,
-            "Unable to find key 'EnableSingleAvailabilityZone' in the configuration file. Queue: q1",
+            None,
+            None,
         ),
         (
             {

--- a/test/unit/slurm/test_fleet_config_generator.py
+++ b/test/unit/slurm/test_fleet_config_generator.py
@@ -47,6 +47,22 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
             "Unable to find key 'Networking' in the configuration file. Queue: q1",
         ),
         (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [
+                            {
+                                "Name": "q1",
+                                "CapacityType": "SPOT",
+                                "ComputeResources": [{"Instances": []}],
+                                "Networking": {"SubnetIds": ["123"]},
+                            }
+                        ]
+                    }
+                },
+                CriticalError,
+                "Unable to find key 'EnableSingleAvailabilityZone' in the configuration file. Queue: q1",
+        ),
+        (
             {
                 "Scheduling": {
                     "SlurmQueues": [
@@ -54,7 +70,7 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
                             "Name": "q1",
                             "CapacityType": "SPOT",
                             "ComputeResources": [{"Instances": []}],
-                            "Networking": {"SubnetIds": ["123"]},
+                            "Networking": {"SubnetIds": ["123"], "EnableSingleAvailabilityZone": None},
                         }
                     ]
                 }
@@ -70,7 +86,7 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
                             "Name": "q1",
                             "CapacityType": "ONDEMAND",
                             "ComputeResources": [{"Name": "cr1", "Instances": []}],
-                            "Networking": {"SubnetIds": ["123"]},
+                            "Networking": {"SubnetIds": ["123"], "EnableSingleAvailabilityZone": None},
                         }
                     ]
                 }
@@ -89,7 +105,7 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
                                 {"Name": "cr1", "Instances": [{"InstanceType": "test"}]},
                                 {"Name": "cr2", "InstanceType": "test"},
                             ],
-                            "Networking": {"SubnetIds": ["123"]},
+                            "Networking": {"SubnetIds": ["123"], "EnableSingleAvailabilityZone": None},
                         }
                     ]
                 }
@@ -108,7 +124,7 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
                                 {"Name": "cr1", "Instances": [{"InstanceType": "test"}, {"InstanceType": "test-2"}]},
                                 {"Name": "cr2", "InstanceType": "test"},
                             ],
-                            "Networking": {"SubnetIds": ["123", "456", "789"]},
+                            "Networking": {"SubnetIds": ["123", "456", "789"], "EnableSingleAvailabilityZone": None},
                         }
                     ]
                 }
@@ -131,7 +147,7 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
                                 },
                                 {"Name": "cr2", "InstanceType": "test", "SpotPrice": "10"},
                             ],
-                            "Networking": {"SubnetIds": ["123", "456", "789"]},
+                            "Networking": {"SubnetIds": ["123", "456", "789"], "EnableSingleAvailabilityZone": None},
                         }
                     ]
                 }
@@ -147,7 +163,7 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
                             "Name": "q1",
                             "CapacityType": "SPOT",
                             "ComputeResources": [{"Name": "cr1", "Instances": [{"InstanceType": "test"}]}],
-                            "Networking": {"SubnetIds": ["123"]},
+                            "Networking": {"SubnetIds": ["123"], "EnableSingleAvailabilityZone": None},
                         }
                     ]
                 }
@@ -165,7 +181,7 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
                             "ComputeResources": [
                                 {"Name": "cr1", "Instances": [{"InstanceType": "test"}], "SpotPrice": 10}
                             ],
-                            "Networking": {"SubnetIds": ["123"]},
+                            "Networking": {"SubnetIds": ["123"], "EnableSingleAvailabilityZone": None},
                         }
                     ]
                 }
@@ -209,6 +225,24 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
             "Unable to find key 'SubnetIds' in the configuration file. Queue: q1",
         ),
         (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [
+                            {
+                                "Name": "q1",
+                                "CapacityType": "SPOT",
+                                "ComputeResources": [
+                                    {"Name": "cr1", "Instances": [{"InstanceType": "test"}], "SpotPrice": 10}
+                                ],
+                                "Networking": {"SubnetIds": ["123"]},
+                            }
+                        ]
+                    }
+                },
+                CriticalError,
+                "Unable to find key 'EnableSingleAvailabilityZone' in the configuration file. Queue: q1",
+        ),
+        (
             {
                 "Scheduling": {
                     "SlurmQueues": [
@@ -231,7 +265,7 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
                                     },
                                 },
                             ],
-                            "Networking": {"SubnetIds": ["123"]},
+                            "Networking": {"SubnetIds": ["123"], "EnableSingleAvailabilityZone": None},
                         }
                     ]
                 }

--- a/test/unit/slurm/test_fleet_config_generator.py
+++ b/test/unit/slurm/test_fleet_config_generator.py
@@ -47,20 +47,20 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
             "Unable to find key 'Networking' in the configuration file. Queue: q1",
         ),
         (
-                {
-                    "Scheduling": {
-                        "SlurmQueues": [
-                            {
-                                "Name": "q1",
-                                "CapacityType": "SPOT",
-                                "ComputeResources": [{"Instances": []}],
-                                "Networking": {"SubnetIds": ["123"]},
-                            }
-                        ]
-                    }
-                },
-                CriticalError,
-                "Unable to find key 'EnableSingleAvailabilityZone' in the configuration file. Queue: q1",
+            {
+                "Scheduling": {
+                    "SlurmQueues": [
+                        {
+                            "Name": "q1",
+                            "CapacityType": "SPOT",
+                            "ComputeResources": [{"Instances": []}],
+                            "Networking": {"SubnetIds": ["123"]},
+                        }
+                    ]
+                }
+            },
+            CriticalError,
+            "Unable to find key 'EnableSingleAvailabilityZone' in the configuration file. Queue: q1",
         ),
         (
             {
@@ -225,22 +225,22 @@ from pcluster_fleet_config_generator import ConfigurationFieldNotFoundError, Cri
             "Unable to find key 'SubnetIds' in the configuration file. Queue: q1",
         ),
         (
-                {
-                    "Scheduling": {
-                        "SlurmQueues": [
-                            {
-                                "Name": "q1",
-                                "CapacityType": "SPOT",
-                                "ComputeResources": [
-                                    {"Name": "cr1", "Instances": [{"InstanceType": "test"}], "SpotPrice": 10}
-                                ],
-                                "Networking": {"SubnetIds": ["123"]},
-                            }
-                        ]
-                    }
-                },
-                CriticalError,
-                "Unable to find key 'EnableSingleAvailabilityZone' in the configuration file. Queue: q1",
+            {
+                "Scheduling": {
+                    "SlurmQueues": [
+                        {
+                            "Name": "q1",
+                            "CapacityType": "SPOT",
+                            "ComputeResources": [
+                                {"Name": "cr1", "Instances": [{"InstanceType": "test"}], "SpotPrice": 10}
+                            ],
+                            "Networking": {"SubnetIds": ["123"]},
+                        }
+                    ]
+                }
+            },
+            CriticalError,
+            "Unable to find key 'EnableSingleAvailabilityZone' in the configuration file. Queue: q1",
         ),
         (
             {

--- a/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/expected_outputs/fleet-config.json
+++ b/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/expected_outputs/fleet-config.json
@@ -27,7 +27,8 @@
             "Networking": {
                 "SubnetIds": [
                     "subnet-0230367ab0e5123a4"
-                ]
+                ],
+                "SingleAvailabilityZone": true
             },
             "AllocationStrategy": "lowest-price"
         }
@@ -57,7 +58,8 @@
                 "SubnetIds": [
                     "subnet-0230367ab0e5123a4",
                     "subnet-0b903123096649662"
-                ]
+                ],
+                "SingleAvailabilityZone": false
             },
             "AllocationStrategy": "lowest-price"
         }
@@ -84,7 +86,8 @@
             "Networking": {
                 "SubnetIds": [
                     "subnet-0230367ab0e5123a4"
-                ]
+                ],
+                "SingleAvailabilityZone": null
             },
             "AllocationStrategy": "capacity-optimized",
             "MaxPrice": 10
@@ -100,7 +103,8 @@
             "Networking": {
                 "SubnetIds": [
                     "subnet-0230367ab0e5123a4"
-                ]
+                ],
+                "SingleAvailabilityZone": null
             },
             "AllocationStrategy": "capacity-optimized"
         }
@@ -131,7 +135,8 @@
             "Networking": {
                 "SubnetIds": [
                     "subnet-0230367ab0e5123a4"
-                ]
+                ],
+                "SingleAvailabilityZone": null
             }
         }
     }

--- a/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/sample_input.yaml
+++ b/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/sample_input.yaml
@@ -253,7 +253,6 @@ Scheduling:
       SecurityGroups: null
       SubnetIds:
         - subnet-0230367ab0e5123a4
-      EnableSingleAvailabilityZone: null
   SlurmSettings:
     Dns:
       DisableManagedDns: false

--- a/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/sample_input.yaml
+++ b/test/unit/slurm/test_fleet_config_generator/test_generate_fleet_config_file/sample_input.yaml
@@ -62,6 +62,7 @@ Scheduling:
       SecurityGroups: null
       SubnetIds:
       - subnet-0230367ab0e5123a4
+      EnableSingleAvailabilityZone: true
     # queue ondemand without capacity reservations and with multiple subnets
   - AllocationStrategy: lowest-price
     CapacityReservationTarget: null
@@ -121,6 +122,7 @@ Scheduling:
       SubnetIds:
       - subnet-0230367ab0e5123a4
       - subnet-0b903123096649662
+      EnableSingleAvailabilityZone: false
     # queue spot
   - AllocationStrategy: capacity-optimized
     CapacityReservationTarget: null
@@ -191,6 +193,7 @@ Scheduling:
       SecurityGroups: null
       SubnetIds:
       - subnet-0230367ab0e5123a4
+      EnableSingleAvailabilityZone: null
     # queue for capacity-block
   - CapacityReservationTarget:
       CapacityReservationId: cr-987654
@@ -250,6 +253,7 @@ Scheduling:
       SecurityGroups: null
       SubnetIds:
         - subnet-0230367ab0e5123a4
+      EnableSingleAvailabilityZone: null
   SlurmSettings:
     Dns:
       DisableManagedDns: false


### PR DESCRIPTION
### Description of changes
Add EnableSingleAvailabilityZone parameter to fleet_config.json

### Tests
* test_fleet_config_generator.py

### References
* [Link to impacted open issues.](https://t.corp.amazon.com/V1695283761/communication)
* [Link to related PRs in other packages (i.e. cookbook, node).](https://quip-amazon.com/AtG8AV3uwdq1#QZE9BA6Hjxy)
* [Link to documentation useful to understand the changes.](https://quip-amazon.com/BxngAMfw8daY/Design-Subnet-Prioritization)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
