### PR TITLE
[Test] Add retry logic for flaky kitchen tests.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
@@ -19,12 +19,11 @@ control 'tag:install_lustre_client_installed' do
         its('version') { should cmp >= minimal_lustre_client_version }
       end
 
-      retry_helpers.with_retries do
-        describe yum.repo('aws-fsx') do
-          it { should exist }
-          it { should be_enabled }
-          its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
-        end
+      describe yum.repo('aws-fsx') do
+        before { retry_helpers.wait_for_command("yum -v repolist all 2>/dev/null | grep -q 'aws-fsx'") }
+        it { should exist }
+        it { should be_enabled }
+        its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
       end
     end
   end
@@ -49,12 +48,11 @@ control 'tag:install_lustre_client_installed' do
         its('version') { should cmp >= minimal_lustre_client_version }
       end
 
-      retry_helpers.with_retries do
-        describe yum.repo('aws-fsx') do
-          it { should exist }
-          it { should be_enabled }
-          its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
-        end
+      describe yum.repo('aws-fsx') do
+        before { retry_helpers.wait_for_command("yum -v repolist all 2>/dev/null | grep -q 'aws-fsx'") }
+        it { should exist }
+        it { should be_enabled }
+        its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
       end
     end
   end
@@ -84,11 +82,10 @@ control 'tag:install_lustre_client_installed' do
   end
 
   if os_properties.alinux2?
-    retry_helpers.with_retries do
-      describe yum.repo('amzn2extra-lustre') do
-        it { should exist }
-        it { should be_enabled }
-      end
+    describe yum.repo('amzn2extra-lustre') do
+      before { retry_helpers.wait_for_command("yum -v repolist all 2>/dev/null | grep -q 'amzn2extra-lustre'") }
+      it { should exist }
+      it { should be_enabled }
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-shared/test/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/libraries/helpers.rb
@@ -5,31 +5,60 @@ class RetryHelpers < Inspec.resource(1)
     Helper methods for retry logic in InSpec tests
   '
   example '
-    retry_helpers.with_retries { some_flaky_operation }
-    retry_helpers.with_retries(max_retries: 3, retry_delay: 2) { some_flaky_operation }
+    # Use inside a before block to wait for a condition
+    describe yum.repo("aws-fsx") do
+      before { retry_helpers.wait_until { command("yum repolist").exit_status == 0 } }
+      it { should exist }
+    end
+
+    # Wait for a specific command to succeed
+    describe yum.repo("aws-fsx") do
+      before { retry_helpers.wait_for_command("yum -v repolist all | grep aws-fsx") }
+      it { should exist }
+    end
   '
 
-  # Executes a block with retry logic for handling transient failures.
+  # Waits until a condition block returns true.
+  # Designed to be used inside a before block in InSpec describe statements.
   #
   # @param max_retries [Integer] Maximum number of retry attempts (default: 10)
   # @param retry_delay [Integer] Seconds to wait between retries (default: 5)
-  # @yield The block to execute with retry protection
-  # @raise [StandardError] Re-raises the last exception if all retries are exhausted
+  # @param description [String] Optional description for logging (default: nil)
+  # @yield Block that returns true when condition is met, false otherwise
+  # @return [Boolean] true if condition was met, false if retries exhausted
   #
-  def with_retries(max_retries: 10, retry_delay: 5)
-    last_exception = nil
+  def wait_until(max_retries: 10, retry_delay: 5, description: nil)
+    desc_text = description ? " (#{description})" : ""
 
     max_retries.times do |attempt|
+      puts "Waiting for condition [#{desc_text}]: attempt #{attempt + 1}/#{max_retries}"
       begin
-        return yield
+        if yield
+          puts "Condition met: #{desc_text}"
+          return true
+        end
       rescue StandardError => e
-        last_exception = e
-        puts "Attempt #{attempt + 1}/#{max_retries} failed: #{e.message}"
-        sleep retry_delay if attempt < max_retries - 1
+        puts "Condition check failed with error, will retry after #{retry_delay}s: #{e.message}"
       end
+      sleep retry_delay if attempt < max_retries - 1
     end
+    puts "Condition not met after #{max_retries} attempts: #{desc_text}"
+    false
+  end
 
-    puts "All #{max_retries} retry attempts exhausted"
-    raise last_exception
+  # Waits for a shell command to succeed (exit status 0).
+  # Designed to be used inside a before block in InSpec describe statements.
+  #
+  # @param cmd [String] The shell command to execute
+  # @param max_retries [Integer] Maximum number of retry attempts (default: 10)
+  # @param retry_delay [Integer] Seconds to wait between retries (default: 5)
+  # @param timeout [Integer] Timeout in seconds for each command (default: 60)
+  # @return [Boolean] true if command succeeded, false if retries exhausted
+  #
+  def wait_for_command(cmd, max_retries: 10, retry_delay: 5, timeout: 60)
+    wait_until(max_retries: max_retries, retry_delay: retry_delay, description: cmd) do
+      result = inspec.command("timeout #{timeout} #{cmd}")
+      result.exit_status == 0
+    end
   end
 end


### PR DESCRIPTION
### Description of changes
We have a flaky kitchen test checking yum repositories that sometimes fails with timeout.
In https://github.com/aws/aws-parallelcluster-cookbook/pull/3088 we added a retry logic that was actually not effective because kitchen tests do not raise exceptions. 
With the current PR we are replacing that approach with a new one that executes yum repolist with retries before the actual test. This approach increases the chance that the test does not timeout.

**Limitation**
This approach reduces the risk of the intermittent failure but it does not solve them completely. Even if not observed so far with this change, there is still a little chance for the test to fail if the repo becomes unresponsive between the retries and the actual test.

**Notes**
1. Skipping the `bad-url-suffix-check` because it fails on false positive: an URL used for kitchen tests, which is expected to have the commercial URL suffix.

### Tests
* Kitchen test succeeded for all OSs and verified the retry mechanism was triggered
```
2026-01-10 00:43:59.174000	Stdout: Performing InSpec tests on the AMI: aws-parallelcluster-environment...
2026-01-10 00:44:06.685000	Stdout: Waiting for condition [ (yum -v repolist all 2>/dev/null | grep -q 'aws-fsx')]: attempt 1/10
2026-01-10 00:44:06.685000	Stdout: Condition met:  (yum -v repolist all 2>/dev/null | grep -q 'aws-fsx')
2026-01-10 00:44:06.685000	Stdout: Waiting for condition [ (yum -v repolist all 2>/dev/null | grep -q 'aws-fsx')]: attempt 1/10
2026-01-10 00:44:06.685000	Stdout: Condition met:  (yum -v repolist all 2>/dev/null | grep -q 'aws-fsx')
2026-01-10 00:44:06.685000	Stdout: Waiting for condition [ (yum -v repolist all 2>/dev/null | grep -q 'aws-fsx')]: attempt 1/10
2026-01-10 00:44:06.685000	Stdout: Condition met:  (yum -v repolist all 2>/dev/null | grep -q 'aws-fsx')
2026-01-10 00:44:06.685000	Stdout:
2026-01-10 00:44:06.685000	Stdout: Profile:   tests from test (tests from test)
2026-01-10 00:44:06.685000	Stdout: Version:   (not specified)
2026-01-10 00:44:06.685000	Stdout: Target:    local://
2026-01-10 00:44:06.685000	Stdout: Target ID: 9267924f-6217-55a8-a29c-22cd91fae666
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
