### PR TITLE
Create check-update log file so CloudWatch agent can monitor it before the service runs

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/recipes/config/config_check_update_systemd_service.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/config_check_update_systemd_service.rb
@@ -53,6 +53,15 @@ file node['cluster']['update']['checkpoint_file'] do
   action :create_if_missing
 end
 
+# Create log file so CloudWatch agent can monitor it before the service runs
+file "#{node['cluster']['log_base_dir']}/pcluster-check-update.log" do
+  content ''
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create_if_missing
+end
+
 service 'pcluster-check-update.timer' do
   action [:enable, :start]
 end


### PR DESCRIPTION
### Description of changes
* Create check-update log file so CloudWatch agent can monitor it before the service runs

### Tests
* Ran test_cloudwatch_logging on al2, al2023, and ubuntu24

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
