### PR TITLE
[Gb200] Add NVIDIA-IMEX verbose and Stats logs to Cloudwatch Log Group

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
@@ -521,6 +521,40 @@
       "feature_conditions": []
     },
     {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/nvidia-imex-stats.log",
+      "log_stream_name": "nvidia-imex-stats",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "amazon",
+        "rocky",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet"
+      ],
+      "feature_conditions": []
+    },
+    {
+      "timestamp_format_key": "default",
+      "file_path": "/var/log/nvidia-imex-verbose.log",
+      "log_stream_name": "nvidia-imex-verbose",
+      "schedulers": [
+        "slurm"
+      ],
+      "platforms": [
+        "amazon",
+        "rocky",
+        "ubuntu"
+      ],
+      "node_roles": [
+        "ComputeFleet"
+      ],
+      "feature_conditions": []
+    },
+    {
       "timestamp_format_key": "json",
       "file_path": "/var/log/parallelcluster/slurm_health_check.events",
       "log_stream_name": "slurm_health_check_events",


### PR DESCRIPTION
### Description of changes
* Add NVIDIA-IMEX verbose and Stats logs to Cloudwatch Log Group
*  Adding specific OS that we support for Gb200

### Tests
* test_gb200

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
