### PR TITLE
[Test] Add retry helper for flaky InSpec controls.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
@@ -19,10 +19,12 @@ control 'tag:install_lustre_client_installed' do
         its('version') { should cmp >= minimal_lustre_client_version }
       end
 
-      describe yum.repo('aws-fsx') do
-        it { should exist }
-        it { should be_enabled }
-        its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
+      with_retry(retries: 3, delay: 5) do
+        describe yum.repo('aws-fsx') do
+          it { should exist }
+          it { should be_enabled }
+          its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
+        end
       end
     end
   end
@@ -47,10 +49,12 @@ control 'tag:install_lustre_client_installed' do
         its('version') { should cmp >= minimal_lustre_client_version }
       end
 
-      describe yum.repo('aws-fsx') do
-        it { should exist }
-        it { should be_enabled }
-        its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
+      with_retry(retries: 3, delay: 5) do
+        describe yum.repo('aws-fsx') do
+          it { should exist }
+          it { should be_enabled }
+          its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
+        end
       end
     end
   end

--- a/cookbooks/aws-parallelcluster-shared/test/libraries/retry_helper.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/libraries/retry_helper.rb
@@ -1,0 +1,15 @@
+# Helper method to retry flaky InSpec checks
+def with_retry(retries: 3, delay: 5)
+  attempts = 0
+  begin
+    attempts += 1
+    yield
+  rescue => e
+    if attempts < retries
+      sleep delay
+      retry
+    else
+      raise e
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
Add retry helper for flaky InSpec controls. 
Use such retry logic to make the yum repo check more resilient to transient failures.

### Tests
* [ONGOING] Inspec control `aws-parallelcluyster-environment::install_lustre_client_installed` faced a failure due to a timeout, now succeeds with the retry logic

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
