### PR TITLE
[Tools] In the utility to upload cookbook: include GitRef as artifact suffix where it was missing.

### DIFF
--- a/util/upload-cookbook.sh
+++ b/util/upload-cookbook.sh
@@ -107,7 +107,7 @@ main() {
     fi
     aws ${_profile} --region "${_region}" s3 cp aws-parallelcluster-cookbook-${_version}-${GIT_REF}.tgz s3://${_bucket}/${_key_path}/aws-parallelcluster-cookbook-${_version}-${GIT_REF}.tgz || _error_exit 'Failed to push cookbook to S3'
     aws ${_profile} --region "${_region}" s3 cp aws-parallelcluster-cookbook-${_version}-${GIT_REF}.md5 s3://${_bucket}/${_key_path}/aws-parallelcluster-cookbook-${_version}-${GIT_REF}.md5 || _error_exit 'Failed to push cookbook md5 to S3'
-    aws ${_profile} --region "${_region}" s3api head-object --bucket ${_bucket} --key ${_key_path}/aws-parallelcluster-cookbook-${_version}.tgz --output text --query LastModified > aws-parallelcluster-cookbook-${_version}-${GIT_REF}.tgz.date || _error_exit 'Failed to fetch LastModified date'
+    aws ${_profile} --region "${_region}" s3api head-object --bucket ${_bucket} --key ${_key_path}/aws-parallelcluster-cookbook-${_version}-${GIT_REF}.tgz --output text --query LastModified > aws-parallelcluster-cookbook-${_version}-${GIT_REF}.tgz.date || _error_exit 'Failed to fetch LastModified date'
     aws ${_profile} --region "${_region}" s3 cp aws-parallelcluster-cookbook-${_version}-${GIT_REF}.tgz.date s3://${_bucket}/${_key_path}/aws-parallelcluster-cookbook-${_version}-${GIT_REF}.tgz.date || _error_exit 'Failed to push cookbook date'
 
     _bucket_region=$(aws ${_profile} s3api get-bucket-location --bucket ${_bucket} --output text)
@@ -122,7 +122,7 @@ main() {
     echo ""
     echo "DevSettings:"
     echo "  Cookbook:"
-    echo "    ChefCookbook: s3://${_bucket}/${_key_path}/aws-parallelcluster-cookbook-${_version}.tgz"
+    echo "    ChefCookbook: s3://${_bucket}/${_key_path}/aws-parallelcluster-cookbook-${_version}-${GIT_REF}.tgz"
 }
 
 main "$@"


### PR DESCRIPTION
### Description of changes
In the utility to upload cookbook: include GitRef as artifact suffix where it was missing.
In https://github.com/aws/aws-parallelcluster-cookbook/commit/c5515b0d38fffbd6befe82620a3f080fa07bf800#diff-7ec838352b1d179da98dd4e7e7cbdc5d05afbb3ef9c6ae7eeb91c4dedfe94379 we added the gitref as artifact suffix. There were couple of places where we should do it to keep the names aligned.

Without this change, the tool fails the check on object existance and prints the wrong devsettings.

### Tests
Used to upload custom cookbook. Now the head request succeeds and the printed devsettings is correct

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
