### PR TITLE
[Test] Mock cookbook virtualenv for Docker tests on AL 2023.

### DIFF
--- a/cookbooks/aws-parallelcluster-tests/recipes/docker_mock.rb
+++ b/cookbooks/aws-parallelcluster-tests/recipes/docker_mock.rb
@@ -74,6 +74,60 @@ if redhat_on_docker?
   end
 end
 
+if alinux2023_on_docker?
+  # Create pcluster-admin user and group
+  group 'pcluster-admin' do
+    gid 400
+  end
+
+  user 'pcluster-admin' do
+    uid 400
+    gid 400
+    home '/home/pcluster-admin'
+    shell '/bin/bash'
+  end
+
+  # Create required directories
+  directory '/opt/parallelcluster/shared' do
+    recursive true
+  end
+
+  # Install Python 3.12 for AL2023 Docker tests
+  package 'python3.12'
+  package 'python3.12-pip'
+
+  # Mock python environment for AL2023 Docker tests
+  # The pyenv/virtualenv setup doesn't work in Docker because it requires S3 access
+  python_version = node['cluster']['python-version']
+  pyenv_root = node['cluster']['system_pyenv_root']
+  virtualenv_path = "#{pyenv_root}/versions/#{python_version}/envs/cookbook_virtualenv"
+
+  directory "#{virtualenv_path}/bin" do
+    recursive true
+  end
+
+  # Create a wrapper script that reports the expected version but uses system Python
+  file "#{virtualenv_path}/bin/python" do
+    content %(#!/bin/bash
+if [[ "$1" == "-V" || "$1" == "--version" ]]; then
+  echo "Python #{python_version}"
+else
+  exec /usr/bin/python3.12 "$@"
+fi
+)
+    mode '0755'
+  end
+
+  link "#{virtualenv_path}/bin/pip" do
+    to '/usr/bin/pip3.12'
+  end
+
+  bash 'Install cookbook requirements for AL2023' do
+    cwd Chef::Config[:file_cache_path]
+    code "/usr/bin/python3.12 -m pip install -r cookbooks/aws-parallelcluster-platform/files/cookbook_virtualenv/requirements.txt"
+  end
+end
+
 file '/usr/bin/ssh-keyscan' do
   content %(
     #!/bin/bash


### PR DESCRIPTION
### Description of changes
Mock cookbook virtualenv for Docker tests on AL 2023.
This is required to execute system tests on Docker for AL 2023 that depend on the cookbook virtualenv, such as the CloudWatch Agent tests.

This change fixes the PR check failure on AL23 ([example](https://github.com/aws/aws-parallelcluster-cookbook/actions/runs/20178487592/job/57932625984?pr=3063):

```
       [2025-12-12T20:22:32+00:00] FATAL: Errno::ENOENT: cloudwatch[Configure CloudWatch] (aws-parallelcluster-environment::init line 16) had an error: Errno::ENOENT: execute[cloudwatch-config-validation] (aws-parallelcluster-environment::init line 156) had an error: Errno::ENOENT: No such file or directory - /opt/parallelcluster/pyenv/versions/3.12.11/envs/cookbook_virtualenv/bin/python
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Converge failed on instance <slurm-config-head-node-x86-64-docker-alinux-2023>.  Please see .kitchen/logs/slurm-config-head-node-x86-64-docker-alinux-2023.log for more details
```

**NOTE** The recursive-deletion-check was reporting a false positive, so it is safe to skip it. It was complaining because in the Docker mock I am creating the directory tree with option `recursive true`. The check complains about it because it thinks it is used for deletion, but in this case it is used for creation, which is fine.

### Tests
* PR checks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
