### PR TITLE
[test] Fix Github system tests on Ubuntu

### DIFF
--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -3,7 +3,7 @@ driver:
   name: dokken
   platform: linux/amd64
   pull_platform_image: false # Use the local images, prevent pull of docker images from Docker Hub,
-  chef_version: 18.7.3 # Chef version aligned with the one used to build the images
+  chef_version: 18.7.10
   chef_image: cincproject/cinc
   env:
     # Since the kernel version of the docker images is not in the expected pattern,
@@ -59,7 +59,7 @@ platforms:
       cluster:
         base_os: ubuntu2404
         # Since the kernel version of the docker images is not compatible (6.2.0-1016-azure), set a fake kernel value to permit to install Lustre on docker.
-        kernel_release: '5.15.0-1028-aws'
+        kernel_release: '6.8.0-1031-aws'
   - name: rhel8
     driver:
       image: <% if ENV['KITCHEN_RHEL8_IMAGE'] %> <%= ENV['KITCHEN_RHEL8_IMAGE'] %> <% else %> registry.access.redhat.com/ubi8/ubi <% end %>


### PR DESCRIPTION
### Description of changes
* This commit fixes the following issue:
1. On Ubuntu 24 mock a kernel version that is actually from Ubuntu 24 instead of 22
2. Upgrade Chef version in system test to fix an known issue https://github.com/chef/chef/pull/14928, which was failing for both Ubuntu22 and Ubuntu 24

### Tests
* Github system tests on Ubuntu is passing

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
