### PR TITLE
[develop][cookbook] Improve curl retry for GitHub package downloads

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
@@ -40,7 +40,7 @@ if !node['cluster']['custom_awsbatchcli_package'].nil? && !node['cluster']['cust
       else
         custom_package_url=#{node['cluster']['custom_awsbatchcli_package']}
       fi
-      curl --retry 3 -L -o aws-parallelcluster.tgz ${custom_package_url}
+      curl --retry 9 --retry-all-errors -L -o aws-parallelcluster.tgz ${custom_package_url}
       mkdir aws-parallelcluster-awsbatch-cli
       tar -xzf aws-parallelcluster.tgz --directory aws-parallelcluster-awsbatch-cli
       cd aws-parallelcluster-awsbatch-cli/*aws-parallelcluster*

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
@@ -61,7 +61,7 @@ bash "install custom aws-parallelcluster-node" do
     else
       custom_package_url=#{node['cluster']['custom_node_package']}
     fi
-    curl --retry 10 --retry-all-errors -L -o aws-parallelcluster-node.tgz ${custom_package_url}
+    curl --retry 9 --retry-all-errors -L -o aws-parallelcluster-node.tgz ${custom_package_url}
     rm -fr aws-parallelcluster-custom-node
     mkdir aws-parallelcluster-custom-node
     tar -xzf aws-parallelcluster-node.tgz --directory aws-parallelcluster-custom-node

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
@@ -61,7 +61,7 @@ bash "install custom aws-parallelcluster-node" do
     else
       custom_package_url=#{node['cluster']['custom_node_package']}
     fi
-    curl --retry 3 -L -o aws-parallelcluster-node.tgz ${custom_package_url}
+    curl --retry 10 --retry-all-errors -L -o aws-parallelcluster-node.tgz ${custom_package_url}
     rm -fr aws-parallelcluster-custom-node
     mkdir aws-parallelcluster-custom-node
     tar -xzf aws-parallelcluster-node.tgz --directory aws-parallelcluster-custom-node

--- a/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
@@ -45,7 +45,7 @@ describe 'aws-parallelcluster-computefleet::custom_parallelcluster_node' do
   else
     custom_package_url=#{custom_node_s3_url}
   fi
-  curl --retry 3 -L -o aws-parallelcluster-node.tgz ${custom_package_url}
+  curl --retry 10 --retry-all-errors -L -o aws-parallelcluster-node.tgz ${custom_package_url}
   rm -fr aws-parallelcluster-custom-node
   mkdir aws-parallelcluster-custom-node
   tar -xzf aws-parallelcluster-node.tgz --directory aws-parallelcluster-custom-node

--- a/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
@@ -45,7 +45,7 @@ describe 'aws-parallelcluster-computefleet::custom_parallelcluster_node' do
   else
     custom_package_url=#{custom_node_s3_url}
   fi
-  curl --retry 10 --retry-all-errors -L -o aws-parallelcluster-node.tgz ${custom_package_url}
+  curl --retry 9 --retry-all-errors -L -o aws-parallelcluster-node.tgz ${custom_package_url}
   rm -fr aws-parallelcluster-custom-node
   mkdir aws-parallelcluster-custom-node
   tar -xzf aws-parallelcluster-node.tgz --directory aws-parallelcluster-custom-node


### PR DESCRIPTION
### Description of changes
- Increase retry count from 3 to 9
- Add `--retry-all-errors` to retry on SSL and HTTP/2 errors

If we retry 9 times, it will wait:
1 + 2 + 4 + 8 + 16 + 32 + 64 + 128 + 256 = 511 seconds = 8.51 minutes
It should can handle the China region network issue.

This fixes intermittent download failures in China regions caused by network instability when accessing GitHub.

### Tests
* build-image E2E test in China region ongoing

### References
* Cookbook PR for improving node package downloading: https://github.com/aws/aws-parallelcluster-cookbook/pull/3085

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
