### PR TITLE
[Test] Package `fftw*` now installed on AL2023 because the Desktop gr…

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
@@ -20,7 +20,9 @@ control 'tag:install_install_packages' do
   end unless instance.custom_ami? || os_properties.alinux2023? || os_properties.ubuntu2404?
   # Need to change the jq --argfile commands as its deprecated in 1.7( latest)
 
-  unless os_properties.centos7?
+  # NOTE: Skipped on AL2023 because the Desktop group (installed for DCV) now pulls in
+  # ImageMagick-libs which depends on fftw-libs-double
+  unless os_properties.centos7? || os_properties.alinux2023?
     # Verify fftw package is not installed
     describe bash('ls 2>/dev/null /usr/lib64/libfftw*') do
       its('stdout') { should be_empty }


### PR DESCRIPTION
### Description of changes
* [Test] Package `fftw*` now installed on AL2023 because the Desktop group (installed for DCV) now pulls in ImageMagick which requires this package. So we skip this check in our spec tests


without this the change the build fails for 
```
2025-12-12 01:06:01.816000	Stdout: [38;5;9m  Ã—  tag:install_install_packages: Test installation of packages (1 failed)[0m
2025-12-12 01:06:01.816000	Stdout: [38;5;41m     âœ”  System Package hostname is expected to be installed[0m
2025-12-12 01:06:01.816000	Stdout: [38;5;9m     Ã—  Bash command ls 2>/dev/null /usr/lib64/libfftw* stdout is expected to be empty
2025-12-12 01:06:01.817000	Stdout:      expected `"/usr/lib64/libfftw3.so.3\n/usr/lib64/libfftw3.so.3.5.8\n/usr/lib64/libfftw3_omp.so.3\n/usr/lib64/libfftw3_omp.so.3.5.8\n/usr/lib64/libfftw3_threads.so.3\n/usr/lib64/libfftw3_threads.so.3.5.8\n".empty?` to be truthy, got false[0m
```

### Tests
```
[ec2-user@ip-172-31-34-169 ~]$ sudo dnf repoquery --whatrequires fftw-libs-double
Last metadata expiration check: 1 day, 16:46:05 ago on Thu Dec 11 04:08:43 2025.
ImageMagick-c++-1:6.9.12.77-1.amzn2023.0.1.aarch64
ImageMagick-c++-1:6.9.12.82-1.amzn2023.0.1.aarch64
ImageMagick-c++-1:6.9.12.82-1.amzn2023.0.10.aarch64
ImageMagick-c++-1:6.9.12.82-1.amzn2023.0.11.aarch64

[ec2-user@ip-172-31-34-169 ~]$ sudo dnf groupinstall "Desktop" --assumeno 2>&1 | grep -i imagemagick
 ImageMagick-libs                          aarch64  1:6.9.13.29-1.amzn2023.0.2      amazonlinux  2.3 M
[ec2-user@ip-172-31-34-169 ~]$
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
