### PR TITLE
Use yum to download DCV GL dependencies for Amazon Linux 2

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_rhel_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_rhel_common.rb
@@ -112,8 +112,13 @@ action_class do
       directory dcv_gl_deps_dir
 
       # Use --resolve to download all transitive dependencies
+      download_cmd = if el_string == 'amzn2'
+                       "yum install --downloadonly --downloaddir=#{dcv_gl_deps_dir} #{dcv_gl_package}"
+                     else
+                       "dnf download --destdir=#{dcv_gl_deps_dir} --resolve #{dcv_gl_package}"
+                     end
       execute 'download dcv-gl dependencies' do
-        command "dnf download --destdir=#{dcv_gl_deps_dir} --resolve #{dcv_gl_package}"
+        command download_cmd
         retries 3
         retry_delay 5
       end


### PR DESCRIPTION
### Description of changes
dnf is not available on Amazon Linux 2

This commit fixes a bug from https://github.com/aws/aws-parallelcluster-cookbook/pull/3086

### Tests
Build image on Amazon Linux 2 succeeded

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
