### PR TITLE
[SlurmDbd] Adding a message to make sure that we do not use # in DB Password

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_slurm_database_password.sh.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/head_node/update_slurm_database_password.sh.erb
@@ -30,6 +30,11 @@ fi
 echo "Reading password from AWS Secrets Manager: ${SECRET_ARN}"
 password_from_secrets_manager=$(aws secretsmanager get-secret-value --secret-id ${SECRET_ARN} --region ${REGION} --query 'SecretString' --output text)
 
+if [[ "${password_from_secrets_manager}" =~ '#' ]]; then
+  echo "You cannot use the # character in the database password as Slurm does not support it with $SLURMDBD_PROPERTY configuration paramter in $SLURMDBD_CONFIG_FILE. Please refer to the official SchedMD documentation for more details."
+  exit 1
+fi
+
 [ "${password_from_dbd_config}" == "${password_from_secrets_manager}" ] && echo "Password match, skipping update" && exit 0
 
 echo "Writing AWS Secrets Manager password to ${SLURMDBD_CONFIG_FILE}"


### PR DESCRIPTION
### Description of changes
* Fail fast with a message which specifies # is not allowed in slurm dbd configuration files.
* As per https://slurm.schedmd.com/slurmdbd.conf.html
> StoragePass
Define the password used to gain access to the database to store the job accounting data. The '#' character is not permitted in a password.

When running manually
```
sudo ./update_slurm_database_password.sh
Reading password from /opt/slurm/etc/slurm_parallelcluster_slurmdbd.conf
Reading password from AWS Secrets Manager: arn:aws:secretsmanager:ap-south-1:447714826191:secret:AccountingClusterAdminSecre-xImvFgSN8JqP-BXWv1l
You cannot use the # character in the database password as Slurm does not support it with StoragePass configuration paramter in /opt/slurm/etc/slurm_parallelcluster_slurmdbd.conf. You can get more details in https://slurm.schedmd.com/slurmdbd.conf.html
[ec2-user@ip-192-168-0-190 slurm]$
```


Related to https://github.com/aws/aws-parallelcluster/issues/5437
### Tests
* Script Test 
*  test_slurm_accounting 


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
