### PR TITLE
Fix kitchen tests after change to install enroot when nvidia is installed

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/enroot_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/enroot_spec.rb
@@ -39,7 +39,7 @@ control 'tag:config_enroot_enabled_on_graphic_instances' do
 end
 
 control 'tag:config_enroot_disabled_on_non_graphic_instances' do
-  only_if { !os_properties.on_docker? && !['yes', true, 'true'].include?(node['cluster']['nvidia']['enabled']) }
+  only_if { !os_properties.on_docker? && !['yes', true, 'true'].include?(node['cluster']['nvidia']['enabled']) && !instance.nvidia_installed? }
 
   describe 'enroot service should be disabled' do
     subject { command("enroot version") }


### PR DESCRIPTION
This fixes https://github.com/aws/aws-parallelcluster-cookbook/pull/2984

### Tests
Build image test of https://github.com/aws/aws-parallelcluster-cookbook/pull/2984 with DLAMI has been done. test_pyxis has been passed with the output AMI

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
