### PR TITLE
Add NVSwitch device ID for p6 instance type

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
@@ -54,10 +54,12 @@ end
 
 # Get number of nv switches
 def get_nvswitches
-  #  A100 (P4) and H100(P5) systems have NVSwitches
+  #  A100 (P4), H100(P5) and B200(P6) systems have NVSwitches
   # NVSwitch device id is 10de:1af1 for P4 instance
   # NVSwitch device id is 10de:22a3 for P5 instance
-  nvswitch_check_p4 = shell_out("lspci -d 10de:1af1 | wc -l")
-  nvswitch_check_p5 = shell_out("lspci -d 10de:22a3 | wc -l")
-  nvswitch_check_p4.stdout.strip.to_i + nvswitch_check_p5.stdout.strip.to_i
+  # NVSwitch device id is 10de:2901 for P6 instance
+  # We sum the count for all these deviceIds as output of lscpi command will be >0
+  # for only one device ID based on the instance type
+  nvswitch_device_ids = ['10de:1af1', '10de:22a3', '10de:2901']
+  nvswitch_device_ids.sum { |id| shell_out("lspci -d #{id} | wc -l").stdout.strip.to_i }
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
@@ -260,3 +260,40 @@ describe 'fabric_manager:configure' do
     end
   end
 end
+
+describe 'fabric_manager:get_nvswitches' do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: ['fabric_manager'])
+  end
+
+  let(:output_of_shell) { double('shell_out') }
+  cached(:resource) do
+    ConvergeFabricManager.setup(chef_run)
+    chef_run.find_resource('fabric_manager', 'setup')
+  end
+
+  before do
+    allow(resource).to receive(:shell_out).and_return(output_of_shell)
+  end
+
+  context 'when count of NVSwitches > 1' do
+    it 'correctly counts multiple NVSwitches' do
+      allow(output_of_shell).to receive(:stdout).and_return("2\n", "0\n", "0\n")
+      expect(resource.get_nvswitches).to eq(2)
+    end
+  end
+
+  context 'when count of NVSwitches == 0' do
+    it 'returns zero when no NVSwitches are found' do
+      allow(output_of_shell).to receive(:stdout).and_return("0\n")
+      expect(resource.get_nvswitches).to eq(0)
+    end
+  end
+
+  context 'when count of NVSwitches gives unexpected output' do
+    it 'handles non-numeric output' do
+      allow(output_of_shell).to receive(:stdout).and_return("error\n")
+      expect(resource.get_nvswitches).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
* Add NVSwitch device ID for p6 instance type as NVIDIA Fabric manager needs to be enabled for GPU Health Checks to be invoked.

Steps for Device ID: https://nvidia.custhelp.com/app/answers/detail/a_id/2040/~/identifying-the-graphics-card-model-and-device-id-in-a-pc


* This PR addresses a technical blocker and does not provide full support of p6 instance type.

### Tests
* Cluster launch with p4d instance type and Log line (which is now removed)
```
[2025-07-03T18:27:07+00:00] INFO: NVSwitch works 6

    * service[nvidia-fabricmanager] action start[2025-07-03T18:27:07+00:00] INFO: Processing service[nvidia-fabricmanager] action start (aws-parallelcluster-platform::test line 36)
 (up to date)
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
