### PR TITLE
[DevSettings] Expose a new Chef attribute `cluster/slurm/reconfigure_timeout`.

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -29,3 +29,6 @@ default['cluster']['pyxis']['runtime_path'] = '/run/pyxis'
 # Block Topology Plugin
 default['cluster']['slurm']['block_topology']['force_configuration'] = false
 default['cluster']['p6egb200_block_sizes'] = nil
+
+# Slurm Reconfigure
+default['cluster']['slurm']['reconfigure_timeout'] = 300 # seconds

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -266,7 +266,7 @@ execute SCONTROL_RECONFIGURE_RESOURCE_NAME do
   command "#{node['cluster']['slurm']['install_dir']}/bin/scontrol reconfigure"
   retries 3
   retry_delay 5
-  timeout 300
+  timeout node['cluster']['slurm']['reconfigure_timeout']
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && !are_bulk_custom_slurm_settings_updated? }
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
@@ -7,6 +7,9 @@ describe 'aws-parallelcluster-slurm::update_head_node' do
     region = "MOCK_REGION"
     cluster_config_version = "MOCK_CLUSTER_CONFIG_VERSION"
     scripts_dir = "/MOCK_SCRIPTS_DIR"
+    slurm_install_dir = "/MOCK_SLURM_INSTALL_DIR"
+    reconfigure_timeout = 600
+
     context "on #{platform}#{version}" do
       [true, false].each do |are_mount_or_unmount_required|
         context "when mount/unmount is #{'not ' unless are_mount_or_unmount_required}required" do
@@ -22,6 +25,8 @@ describe 'aws-parallelcluster-slurm::update_head_node' do
               node.override['cluster']['region'] = region
               node.override['cluster']['cluster_config_version'] = cluster_config_version
               node.override['cluster']['scripts_dir'] = scripts_dir
+              node.override['cluster']['slurm']['install_dir'] = slurm_install_dir
+              node.override['cluster']['slurm']['reconfigure_timeout'] = reconfigure_timeout
             end
             runner.converge(described_recipe)
           end
@@ -61,6 +66,13 @@ describe 'aws-parallelcluster-slurm::update_head_node' do
           it 'starts clustermgtd unconditionally' do
             is_expected.to run_execute('start clustermgtd').with(
               command: "#{cookbook_venv_path}/bin/supervisorctl start clustermgtd"
+            )
+          end
+
+          it 'runs scontrol reconfigure with timeout from attribute' do
+            is_expected.to run_execute('reload config for running nodes').with(
+              command: "#{slurm_install_dir}/bin/scontrol reconfigure",
+              timeout: reconfigure_timeout
             )
           end
         end


### PR DESCRIPTION
### Description of changes
Expose a new Chef attribute `cluster/slurm/reconfigure_timeout`.
The attribute is used to set the timeout for Slurm reconfigure command, which is executed during the cluster update.
The default value is kept to the original value: 300 seconds.

Related to this PR there is the on for the CLI https://github.com/aws/aws-parallelcluster/pull/7188 where we make use of this attribute. See that Pr for a full picture about the user experience.

### Tests
* Spec unit test (changes are covered)
* Used with CLI changes from [PR](https://github.com/aws/aws-parallelcluster/pull/7188) to inject custom timeout and verified that we can control the timeout through dev settings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
