### PR TITLE
[Gb200] Skip IMEX configuration File creation if the Directory does not exist

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -24,7 +24,9 @@ if platform?('amazon') && node['platform_version'] == "2"
 end
 
 # nvidia-imex
-default['cluster']['nvidia']['imex']['shared_dir'] = "#{node['cluster']['shared_dir']}/nvidia-imex"
+default['cluster']['nvidia']['imex']['conf_dir'] = "/etc/nvidia-imex"
+default['cluster']['nvidia']['imex']['main_config'] = "#{node['cluster']['nvidia']['imex']['conf_dir']}/config.cfg"
+default['cluster']['nvidia']['imex']['nodes_config'] = "#{node['cluster']['nvidia']['imex']['conf_dir']}/nodes_config.cfg"
 default['cluster']['nvidia']['imex']['force_configuration'] = false
 
 # NVIDIA NVLSM

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
@@ -19,53 +19,52 @@ action :install do
   return unless nvidia_enabled_or_installed?
   return if on_docker? || imex_installed? || aws_region.start_with?("us-iso")
 
-  # We are using the existence of this directory to verify if Imex was installed by ParallelCluster
-  directory node['cluster']['nvidia']['imex']['shared_dir']
-
   action_install_imex
+
+  action_create_configuration_files
   # Save Imex version in Node Attributes for InSpec Tests
   node.default['cluster']['nvidia']['imex']['version'] = nvidia_imex_full_version
   node.default['cluster']['nvidia']['imex']['package'] = nvidia_imex_package
   node_attributes 'dump node attributes'
 end
 
+action :create_configuration_files do
+  # We create or update IMEX configuration files if ParallelCluster is installing IMEX
+  template nvidia_imex_nodes_conf_file do
+    source 'nvidia-imex/nvidia-imex-nodes.erb'
+    owner 'root'
+    group 'root'
+    mode '0755'
+    action :create
+  end
+
+  template nvidia_imex_main_conf_file do
+    source 'nvidia-imex/nvidia-imex-config.erb'
+    owner 'root'
+    group 'root'
+    mode '0755'
+    action :create
+    variables(imex_nodes_config_file_path: nvidia_imex_nodes_conf_file)
+  end
+
+  # We keep nvidia-imex.service file in this location to give precedence to pcluster configured service file.
+  template "/etc/systemd/system/#{nvidia_imex_service}.service" do
+    source 'nvidia-imex/nvidia-imex.service.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    action :create
+    variables(imex_main_config_file_path: nvidia_imex_main_conf_file)
+  end
+end
+
 action :configure do
   return unless imex_installed? && node['cluster']['node_type'] == "ComputeFleet"
   # Start nvidia-imex on p6e-gb200 and only on ComputeFleet
-  if (is_gb200_node? && pcluster_installed_imex?) || enable_force_configuration?
-    # For each Compute Resource, we generate a unique NVIDIA IMEX configuration file,
-    # if one doesn't already exist in a common, shared location.
-    template nvidia_imex_nodes_conf_file do
-      source 'nvidia-imex/nvidia-imex-nodes.erb'
-      owner 'root'
-      group 'root'
-      mode '0755'
-      action :create_if_missing
-    end
-
-    template nvidia_imex_main_conf_file do
-      source 'nvidia-imex/nvidia-imex-config.erb'
-      owner 'root'
-      group 'root'
-      mode '0755'
-      action :create_if_missing
-      variables(imex_nodes_config_file_path: nvidia_imex_nodes_conf_file)
-    end
-
-    # We keep nvidia-imex.service file in this location to give precedence to pcluster configured service file.
-    template "/etc/systemd/system/#{nvidia_imex_service}.service" do
-      source 'nvidia-imex/nvidia-imex.service.erb'
-      owner 'root'
-      group 'root'
-      mode '0644'
-      action :create
-      variables(imex_main_config_file_path: nvidia_imex_main_conf_file)
-    end
-
+  if is_gb200_node? || enable_force_configuration?
     service nvidia_imex_service do
       action %i(enable start)
       supports status: true
-      only_if { ::File.exist?("/etc/systemd/system/#{nvidia_imex_service}.service") }
     end
   end
 end
@@ -95,18 +94,13 @@ def nvidia_enabled_or_installed?
 end
 
 def nvidia_imex_main_conf_file
-  "#{node['cluster']['nvidia']['imex']['shared_dir']}/config_#{node['cluster']['scheduler_queue_name']}_#{node['cluster']['scheduler_compute_resource_name']}.cfg"
+  "#{node['cluster']['nvidia']['imex']['main_config']}"
 end
 
 def nvidia_imex_nodes_conf_file
-  "#{node['cluster']['nvidia']['imex']['shared_dir']}/nodes_config_#{node['cluster']['scheduler_queue_name']}_#{node['cluster']['scheduler_compute_resource_name']}.cfg"
+  "#{node['cluster']['nvidia']['imex']['nodes_config']}"
 end
 
 def enable_force_configuration?
   ['true', 'yes', true].include?(node['cluster']['nvidia']['imex']['force_configuration'])
-end
-
-def pcluster_installed_imex?
-  # We configure Imex only if the shared directory exists
-  Dir.exist?(node['cluster']['nvidia']['imex']['shared_dir'])
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
@@ -19,6 +19,7 @@ action :install do
   return unless nvidia_enabled_or_installed?
   return if on_docker? || imex_installed? || aws_region.start_with?("us-iso")
 
+  # We are using the existence of this directory to verify if Imex was installed by ParallelCluster
   directory node['cluster']['nvidia']['imex']['shared_dir']
 
   action_install_imex
@@ -31,7 +32,7 @@ end
 action :configure do
   return unless imex_installed? && node['cluster']['node_type'] == "ComputeFleet"
   # Start nvidia-imex on p6e-gb200 and only on ComputeFleet
-  if is_gb200_node? || enable_force_configuration?
+  if (is_gb200_node? && pcluster_installed_imex?) || enable_force_configuration?
     # For each Compute Resource, we generate a unique NVIDIA IMEX configuration file,
     # if one doesn't already exist in a common, shared location.
     template nvidia_imex_nodes_conf_file do
@@ -51,6 +52,7 @@ action :configure do
       variables(imex_nodes_config_file_path: nvidia_imex_nodes_conf_file)
     end
 
+    # We keep nvidia-imex.service file in this location to give precedence to pcluster configured service file.
     template "/etc/systemd/system/#{nvidia_imex_service}.service" do
       source 'nvidia-imex/nvidia-imex.service.erb'
       owner 'root'
@@ -63,6 +65,7 @@ action :configure do
     service nvidia_imex_service do
       action %i(enable start)
       supports status: true
+      only_if { ::File.exist?("/etc/systemd/system/#{nvidia_imex_service}.service") }
     end
   end
 end
@@ -101,4 +104,9 @@ end
 
 def enable_force_configuration?
   ['true', 'yes', true].include?(node['cluster']['nvidia']['imex']['force_configuration'])
+end
+
+def pcluster_installed_imex?
+  # We configure Imex only if the shared directory exists
+  Dir.exist?(node['cluster']['nvidia']['imex']['shared_dir'])
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 nvidia_version = "1.2.3"
 SOURCE_DIR = 'SOURCE_DIR'.freeze
 nvidia_imex_shared_dir = "SHARED_DIR/nvidia-imex"
+imex_service_file = "/etc/systemd/system/nvidia-imex.service"
 imex_binary = '/usr/bin/nvidia-imex'
 imex_ctl_binary = '/usr/bin/nvidia-imex-ctl'
 queue_name = 'queue-name'
@@ -296,118 +297,152 @@ end
 
 describe 'nvidia_imex:configure' do
   [%w(false), [false], %w(no), %w(true), [true], %w(yes)].each do |force_indicator|
-    for_all_oses do |platform, version|
-      context "on #{platform}#{version} with force_configuration #{force_indicator}" do
-        context "when nvidia-imex binary is not installed" do
-          cached(:chef_run) do
-            stubs_for_resource('nvidia_imex') do |res|
-              allow(res).to receive(:imex_installed?).and_return(false)
-            end
-            runner = runner(platform: platform, version: version, step_into: ['nvidia_imex'])
-            ConvergeNvidiaImex.configure(runner)
-          end
-          cached(:node) { chef_run.node }
-
-          it 'does not configure nvidia-imex' do
-            is_expected.not_to configure_nvidia_imex('nvidia-imex')
-          end
-        end
-
-        %w(HeadNode LoginNode ComputeFleet).each do |node_type|
-          context "when get_nvswitch_count > 1 on #{node_type} node" do
-            cached(:chef_run) do
-              stubs_for_provider('nvidia_imex[configure]') do |pro|
-                allow(pro).to receive(:imex_installed?).and_return(true)
-                allow(pro).to receive(:get_device_ids).and_return({ 'gb200' => 'test' })
-                allow(pro).to receive(:get_nvswitch_count).with('test').and_return(4)
-                allow(pro).to receive(:enable_force_configuration?).and_return(force_indicator)
+    [true, false].each do |shared_dir_exists|
+      [true, false].each do |imex_service_file_exists|
+        for_all_oses do |platform, version|
+          context "on #{platform}#{version} with force_configuration #{force_indicator} with shared_dir existence #{shared_dir_exists}" do
+            context "when nvidia-imex binary is not installed" do
+              cached(:chef_run) do
+                stubs_for_resource('nvidia_imex') do |res|
+                  allow(res).to receive(:imex_installed?).and_return(false)
+                  allow(Dir).to receive(:exist?).with(nvidia_imex_shared_dir).and_return(shared_dir_exists)
+                  allow(File).to receive(:exist?).with(imex_service_file).and_return(imex_service_file_exists)
+                end
+                runner = runner(platform: platform, version: version, step_into: ['nvidia_imex'])
+                ConvergeNvidiaImex.configure(runner)
               end
-              runner(platform: platform, version: version, step_into: ['nvidia_imex'])
-            end
-            cached(:node) { chef_run.node }
+              cached(:node) { chef_run.node }
 
-            before do
-              chef_run.node.override['cluster']['region'] = 'aws_region'
-              chef_run.node.override['cluster']['nvidia']['imex']['force_configuration'] = force_indicator
-              chef_run.node.override['cluster']['nvidia']['imex']['shared_dir'] = nvidia_imex_shared_dir
-              chef_run.node.override['cluster']['node_type'] = node_type
-              chef_run.node.override['cluster']['scheduler_queue_name'] = queue_name
-              chef_run.node.override['cluster']['scheduler_compute_resource_name'] = compute_resource_name
-
-              ConvergeNvidiaImex.configure(chef_run)
-            end
-
-            if (platform == 'amazon' && version == '2') || %w(HeadNode LoginNode).include?(node_type)
               it 'does not configure nvidia-imex' do
-                is_expected.not_to create_if_missing_template("#{nvidia_imex_shared_dir}/nodes_config_#{queue_name}_#{compute_resource_name}.cfg")
-                  .with(source: 'nvidia-imex/nvidia-imex-nodes.erb')
-                  .with(user: 'root')
-                  .with(group: 'root')
-                  .with(mode: '0755')
-                is_expected.not_to create_if_missing_template("#{nvidia_imex_shared_dir}/config_#{queue_name}_#{compute_resource_name}.cfg")
-                  .with(source: 'nvidia-imex/nvidia-imex-config.erb')
-                  .with(user: 'root')
-                  .with(group: 'root')
-                  .with(mode: '0755')
-                  .with(variables: { imex_nodes_config_file_path: "#{nvidia_imex_shared_dir}/nodes_config_#{queue_name}_#{compute_resource_name}.cfg" })
-                is_expected.not_to create_template("/etc/systemd/system/nvidia-imex.service")
-                  .with(source: 'nvidia-imex/nvidia-imex.service.erb')
-                  .with(user: 'root')
-                  .with(group: 'root')
-                  .with(mode: '0644')
-                  .with(variables: { imex_main_config_file_path: "#{nvidia_imex_shared_dir}/config_#{queue_name}_#{compute_resource_name}.cfg" })
-                is_expected.not_to start_service('nvidia-imex').with_action(%i(enable start)).with_supports({ status: true })
-              end
-            else
-              it 'it starts nvidia-imex service' do
-                is_expected.to create_if_missing_template("#{nvidia_imex_shared_dir}/nodes_config_#{queue_name}_#{compute_resource_name}.cfg")
-                  .with(source: 'nvidia-imex/nvidia-imex-nodes.erb')
-                  .with(user: 'root')
-                  .with(group: 'root')
-                  .with(mode: '0755')
-                is_expected.to create_if_missing_template("#{nvidia_imex_shared_dir}/config_#{queue_name}_#{compute_resource_name}.cfg")
-                  .with(source: 'nvidia-imex/nvidia-imex-config.erb')
-                  .with(user: 'root')
-                  .with(group: 'root')
-                  .with(mode: '0755')
-                  .with(variables: { imex_nodes_config_file_path: "#{nvidia_imex_shared_dir}/nodes_config_#{queue_name}_#{compute_resource_name}.cfg" })
-                is_expected.to create_template("/etc/systemd/system/nvidia-imex.service")
-                  .with(source: 'nvidia-imex/nvidia-imex.service.erb')
-                  .with(user: 'root')
-                  .with(group: 'root')
-                  .with(mode: '0644')
-                  .with(variables: { imex_main_config_file_path: "#{nvidia_imex_shared_dir}/config_#{queue_name}_#{compute_resource_name}.cfg" })
-                is_expected.to start_service('nvidia-imex').with_action(%i(enable start)).with_supports({ status: true })
+                is_expected.not_to configure_nvidia_imex('nvidia-imex')
               end
             end
-          end
-        end
 
-        context "when get_nvswitch_count <= 1" do
-          cached(:chef_run) do
-            stubs_for_provider('nvidia_imex[configure]') do |pro|
-              allow(pro).to receive(:imex_installed?).and_return(true)
-              allow(pro).to receive(:get_device_ids).and_return({ 'gb200' => 'test' })
-              allow(pro).to receive(:get_nvswitch_count).with('test').and_return(1)
-              allow(pro).to receive(:enable_force_configuration?).and_return(force_indicator)
+            %w(HeadNode LoginNode ComputeFleet).each do |node_type|
+              context "when get_nvswitch_count > 1 on #{node_type} node" do
+                cached(:chef_run) do
+                  stubs_for_provider('nvidia_imex[configure]') do |pro|
+                    allow(pro).to receive(:imex_installed?).and_return(true)
+                    allow(pro).to receive(:get_device_ids).and_return({ 'gb200' => 'test' })
+                    allow(pro).to receive(:get_nvswitch_count).with('test').and_return(4)
+                    allow(pro).to receive(:enable_force_configuration?).and_return(force_indicator)
+                    allow(Dir).to receive(:exist?).with(nvidia_imex_shared_dir).and_return(shared_dir_exists)
+                    allow(File).to receive(:exist?).with(imex_service_file).and_return(imex_service_file_exists)
+                  end
+                  runner(platform: platform, version: version, step_into: ['nvidia_imex'])
+                end
+                cached(:node) { chef_run.node }
+
+                before do
+                  chef_run.node.override['cluster']['region'] = 'aws_region'
+                  chef_run.node.override['cluster']['nvidia']['imex']['force_configuration'] = force_indicator
+                  chef_run.node.override['cluster']['nvidia']['imex']['shared_dir'] = nvidia_imex_shared_dir
+                  chef_run.node.override['cluster']['node_type'] = node_type
+                  chef_run.node.override['cluster']['scheduler_queue_name'] = queue_name
+                  chef_run.node.override['cluster']['scheduler_compute_resource_name'] = compute_resource_name
+
+                  ConvergeNvidiaImex.configure(chef_run)
+                end
+
+                if (platform == 'amazon' && version == '2') || %w(HeadNode LoginNode).include?(node_type)
+                  it 'does not configure nvidia-imex' do
+                    is_expected.not_to create_if_missing_template("#{nvidia_imex_shared_dir}/nodes_config_#{queue_name}_#{compute_resource_name}.cfg")
+                      .with(source: 'nvidia-imex/nvidia-imex-nodes.erb')
+                      .with(user: 'root')
+                      .with(group: 'root')
+                      .with(mode: '0755')
+                    is_expected.not_to create_if_missing_template("#{nvidia_imex_shared_dir}/config_#{queue_name}_#{compute_resource_name}.cfg")
+                      .with(source: 'nvidia-imex/nvidia-imex-config.erb')
+                      .with(user: 'root')
+                      .with(group: 'root')
+                      .with(mode: '0755')
+                      .with(variables: { imex_nodes_config_file_path: "#{nvidia_imex_shared_dir}/nodes_config_#{queue_name}_#{compute_resource_name}.cfg" })
+                    is_expected.not_to create_template(imex_service_file)
+                      .with(source: 'nvidia-imex/nvidia-imex.service.erb')
+                      .with(user: 'root')
+                      .with(group: 'root')
+                      .with(mode: '0644')
+                      .with(variables: { imex_main_config_file_path: "#{nvidia_imex_shared_dir}/config_#{queue_name}_#{compute_resource_name}.cfg" })
+                    is_expected.not_to start_service('nvidia-imex').with_action(%i(enable start)).with_supports({ status: true })
+                  end
+                else
+                  it 'it starts nvidia-imex service' do
+                    if shared_dir_exists
+                      is_expected.to create_if_missing_template("#{nvidia_imex_shared_dir}/nodes_config_#{queue_name}_#{compute_resource_name}.cfg")
+                        .with(source: 'nvidia-imex/nvidia-imex-nodes.erb')
+                        .with(user: 'root')
+                        .with(group: 'root')
+                        .with(mode: '0755')
+                      is_expected.to create_if_missing_template("#{nvidia_imex_shared_dir}/config_#{queue_name}_#{compute_resource_name}.cfg")
+                        .with(source: 'nvidia-imex/nvidia-imex-config.erb')
+                        .with(user: 'root')
+                        .with(group: 'root')
+                        .with(mode: '0755')
+                        .with(variables: { imex_nodes_config_file_path: "#{nvidia_imex_shared_dir}/nodes_config_#{queue_name}_#{compute_resource_name}.cfg" })
+                      is_expected.to create_template(imex_service_file)
+                        .with(source: 'nvidia-imex/nvidia-imex.service.erb')
+                        .with(user: 'root')
+                        .with(group: 'root')
+                        .with(mode: '0644')
+                        .with(variables: { imex_main_config_file_path: "#{nvidia_imex_shared_dir}/config_#{queue_name}_#{compute_resource_name}.cfg" })
+                    else
+                      is_expected.not_to create_if_missing_template("#{nvidia_imex_shared_dir}/nodes_config_#{queue_name}_#{compute_resource_name}.cfg")
+                        .with(source: 'nvidia-imex/nvidia-imex-nodes.erb')
+                        .with(user: 'root')
+                        .with(group: 'root')
+                        .with(mode: '0755')
+                      is_expected.not_to create_if_missing_template("#{nvidia_imex_shared_dir}/config_#{queue_name}_#{compute_resource_name}.cfg")
+                        .with(source: 'nvidia-imex/nvidia-imex-config.erb')
+                        .with(user: 'root')
+                        .with(group: 'root')
+                        .with(mode: '0755')
+                        .with(variables: { imex_nodes_config_file_path: "#{nvidia_imex_shared_dir}/nodes_config_#{queue_name}_#{compute_resource_name}.cfg" })
+                      is_expected.not_to create_template(imex_service_file)
+                        .with(source: 'nvidia-imex/nvidia-imex.service.erb')
+                        .with(user: 'root')
+                        .with(group: 'root')
+                        .with(mode: '0644')
+                        .with(variables: { imex_main_config_file_path: "#{nvidia_imex_shared_dir}/config_#{queue_name}_#{compute_resource_name}.cfg" })
+                        if imex_service_file_exists
+                          is_expected.to start_service('nvidia-imex').with_action(%i(enable start)).with_supports({ status: true })
+                        else
+                          is_expected.not_to start_service('nvidia-imex').with_action(%i(enable start)).with_supports({ status: true })
+                        end
+                    end
+                  end
+                end
+              end
             end
-            runner = runner(platform: platform, version: version, step_into: ['nvidia_imex'])
-            ConvergeNvidiaImex.configure(runner)
-          end
-          cached(:node) { chef_run.node }
 
-          before do
-            chef_run.node.override['cluster']['region'] = 'aws_region'
-            chef_run.node.override['cluster']['nvidia']['imex']['force_configuration'] = force_indicator
-          end
+            context "when get_nvswitch_count <= 1" do
+              cached(:chef_run) do
+                stubs_for_provider('nvidia_imex[configure]') do |pro|
+                  allow(pro).to receive(:imex_installed?).and_return(true)
+                  allow(pro).to receive(:get_device_ids).and_return({ 'gb200' => 'test' })
+                  allow(pro).to receive(:get_nvswitch_count).with('test').and_return(1)
+                  allow(pro).to receive(:enable_force_configuration?).and_return(force_indicator)
+                  allow(Dir).to receive(:exist?).with(nvidia_imex_shared_dir).and_return(shared_dir_exists)
+                  allow(File).to receive(:exist?).with(imex_service_file).and_return(imex_service_file_exists)
+                end
+                runner = runner(platform: platform, version: version, step_into: ['nvidia_imex'])
+                ConvergeNvidiaImex.configure(runner)
+              end
+              cached(:node) { chef_run.node }
 
-          if ['true', 'yes', true].include?(force_indicator)
-            it 'does configure nvidia-imex' do
-              is_expected.to start_service('nvidia-imex').with_action(%i(enable start)).with_supports({ status: true })
-            end
-          else
-            it 'does not configure nvidia-imex' do
-              is_expected.not_to start_service('nvidia-imex').with_action(%i(enable start)).with_supports({ status: true })
+              before do
+                chef_run.node.override['cluster']['region'] = 'aws_region'
+                chef_run.node.override['cluster']['nvidia']['imex']['force_configuration'] = force_indicator
+              end
+
+              if ['true', 'yes', true].include?(force_indicator) && imex_service_file_exists
+                it 'does configure nvidia-imex' do
+                  is_expected.to start_service('nvidia-imex').with_action(%i(enable start)).with_supports({ status: true })
+                end
+              else
+                it 'does not configure nvidia-imex' do
+                  is_expected.not_to start_service('nvidia-imex').with_action(%i(enable start)).with_supports({ status: true })
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
### Description of changes - OLDER NOTES NEED TO BE UPDATED


Skip IMEX configuration File creation if the Directory does not exist
* We create the Directory as part of AMI creation
* Skip starting Imex service if the service file does not exist.
Without this change we see below error
```
* template[/opt/parallelcluster/shared/nvidia-imex/nodes_config_q1_cr1.cfg] action create_if_missing[2025-09-18T00:59:55+00:00] INFO: Processing template[/opt/parallelcluster/shared/nvidia-imex/nodes_config_q1_cr1.cfg] action create_if_missing (aws-parallelcluster-platform::nvidia_config line 37)
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]: 
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]:      * Parent directory /opt/parallelcluster/shared/nvidia-imex does not exist.
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]:      ================================================================================
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]:      Error executing action `create_if_missing` on resource 'template[/opt/parallelcluster/shared/nvidia-imex/nodes_config_q1_cr1.cfg]'
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]:      ================================================================================
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]: 
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]:      Chef::Exceptions::EnclosingDirectoryDoesNotExist
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]:      ------------------------------------------------
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]:      Parent directory /opt/parallelcluster/shared/nvidia-imex does not exist.
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]: 
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]:      Resource Declaration:
Sep 18 01:00:00 ip-172-31-42-141 user-data[28237]:      ---------------------
```
* in DLAMI the service file is at `/usr/lib/systemd/system/nvidia-imex.service` and they do not configure `/etc/nvidia-imex/nodes_config.cfg` so we should not enable the service as well
 ```
* ○ nvidia-imex.service - NVIDIA IMEX service
     Loaded: loaded (/usr/lib/systemd/system/nvidia-imex.service; enabled; preset: disabled)
     Active: inactive (dead) since Thu 2025-09-18 17:54:33 UTC; 1h 7min ago
   Duration: 2ms
    Process: 2284 ExecStart=/usr/bin/nvidia-imex -c /etc/nvidia-imex/config.cfg (code=exited, status=0/SUCCESS)
   Main PID: 2371 (code=exited, status=0/SUCCESS)
        CPU: 21ms

Sep 18 17:54:31 ip-172-31-69-32.ec2.internal systemd[1]: Starting nvidia-imex.service - NVIDIA IMEX service...
Sep 18 17:54:33 ip-172-31-69-32.ec2.internal systemd[1]: Started nvidia-imex.service - NVIDIA IMEX service.
Sep 18 17:54:33 ip-172-31-69-32.ec2.internal systemd[1]: nvidia-imex.service: Deactivated successfully.
```
### Tests
* [ONGOING] test_gb200 with Custom AMI 

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
