### PR TITLE
Add delay to slurm config spec test

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_config_spec.rb
@@ -46,7 +46,7 @@ control 'tag:config_slurm_correctly_installed_on_compute_node' do
   end
 
   describe 'check cgroup memory resource controller is enabled' do
-    subject { bash("grep memory /proc/cgroups | awk '{print $4}'") }
+    subject { bash("sleep 5 && grep memory /proc/cgroups | awk '{print $4}'") }
     its('exit_status') { should eq 0 }
     its('stdout.strip') { should cmp 1 }
   end


### PR DESCRIPTION
### Description of changes
* Add delay to slurm config spec test before checking the cgroup memory resource controller

### Tests
* Ran kitchen test

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
