### PR TITLE
Do not count missing records as a failure of the cluster readiness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Rdma-core: rdma-core-59.0-1
   - Open MPI: openmpi40-aws-4.1.7-2 and openmpi50-aws-5.0.8-11
 
+**BUG FIXES**
+- Prevent cluster readiness check failures due to instances launched while the check is in progress.
+
 3.14.0
 ------
 

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
@@ -114,7 +114,8 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
 
         if incomplete or wrong:
             raise CheckFailedError(
-                f"Check failed due to the following erroneous records:\n"
+                f"Check failed due to the following erroneous records "
+                f"(missing records are not counted for the failure):\n"
                 f"  * missing records ({len(missing)}): {missing}\n"
                 f"  * incomplete records ({len(incomplete)}): {incomplete}\n"
                 f"  * wrong records ({len(wrong)}): {wrong}"

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
@@ -112,13 +112,16 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
 
         missing, incomplete, wrong = _check_cluster_config_items(instance_ids, items, expected_config_version)
 
-        if missing or incomplete or wrong:
+        if incomplete or wrong:
             raise CheckFailedError(
                 f"Check failed due to the following erroneous records:\n"
                 f"  * missing records ({len(missing)}): {missing}\n"
                 f"  * incomplete records ({len(incomplete)}): {incomplete}\n"
                 f"  * wrong records ({len(wrong)}): {wrong}"
             )
+        if missing:
+            logger.warning(f"Ignoring the following missing records due them being recently bootstrapped:\n"
+                           f"  *  missing records ({len(missing)}): {missing}")
         logger.info("Verified cluster configuration for cluster node(s) %s", instance_ids)
 
 

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
@@ -120,8 +120,12 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
                 f"  * wrong records ({len(wrong)}): {wrong}"
             )
         if missing:
-            logger.warning(f"Ignoring the following missing records due them being recently bootstrapped:\n"
-                           f"  *  missing records ({len(missing)}): {missing}")
+            logger.warning(
+                "Ignoring the following missing records due them being recently bootstrapped:\n"
+                "  *  missing records (%s): %s",
+                len(missing),
+                missing,
+            )
         logger.info("Verified cluster configuration for cluster node(s) %s", instance_ids)
 
 

--- a/test/unit/head_node_checks/test_check_cluster_ready.py
+++ b/test/unit/head_node_checks/test_check_cluster_ready.py
@@ -93,7 +93,7 @@ def _mocked_request_batch_get_items(table_name: str, compute_nodes: [str], ddb_r
                 "i-cmp123456789": {"UNEXPECTED_KEY_A": {"S": "UNEXPECTED_KEY_VALUE_A"}},
                 "i-lgn123456789": {"UNEXPECTED_KEY_B": {"S": "UNEXPECTED_KEY_VALUE_B"}},
             },
-            "Check failed due to the following erroneous records:\n"
+            "Check failed due to the following erroneous records (missing records are not counted for the failure):\n"
             "  * missing records (0): []\n"
             "  * incomplete records (2): ['i-cmp123456789', 'i-lgn123456789']\n"
             "  * wrong records (0): []",
@@ -106,7 +106,7 @@ def _mocked_request_batch_get_items(table_name: str, compute_nodes: [str], ddb_r
                 "i-cmp123456789": {"cluster_config_version": {"S": "WRONG_CLUSTER_CONFIG_VERSION_A"}},
                 "i-lgn123456789": {"cluster_config_version": {"S": "WRONG_CLUSTER_CONFIG_VERSION_B"}},
             },
-            "Check failed due to the following erroneous records:\n"
+            "Check failed due to the following erroneous records (missing records are not counted for the failure):\n"
             "  * missing records (0): []\n"
             "  * incomplete records (0): []\n"
             "  * wrong records (2): [('i-cmp123456789', 'WRONG_CLUSTER_CONFIG_VERSION_A'), "
@@ -124,7 +124,7 @@ def _mocked_request_batch_get_items(table_name: str, compute_nodes: [str], ddb_r
                 "i-cmp1234567893": {"cluster_config_version": {"S": "WRONG_CLUSTER_CONFIG_VERSION_A"}},
                 "i-lgn1234567893": {"cluster_config_version": {"S": "WRONG_CLUSTER_CONFIG_VERSION_B"}},
             },
-            "Check failed due to the following erroneous records:\n"
+            "Check failed due to the following erroneous records (missing records are not counted for the failure):\n"
             "  * missing records (2): ['i-cmp1234567894', 'i-lgn1234567894']\n"
             "  * incomplete records (2): ['i-cmp1234567892', 'i-lgn1234567892']\n"
             "  * wrong records (2): [('i-cmp1234567893', 'WRONG_CLUSTER_CONFIG_VERSION_A'), "

--- a/test/unit/head_node_checks/test_check_cluster_ready.py
+++ b/test/unit/head_node_checks/test_check_cluster_ready.py
@@ -83,10 +83,7 @@ def _mocked_request_batch_get_items(table_name: str, compute_nodes: [str], ddb_r
             ["i-cmp123456789"],
             ["i-lgn123456789"],
             {},
-            "Check failed due to the following erroneous records:\n"
-            "  * missing records (2): ['i-cmp123456789', 'i-lgn123456789']\n"
-            "  * incomplete records (0): []\n"
-            "  * wrong records (0): []",
+            None,
             id="Check with missing DDB records",
         ),
         pytest.param(


### PR DESCRIPTION
### Description of changes
* Do not count missing records as a failure of the cluster readiness check
* Cherry-Pick: https://github.com/aws/aws-parallelcluster-cookbook/pull/3062

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
