### PR TITLE
fix: exclude ASG terminating instances from cluster readiness check

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
@@ -14,7 +14,7 @@ import logging
 import click
 from common.constants import CLUSTER_CONFIG_DDB_ID
 from common.ddb_utils import get_cluster_config_records
-from common.ec2_utils import list_cluster_instance_ids_iterator
+from common.ec2_utils import get_asg_terminating_instance_ids, list_cluster_instance_ids_iterator
 from common.exceptions import CheckFailedError
 
 logger = logging.getLogger(__name__)
@@ -93,12 +93,21 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
         expected_config_version,
     )
 
+    # Get instances that are in ASG terminating states (Terminating:Wait, Terminating:Proceed).
+    # These instances may still appear as 'running' in EC2 but should be excluded from validation
+    # since they are being removed and will never update to the new config version.
+    terminating_instance_ids = get_asg_terminating_instance_ids(cluster_name, region)
+    if terminating_instance_ids:
+        logger.info("Excluding %s instance(s) in ASG terminating states: %s", len(terminating_instance_ids), terminating_instance_ids)
+
     for instance_ids in list_cluster_instance_ids_iterator(
         cluster_name=cluster_name,
         node_type=["Compute", "LoginNode"],
         instance_state=["running"],
         region=region,
     ):
+        # Filter out instances that are in ASG terminating states
+        instance_ids = [i for i in instance_ids if i not in terminating_instance_ids]
         n_instance_ids = len(instance_ids)
 
         if not n_instance_ids:

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/common/ec2_utils.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/common/ec2_utils.py
@@ -62,3 +62,34 @@ def _get_filters_to_list_instances(cluster_name: str, instance_state: [str] = No
         filters.append({"Name": "instance-state-name", "Values": list(instance_state)})
 
     return filters
+
+
+@retry(stop_max_attempt_number=5, wait_fixed=3000)
+def get_asg_terminating_instance_ids(cluster_name: str, region: str) -> set:
+    """
+    Return instance IDs that are in ASG terminating lifecycle states.
+
+    Instances in Terminating:Wait or Terminating:Proceed states are being terminated
+    but may still appear as 'running' in EC2. These should be excluded from readiness checks.
+
+    :param cluster_name: name of the cluster.
+    :param region: AWS region name (eg: us-east-1).
+    :return: set of instance IDs in terminating states.
+    """
+    asg = boto_client("autoscaling", region_name=region)
+
+    terminating_ids = set()
+    paginator = asg.get_paginator("describe_auto_scaling_instances")
+
+    for page in paginator.paginate(PaginationConfig=BOTO_PAGINATION_CONFIG):
+        for instance in page.get("AutoScalingInstances", []):
+            # Check if instance belongs to this cluster by matching ASG name pattern
+            asg_name = instance.get("AutoScalingGroupName", "")
+            if cluster_name not in asg_name:
+                continue
+
+            lifecycle_state = instance.get("LifecycleState", "")
+            if lifecycle_state in ("Terminating:Wait", "Terminating:Proceed"):
+                terminating_ids.add(instance["InstanceId"])
+
+    return terminating_ids


### PR DESCRIPTION
## Summary

- Add `get_asg_terminating_instance_ids()` function to query instances in ASG terminating lifecycle states
- Exclude instances in `Terminating:Wait` or `Terminating:Proceed` from readiness check validation

## Problem

When LoginNodes are deleted (e.g., setting `Count: 0`), the cluster update fails because:

1. ASG sets desired capacity to 0, instances enter `Terminating:Wait` state
2. EC2 still reports these instances as `running` (lifecycle hook hasn't completed)
3. Readiness check includes these instances and expects new config version
4. Instances will never update (they're being terminated) → check fails repeatedly
5. CloudFormation times out and rolls back

## Solution

Query ASG lifecycle states before readiness check and exclude instances that are in:
- `Terminating:Wait`
- `Terminating:Proceed`

These instances are being removed and should not be validated against the new config version.

## Test Plan

- [ ] Deploy cluster with LoginNodes (Count: 2+)
- [ ] Update cluster to remove LoginNodes (Count: 0)
- [ ] Verify cluster update succeeds without waiting for lifecycle hook timeout
- [ ] Verify partial scale-down (Count: 4 → 2) also works correctly

Fixes aws/aws-parallelcluster#7172