### PR TITLE
Fix github system test on Ubuntu22 and 24

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/partial/_cloudwatch_install_package_debian.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/cloudwatch/partial/_cloudwatch_install_package_debian.rb
@@ -1,7 +1,7 @@
 action :cloudwatch_install_package do
   dpkg_package package_path do
     source package_path
-  end
+  end unless on_docker?
 end
 
 action_class do

--- a/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cloudwatch_spec.rb
@@ -36,7 +36,7 @@ control 'tag:install_cloudwatch_packaged_installed' do
   title "Check if cloudwatch package is installed"
   describe package('amazon-cloudwatch-agent') do
     it { should be_installed }
-  end
+  end unless os_properties.ubuntu_on_docker?
 end
 
 control 'tag:config_cloudwatch_configured' do

--- a/cookbooks/aws-parallelcluster-shared/test/libraries/os_properties.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/libraries/os_properties.rb
@@ -36,6 +36,10 @@ class OsProperties < Inspec.resource(1)
     inspec.os.name == 'ubuntu'
   end
 
+  def ubuntu_on_docker?
+    on_docker? && ubuntu?
+  end
+
   def redhat8?
     redhat? && inspec.os.release.to_i == 8
   end


### PR DESCRIPTION
### Description of changes
* Systemtest started to fail on Ubuntu22 and 24 since https://github.com/aws/aws-parallelcluster-cookbook/actions/runs/18596560524/job/53024225638?pr=3034, which did not modify anything related to the error:
```
       ---- Begin output of ["dpkg", "-i", "/opt/parallelcluster/sources/amazon-cloudwatch-agent.deb"] ----
       STDOUT: Selecting previously unselected package amazon-cloudwatch-agent.
       (Reading database ... 98810 files and directories currently installed.)
       Preparing to unpack .../amazon-cloudwatch-agent.deb ...
       create group cwagent, result: 0
       create user cwagent, result: 0
       Unpacking amazon-cloudwatch-agent (1.300060.0b1248-1) ...
       Setting up amazon-cloudwatch-agent (1.300060.0b1248-1) ...
       STDERR: /usr/bin/systemctl: 4: [: unexpected operator
       sysv-init is not supported
       dpkg: error processing package amazon-cloudwatch-agent (--install):
        installed amazon-cloudwatch-agent package post-installation script subprocess returned error exit status 1
       Errors were encountered while processing:
        amazon-cloudwatch-agent
       ---- End output of ["dpkg", "-i", "/opt/parallelcluster/sources/amazon-cloudwatch-agent.deb"] ----
       Ran ["dpkg", "-i", "/opt/parallelcluster/sources/amazon-cloudwatch-agent.deb"] returned 1
```
This is likely due to an upgrade in docker or CloudWatch agent. Anyway, our build image, which does not rely on Docker, continues to succeed. Therefore, this PR skips CloudWatch agent installation on Ubuntu on Docker

### Tests
* System test on Ubuntu has passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
