### PR TITLE
Avoid Python re-installation if already installed

### DIFF
--- a/cookbooks/aws-parallelcluster-shared/resources/install_pyenv.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/install_pyenv.rb
@@ -53,5 +53,6 @@ action :run do
     make
     make install
     VENV
+    not_if { Dir.glob("#{prefix}/versions/#{python_version}/bin/python*").any? }
   end
 end


### PR DESCRIPTION
### Description of changes
This saves 8 minutes from build-image command

### Tests
build-image on all OSes except Ubuntu24 has passed. build-image on Ubuntu 24 failed for known unrelated reasons.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
