### PR TITLE
Add --no-drm flag to nvidia installation

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/nvidia_driver_ubuntu22+.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/nvidia_driver_ubuntu22+.rb
@@ -22,6 +22,12 @@ def rebuild_initramfs?
   true
 end
 
+def drm
+  if node['platform_version'].to_i == 24
+    '--no-drm '
+  end
+end
+
 def set_compiler?
   true
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
@@ -79,7 +79,7 @@ action :setup do
     cwd '/tmp'
     code <<-NVIDIA
       set -e
-      #{compiler_path} ./nvidia.run --silent --dkms #{drm}--disable-nouveau -m=#{nvidia_kernel_module}
+      #{compiler_path} ./nvidia.run --silent --dkms --disable-nouveau -m=#{nvidia_kernel_module} --ui=none --no-questions
       rm -f /tmp/nvidia.run
     NVIDIA
     creates '/usr/bin/nvidia-smi'

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
@@ -79,7 +79,7 @@ action :setup do
     cwd '/tmp'
     code <<-NVIDIA
       set -e
-      #{compiler_path} ./nvidia.run --silent --dkms --disable-nouveau -m=#{nvidia_kernel_module}
+      #{compiler_path} ./nvidia.run --silent --dkms #{drm}--disable-nouveau -m=#{nvidia_kernel_module}
       rm -f /tmp/nvidia.run
     NVIDIA
     creates '/usr/bin/nvidia-smi'
@@ -89,6 +89,10 @@ action :setup do
     command 'update-initramfs -u'
     only_if 'lsinitramfs /boot/initrd.img-$(uname -r) | grep nouveau'
   end if rebuild_initramfs?
+end
+
+def drm
+  ''
 end
 
 def _nvidia_driver_version

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
@@ -249,6 +249,8 @@ describe 'nvidia_driver:setup' do
             end
           end
 
+          drm = platform == 'ubuntu' && version == '24' ? '--no-drm' : ''
+
           it 'installs nvidia driver' do
             is_expected.to run_bash('nvidia.run advanced')
               .with(
@@ -257,7 +259,7 @@ describe 'nvidia_driver:setup' do
                 cwd: '/tmp',
                 creates: '/usr/bin/nvidia-smi'
               )
-              .with_code(%r{CC=/usr/bin/gcc10-gcc ./nvidia.run --silent --dkms --disable-nouveau -m=#{kernel_module}})
+              .with_code(%r{CC=/usr/bin/gcc10-gcc ./nvidia.run --silent --dkms #{drm} --disable-nouveau -m=#{kernel_module}})
               .with_code(%r{rm -f /tmp/nvidia.run})
           end
         elsif platform == 'ubuntu' && version == '22.04'


### PR DESCRIPTION
### Description of changes
* Add --no-drm flag to nvidia installation
* First stage build for ubuntu24 was failing with the following error:
```
ERROR: The nvidia-drm kernel module failed to load. This kernel module is required for the proper operation of DRM-KMS. If you do not need to use DRM-KMS, you can try to install this driver package again with the '--no-drm' option.
2025-10-01 07:41:45.660000
```

### Tests
* Ran first stage build

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
