### PR TITLE
Remove -x from pcluster-check-update service

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/templates/check_update/pcluster-check-update.sh.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/check_update/pcluster-check-update.sh.erb
@@ -4,7 +4,7 @@
 # This script checks if a cluster update is needed by comparing the shared update file
 # with the local checkpoint. If they differ, it triggers the update action.
 
-set -ex
+set -e
 
 SHARED_TRIGGER_FILE="<%= node['cluster']['update']['trigger_file'] %>"
 LOCAL_CHECKPOINT="<%= node['cluster']['update']['checkpoint_file'] %>"


### PR DESCRIPTION
### Description of changes
* Remove -x from pcluster-check-update service
* Standard logs have enough details
* -x exposes us to logs timestamp reshuffling because the line emitted by the xtracer do not have any timestamp.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
