### PR TITLE
Fix cluster creation failure without Internet access when GPU instances and DCV are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **BUG FIXES**
 - Fix timestamp formats in CloudWatch log configuration to let CloudWatch parse the correct timestamps.
 - Fix an issue that was blocking the logging of slurm health check events.
+- Fix cluster creation failure without Internet access when GPU instances and DCV are used.
 
 3.14.1
 ------

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_rhel_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_rhel_common.rb
@@ -105,6 +105,24 @@ action_class do
   end
 
   def post_install
+    # Download dependencies for nice-dcv-gl (for offline installation during cluster creation)
+    dcv_gl_deps_dir = "#{node['cluster']['sources_dir']}/dcv-gl-deps"
+    dcv_gl_package = "#{node['cluster']['sources_dir']}/#{dcv_package}/#{dcv_gl}"
+    directory dcv_gl_deps_dir
+
+    # Use --resolve to download all transitive dependencies
+    execute 'download dcv-gl dependencies' do
+      command "dnf download --destdir=#{dcv_gl_deps_dir} --resolve #{dcv_gl_package}"
+      retries 3
+      retry_delay 5
+    end
+
+    # Remove dcv-gl package itself (we only want dependencies in dcv_gl_deps_dir)
+    execute 'remove dcv-gl from deps dir' do
+      command "rm -f #{dcv_gl_deps_dir}/nice-dcv-gl-*.rpm"
+      only_if { ::Dir.exist?(dcv_gl_deps_dir) }
+    end
+
     # stop firewall
     service "firewalld" do
       action %i(disable stop)
@@ -114,10 +132,19 @@ action_class do
   end
 
   def install_dcv_gl
+    # The following installation happens during cluster creation time.
+    # So `rpm` installation is needed to remove requirement of Internet access.
+    # Install dependencies from downloaded RPMs (offline)
+    dcv_gl_deps_dir = "#{node['cluster']['sources_dir']}/dcv-gl-deps"
+    execute 'install dcv-gl dependencies offline' do
+      command "rpm -ivh #{dcv_gl_deps_dir}/*.rpm"
+      only_if { ::Dir.exist?(dcv_gl_deps_dir) && !::Dir.empty?(dcv_gl_deps_dir) }
+    end
+
     package = "#{node['cluster']['sources_dir']}/#{dcv_package}/#{dcv_gl}"
-    package package do
-      action :install
-      source package
+    # Install dcv-gl without repo access
+    execute 'install dcv-gl offline' do
+      command "rpm -ivh #{package}"
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -568,7 +568,14 @@ describe 'dcv:setup' do
 
         it 'executes postinstall operations' do
           case platform
-          when 'redhat', 'centos'
+          when 'redhat', 'centos', 'rocky'
+            # Download dcv-gl dependencies for offline installation
+            is_expected.to create_directory("#{sources_dir}/dcv-gl-deps")
+            is_expected.to run_execute('download dcv-gl dependencies')
+              .with_command(%r{dnf download --destdir=#{sources_dir}/dcv-gl-deps --resolve})
+              .with_retries(3)
+              .with_retry_delay(5)
+
             # stop firewall
             is_expected.to disable_service('firewalld').with_action(%i(disable stop))
 
@@ -853,8 +860,8 @@ describe 'dcv:configure' do
             is_expected.to run_execute('apt install dcv-gl')
               .with_command("apt -y install #{sources_dir}/#{dcv_package}/#{dcv_gl}")
           else
-            is_expected.to install_package("#{sources_dir}/#{dcv_package}/#{dcv_gl}")
-              .with_source("#{sources_dir}/#{dcv_package}/#{dcv_gl}")
+            is_expected.to run_execute('install dcv-gl offline')
+              .with_command("rpm -ivh #{sources_dir}/#{dcv_package}/#{dcv_gl}")
           end
         end
 

--- a/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
@@ -196,6 +196,15 @@ control 'tag:config_expected_versions_of_nice-dcv-gl_installed' do
   end
 end
 
+control 'tag:install_dcv_gl_deps_downloaded' do
+  title 'Check dcv-gl dependencies are downloaded for offline installation'
+  only_if { instance.dcv_install_enabled? && !os_properties.debian_family? && !os_properties.redhat_on_docker? }
+
+  describe directory("#{node['cluster']['sources_dir']}/dcv-gl-deps") do
+    it { should exist }
+  end
+end
+
 control 'tag:config_dcv_correctly_installed' do
   only_if do
     instance.head_node? && instance.dcv_installed? && !os_properties.redhat_on_docker?


### PR DESCRIPTION
### Description of changes
When creating a cluster with GPU head node/login node with DCV enabled, cookbook installs DCV GL as recommended by https://docs.aws.amazon.com/dcv/latest/adminguide/manage-gpu.html. This installation may require additional dependencies. This commit downloads the additional dependencies during image build to enable cluster creation without Internet access when GPU instances and DCV are used.

DCV GL has to be installed during cluster creation and not in image build because running DCV GL on a non-GPU instance may cause problem.


### Tests
The following test has passed:
```
test-suites:
  networking:
    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
      dimensions:
        - regions: ["use1-az2"]
          instances: ["g5.xlarge"]
          oss: ["rhel9"]
          schedulers: ["slurm"]
```

### References
* Added integration test in CLI repo https://github.com/aws/aws-parallelcluster/pull/7185

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
