### PR TITLE
Delete cluster name state file whenever slurm accounting is configured or updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Ubuntu 20.04 is no longer supported.
 - Upgrade Slurm to version 24.11.5.
+- Addressed cluster id mismatch known issue by deleting the file `/var/spool/slurm.state/clustername` before configuring Slurm accounting.
 - Upgrade DCV to version 2024.0-19030.
 - Remove `berkshelf`. All cookbooks are local and do not need `berkshelf` dependency management.
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
@@ -76,6 +76,10 @@ service "slurmdbd" do
   action action
 end unless on_docker?
 
+file "/var/spool/slurm.state/clustername" do
+  action "delete"
+end
+
 if node['cluster']['slurmdbd_service_enabled'] == "true"
   # After starting slurmdbd the database may not be fully responsive yet and
   # its bootstrapping may fail. We need to wait for sacctmgr to successfully
@@ -87,11 +91,6 @@ if node['cluster']['slurmdbd_service_enabled'] == "true"
     retries node['cluster']['slurmdbd_response_retries']
     retry_delay 10
   end unless kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")
-
-
-  file '/var/spool/slurm.state/clustername' do
-    action :delete
-  end
 
   bash "bootstrap slurm database" do
     user 'root'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
@@ -88,13 +88,9 @@ if node['cluster']['slurmdbd_service_enabled'] == "true"
     retry_delay 10
   end unless kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")
 
-  bash "Remove existing cluster name state file" do
-    user 'root'
-    group 'root'
-    code <<-CLUSTERSTATE
-      rm /var/spool/slurm.state/clustername
-    CLUSTERSTATE
-    only_if { ::File.exist?('/var/spool/slurm.state/clustername') }
+
+  file '/var/spool/slurm.state/clustername' do
+    action :delete
   end
 
   bash "bootstrap slurm database" do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
@@ -88,6 +88,15 @@ if node['cluster']['slurmdbd_service_enabled'] == "true"
     retry_delay 10
   end unless kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")
 
+  bash "Remove existing cluster name state file" do
+    user 'root'
+    group 'root'
+    code <<-CLUSTERSTATE
+      rm /var/spool/slurm.state/clustername
+    CLUSTERSTATE
+    only_if { ::File.exist?('/var/spool/slurm.state/clustername') }
+  end
+
   bash "bootstrap slurm database" do
     user 'root'
     group 'root'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/clear_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/clear_slurm_accounting.rb
@@ -24,11 +24,6 @@ service "slurmdbd" do
   action %i(disable stop)
 end
 
-bash "Remove existing cluster name state file" do
-  user 'root'
-  group 'root'
-  code <<-CLUSTERSTATE
-      rm /var/spool/slurm.state/clustername
-    CLUSTERSTATE
-  only_if { ::File.exist?('/var/spool/slurm.state/clustername') }
+file '/var/spool/slurm.state/clustername' do
+  action :delete
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/clear_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/clear_slurm_accounting.rb
@@ -23,3 +23,12 @@ service "slurmdbd" do
   supports restart: false
   action %i(disable stop)
 end
+
+bash "Remove existing cluster name state file" do
+  user 'root'
+  group 'root'
+  code <<-CLUSTERSTATE
+      rm /var/spool/slurm.state/clustername
+    CLUSTERSTATE
+  only_if { ::File.exist?('/var/spool/slurm.state/clustername') }
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/clear_slurm_accounting_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/clear_slurm_accounting_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::clear_slurm_accounting' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner = runner(platform: platform, version: version) do |node|
+          mock_file_exists("/var/spool/slurm.state/clustername", true)
+          node.override['cluster']['slurmdbd_service_enabled'] = true
+        end
+        runner.converge(described_recipe)
+      end
+      cached(:node) { chef_run.node }
+
+      it 'stops the slurm database daemon' do
+        is_expected.to disable_service("slurmdbd")
+      end
+
+      it 'deletes the Slurm database password update script' do
+        is_expected.to delete_file("#{node['cluster']['scripts_dir']}/slurm/update_slurm_database_password.sh")
+      end
+
+      it 'Removes existing cluster name state file' do
+        is_expected.to delete_file('/var/spool/slurm.state/clustername')
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurm_accounting_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurm_accounting_spec.rb
@@ -10,6 +10,7 @@ describe 'aws-parallelcluster-slurm::config_slurm_accounting' do
               allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
               allow_any_instance_of(Object).to receive(:dig).and_return(true)
               RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+              mock_file_exists("/var/spool/slurm.state/clustername", true)
               node.override['cluster']['slurmdbd_service_enabled'] = enable_service
             end
             runner.converge(described_recipe)
@@ -70,6 +71,9 @@ describe 'aws-parallelcluster-slurm::config_slurm_accounting' do
             )
           end
           if enable_service == "true"
+            it 'Removes existing cluster name state file' do
+              is_expected.to delete_file('/var/spool/slurm.state/clustername')
+            end
             it 'starts the slurm database daemon' do
               is_expected.to enable_service("slurmdbd")
               is_expected.to start_service("slurmdbd")


### PR DESCRIPTION
### Description of changes
* Covers slurm known error where cluster id saved in `/var/spool/slurm.state/clustername` does not match the cluster id that slurm dbd has 
* This fix needs to be in both `clear_slurm_accounting` and `config_slurm_accounting`
  * If a cluster is created without slurm accounting and then updated to have slurm accounting it will run `config_slurm_accounting` and have the cluster id mismatch
  * If a cluster is created with slurm accounting and then updated, it will run `clear_slurm_accounting` and have the cluster id mismatch
* Example error message:
```
[2025-07-10T00:54:46.362] fatal: CLUSTER ID MISMATCH.
slurmctld has been started with "ClusterID=4018"  from the state files in StateSaveLocation, but the DBD thinks it should be "3073".
Running multiple clusters from a shared StateSaveLocation WILL CAUSE CORRUPTION.
Remove /var/spool/slurm.state/clustername to override this safety check if this is intentional.
```

### Tests
* Created a new AMI with the cookbook changes and ran the `test_slurm_accounting` and `test_slurm integ` tests.
* Tested the if I have one job running and one job pending and then stop slurmctld and delete `/var/spool/slurm.state/clustername`, once I restart slurmctld, the slurm state remains the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
