### PR TITLE
[IMEX] Remove unnecessary condition to skip creation of main and nodes config file.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
@@ -39,8 +39,7 @@ action :configure do
       owner 'root'
       group 'root'
       mode '0755'
-      action :create
-      not_if { file_exists_and_cluster_update?(nvidia_imex_nodes_conf_file) }
+      action :create_if_missing
     end
 
     template nvidia_imex_main_conf_file do
@@ -48,8 +47,7 @@ action :configure do
       owner 'root'
       group 'root'
       mode '0755'
-      action :create
-      not_if { file_exists_and_cluster_update?(nvidia_imex_main_conf_file) }
+      action :create_if_missing
       variables(imex_nodes_config_file_path: nvidia_imex_nodes_conf_file)
     end
 
@@ -91,10 +89,6 @@ end
 
 def nvidia_enabled_or_installed?
   nvidia_enabled? || nvidia_installed?
-end
-
-def file_exists_and_cluster_update?(file_path)
-  ::File.exist?(file_path) && !are_queues_updated?
 end
 
 def nvidia_imex_main_conf_file

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
@@ -336,12 +336,12 @@ describe 'nvidia_imex:configure' do
 
             if (platform == 'amazon' && version == '2') || %w(HeadNode LoginNode).include?(node_type)
               it 'does not configure nvidia-imex' do
-                is_expected.not_to create_template("#{nvidia_imex_shared_dir}/nodes_config_#{launch_template_id}.cfg")
+                is_expected.not_to create_if_missing_template("#{nvidia_imex_shared_dir}/nodes_config_#{launch_template_id}.cfg")
                   .with(source: 'nvidia-imex/nvidia-imex-nodes.erb')
                   .with(user: 'root')
                   .with(group: 'root')
                   .with(mode: '0755')
-                is_expected.not_to create_template("#{nvidia_imex_shared_dir}/config_#{launch_template_id}.cfg")
+                is_expected.not_to create_if_missing_template("#{nvidia_imex_shared_dir}/config_#{launch_template_id}.cfg")
                   .with(source: 'nvidia-imex/nvidia-imex-config.erb')
                   .with(user: 'root')
                   .with(group: 'root')
@@ -357,12 +357,12 @@ describe 'nvidia_imex:configure' do
               end
             else
               it 'it starts nvidia-imex service' do
-                is_expected.to create_template("#{nvidia_imex_shared_dir}/nodes_config_#{launch_template_id}.cfg")
+                is_expected.to create_if_missing_template("#{nvidia_imex_shared_dir}/nodes_config_#{launch_template_id}.cfg")
                   .with(source: 'nvidia-imex/nvidia-imex-nodes.erb')
                   .with(user: 'root')
                   .with(group: 'root')
                   .with(mode: '0755')
-                is_expected.to create_template("#{nvidia_imex_shared_dir}/config_#{launch_template_id}.cfg")
+                is_expected.to create_if_missing_template("#{nvidia_imex_shared_dir}/config_#{launch_template_id}.cfg")
                   .with(source: 'nvidia-imex/nvidia-imex-config.erb')
                   .with(user: 'root')
                   .with(group: 'root')


### PR DESCRIPTION
### Description of changes
Remove unnecessary condition to skip creation of main and nodes config file.
We figured out there is no reason to skip the configuration of IMEX config file when queues are updated.
The only relevant condition is to skip it when the files are already created because we do not want to overwrite configurations made by the user (or by an automation) on cluster create/update.

### Tests
* [SUCCEEDED] `test_gb200`
* Spec test (updated)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
