### PR TITLE
Only download DCV GL dependencies for x86 instances

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_rhel_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_rhel_common.rb
@@ -105,22 +105,24 @@ action_class do
   end
 
   def post_install
-    # Download dependencies for nice-dcv-gl (for offline installation during cluster creation)
-    dcv_gl_deps_dir = "#{node['cluster']['sources_dir']}/dcv-gl-deps"
-    dcv_gl_package = "#{node['cluster']['sources_dir']}/#{dcv_package}/#{dcv_gl}"
-    directory dcv_gl_deps_dir
+    if x86_instance?
+      # Download dependencies for nice-dcv-gl (for offline installation during cluster creation)
+      dcv_gl_deps_dir = "#{node['cluster']['sources_dir']}/dcv-gl-deps"
+      dcv_gl_package = "#{node['cluster']['sources_dir']}/#{dcv_package}/#{dcv_gl}"
+      directory dcv_gl_deps_dir
 
-    # Use --resolve to download all transitive dependencies
-    execute 'download dcv-gl dependencies' do
-      command "dnf download --destdir=#{dcv_gl_deps_dir} --resolve #{dcv_gl_package}"
-      retries 3
-      retry_delay 5
-    end
+      # Use --resolve to download all transitive dependencies
+      execute 'download dcv-gl dependencies' do
+        command "dnf download --destdir=#{dcv_gl_deps_dir} --resolve #{dcv_gl_package}"
+        retries 3
+        retry_delay 5
+      end
 
-    # Remove dcv-gl package itself (we only want dependencies in dcv_gl_deps_dir)
-    execute 'remove dcv-gl from deps dir' do
-      command "rm -f #{dcv_gl_deps_dir}/nice-dcv-gl-*.rpm"
-      only_if { ::Dir.exist?(dcv_gl_deps_dir) }
+      # Remove dcv-gl package itself (we only want dependencies in dcv_gl_deps_dir)
+      execute 'remove dcv-gl from deps dir' do
+        command "rm -f #{dcv_gl_deps_dir}/nice-dcv-gl-*.rpm"
+        only_if { ::Dir.exist?(dcv_gl_deps_dir) }
+      end
     end
 
     # stop firewall

--- a/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
@@ -198,7 +198,7 @@ end
 
 control 'tag:install_dcv_gl_deps_downloaded' do
   title 'Check dcv-gl dependencies are downloaded for offline installation'
-  only_if { instance.dcv_install_enabled? && !os_properties.debian_family? && !os_properties.redhat_on_docker? }
+  only_if { instance.dcv_install_enabled? && !os_properties.debian_family? && !os_properties.redhat_on_docker? && os_properties.x86? }
 
   describe directory("#{node['cluster']['sources_dir']}/dcv-gl-deps") do
     it { should exist }


### PR DESCRIPTION
### Description of changes
DCV GL is not available for ARM. This can be verified by downloading DCV server archive https://www.amazondcv.com/.

This commit fixes a bug from https://github.com/aws/aws-parallelcluster-cookbook/pull/3086

### Tests
* Build image on all OSes on ARM and x86 have passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
