### PR TITLE
Add build-image support for kernel 6.12 of AL2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **ENHANCEMENTS**
 - Remove UnkillableStepTimeout from slurm.conf and let slurm set this value.
+- Add `build-image` support for kernel 6.12 of Amazon Linux 2023. The official ParallelCluster Amazon Linux 2023 AMIs use kernel 6.12.
 
 **CHANGES**
 - Ubuntu 20.04 is no longer supported.

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/nvidia_driver_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/nvidia_driver_alinux2023.rb
@@ -34,5 +34,9 @@ end
 
 def extra_packages
   kernel_version = node['kernel']['release'].chomp('.x86_64').chomp('.aarch64')
-  ["kernel-modules-extra-#{kernel_version}", "kernel-modules-extra-common"]
+  if kernel_version.start_with?("6.12.")
+    ["kernel6.12-modules-extra-#{kernel_version}", "kernel6.12-modules-extra-common"]
+  else
+    ["kernel-modules-extra-#{kernel_version}", "kernel-modules-extra-common"]
+  end
 end


### PR DESCRIPTION
### Description of changes
The kernel packages name patterns follow the official AL2023 doc https://docs.aws.amazon.com/linux/al2023/ug/kernel-update.html#al2023-kernel-faq

Although both 6.1 and 6.12 are actively supported, supporting p6e-GB200 requires kernel 6.12.

### Tests
* First stage build has been passed

### References
* CLI PR https://github.com/aws/aws-parallelcluster/pull/6951

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
