### PR TITLE
Not running is_fleet_ready checks if static node count is 0

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -178,6 +178,21 @@ def wait_cluster_ready
   end
 end
 
+def get_static_node_count
+  require 'yaml'
+  cluster_config = YAML.safe_load(File.read(node['cluster']['cluster_config_path']))
+  total_min_count = 0
+  slurm_queues_section = cluster_config.dig("Scheduling", "SlurmQueues")
+  if slurm_queues_section
+    slurm_queues_section.each do |queue_config|
+      queue_config['ComputeResources'].each do |compute_resource_config|
+        total_min_count += compute_resource_config['MinCount'].to_i
+      end
+    end
+  end
+  total_min_count
+end
+
 def wait_static_fleet_running
   ruby_block "wait for static fleet capacity" do
     block do
@@ -203,15 +218,21 @@ def wait_static_fleet_running
       fleet_status_command = Shellwords.escape(
         "/usr/local/bin/get-compute-fleet-status.sh"
       )
+
+      total_static_node_count = get_static_node_count
+      Chef::Log.info("Count of cluster static nodes is #{total_static_node_count}")
+
       # Example output for sinfo
       # sinfo -h -o '%N %t'
       # queue-0-dy-compute-resource-g4dn-0-[1-10],queue-1-dy-compute-resource-g4dn-1-[1-10] idle~
       # queue-2-dy-compute-resource-g4dn-2-[1-10],queue-3-dy-compute-resource-g4dn-3-[1-10] idle
-      until shell_out!("/bin/bash -c /usr/local/bin/is_fleet_ready.sh").stdout.strip.empty?
-        check_for_protected_mode(fleet_status_command)
+      if total_static_node_count.to_i > 0
+        until shell_out!("/bin/bash -c /usr/local/bin/is_fleet_ready.sh").stdout.strip.empty?
+          check_for_protected_mode(fleet_status_command)
 
-        Chef::Log.info("Waiting for static fleet capacity provisioning")
-        sleep(15)
+          Chef::Log.info("Waiting for static fleet capacity provisioning")
+          sleep(15)
+        end
       end
       Chef::Log.info("Static fleet capacity is ready")
     end


### PR DESCRIPTION


### Description of changes
Initial PR was closed as I forced push some changes https://github.com/aws/aws-parallelcluster-cookbook/pull/2960

 * Adding log for checking output
 * Using Ruby yaml for looping to get count od static nodes
 * Run static fleet checks if there are any static nodes


### Tests
```
ruby_block[wait for static fleet capacity] action run[2025-06-17T15:34:30+00:00] INFO: Processing ruby_block[wait for static fleet capacity] action run (aws-parallelcluster-slurm::finalize_head_node line 197)
[2025-06-17T15:34:30+00:00] INFO: Count of cluster static nodes is 0
[2025-06-17T15:34:30+00:00] INFO: Static fleet capacity is ready
```
```

  ruby_block[wait for static fleet capacity] action run[2025-06-17T15:43:04+00:00] INFO: Processing ruby_block[wait for static fleet capacity] action run (aws-parallelcluster-entrypoints::test line 197)
[2025-06-17T15:43:04+00:00] INFO: Count of cluster static nodes is 12
[2025-06-17T15:43:04+00:00] INFO: Static fleet capacity is ready
[2025-06-17T15:43:04+00:00] INFO: ruby_block[wait for static fleet capacity] called

```


### Tests 
* Manual test
* ONGOING BELOW
```
test-suites:
  update:
    test_update.py::test_dynamic_file_systems_update:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - alinux2023
        regions:
        - eu-west-2
        schedulers:
        - slurm
    test_update.py::test_dynamic_file_systems_update_data_loss:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - rhel9
        regions:
        - eu-west-2
        schedulers:
        - slurm
    test_update.py::test_dynamic_file_systems_update_rollback:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - rocky9
        regions:
        - rocky9
        schedulers:
        - slurm
    test_update.py::test_login_nodes_update:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - rhel8
        regions:
        - us-east-2
        schedulers:
        - slurm
    test_update.py::test_multi_az_create_and_update:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - alinux2
        regions:
        - eu-west-2
        schedulers:
        - slurm
    test_update.py::test_update_slurm:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - rhel8
        regions:
        - eu-central-1

```


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
