### PR TITLE
[SlurmTopo] Solve the update failures by defining when to update topology.conf

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -28,3 +28,4 @@ default['cluster']['pyxis']['runtime_path'] = '/run/pyxis'
 
 # Block Topology Plugin
 default['cluster']['slurm']['block_topology']['force_configuration'] = false
+default['cluster']['p6egb200_block_sizes'] = nil

--- a/cookbooks/aws-parallelcluster-slurm/resources/block_topology/partial/_block_topology_common.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/block_topology/partial/_block_topology_common.rb
@@ -63,10 +63,8 @@ def topology_generator_command_args
   if node['cluster']['p6egb200_block_sizes'].nil? && are_queues_updated? && ::File.exist?("#{node['cluster']['slurm']['install_dir']}/etc/topology.conf")
     # If topology.conf exist and Capacity Block is removed, we cleanup
     " --cleanup"
-  elsif node['cluster']['p6egb200_block_sizes'].nil? && !are_queues_updated?
-    # We do nothing if p6e-gb200 is not used and queues are not updated
-    nil
-  else
+  elsif !node['cluster']['p6egb200_block_sizes'].nil?
+    # We add/update topology.conf if p6egb200_block_sizes is not null
     " --block-sizes #{node['cluster']['p6egb200_block_sizes']}"
   end
 end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/resources/block_topology_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/resources/block_topology_spec.rb
@@ -154,11 +154,24 @@ describe 'block_topology:topology_generator_command_args' do
       cached(:chef_run) do
         runner(platform: platform, version: version, step_into: ['block_topology']) do |node|
           node.override['cluster']['p6egb200_block_sizes'] = nil
+          node.override['cluster']['slurm']['install_dir'] = slurm_install_dir
         end
       end
       cached(:resource) do
         ConvergeBlockTopology.update(chef_run)
         chef_run.find_resource('block_topology', 'update')
+      end
+
+      context "when queues are updated and topolog.conf does exists" do
+        before do
+          allow_any_instance_of(Object).to receive(:are_queues_updated?).and_return(true)
+          allow(File).to receive(:exist?).with("#{slurm_install_dir}/etc/topology.conf").and_return(true)
+          chef_run.node.override['cluster']['p6egb200_block_sizes'] = nil
+        end
+
+        it 'returns cleanup' do
+          expect(resource.topology_generator_command_args).to eq(" --cleanup")
+        end
       end
 
       context "when queues are not updated and topolog.conf does not exists" do
@@ -169,6 +182,18 @@ describe 'block_topology:topology_generator_command_args' do
 
         it 'it gives nil' do
           expect(resource.topology_generator_command_args).to eq(nil)
+        end
+      end
+
+      context "when queues are updated and topolog.conf does not exists" do
+        before do
+          allow_any_instance_of(Object).to receive(:are_queues_updated?).and_return(true)
+          allow(File).to receive(:exist?).with("#{slurm_install_dir}/etc/topology.conf").and_return(false)
+          chef_run.node.override['cluster']['p6egb200_block_sizes'] = block_sizes
+        end
+
+        it 'returns block-sizes argument' do
+          expect(resource.topology_generator_command_args).to eq(" --block-sizes #{block_sizes}")
         end
       end
 


### PR DESCRIPTION
### Description of changes
* Solve the update failures by defining when to update topology.conf only if `p6egb200_block_sizes` is not nil.
* Add a default value of p6egb200_block_sizes as nil

### Tests
* Unit Test 
* Successfully created a cluster and force updated the cluster. 
 ```
 DevSettings:
  Cookbook:
    ChefCookbook: https://github.com/himani2411/aws-parallelcluster-cookbook/tarball/slurm-topo-update-fix
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
