### PR TITLE
Remove device name and ip address from required parameters of configure_nw_interfaces.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Addressed cluster id mismatch known issue by deleting the file `/var/spool/slurm.state/clustername` before configuring Slurm accounting.
 - Upgrade DCV to version 2024.0-19030.
 - Remove `berkshelf`. All cookbooks are local and do not need `berkshelf` dependency management.
+- Add support for GB200 instance types
 
 **BUG FIXES**
 - Fix a race condition in CloudWatch Agent startup that could cause nodes bootstrap failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Addressed cluster id mismatch known issue by deleting the file `/var/spool/slurm.state/clustername` before configuring Slurm accounting.
 - Upgrade DCV to version 2024.0-19030.
 - Remove `berkshelf`. All cookbooks are local and do not need `berkshelf` dependency management.
-- Add support for GB200 instance types
+- Add support for GB200 instance types.
 - Install nvidia-imex for all OSs except AL2.
 
 **BUG FIXES**

--- a/cookbooks/aws-parallelcluster-environment/files/amazon-2023/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/amazon-2023/network_interfaces/configure_nw_interface.sh
@@ -3,16 +3,27 @@
 set -ex
 
 if
-  [ -z "${DEVICE_NAME}" ] ||          # name of the device
   [ -z "${DEVICE_NUMBER}" ] ||       # index of the device
   [ -z "${NETWORK_CARD_INDEX}" ] ||   # index of the network card
-  [ -z "${DEVICE_IP_ADDRESS}" ] ||       # ip of the device
   [ -z "${MAC}" ] ||                 # mac address of the device
   [ -z "${CIDR_BLOCK}" ]                 # CIDR block of the subnet
 then
   echo 'One or more environment variables missing'
   exit 1
 fi
+
+# Check if this is an EFA-only interface (no device name or IP)
+if [ -z "${DEVICE_NAME}" ] && [ -z "${DEVICE_IP_ADDRESS}" ]; then
+  echo "EFA-only interface detected - skipping IP configuration"
+  exit 0
+fi
+
+# If one of these is missing but not both, it is an invalid configuration
+if [ -z "${DEVICE_NAME}" ] || [ -z "${DEVICE_IP_ADDRESS}" ]; then
+    echo "Device name or IP address is missing"
+    exit 1
+fi
+
 echo "Configuring NIC, Device name: ${DEVICE_NAME}, Device number: ${DEVICE_NUMBER}, Network card index:${NETWORK_CARD_INDEX}"
 
 configuration_directory="/etc/systemd/network"

--- a/cookbooks/aws-parallelcluster-environment/files/default/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/default/network_interfaces/configure_nw_interface.sh
@@ -22,6 +22,12 @@ then
   exit 1
 fi
 
+# Check if this is an EFA-only interface (no device name or IP)
+if [ -z "${DEVICE_NAME}" ] || [ -z "${DEVICE_IP_ADDRESS}" ]; then
+  echo "EFA-only interface detected - skipping IP configuration"
+  exit 0
+fi
+
 SUFFIX=$NETWORK_CARD_INDEX$(printf "%02d" $DEVICE_NUMBER)
 
 ROUTE_TABLE="$(( $SUFFIX + 1000 ))"

--- a/cookbooks/aws-parallelcluster-environment/files/default/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/default/network_interfaces/configure_nw_interface.sh
@@ -8,12 +8,13 @@
 
 set -e
 
+# commented out inputs are not required and don't exist for efa-only interfaces
 if
-  [ -z "${DEVICE_NAME}" ] ||          # name of the device
+#  [ -z "${DEVICE_NAME}" ] ||          # name of the device
   [ -z "${DEVICE_NUMBER}" ] ||        # index of the device
   [ -z "${NETWORK_CARD_INDEX}" ] ||   # index of the network card
   [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
-  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
+#  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
   [ -z "${CIDR_PREFIX_LENGTH}" ] ||   # the prefix length of the device IP cidr block
   [ -z "${NETMASK}" ]                 # netmask to apply to device ip address
 then

--- a/cookbooks/aws-parallelcluster-environment/files/default/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/default/network_interfaces/configure_nw_interface.sh
@@ -8,7 +8,6 @@
 
 set -e
 
-# commented out inputs that are not required and don't exist for efa-only interfaces
 if
   [ -z "${DEVICE_NUMBER}" ] ||        # index of the device
   [ -z "${NETWORK_CARD_INDEX}" ] ||   # index of the network card
@@ -21,9 +20,15 @@ then
 fi
 
 # Check if this is an EFA-only interface (no device name or IP)
-if [ -z "${DEVICE_NAME}" ] || [ -z "${DEVICE_IP_ADDRESS}" ]; then
+if [ -z "${DEVICE_NAME}" ] && [ -z "${DEVICE_IP_ADDRESS}" ]; then
   echo "EFA-only interface detected - skipping IP configuration"
   exit 0
+fi
+
+# If one of these is missing but not both, it is an invalid configuration
+if [ -z "${DEVICE_NAME}" ] || [ -z "${DEVICE_IP_ADDRESS}" ]; then
+    echo "One or more environment variables missing"
+    exit 1
 fi
 
 SUFFIX=$NETWORK_CARD_INDEX$(printf "%02d" $DEVICE_NUMBER)

--- a/cookbooks/aws-parallelcluster-environment/files/default/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/default/network_interfaces/configure_nw_interface.sh
@@ -6,7 +6,7 @@
 #   interface
 # - A routing rule to make the OS use the specific routing table for this network interface
 
-set -e
+set -ex
 
 if
   [ -z "${DEVICE_NUMBER}" ] ||        # index of the device
@@ -27,7 +27,7 @@ fi
 
 # If one of these is missing but not both, it is an invalid configuration
 if [ -z "${DEVICE_NAME}" ] || [ -z "${DEVICE_IP_ADDRESS}" ]; then
-    echo "One or more environment variables missing"
+    echo "Device name or IP address is missing"
     exit 1
 fi
 

--- a/cookbooks/aws-parallelcluster-environment/files/default/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/default/network_interfaces/configure_nw_interface.sh
@@ -8,13 +8,11 @@
 
 set -e
 
-# commented out inputs are not required and don't exist for efa-only interfaces
+# commented out inputs that are not required and don't exist for efa-only interfaces
 if
-#  [ -z "${DEVICE_NAME}" ] ||          # name of the device
   [ -z "${DEVICE_NUMBER}" ] ||        # index of the device
   [ -z "${NETWORK_CARD_INDEX}" ] ||   # index of the network card
   [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
-#  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
   [ -z "${CIDR_PREFIX_LENGTH}" ] ||   # the prefix length of the device IP cidr block
   [ -z "${NETMASK}" ]                 # netmask to apply to device ip address
 then

--- a/cookbooks/aws-parallelcluster-environment/files/redhat-8.network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/redhat-8.network_interfaces/configure_nw_interface.sh
@@ -9,18 +9,28 @@
 # RedHat 8 official documentation:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/configuring-policy-based-routing-to-define-alternative-routes_configuring-and-managing-networking
 
-set -e
+set -ex
 
 if
-  [ -z "${DEVICE_NAME}" ] ||          # name of the device
   [ -z "${DEVICE_NUMBER}" ] ||        # index of the device
   [ -z "${NETWORK_CARD_INDEX}" ] ||   # index of the network card
   [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
-  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
   [ -z "${CIDR_PREFIX_LENGTH}" ]      # the prefix length of the device IP cidr block
 then
   echo 'One or more environment variables missing'
   exit 1
+fi
+
+# Check if this is an EFA-only interface (no device name or IP)
+if [ -z "${DEVICE_NAME}" ] && [ -z "${DEVICE_IP_ADDRESS}" ]; then
+  echo "EFA-only interface detected - skipping IP configuration"
+  exit 0
+fi
+
+# If one of these is missing but not both, it is an invalid configuration
+if [ -z "${DEVICE_NAME}" ] || [ -z "${DEVICE_IP_ADDRESS}" ]; then
+    echo "Device name or IP address is missing"
+    exit 1
 fi
 
 con_name="System ${DEVICE_NAME}"

--- a/cookbooks/aws-parallelcluster-environment/files/rocky/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/rocky/network_interfaces/configure_nw_interface.sh
@@ -9,18 +9,28 @@
 # RedHat 8 official documentation:
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/configuring-policy-based-routing-to-define-alternative-routes_configuring-and-managing-networking
 
-set -e
+set -ex
 
 if
-  [ -z "${DEVICE_NAME}" ] ||          # name of the device
   [ -z "${DEVICE_NUMBER}" ] ||        # index of the device
   [ -z "${NETWORK_CARD_INDEX}" ] ||   # index of the network card
   [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
-  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
   [ -z "${CIDR_PREFIX_LENGTH}" ]      # the prefix length of the device IP cidr block
 then
   echo 'One or more environment variables missing'
   exit 1
+fi
+
+# Check if this is an EFA-only interface (no device name or IP)
+if [ -z "${DEVICE_NAME}" ] && [ -z "${DEVICE_IP_ADDRESS}" ]; then
+  echo "EFA-only interface detected - skipping IP configuration"
+  exit 0
+fi
+
+# If one of these is missing but not both, it is an invalid configuration
+if [ -z "${DEVICE_NAME}" ] || [ -z "${DEVICE_IP_ADDRESS}" ]; then
+    echo "Device name or IP address is missing"
+    exit 1
 fi
 
 con_name="System ${DEVICE_NAME}"

--- a/cookbooks/aws-parallelcluster-environment/files/ubuntu/network_interfaces/configure_nw_interface.sh
+++ b/cookbooks/aws-parallelcluster-environment/files/ubuntu/network_interfaces/configure_nw_interface.sh
@@ -6,20 +6,30 @@
 #   interface
 # - A routing rule to make the OS use the specific routing table for this network interface
 
-set -e
+set -ex
 
 if
-  [ -z "${DEVICE_NAME}" ] ||          # name of the device
   [ -z "${DEVICE_NUMBER}" ] ||        # index of the device
   [ -z "${NETWORK_CARD_INDEX}" ] ||   # index of the network card
   [ -z "${GW_IP_ADDRESS}" ] ||        # gateway ip address
-  [ -z "${DEVICE_IP_ADDRESS}" ] ||    # ip address to assign to the interface
   [ -z "${CIDR_PREFIX_LENGTH}" ] ||   # the prefix length of the device IP cidr block
   [ -z "${NETMASK}" ] ||              # netmask to apply to device ip address
   [ -z "${CIDR_BLOCK}" ]              # (full) subnet cidr block
 then
   echo 'One or more environment variables missing'
   exit 1
+fi
+
+# Check if this is an EFA-only interface (no device name or IP)
+if [ -z "${DEVICE_NAME}" ] && [ -z "${DEVICE_IP_ADDRESS}" ]; then
+  echo "EFA-only interface detected - skipping IP configuration"
+  exit 0
+fi
+
+# If one of these is missing but not both, it is an invalid configuration
+if [ -z "${DEVICE_NAME}" ] || [ -z "${DEVICE_IP_ADDRESS}" ]; then
+    echo "Device name or IP address is missing"
+    exit 1
 fi
 
 STATIC_IP_CONFIG=$(cat<<END


### PR DESCRIPTION
### Description of changes
* Remove device name and ip address from required parameters of `configure_nw_interfaces.sh`
* Device name and ip address do not exist for efa-only nw interfaces.
* This adds a check that is device name and ip address are not included, then it is an efa-only interface so the rest of the script is skipped.
* We use [ec2 instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) to get the parameters like ip address, network card index etc. This instance metadata does not have interface_type so we can not use it to see if it is efa-only. This limitation is why we are validating that it is efa-only using device_name and ip addess.

### Tests
* Ran 'test_multiple_nics` integration test

### References
* CLI change: https://github.com/aws/aws-parallelcluster/pull/6930

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
