### PR TITLE
[Release-3.14.1] Add chef attribute to optionally skip the installation of dcv

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -30,7 +30,7 @@ default['cluster']['nvidia']['imex']['force_configuration'] = false
 default['cluster']['nvidia']['nvlsm']['enabled'] = true
 
 # DCV
-default['cluster']['dcv']['skip_install'] = false
+default['cluster']['dcv']['install_enabled'] = true
 default['cluster']['dcv']['authenticator']['user'] = "dcvextauth"
 default['cluster']['dcv']['authenticator']['user_id'] = node['cluster']['reserved_base_uid'] + 3
 default['cluster']['dcv']['authenticator']['group'] = node['cluster']['dcv']['authenticator']['user']

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -30,6 +30,8 @@ default['cluster']['nvidia']['imex']['force_configuration'] = false
 default['cluster']['nvidia']['nvlsm']['enabled'] = true
 
 # DCV
+# Set to true to skip DCV installation (useful for troubleshooting build issues)
+default['cluster']['dcv']['skip_install'] = false
 default['cluster']['dcv']['authenticator']['user'] = "dcvextauth"
 default['cluster']['dcv']['authenticator']['user_id'] = node['cluster']['reserved_base_uid'] + 3
 default['cluster']['dcv']['authenticator']['group'] = node['cluster']['dcv']['authenticator']['user']

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -30,7 +30,6 @@ default['cluster']['nvidia']['imex']['force_configuration'] = false
 default['cluster']['nvidia']['nvlsm']['enabled'] = true
 
 # DCV
-# Set to true to skip DCV installation (useful for troubleshooting build issues)
 default['cluster']['dcv']['skip_install'] = false
 default['cluster']['dcv']['authenticator']['user'] = "dcvextauth"
 default['cluster']['dcv']['authenticator']['user_id'] = node['cluster']['reserved_base_uid'] + 3

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
@@ -100,8 +100,8 @@ action_class do
 end
 
 action :setup do
-  if node['cluster']['dcv']['skip_install']
-    Chef::Log.warn("Skipping DCV installation because node['cluster']['dcv']['skip_install'] is set to true")
+  unless node['cluster']['dcv']['install_enabled']
+    Chef::Log.warn("Skipping DCV installation because node['cluster']['dcv']['install_enabled'] is set to false")
     return
   end
   return if dcv_installed?

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
@@ -100,6 +100,10 @@ action_class do
 end
 
 action :setup do
+  if node['cluster']['dcv']['skip_install']
+    Chef::Log.warn("Skipping DCV installation because node['cluster']['dcv']['skip_install'] is set to true")
+    return
+  end
   return if dcv_installed?
   return if redhat_on_docker?
 

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -657,11 +657,11 @@ describe 'dcv:setup' do
         end
       end
 
-      context "when skip_install is true" do
+      context "when install_enabled is false" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version, step_into: ['dcv']) do |node|
             node_setup.call(node)
-            node.override['cluster']['dcv']['skip_install'] = true
+            node.override['cluster']['dcv']['install_enabled'] = false
           end
           stubs_for_resource('dcv') do |res|
             allow(res).to receive(:dcv_sha256sum).and_return(checksum)
@@ -682,7 +682,7 @@ describe 'dcv:setup' do
           ConvergeDcv.setup(runner)
         end
 
-        it 'skips dcv installation' do
+        it 'does not install dcv when install_enabled is false' do
           is_expected.not_to create_if_missing_cookbook_file("#{scripts_dir}/pcluster_dcv_connect.sh")
           is_expected.not_to create_group(authenticator_group)
           is_expected.not_to create_user(authenticator_user)

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -657,6 +657,39 @@ describe 'dcv:setup' do
         end
       end
 
+      context "when skip_install is true" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version, step_into: ['dcv']) do |node|
+            node_setup.call(node)
+            node.override['cluster']['dcv']['skip_install'] = true
+          end
+          stubs_for_resource('dcv') do |res|
+            allow(res).to receive(:dcv_sha256sum).and_return(checksum)
+            allow(res).to receive(:dcv_supported?).and_return(true)
+            allow(res).to receive(:prereq_packages).and_return(alinux_prereq_packages) if platform == 'amazon'
+            allow(res).to receive(:dcv_package).and_return(dcv_package)
+            allow(res).to receive(:dcv_server).and_return(dcv_server)
+            allow(res).to receive(:xdcv).and_return(xdcv)
+            allow(res).to receive(:dcv_web_viewer).and_return(dcv_web_viewer)
+            allow(res).to receive(:dcv_url_arch).and_return(dcv_url_arch)
+            allow(res).to receive(:dcv_pkg_arch).and_return(dcv_pkg_arch)
+            allow(res).to receive(:dcv_url).and_return(dcv_url)
+            allow(res).to receive(:dcv_tarball).and_return(dcv_tarball)
+            allow(res).to receive(:dcvauth_virtualenv).and_return(dcvauth_virtualenv)
+            allow(res).to receive(:dcvauth_virtualenv_path).and_return(dcvauth_virtualenv_path)
+          end
+          method_setup.call
+          ConvergeDcv.setup(runner)
+        end
+
+        it 'skips dcv installation' do
+          is_expected.not_to create_if_missing_cookbook_file("#{scripts_dir}/pcluster_dcv_connect.sh")
+          is_expected.not_to create_group(authenticator_group)
+          is_expected.not_to create_user(authenticator_user)
+          is_expected.not_to run_execute('set default systemd runlevel to multi-user.target')
+        end
+      end
+
       context "when not official ami build" do
         cached(:chef_run) do
           runner = runner(platform: platform, version: version, step_into: ['dcv']) do |node|

--- a/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
@@ -11,7 +11,7 @@
 
 control 'tag:install_dcv_connect_script_installed' do
   title 'Check pcluster dcv connect script is installed'
-  only_if { !os_properties.redhat_on_docker? }
+  only_if { instance.dcv_install_enabled? && !os_properties.redhat_on_docker? }
 
   describe file("#{node['cluster']['scripts_dir']}/pcluster_dcv_connect.sh") do
     it { should be_file }
@@ -23,7 +23,7 @@ end
 
 control 'tag:install_dcv_authenticator_user_and_group_set_up' do
   title 'Check that dcv authenticator user and group have been set up'
-  only_if { !os_properties.redhat_on_docker? && !(os_properties.ubuntu? && os_properties.arm?) && !os_properties.alinux2023? }
+  only_if { instance.dcv_install_enabled? && !os_properties.redhat_on_docker? && !(os_properties.ubuntu? && os_properties.arm?) && !os_properties.alinux2023? }
 
   describe group(node['cluster']['dcv']['authenticator']['group']) do
     it { should exist }
@@ -39,7 +39,7 @@ end
 
 control 'tag:install_dcv_disabled_lock_screen' do
   title 'Check that the lock screen has been disabled'
-  only_if { !os_properties.redhat_on_docker? && !(os_properties.ubuntu? && os_properties.arm?) && !os_properties.alinux2023? }
+  only_if { instance.dcv_install_enabled? && !os_properties.redhat_on_docker? && !(os_properties.ubuntu? && os_properties.arm?) && !os_properties.alinux2023? }
 
   describe bash('gsettings get org.gnome.desktop.lockdown disable-lock-screen') do
     its('exit_status') { should eq 0 }
@@ -54,7 +54,7 @@ end
 
 control 'tag:install_dcv_installed' do
   title 'Check dcv is installed'
-  only_if { !os_properties.redhat_on_docker? && !(os_properties.ubuntu? && os_properties.arm?) && !os_properties.alinux2023? }
+  only_if { instance.dcv_install_enabled? && !os_properties.redhat_on_docker? && !(os_properties.ubuntu? && os_properties.arm?) && !os_properties.alinux2023? }
 
   pkgs = %W(nice-dcv-server nice-xdcv nice-dcv-web-viewer)
   pkgs.each do |pkg|
@@ -66,7 +66,7 @@ end
 
 control 'tag:install_dcv_external_authenticator_virtualenv_created' do
   title 'Check dcv external authenticator virtual environment is created'
-  only_if { !os_properties.redhat_on_docker? && !(os_properties.ubuntu? && os_properties.arm?) && !os_properties.alinux2023? }
+  only_if { instance.dcv_install_enabled? && !os_properties.redhat_on_docker? && !(os_properties.ubuntu? && os_properties.arm?) && !os_properties.alinux2023? }
 
   describe file("#{node['cluster']['dcv']['authenticator']['virtualenv_path']}/bin/activate") do
     it { should be_file }
@@ -76,7 +76,7 @@ end
 
 control 'tag:install_dcv_debian_specific_setup' do
   title 'Check debian specific setup'
-  only_if { os_properties.debian_family? && !(os_properties.ubuntu? && os_properties.arm?) && !os_properties.alinux2023? }
+  only_if { instance.dcv_install_enabled? && os_properties.debian_family? && !(os_properties.ubuntu? && os_properties.arm?) && !os_properties.alinux2023? }
 
   pkgs = %W(whoopsie ubuntu-desktop mesa-utils)
   pkgs.each do |pkg|
@@ -97,7 +97,7 @@ end
 
 control 'tag:install_dcv_rhel_and_centos_specific_setup' do
   title 'Check rhel and centos specific setup'
-  only_if { !os_properties.on_docker? }
+  only_if { instance.dcv_install_enabled? && !os_properties.on_docker? }
   only_if { !os_properties.alinux2023? }
   only_if { os_properties.centos? || os_properties.redhat? }
 
@@ -136,7 +136,7 @@ end
 control 'tag:install_dcv_alinux2_specific_setup' do
   title 'Check alinux2 specific setup'
 
-  only_if { os_properties.alinux2? }
+  only_if { instance.dcv_install_enabled? && os_properties.alinux2? }
 
   prereq_packages = %w(gdm gnome-session gnome-classic-session gnome-session-xsession
                        xorg-x11-server-Xorg xorg-x11-fonts-Type1 xorg-x11-drivers
@@ -160,7 +160,7 @@ end
 
 control 'tag:install_dcv_switch_runlevel_to_multiuser_target' do
   title 'Check that runlevel is switched to multi-user.target'
-  only_if { !os_properties.on_docker? }
+  only_if { instance.dcv_install_enabled? && !os_properties.on_docker? }
   only_if { !os_properties.alinux2023? }
 
   describe bash('systemctl get-default') do

--- a/cookbooks/aws-parallelcluster-shared/test/libraries/instance.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/libraries/instance.rb
@@ -39,6 +39,10 @@ class Instance < Inspec.resource(1)
     inspec.file("/etc/dcv/dcv.conf").exist?
   end
 
+  def dcv_install_enabled?
+    inspec.node['cluster']['dcv']['install_enabled'] != false
+  end
+
   def imds_token
     @imds_token = inspec.http('http://169.254.169.254/latest/api/token', method: 'PUT', headers: {
       "X-aws-ec2-metadata-token-ttl-seconds": 900,


### PR DESCRIPTION
### Description of changes
* Add chef attribute `['cluster']['dcv']['install_enabled']` to optionally skip the installation of dcv

### Tests
* Kitchen tests passed.
* build-image tests passed.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
