### PR TITLE
[Build] Mitigate the impact of out-of-sync repo mirrors in Rocky and RHEL by refreshing local cache + add retries to flaky kitchen test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 3.15.0
 ------
 
+**CHANGES**
+- Mitigate the risk of transient build-image failures in RHEL and Rocky caused by out-of-sync repo mirrors.
+
 **BUG FIXES**
 - Fix timestamp formats in CloudWatch log configuration to let CloudWatch parse the correct timestamps.
 - Fix an issue that was blocking the logging of slurm health check events.

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_redhat8.rb
@@ -17,7 +17,7 @@ provides :install_packages, platform: 'redhat' do |node|
 end
 
 use 'partial/_install_packages_common.rb'
-use 'partial/_install_packages_rhel_amazon.rb'
+use 'partial/_install_packages_rhel_rocky.rb'
 
 def default_packages
   # environment-modules required by EFA, Intel MPI and ARM PL

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/install_packages_rocky8.rb
@@ -17,7 +17,7 @@ provides :install_packages, platform: 'rocky' do |node|
 end
 
 use 'partial/_install_packages_common.rb'
-use 'partial/_install_packages_rhel_amazon.rb'
+use 'partial/_install_packages_rhel_rocky.rb'
 
 def default_packages
   # environment-modules required by EFA, Intel MPI and ARM PL

--- a/cookbooks/aws-parallelcluster-platform/resources/install_packages/partial/_install_packages_rhel_rocky.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/install_packages/partial/_install_packages_rhel_rocky.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+#
+# Copyright:: 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+action :install do
+  ruby_block 'install_packages_with_metadata_refresh' do
+    block do
+      packages = Array(new_resource.packages)
+
+      Chef::Log.info("Installing packages: #{packages.join(', ')}")
+
+      on_retry = lambda do |_attempt, _exception|
+        # This cleanup forces DNF to re-evaluate available mirrors
+        # and which mirror to use on the next attempt.
+        run_cmd('dnf clean metadata')
+      end
+
+      with_retries(
+        max_retries: 10,
+        retry_delay: 5,
+        on_retry: on_retry
+      ) do
+        # --refresh forces DNF to refresh the metadata from the mirror it's currently using.
+        run_cmd("dnf install -y --refresh #{packages.join(' ')}", raise_on_error: true)
+        Chef::Log.info("Package installation succeeded")
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/install_packages_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/install_packages_spec.rb
@@ -32,11 +32,17 @@ describe 'install_packages:setup' do
       end
 
       if %w(amazon centos redhat rocky).include?(platform)
-        it 'installs default packages' do
-          is_expected.to install_package(default_packages)
-            .with(retries: 10)
-            .with(retry_delay: 5)
-            .with(flush_cache: { before: true })
+        if platform == 'amazon'
+          it 'installs default packages' do
+            is_expected.to install_package(default_packages)
+              .with(retries: 10)
+              .with(retry_delay: 5)
+              .with(flush_cache: { before: true })
+          end
+        else
+          it 'installs default packages with mirror refresh retry logic' do
+            is_expected.to run_ruby_block('install_packages_with_metadata_refresh')
+          end
         end
 
         if platform == 'amazon' && version == '2'

--- a/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
@@ -117,3 +117,72 @@ end
 def cluster_readiness_check_on_update_enabled?
   node['cluster']['in_place_update_on_fleet_enabled'] == 'true'
 end
+
+# Executes a block with retry logic for handling transient failures.
+#
+# @param max_retries [Integer] Maximum number of retry attempts (default: 10)
+# @param retry_delay [Integer] Seconds to wait between retries (default: 5)
+# @param on_retry [Proc] Optional callback executed after each failed attempt (receives attempt number and exception)
+# @yield The block to execute with retry protection
+# @raise [StandardError] Re-raises the last exception if all retries are exhausted
+#
+# @example Basic usage
+#   with_retries do
+#     some_flaky_operation
+#   end
+#
+# @example Advanced usage
+#   with_retries(max_retries: 5, retry_delay: 10, on_retry: ->(attempt, e) { cleanup }) do
+#     some_flaky_operation
+#   end
+#
+def with_retries(max_retries: 10, retry_delay: 5, on_retry: nil)
+  last_exception = nil
+
+  max_retries.times do |attempt|
+    begin
+      return yield
+    rescue StandardError => e
+      last_exception = e
+      Chef::Log.error("Attempt #{attempt + 1}/#{max_retries} failed: #{e.message}")
+
+      if attempt < max_retries - 1
+        if on_retry
+          Chef::Log.info("Executing on_retry callback...")
+          begin
+            on_retry.call(attempt, e)
+          rescue StandardError => retry_error
+            Chef::Log.error("on_retry callback failed (ignored): #{retry_error.message}")
+          end
+        end
+        Chef::Log.info("Sleeping #{retry_delay}s before next attempt...")
+        sleep retry_delay
+      end
+    end
+  end
+
+  Chef::Log.error("All #{max_retries} retry attempts exhausted")
+  raise last_exception
+end
+
+# Executes a shell command with logging of command, exit status, stdout, and stderr.
+#
+# @param cmd [String] The shell command to execute
+# @param timeout [Integer] Command timeout in seconds (default: nil)
+# @param raise_on_error [Boolean] If true, raises exception on non-zero exit (default: false)
+# @return [Mixlib::ShellOut] The shell_out result object
+#
+# @example Basic usage (non-raising)
+#   run_cmd('dnf clean metadata')
+#
+# @example With timeout and raise on error
+#   run_cmd('dnf install -y package', timeout: 600, raise_on_error: true)
+#
+def run_cmd(cmd, timeout: nil, raise_on_error: false)
+  Chef::Log.info("Executing: #{cmd}")
+  result = raise_on_error ? shell_out!(cmd, timeout: timeout) : shell_out(cmd, timeout: timeout)
+  Chef::Log.info("Exit status: #{result.exitstatus}")
+  Chef::Log.info("Stdout: #{result.stdout}") unless result.stdout.strip.empty?
+  Chef::Log.info("Stderr: #{result.stderr}") unless result.stderr.strip.empty?
+  result
+end


### PR DESCRIPTION
### Description of changes
Mitigate the impact of out-of-sync repo mirrors in Rocky and RHEL by refreshing local cache at every failure.
The strategy to mitigate consists in two steps:
1. Execute dns install with --refresh option to force DNF to re-download metadata from the mirror it's currently using. 
1. Cleanup DNF metadata at every retry to force DNF to re-evaluate available mirrors and select another one the next attempt.

To mitigate this issue I introduced an utility function to wrap code with retries and custom callback between retries, which could be helpful also in other flaky scenarios.

### Tests
1. Build image on all supported OS, which includes the execution of the flaky kitchen test.
1. Injected fault to trigger the retry logic: example of output
```
Stdout:       * ruby_block[install_packages_with_metadata_refresh] action run[2026-01-07T18:10:40+00:00] INFO: Processing ruby_block[install_packages_with_metadata_refresh] action run (aws-parallelcluster-platform::install line 27)
Stdout: [2026-01-07T18:10:40+00:00] INFO: Installing packages: vim, ...
Stdout: [2026-01-07T18:10:40+00:00] WARN: TESTING: Injecting artificial failure on attempt 1
Stdout: [2026-01-07T18:10:40+00:00] ERROR: Attempt 1/10 failed: Artificial failure for testing retry mechanism (attempt 1)
Stdout: [2026-01-07T18:10:40+00:00] INFO: Executing custom on_retry callback...
Stdout: [2026-01-07T18:10:40+00:00] INFO: Executing: dnf clean metadata --quiet
Stdout: [2026-01-07T18:10:40+00:00] INFO: Exit status: 0
Stdout: [2026-01-07T18:10:40+00:00] INFO: Sleeping 5 seconds before next attempt...
Stdout: [2026-01-07T18:10:45+00:00] WARN: TESTING: Injecting artificial failure on attempt 2
Stdout: [2026-01-07T18:10:45+00:00] ERROR: Attempt 2/10 failed: Artificial failure for testing retry mechanism (attempt 2)
Stdout: [2026-01-07T18:10:45+00:00] INFO: Executing custom on_retry callback...
Stdout: [2026-01-07T18:10:45+00:00] INFO: Executing: dnf clean metadata --quiet
Stdout: [2026-01-07T18:10:46+00:00] INFO: Exit status: 0
Stdout: [2026-01-07T18:10:46+00:00] INFO: Sleeping 5 seconds before next attempt...
Stdout: [2026-01-07T18:10:51+00:00] INFO: Executing: dnf install -y --refresh vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf libtool httpd boost-devel mlocate R atlas-devel blas-devel libffi-devel dkms libedit-devel jq libical-devel sendmail libxml2-devel libglvnd-devel libgcrypt-devel libevent-devel glibc-static bind-utils iproute NetworkManager-config-routing-rules python3 python3-pip iptables libcurl-devel yum-plugin-versionlock coreutils moreutils curl environment-modules gcc gcc-c++ bzip2 dos2unix
Stdout: [2026-01-07T18:14:21+00:00] INFO: Exit status: 0
Stdout: [2026-01-07T18:14:21+00:00] INFO: Stdout: Updating Subscription Management repositories.
Stdout: Unable to read consumer identity
Stdout: 
Stdout: This system is not registered with an entitlement server. You can use subscription-manager to register.
Stdout: 
Stdout: Extra Packages for 8 - x86_64                    37 MB/s |  14 MB     00:00    
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
