### PR TITLE
[Logs] Fix a race condition in CloudWatch Agent startup that could cause nodes bootstrap failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade DCV to version 2024.0-19030.
 - Remove `berkshelf`. All cookbooks are local and do not need `berkshelf` dependency management.
 
+**BUG FIXES**
+- Fix a race condition in CloudWatch Agent startup that could cause nodes bootstrap failures.
+
 3.13.2
 ------
 

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/write_cloudwatch_agent_json.py
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/write_cloudwatch_agent_json.py
@@ -13,7 +13,7 @@ import socket
 
 from cloudwatch_agent_common_utils import render_jinja_template
 
-AWS_CLOUDWATCH_CFG_PATH = "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
+AWS_CLOUDWATCH_CFG_PATH = "/etc/parallelcluster/amazon-cloudwatch-agent/amazon-cloudwatch-agent.json"
 DEFAULT_METRICS_COLLECTION_INTERVAL = 60
 
 
@@ -45,6 +45,7 @@ def gethostname():
 
 def write_config(config):
     """Write config to AWS_CLOUDWATCH_CFG_PATH."""
+    os.makedirs(os.path.dirname(AWS_CLOUDWATCH_CFG_PATH), exist_ok=True)
     with open(AWS_CLOUDWATCH_CFG_PATH, "w+", encoding="utf-8") as output_config_file:
         json.dump(config, output_config_file, indent=4)
 

--- a/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/partial/_cloudwatch_common.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/partial/_cloudwatch_common.rb
@@ -163,6 +163,8 @@ action :configure do
     command "#{cookbook_virtualenv_path}/bin/python #{validator_script_path}"
   end unless redhat_on_docker?
 
+  CW_AGENT_CONFIG_JSON = '/etc/parallelcluster/amazon-cloudwatch-agent/amazon-cloudwatch-agent.json'
+
   execute "cloudwatch-config-creation" do
     user 'root'
     timeout 300
@@ -182,6 +184,6 @@ action :configure do
   execute "cloudwatch-agent-start" do
     user 'root'
     timeout 300
-    command "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s || /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
+    command "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c file:#{CW_AGENT_CONFIG_JSON} -s || /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:#{CW_AGENT_CONFIG_JSON} -s"
   end unless node['cluster']['cw_logging_enabled'] != 'true' || on_docker?
 end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/cloudwatch_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/cloudwatch_spec.rb
@@ -255,7 +255,7 @@ describe 'cloudwatch:configure' do
           is_expected.to run_execute("cloudwatch-agent-start").with(
             user: 'root',
             timeout: 300,
-            command: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s || /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
+            command: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c file:/etc/parallelcluster/amazon-cloudwatch-agent/amazon-cloudwatch-agent.json -s || /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/etc/parallelcluster/amazon-cloudwatch-agent/amazon-cloudwatch-agent.json -s"
           )
         end
       end
@@ -313,7 +313,7 @@ describe 'cloudwatch:configure' do
           is_expected.to run_execute("cloudwatch-agent-start").with(
             user: 'root',
             timeout: 300,
-            command: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s || /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
+            command: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c file:/etc/parallelcluster/amazon-cloudwatch-agent/amazon-cloudwatch-agent.json -s || /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/etc/parallelcluster/amazon-cloudwatch-agent/amazon-cloudwatch-agent.json -s"
           )
         end
       end


### PR DESCRIPTION
### Description of changes
Fix a race condition in CloudWatch Agent startup that could cause nodes bootstrap failures. 
To do that we simply need to move the staging configuration created by pcluster from `/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json` to `/etc/parallelcluster/amazon-cloudwatch-agent/amazon-cloudwatch-agent.json`.

**Why moving that file solves the race condition?**
We start the CloudWatch Agent by using `amazon-cloudwatch-agent-ctl`, providing as input the configuration file we author; see [code](https://github.com/aws/aws-parallelcluster-cookbook/blob/81c9d4e88cfd745275d3555471442fd2cc1a51c3/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/partial/_cloudwatch_common.rb#L184-L188). In particular we execute two times that command in two different modes, as safety net. However, that command assumes to have full control over directories in `/opt/aws/amazon-cloudwatch-agent/etc/`. In particular, there is a path in the code that may trigger the removal of files in that directory, thus removing the configuration file. So when the first command fails and the second one is execute, the config file provided as input may have been deleted by the first execution.

Moving the config file out of `/opt/aws/amazon-cloudwatch-agent/etc/` is the mitigation suggested by the CloudWatch team itself.


### Tests
* [SUCCESS] Cluster creation succeeded on Ubuntu24 (the OS where, for unknown reasons, this race condition occurred the most) and verified that logs are pushed to CloudWatch.
* [SUCCESS] `test_cloudwatch_logging`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
