### PR TITLE
[Isolated] Install Pypi dependencies for boto3 and cfn-bootstrap scripts

### DIFF
--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
@@ -19,6 +19,27 @@
 
 # TODO: once the pyenv Chef resource supports installing packages from a path (e.g. `pip install .`), convert the
 # bash block to a recipe that uses the pyenv resource.
+if aws_region.start_with?("us-iso") && platform?('amazon') && node['platform_version'] == "2"
+  remote_file "#{node['cluster']['base_dir']}/node-dependencies.tgz" do
+    source "#{node['cluster']['artifacts_s3_url']}/dependencies/PyPi/#{node['kernel']['machine']}/node-dependencies.tgz"
+    mode '0644'
+    retries 3
+    retry_delay 5
+    action :create_if_missing
+  end
+
+  bash 'pip install' do
+    user 'root'
+    group 'root'
+    cwd "#{node['cluster']['base_dir']}"
+    code <<-REQ
+      set -e
+      tar xzf node-dependencies.tgz
+      cd node
+      #{node_virtualenv_path}/bin/pip install * -f ./ --no-index
+      REQ
+  end
+end
 
 bash "install custom aws-parallelcluster-node" do
   cwd Chef::Config[:file_cache_path]

--- a/cookbooks/aws-parallelcluster-environment/recipes/install/cfn_bootstrap.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/install/cfn_bootstrap.rb
@@ -33,6 +33,28 @@ activate_virtual_env virtualenv_name do
   not_if { ::File.exist?("#{virtualenv_path}/bin/activate") }
 end
 
+if aws_region.start_with?("us-iso")
+  remote_file "#{node['cluster']['base_dir']}/cfn-dependencies.tgz" do
+    source "#{node['cluster']['artifacts_s3_url']}/dependencies/PyPi/#{node['kernel']['machine']}/cfn-dependencies.tgz"
+    mode '0644'
+    retries 3
+    retry_delay 5
+    action :create_if_missing
+  end
+
+  bash 'pip install' do
+    user 'root'
+    group 'root'
+    cwd "#{node['cluster']['base_dir']}"
+    code <<-REQ
+      set -e
+      tar xzf cfn-dependencies.tgz
+      cd cfn
+      #{virtualenv_path}/bin/pip install * -f ./ --no-index
+      REQ
+  end
+end
+
 cfnbootstrap_version = '2.0-33'
 cfnbootstrap_package = "aws-cfn-bootstrap-py3-#{cfnbootstrap_version}.tar.gz"
 


### PR DESCRIPTION
### Description of changes
* [Isolated] Install Pypi dependencies for boto3 (node_dependencies.tgz) and cfn-bootstrap scripts

Some failures like those related to boto3 (node_dependencies.tgz) are seen only in AL2.

These dependencies were removed in https://github.com/aws/aws-parallelcluster-cookbook/pull/2869 under the understanding that they are never installed but during the tests we see they are required as we get below errors
```
ERROR: Could not find a version that satisfies the requirement setuptools>=40.8.0 (from versions: none)

ERROR: No matching distribution found for setuptools>=40.8.0

Error executing action 'run' on resource 'bash[Install CloudFormation helpers from aws-cfn-bootstrap-py3-2.0-33.tar.gz
```

```
Recipe: aws-parallelcuster-computefleet::custom_parallelcluster_node
* bash[install custom aws-parallelcluster-node] action run[2025-04-xxxxxx]
Could not find a version that satisfies the requirement boto3>=1.7.55
```

### Tests
* BUILD IMAGE in Isolate regions

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
