### PR TITLE
Remove cfn-hup.log from computefleet cloudwatch agent config

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
@@ -75,7 +75,6 @@
       "platforms": {{ default_platforms | tojson}},
       "node_roles": [
         "HeadNode",
-        "ComputeFleet",
         "LoginNode",
         "ExternalSlurmDbd"
       ],


### PR DESCRIPTION
### Description of changes
* Remove cfn-hup.log from computefleet cloudwatch agent config
* We no longer use cfn-hup on compute nodes, so the cfn-hup.log is no longer created
* There is now a pcluster-check-update.log

### Tests
* Ran test_cloudwatch_logging

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
