### PR TITLE
[PMIX] Revert PMIX to 5.0.6 & install sssd-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.15.0
+------
+
 3.14.1
 ------
 
@@ -10,6 +13,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Add chef attribute `cluster/in_place_update_on_fleet_enabled` to disable in-place updates on compute and login nodes
    and achieve better performance at scale. 
 - Load kernel module `drm_client_lib` before installation of NVIDIA driver, if available on the kernel.
+- Reduce dependency footprint by installing the package `sssd-common` rather than `sssd`.
 - Upgrade Slurm to version 24.11.7 (from 24.11.6).
 - Upgrade Pmix to 5.0.9 (from 5.0.6).
 - Upgrade libjwt to version 1.18.4 (from 1.17.0) for all OSs except Amazon Linux 2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
-3.15.0
-------
-
 3.14.1
 ------
 
@@ -15,7 +12,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Load kernel module `drm_client_lib` before installation of NVIDIA driver, if available on the kernel.
 - Reduce dependency footprint by installing the package `sssd-common` rather than `sssd`.
 - Upgrade Slurm to version 24.11.7 (from 24.11.6).
-- Upgrade Pmix to 5.0.9 (from 5.0.6).
 - Upgrade libjwt to version 1.18.4 (from 1.17.0) for all OSs except Amazon Linux 2.
 - Upgrade amazon-efs-utils to version 2.4.0 (from v2.3.1).
 - Upgrade EFA installer to 1.44.0 (from 1.43.2).

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_debian.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_debian.rb
@@ -25,6 +25,6 @@ end
 
 action_class do
   def required_packages
-    %w(sssd sssd-tools sssd-ldap)
+    %w(sssd-common sssd-tools sssd-ldap)
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_alinux2.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_alinux2.rb
@@ -19,6 +19,6 @@ use 'partial/_system_authentication_alinux_centos'
 
 action_class do
   def required_packages
-    %w(sssd sssd-tools sssd-ldap authconfig)
+    %w(sssd-common sssd-tools sssd-ldap authconfig)
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_alinux2023.rb
@@ -21,6 +21,6 @@ use 'partial/_system_authentication_alinux_centos'
 
 action_class do
   def required_packages
-    %w(sssd sssd-tools sssd-ldap authconfig)
+    %w(sssd-common sssd-tools sssd-ldap authconfig)
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_redhat8.rb
@@ -36,6 +36,6 @@ end
 
 action_class do
   def required_packages
-    %w(sssd sssd-tools sssd-ldap authselect oddjob-mkhomedir)
+    %w(sssd-common sssd-tools sssd-ldap authselect oddjob-mkhomedir)
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/system_authentication_rocky8.rb
@@ -36,6 +36,6 @@ end
 
 action_class do
   def required_packages
-    %w(sssd sssd-tools sssd-ldap authselect oddjob-mkhomedir)
+    %w(sssd-common sssd-tools sssd-ldap authselect oddjob-mkhomedir)
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/system_authentication_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/system_authentication_spec.rb
@@ -24,11 +24,11 @@ describe 'system_authentication:setup' do
       cached(:required_packages) do
         case platform
         when 'amazon', 'centos'
-          %w(sssd sssd-tools sssd-ldap authconfig)
+          %w(sssd-common sssd-tools sssd-ldap authconfig)
         when 'redhat', 'rocky'
-          %w(sssd sssd-tools sssd-ldap authselect oddjob-mkhomedir)
+          %w(sssd-common sssd-tools sssd-ldap authselect oddjob-mkhomedir)
         else
-          %w(sssd sssd-tools sssd-ldap)
+          %w(sssd-common sssd-tools sssd-ldap)
         end
       end
       cached(:chef_run) do

--- a/cookbooks/aws-parallelcluster-environment/test/controls/system_authentication_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/system_authentication_spec.rb
@@ -12,7 +12,7 @@
 control 'tag:install_system_authentication_packages_installed' do
   title 'Check that system authentication packages are installed correctly'
 
-  packages = %w(sssd sssd-tools sssd-ldap)
+  packages = %w(sssd-common sssd-tools sssd-ldap)
 
   if os_properties.redhat8?
     packages.append("authselect")

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -13,8 +13,8 @@ default["cluster"]["scheduler_compute_resource_name"] = nil
 default['cluster']['enable_nss_slurm'] = node['cluster']['directory_service']['enabled']
 
 # PMIX Version and Checksum
-default['cluster']['pmix']['version'] = '5.0.9'
-default['cluster']['pmix']['sha256'] = '11b9911aadaac590e5b02749caa618837de9fb644183c1bdc04378b54bf396bb'
+default['cluster']['pmix']['version'] = '5.0.6'
+default['cluster']['pmix']['sha256'] = '5a5e0cd36067144e2171d59164d59ea478a2e540ccf4eee4530f55fc6e8cf78b'
 
 # Slurmdbd
 default['cluster']['slurmdbd_service_enabled'] = "true"


### PR DESCRIPTION
### Description of changes
* Cherry pick https://github.com/aws/aws-parallelcluster-cookbook/pull/3046
* [Revert the PMIX ersion from 5.09 to ](https://github.com/aws/aws-parallelcluster-cookbook/commit/bef143fd2798fa24140fcc18d1857c98bb5a7741)

### Tests
Test_essential_features

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
