### PR TITLE
fix(dcv): Optimize Ubuntu DCV installation and prevent restart prompts

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_ubuntu_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_ubuntu_common.rb
@@ -45,6 +45,7 @@ action_class do
       code <<-PREREQ
         set -e
         DEBIAN_FRONTEND=noninteractive
+        NEEDRESTART_MODE=l
         apt -y install whoopsie
         apt -y install ubuntu-desktop && apt -y install mesa-utils || (dpkg --configure -a && exit 1)
         apt -y purge ifupdown

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -472,6 +472,7 @@ describe 'dcv:setup' do
           when 'ubuntu'
             is_expected.to periodic_apt_update('')
             is_expected.to run_bash('install pre-req').with_cwd(Chef::Config[:file_cache_path]).with_retries(10).with_retry_delay(5)
+                                                      .with_code(/NEEDRESTART_MODE=l/)
                                                       .with_code(/apt -y install whoopsie/)
                                                       .with_code(/apt -y install ubuntu-desktop && apt -y install mesa-utils || (dpkg --configure -a && exit 1)/)
                                                       .with_code(/apt -y purge ifupdown/)


### PR DESCRIPTION
- Add NEEDRESTART_MODE=l environment variable to suppress needrestart prompts during installation
- Install ubuntu-desktop with --no-install-recommends flag to reduce unnecessary package dependencies
- Update unit tests to verify NEEDRESTART_MODE is set and ubuntu-desktop installation uses --no-install-recommends
- Prevents interactive restart dialogs during automated DCV setup on Ubuntu systems


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
