### PR TITLE
[Performance] Remove cfn-hup from compute nodes as a temporary mitigation to restore good performance.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/supervisord_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/supervisord_config_spec.rb
@@ -70,7 +70,6 @@ describe 'aws-parallelcluster-platform::supervisord_config' do
 
         it 'has the correct content' do
           is_expected.to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')
-            .with_content("[program:cfn-hup]")
             .with_content("[program:computemgtd]")
 
           is_expected.not_to render_file('/etc/parallelcluster/parallelcluster_supervisord.conf')

--- a/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/supervisord/parallelcluster_supervisord.conf.erb
@@ -2,7 +2,7 @@
 # Local modifications could be overwritten.
 <%# HeadNode, ComputeFleet, LoginNode -%>
 <% case node['cluster']['node_type'] -%>
-<% when 'HeadNode', 'ComputeFleet', 'LoginNode' -%>
+<% when 'HeadNode', 'LoginNode' -%>
 [program:cfn-hup]
 command = <%= node['cluster']['scripts_dir']%>/cfn-hup-runner.sh
 autorestart = true


### PR DESCRIPTION
**IMPORTANT NOTE** This change is not meant to be merged to develop or release branches. 
This is a temporary mitigation that will be vended as a custom cookbook to address a performance degradation. 
This change solves a major performance degradation, **but comes with the cost of removing the support for cluster updates.**

### Description of changes
Remove cfn-hup from compute nodes as a temporary mitigation to restore good performance.
Running cfn-hup on compute nodes can cause a major performance degradation on large clusters.
This change will be vended as a custom cookbook to mitigate the performance degradation.


* Describe *what* you're changing and *why* you're doing these changes.

### Tests
* Cluster creation succeeds
* Validated that this change is enough to fix a 20-30% performance degradation on a production weather forecasting workload on large cluster (198 nodes).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
