### PR TITLE
[Test] Add retry utility for kitchen tests and use it to mitigate failure on flaky test

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
@@ -19,10 +19,12 @@ control 'tag:install_lustre_client_installed' do
         its('version') { should cmp >= minimal_lustre_client_version }
       end
 
-      describe yum.repo('aws-fsx') do
-        it { should exist }
-        it { should be_enabled }
-        its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
+      retry_helpers.with_retries do
+        describe yum.repo('aws-fsx') do
+          it { should exist }
+          it { should be_enabled }
+          its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
+        end
       end
     end
   end
@@ -47,10 +49,12 @@ control 'tag:install_lustre_client_installed' do
         its('version') { should cmp >= minimal_lustre_client_version }
       end
 
-      describe yum.repo('aws-fsx') do
-        it { should exist }
-        it { should be_enabled }
-        its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
+      retry_helpers.with_retries do
+        describe yum.repo('aws-fsx') do
+          it { should exist }
+          it { should be_enabled }
+          its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
+        end
       end
     end
   end
@@ -80,9 +84,11 @@ control 'tag:install_lustre_client_installed' do
   end
 
   if os_properties.alinux2?
-    describe yum.repo('amzn2extra-lustre') do
-      it { should exist }
-      it { should be_enabled }
+    retry_helpers.with_retries do
+      describe yum.repo('amzn2extra-lustre') do
+        it { should exist }
+        it { should be_enabled }
+      end
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-shared/test/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/libraries/helpers.rb
@@ -1,0 +1,35 @@
+class RetryHelpers < Inspec.resource(1)
+  name 'retry_helpers'
+
+  desc '
+    Helper methods for retry logic in InSpec tests
+  '
+  example '
+    retry_helpers.with_retries { some_flaky_operation }
+    retry_helpers.with_retries(max_retries: 3, retry_delay: 2) { some_flaky_operation }
+  '
+
+  # Executes a block with retry logic for handling transient failures.
+  #
+  # @param max_retries [Integer] Maximum number of retry attempts (default: 10)
+  # @param retry_delay [Integer] Seconds to wait between retries (default: 5)
+  # @yield The block to execute with retry protection
+  # @raise [StandardError] Re-raises the last exception if all retries are exhausted
+  #
+  def with_retries(max_retries: 10, retry_delay: 5)
+    last_exception = nil
+
+    max_retries.times do |attempt|
+      begin
+        return yield
+      rescue StandardError => e
+        last_exception = e
+        puts "Attempt #{attempt + 1}/#{max_retries} failed: #{e.message}"
+        sleep retry_delay if attempt < max_retries - 1
+      end
+    end
+
+    puts "All #{max_retries} retry attempts exhausted"
+    raise last_exception
+  end
+end


### PR DESCRIPTION
### Description of changes
Add retry utility for kitchen tests and use it to mitigate failure on flaky test which sometimes fails due to  to timeout on yum repolist command.

Notes:
1. Skipping the `bad-url-suffix-check` because it fails on false positive: an URL used for kitchen tests, which is expected to have the commercial URL suffix.

### Tests
* Kitchen test succeeded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
