### PR TITLE
[Dependencies] Reduce dependency footprint by installing only sssd-common rather than sssd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Add chef attribute `cluster/in_place_update_on_fleet_enabled` to disable in-place updates on compute and login nodes
    and achieve better performance at scale. 
-- Load kernel module `drm_client_lib` before installation of NVIDIA driver, if available on the kernel.
+- Load kernel module `drm_client_lib` before installation of NVIDIA driver, if available on the kernel. 
+- Reduce dependency footprint by installing the package `sssd-common` rather than `sssd`.
+
 
 3.14.0
 ------

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_debian.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_debian.rb
@@ -25,6 +25,6 @@ end
 
 action_class do
   def required_packages
-    %w(sssd sssd-tools sssd-ldap)
+    %w(sssd-common sssd-tools sssd-ldap)
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_alinux2.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_alinux2.rb
@@ -19,6 +19,6 @@ use 'partial/_system_authentication_alinux_centos'
 
 action_class do
   def required_packages
-    %w(sssd sssd-tools sssd-ldap authconfig)
+    %w(sssd-common sssd-tools sssd-ldap authconfig)
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_alinux2023.rb
@@ -21,6 +21,6 @@ use 'partial/_system_authentication_alinux_centos'
 
 action_class do
   def required_packages
-    %w(sssd sssd-tools sssd-ldap authconfig)
+    %w(sssd-common sssd-tools sssd-ldap authconfig)
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_redhat8.rb
@@ -36,6 +36,6 @@ end
 
 action_class do
   def required_packages
-    %w(sssd sssd-tools sssd-ldap authselect oddjob-mkhomedir)
+    %w(sssd-common sssd-tools sssd-ldap authselect oddjob-mkhomedir)
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_rocky8.rb
@@ -36,6 +36,6 @@ end
 
 action_class do
   def required_packages
-    %w(sssd sssd-tools sssd-ldap authselect oddjob-mkhomedir)
+    %w(sssd-common sssd-tools sssd-ldap authselect oddjob-mkhomedir)
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/system_authentication_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/system_authentication_spec.rb
@@ -24,11 +24,11 @@ describe 'system_authentication:setup' do
       cached(:required_packages) do
         case platform
         when 'amazon', 'centos'
-          %w(sssd sssd-tools sssd-ldap authconfig)
+          %w(sssd-common sssd-tools sssd-ldap authconfig)
         when 'redhat', 'rocky'
-          %w(sssd sssd-tools sssd-ldap authselect oddjob-mkhomedir)
+          %w(sssd-common sssd-tools sssd-ldap authselect oddjob-mkhomedir)
         else
-          %w(sssd sssd-tools sssd-ldap)
+          %w(sssd-common sssd-tools sssd-ldap)
         end
       end
       cached(:chef_run) do

--- a/cookbooks/aws-parallelcluster-environment/test/controls/system_authentication_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/system_authentication_spec.rb
@@ -12,7 +12,7 @@
 control 'tag:install_system_authentication_packages_installed' do
   title 'Check that system authentication packages are installed correctly'
 
-  packages = %w(sssd sssd-tools sssd-ldap)
+  packages = %w(sssd-common sssd-tools sssd-ldap)
 
   if os_properties.redhat8?
     packages.append("authselect")


### PR DESCRIPTION
### Description of changes
Reduce dependency footprint by installing only sssd-common rather than sssd.
sssd contains sssd-common + other packages that we do not need. 
We identified this improvement just now because those unnecessary extra packages were temporarily unavailable in the RHEL repository.

### Tests
Manually verified that I can create a RHEL8 cluster integrated with an external MsAD using a custom ami that only has sssd-common installed rather than sssd.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
