### PR TITLE
[Logging] Fix and standardize timestamp formats across Cloudwatch log configurations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 3.15.0
 ------
 
+**BUG FIXES**
+- Fix timestamp formats in CloudWatch log configuration to let CloudWatch parse the correct timestamps.
+
 3.14.1
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Fix timestamp formats in CloudWatch log configuration to let CloudWatch parse the correct timestamps.
+- Fix an issue that was blocking the logging of slurm health check events.
 
 3.14.1
 ------

--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
@@ -2,10 +2,9 @@
   "timestamp_formats": {
     "month_first": "%b %-d %H:%M:%S",
     "default": "%Y-%m-%d %H:%M:%S,%f",
-    "bracket_default": "[%Y-%m-%d %H:%M:%S]",
-    "slurm": "%Y-%m-%dT%H:%M:%S.%f",
-    "chef": "[%Y-%m-%dT%H:%M:%S",
-    "json": ""
+    "default_seconds": "%Y-%m-%d %H:%M:%S",
+    "iso8610": "%Y-%m-%dT%H:%M:%S.%f",
+    "iso8610_seconds": "%Y-%m-%dT%H:%M:%S"
   },
   "log_configs": [
     {
@@ -31,7 +30,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "month_first",
+      "timestamp_format_key": "iso8610",
       "file_path": "/var/log/syslog",
       "log_stream_name": "syslog",
       "schedulers": [
@@ -83,7 +82,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "chef",
+      "timestamp_format_key": "iso8610_seconds",
       "file_path": "/var/log/chef-client.log",
       "log_stream_name": "chef-client",
       "schedulers": [
@@ -100,7 +99,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "json",
+      "timestamp_format_key": "iso8610",
       "file_path": "/var/log/parallelcluster/bootstrap_error_msg",
       "log_stream_name": "bootstrap_error_msg",
       "schedulers": [
@@ -174,7 +173,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "json",
+      "timestamp_format_key": "iso8610",
       "file_path": "/var/log/parallelcluster/clustermgtd.events",
       "log_stream_name": "clustermgtd_events",
       "schedulers": [
@@ -187,7 +186,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "json",
+      "timestamp_format_key": "iso8610",
       "file_path": "/var/log/parallelcluster/slurm_resume.events",
       "log_stream_name": "slurm_resume_events",
       "schedulers": [
@@ -265,7 +264,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "slurm",
+      "timestamp_format_key": "iso8610",
       "file_path": "/var/log/slurmd.log",
       "log_stream_name": "slurmd",
       "schedulers": [
@@ -278,7 +277,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "slurm",
+      "timestamp_format_key": "iso8610",
       "file_path": "/var/log/slurmctld.log",
       "log_stream_name": "slurmctld",
       "schedulers": [
@@ -291,7 +290,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "slurm",
+      "timestamp_format_key": "iso8610",
       "file_path": "/var/log/slurmdbd.log",
       "log_stream_name": "slurmdbd",
       "schedulers": [
@@ -325,7 +324,7 @@
       ]
     },
     {
-      "timestamp_format_key": "default",
+      "timestamp_format_key": "default_seconds",
       "file_path": "/var/log/sssd/sssd.log",
       "log_stream_name": "sssd",
       "schedulers": [
@@ -346,7 +345,7 @@
       ]
     },
     {
-      "timestamp_format_key": "default",
+      "timestamp_format_key": "default_seconds",
       "file_path": "/var/log/sssd/sssd_default.log",
       "log_stream_name": "sssd_domain_default",
       "schedulers": [
@@ -389,7 +388,7 @@
       ]
     },
     {
-      "timestamp_format_key": "bracket_default",
+      "timestamp_format_key": "default",
       "file_path": "/var/log/parallelcluster/pcluster_dcv_connect.log",
       "log_stream_name": "dcv-ext-authenticator",
       "schedulers": [
@@ -522,7 +521,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "json",
+      "timestamp_format_key": "iso8610",
       "file_path": "/var/log/parallelcluster/slurm_health_check.events",
       "log_stream_name": "slurm_health_check_events",
       "schedulers": [

--- a/cookbooks/aws-parallelcluster-environment/templates/directory_service/generate_ssh_key.sh.erb
+++ b/cookbooks/aws-parallelcluster-environment/templates/directory_service/generate_ssh_key.sh.erb
@@ -1,4 +1,5 @@
 #!/bin/bash
+PS4="[$(date '+%Y-%m-%d %H:%M:%S,%3N')] "
 set -ex
 env
 

--- a/cookbooks/aws-parallelcluster-platform/files/dcv/pcluster_dcv_connect.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/dcv/pcluster_dcv_connect.sh
@@ -40,12 +40,6 @@ LOG_FILE_PATH="/var/log/parallelcluster/pcluster_dcv_connect.log"
 LOG_FILE_MAX_SIZE=5242880 # 5MB
 
 
-_fail() {
-  message=$1
-  >&2 echo "ERROR: ${message}"
-  exit 1
-}
-
 _validate_json() {
   json_param=$1
   message=$2
@@ -82,8 +76,14 @@ _log() {
     fi
 
     # append log
-    log_time=$(date "+%Y-%m-%d %H:%M:%S")
+    log_time=$(date "+%Y-%m-%d %H:%M:%S,%3N")
     echo "[${log_time}]: ${text}" >> "${LOG_FILE_PATH}"
+}
+
+_fail() {
+  message=$1
+  _log "ERROR: ${message}"
+  exit 1
 }
 
 _create_dcv_session() {

--- a/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/logging/health_check_manager_logging.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/config_slurm/scripts/logging/health_check_manager_logging.conf
@@ -22,7 +22,7 @@ formatter=defaultFormatter
 args=('/var/log/parallelcluster/slurm_health_check.log', 'a', None, False)
 
 [logger_events]
-level=WARNING
+level=INFO
 handlers=eventsHandler
 propagate=0
 qualname=slurm_plugin.prolog.events
@@ -32,6 +32,6 @@ format=%(message)s
 
 [handler_eventsHandler]
 class=FileHandler
-level=WARNING
+level=INFO
 formatter=eventsFormatter
 args=('/var/log/parallelcluster/slurm_health_check.events', 'a', None, False)


### PR DESCRIPTION
### Description of changes
[Logging] Fix and consolidate timestamp formats across Cloudwatch log configurations.
1.  Reduce the variants of timestamp formats to the minimum required.
1.  Update CloudWatch agent config to use iso8610 format for JSON event logs (clustermgtd, slurm_resume), syslog and Slurm logs (slurmd, slurmctld, slurmdbd).
1.  Update SSSD log timestamp format to default_seconds.
1.  Change DCV authenticator log format from bracket_default to default.
1.  Add millisecond precision to pam_ssh_key_generator.
1.  Add millisecond precision to dcv-ext-authenticator.

Also fixed an issue that was blocking the logging of slurm health check events.

#### Limitations
1. xDCV emits log lines with timestamp relative to boot time, not an absolute timestamp. There is no way to configure it to emit absolute timestamps.
3. Cannot force CloutInit to include timestamp to every log line
4. In Chef logs, we could increase tghe preciison of timestamp form seconds to millis by using a custom lgo formatter. It works but the custom formatter is only applied after some log lines, leading to a mixed precision that messes up the parsing by cloudwatch, So I kept the current implementation with by-seconds precision.

### Tests
Manually verified that all the logs in the Cw agent configuration have the correct timestamp format and CW is able to parse it. Here is the test report:

| Log | Expected format | Actual Timestamp | Outcome |
|-----------|---------------------|-------|-|
| /var/log/messages | %b %-d %H:%M:%S | `Dec 15 17:42:31`| ✅ |
| /var/log/cfn-init.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 17:43:04,577` | ✅ |
| /var/log/cfn-hup.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 17:57:45,078` | ✅ |
| /var/log/supervisord.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 17:42:46,215` | ✅ |
| /var/log/parallelcluster/clustermgtd | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 18:05:48,583` | ✅ |
| /var/log/cloud-init.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 17:42:49,937` | ✅ |
| /var/log/parallelcluster/computemgtd | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 17:52:49,617` | ✅ |
| /var/log/parallelcluster/slurm_fleet_status_manager.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 21:45:46,232` | ✅ |
| /var/log/parallelcluster/slurm_suspend.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 18:34:48,375` | ✅ |
| /var/log/parallelcluster/slurm_resume.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 18:11:33,444` | ✅ |
| /var/log/parallelcluster/clusterstatusmgtd | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 18:09:39,234` | ✅ |
| /var/log/dcv/server.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 21:17:29,020028` | ✅ |
| /var/log/parallelcluster/pcluster_dcv_authenticator.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 18:29:43,746` | ✅  |
| /var/log/dcv/sessionlauncher.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 21:59:10,310301` | ✅  |
| /var/log/dcv/agent..log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 21:59:19,946561` | ✅ |
| /var/log/dcv/dcv-xsession..log | %Y-%m-%d %H:%M:%S,%f |  `2025-12-15 21:59:10,572343876`| ✅ |
| /var/log/parallelcluster/slurm_health_check.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 23:14:19,038` | ✅ |
| /var/log/slurmd.log | %Y-%m-%dT%H:%M:%S.%f | `[2025-12-15T17:42:49.324]` | ✅ CONSOLIDATED |
| /var/log/slurmctld.log | %Y-%m-%dT%H:%M:%S.%f | `[2025-12-15T17:39:29.652] ` | ✅ CONSOLIDATED|
| /var/log/slurmdbd.log | %Y-%m-%dT%H:%M:%S.%f | `[2025-12-15T22:02:50.308]` | ✅ CONSOLIDATED |
| /var/log/parallelcluster/compute_console_output.log | %Y-%m-%d %H:%M:%S,%f | `2025-12-15 21:55:53,148` | ✅ NO ISSUE. Console logs are emitted with the timestamp of the time the head node captures them. This is the expected behavior. There is no way to emit console logs with their own timestamp because console logs are emitted with timestamp relative t the boot of the system, not with the absolute timestamp |
| /var/log/parallelcluster/pcluster_dcv_connect.log | %Y-%m-%d %H:%M:%S,%f | `[2025-12-23 19:09:08,176]` | ✅ FIXED by increasing the resolution to millis |
| /var/log/parallelcluster/slurm_resume.events | %Y-%m-%dT%H:%M:%S.%f  | `{"datetime": "2026-01-05T18:32:30.284+00:00"` | ✅ FIXED (Note: this log is meant to contain only failed launches) |
| /var/log/syslog | %Y-%m-%dT%H:%M:%S.%f | `2026-01-05T19:20:40.174910+00:00` | ✅ FIXED,|
| /var/log/parallelcluster/slurm_health_check.events | %Y-%m-%dT%H:%M:%S.%f | `{ "datetime": "2026-01-05T18:09:32.030+00:00",` | ✅ FIXED, logs are now emitted and with the correct timestamp |
| /var/log/chef-client.log | %Y-%m-%d %H:%M:%S | `[2026-01-05T22:29:56+00:00]` | ✅ CONSOLIDATED Cannot increase precision to millis because we could do it only for certain log lines, which woukld mess the things up |
| /var/log/parallelcluster/clustermgtd.events | %Y-%m-%dT%H:%M:%S.%f | `{"datetime": "2025-12-15T17:44:48.890+00:00"` | ✅ FIXED |
| /var/log/parallelcluster/bootstrap_error_msg | %Y-%m-%dT%H:%M:%S.%f | `{"datetime": "2025-12-15T23:07:28.627+00:00", "version": 0,` | ✅ FIXED |
| /var/log/sssd/sssd.log | %Y-%m-%d %H:%M:%S | `(2025-12-15 22:01:49)` | ✅ FIXED, but cannot increase the resolution of the timestamp |
| /var/log/sssd/sssd_default.log | %Y-%m-%d %H:%M:%S | `(2025-12-15 22:02:21)` | ✅ FIXED, but cannot increase the resolution of the timestamp |
| /var/log/cloud-init-output.log | %Y-%m-%d %H:%M:%S,%f | | ❌  BLOCKED missing timestamp from logs |
| /var/log/dcv/Xdcv.*.log | %Y-%m-%d %H:%M:%S,%f | | ❌  BLOCKED the timestamp from tghe logs is the time since the server boot. This cannot be changed https://docs.aws.amazon.com/dcv/latest/adminguide/config-param-ref.html#log |
| /var/log/parallelcluster/pam_ssh_key_generator.log | %Y-%m-%d %H:%M:%S,%f | `[2025-12-23 18:04:12,956] ` | ✅ FIXED |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
