### PR TITLE
[Develop][Bug] Fix incorrect timestamp parsing for chef-client.log in CloudWatch Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Open MPI: openmpi40-aws-4.1.7-2 and openmpi50-aws-5.0.8-11
 
 **BUG FIXES**
-- Fix incorrect timestamp parsing for chef-client.log in CloudWatch Agent configuration. The timestamp format now correctly matches Chef's output format `[YYYY-MM-DDTHH:MM:SS+TZ]`.
+- Fix incorrect timestamp parsing for chef-client.log in CloudWatch Agent configuration.
 - Prevent cluster readiness check failures due to instances launched while the check is in progress.
 - Fix race condition where compute nodes could deploy the wrong cluster config version after an update failure.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Open MPI: openmpi40-aws-4.1.7-2 and openmpi50-aws-5.0.8-11
 
 **BUG FIXES**
+- Fix incorrect timestamp parsing for chef-client.log in CloudWatch Agent configuration. The timestamp format now correctly matches Chef's output format `[YYYY-MM-DDTHH:MM:SS+TZ]`.
 - Prevent cluster readiness check failures due to instances launched while the check is in progress.
 - Fix race condition where compute nodes could deploy the wrong cluster config version after an update failure.
 

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
@@ -4,6 +4,7 @@
     "default": "%Y-%m-%d %H:%M:%S,%f",
     "bracket_default": "[%Y-%m-%d %H:%M:%S]",
     "slurm": "%Y-%m-%dT%H:%M:%S.%f",
+    "chef": "[%Y-%m-%dT%H:%M:%S",
     "json": ""
   },
   "log_configs": [
@@ -82,7 +83,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "default",
+      "timestamp_format_key": "chef",
       "file_path": "/var/log/chef-client.log",
       "log_stream_name": "chef-client",
       "schedulers": [


### PR DESCRIPTION
### Description of changes
This is a cherry-pick PR of https://github.com/aws/aws-parallelcluster-cookbook/pull/3061

The CloudWatch Agent configuration was using the `default` timestamp format (%Y-%m-%d %H:%M:%S,%f) for chef-client.log, but Chef/Cinc outputs ISO 8601 timestamps in format: `[YYYY-MM-DDTHH:MM:SS+TZ]`.

This mismatch caused CloudWatch to fail parsing timestamps, resulting in log lines being associated with incorrect timestamps.

- Add new 'chef' timestamp format: `[%Y-%m-%dT%H:%M:%S`
  (Note: CloudWatch Agent's %z only supports timezone without colon like -0700, but Chef outputs +02:00 format. We only match up to seconds and let CloudWatch handle the rest.)
- Update chef-client.log configuration to use the new 'chef' format

### Tests
Manually tests done, I create a cluster and export the cluster logs. Now in the chef-client log, I can see CW timestamp matches chef timestamp, e.g.:
```
2025-12-12T20:14:16.000Z [2025-12-12T20:14:16+00:00] INFO: Retrying execution of execute[check if clustermgtd heartbeat is available], 29 attempts left
2025-12-12T20:15:38.000Z [2025-12-12T20:15:38+00:00] INFO: Waiting for static fleet capacity provisioning
2025-12-12T20:15:07.000Z [2025-12-12T20:15:07+00:00] INFO: Waiting for static fleet capacity provisioning
```

### Reference
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html#CloudWatch-Agent-Configuration-File-Logssection
Expand `CloudWatch agent configuration file: Logs section` section:
>%z
    Time zone, expressed as the offset between the local time zone and UTC. For example, -0700. Only this format is supported. For example, -07:00 isn't a valid format.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
