### PR TITLE
fix: only check modified queues during cluster readiness validation

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
@@ -9,7 +9,10 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
+import os
+import re
 
 import click
 from common.constants import CLUSTER_CONFIG_DDB_ID
@@ -72,7 +75,48 @@ def _check_cluster_config_items(instance_ids: [str], items: [{}], expected_confi
     return missing, incomplete, wrong
 
 
-def check_deployed_config_version(cluster_name: str, table_name: str, expected_config_version: str, region: str):
+def _read_change_set(shared_dir="/opt/parallelcluster/shared"):
+    """
+    Read change-set.json and extract modified queue names.
+
+    :param shared_dir: path to the shared directory containing change-set.json
+    :return: Set of queue names that were modified, or None if unavailable (fallback to checking all nodes).
+    """
+    try:
+        change_set_path = os.path.join(shared_dir, "change-set.json")
+        if not os.path.exists(change_set_path):
+            logger.info("change-set.json not found at %s, will check all nodes", change_set_path)
+            return None
+
+        with open(change_set_path, "r") as f:
+            change_set = json.load(f)
+
+        modified_queues = set()
+        for change in change_set.get("changeSet", []):
+            # Extract queue name from parameter paths like: Scheduling.SlurmQueues[queue_name].*
+            # Queue names must match AWS ParallelCluster naming convention: ^[a-z][a-z0-9-]*$
+            parameter = change.get("parameter", "")
+            match = re.match(r"Scheduling\.SlurmQueues\[([a-z][a-z0-9-]*)\]", parameter)
+            if match:
+                queue_name = match.group(1)
+                modified_queues.add(queue_name)
+                logger.debug("Found modified queue in change-set: %s (from parameter: %s)", queue_name, parameter)
+
+        if modified_queues:
+            logger.info("Found %d modified queue(s) in change-set: %s", len(modified_queues), sorted(modified_queues))
+            logger.info("Will check nodes only in modified queues")
+            return modified_queues
+        else:
+            logger.info("No queue modifications found in change-set, will check all nodes")
+            return None
+    except Exception as e:
+        logger.warning("Failed to parse change-set.json: %s. Will check all nodes as fallback.", e)
+        return None
+
+
+def check_deployed_config_version(
+    cluster_name: str, table_name: str, expected_config_version: str, region: str, shared_dir="/opt/parallelcluster/shared"
+):
     """
     Verify that every compute/login node in the cluster has deployed the expected config version.
 
@@ -85,6 +129,7 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
     :param table_name: DDB table to read the deployed config version from.
     :param expected_config_version: expected config version.
     :param region: AWS region name (eg: us-east-1).
+    :param shared_dir: path to the shared directory containing change-set.json.
     :return: None
     """
     logger.info(
@@ -93,41 +138,81 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
         expected_config_version,
     )
 
-    for instance_ids in list_cluster_instance_ids_iterator(
-        cluster_name=cluster_name,
-        node_type=["Compute", "LoginNode"],
-        instance_state=["running"],
-        region=region,
-    ):
-        n_instance_ids = len(instance_ids)
+    # Read change-set to determine which queues were modified
+    modified_queues = _read_change_set(shared_dir)
 
-        if not n_instance_ids:
-            logger.warning("Found empty batch of cluster nodes: nothing to check")
-            continue
+    if modified_queues:
+        # Only check compute nodes in modified queues
+        logger.info("Checking compute nodes in modified queues: %s", modified_queues)
+        for instance_ids in list_cluster_instance_ids_iterator(
+            cluster_name=cluster_name,
+            node_type=["Compute"],
+            instance_state=["running"],
+            region=region,
+            queue_names=list(modified_queues),
+        ):
+            _check_and_verify_instances(instance_ids, table_name, expected_config_version, region)
 
-        logger.info("Found batch of %s cluster node(s): %s", n_instance_ids, instance_ids)
+        # Always check LoginNode separately (no queue tags)
+        logger.info("Checking LoginNode instances")
+        for instance_ids in list_cluster_instance_ids_iterator(
+            cluster_name=cluster_name,
+            node_type=["LoginNode"],
+            instance_state=["running"],
+            region=region,
+        ):
+            _check_and_verify_instances(instance_ids, table_name, expected_config_version, region)
+    else:
+        # Fallback: check all compute and login nodes (original behavior)
+        logger.info("Checking all compute and login nodes (no queue filtering)")
+        for instance_ids in list_cluster_instance_ids_iterator(
+            cluster_name=cluster_name,
+            node_type=["Compute", "LoginNode"],
+            instance_state=["running"],
+            region=region,
+        ):
+            _check_and_verify_instances(instance_ids, table_name, expected_config_version, region)
 
-        items = get_cluster_config_records(table_name, instance_ids, region)
-        logger.info("Retrieved %s DDB item(s):\n\t%s", len(items), "\n\t".join([str(i) for i in items]))
 
-        missing, incomplete, wrong = _check_cluster_config_items(instance_ids, items, expected_config_version)
+def _check_and_verify_instances(instance_ids: [str], table_name: str, expected_config_version: str, region: str):
+    """
+    Helper function to check and verify instances against the expected config version.
 
-        if incomplete or wrong:
-            raise CheckFailedError(
-                f"Check failed due to the following erroneous records "
-                f"(missing records are not counted for the failure):\n"
-                f"  * missing records ({len(missing)}): {missing}\n"
-                f"  * incomplete records ({len(incomplete)}): {incomplete}\n"
-                f"  * wrong records ({len(wrong)}): {wrong}"
-            )
-        if missing:
-            logger.warning(
-                "Ignoring the following missing records due them being recently bootstrapped:\n"
-                "  *  missing records (%s): %s",
-                len(missing),
-                missing,
-            )
-        logger.info("Verified cluster configuration for cluster node(s) %s", instance_ids)
+    :param instance_ids: list of instance IDs to check.
+    :param table_name: DDB table to read the deployed config version from.
+    :param expected_config_version: expected config version.
+    :param region: AWS region name (eg: us-east-1).
+    :return: None
+    """
+    n_instance_ids = len(instance_ids)
+
+    if not n_instance_ids:
+        logger.warning("Found empty batch of cluster nodes: nothing to check")
+        return
+
+    logger.info("Found batch of %s cluster node(s): %s", n_instance_ids, instance_ids)
+
+    items = get_cluster_config_records(table_name, instance_ids, region)
+    logger.info("Retrieved %s DDB item(s):\n\t%s", len(items), "\n\t".join([str(i) for i in items]))
+
+    missing, incomplete, wrong = _check_cluster_config_items(instance_ids, items, expected_config_version)
+
+    if incomplete or wrong:
+        raise CheckFailedError(
+            f"Check failed due to the following erroneous records "
+            f"(missing records are not counted for the failure):\n"
+            f"  * missing records ({len(missing)}): {missing}\n"
+            f"  * incomplete records ({len(incomplete)}): {incomplete}\n"
+            f"  * wrong records ({len(wrong)}): {wrong}"
+        )
+    if missing:
+        logger.warning(
+            "Ignoring the following missing records due them being recently bootstrapped:\n"
+            "  *  missing records (%s): %s",
+            len(missing),
+            missing,
+        )
+    logger.info("Verified cluster configuration for cluster node(s) %s", instance_ids)
 
 
 @click.command(help="Verify that the cluster has completed the deployment of the expected cluster configuration.")

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/common/constants.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/common/constants.py
@@ -17,6 +17,7 @@ BOTO_PAGINATION_CONFIG = {"PageSize": 100}
 # TAGS
 CLUSTER_NAME_TAG = "parallelcluster:cluster-name"
 NODE_TYPE_TAG = "parallelcluster:node-type"
+QUEUE_NAME_TAG = "parallelcluster:queue-name"
 
 # DDB
 CLUSTER_CONFIG_DDB_ID = "CLUSTER_CONFIG.{instance_id}"

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/common/ec2_utils.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/common/ec2_utils.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from common.aws import boto_client
-from common.constants import BOTO_PAGINATION_CONFIG, CLUSTER_NAME_TAG, NODE_TYPE_TAG
+from common.constants import BOTO_PAGINATION_CONFIG, CLUSTER_NAME_TAG, NODE_TYPE_TAG, QUEUE_NAME_TAG
 from retrying import retry
 
 
@@ -20,6 +20,7 @@ def list_cluster_instance_ids_iterator(
     region: str,
     instance_state: [str] = ("pending", "running", "stopping", "stopped"),
     node_type: [str] = None,
+    queue_names: [str] = None,
 ):
     """
     Generate an iterator over batch of cluster instances.
@@ -28,11 +29,12 @@ def list_cluster_instance_ids_iterator(
     :param region: AWS region name (eg: us-east-1)
     :param instance_state: list of instance states to include in the filter; default is None.
     :param node_type: list of node types to include in the filter; default is None.
+    :param queue_names: list of queue names to include in the filter; default is None.
     :return: the iterator to iterate over batch of cluster instances.
     """
     ec2 = boto_client("ec2", region_name=region)
 
-    filters = _get_filters_to_list_instances(cluster_name, instance_state, node_type)
+    filters = _get_filters_to_list_instances(cluster_name, instance_state, node_type, queue_names)
 
     paginator = ec2.get_paginator("describe_instances")
 
@@ -44,19 +46,25 @@ def list_cluster_instance_ids_iterator(
         yield instances
 
 
-def _get_filters_to_list_instances(cluster_name: str, instance_state: [str] = None, node_type: [str] = None):
+def _get_filters_to_list_instances(
+    cluster_name: str, instance_state: [str] = None, node_type: [str] = None, queue_names: [str] = None
+):
     """
     Generate a list of filters to be used in EC2 requests to filter cluster instances.
 
     :param cluster_name: name of the cluster.
     :param instance_state: list of instance states to include in the filter; default is None.
     :param node_type: list of node types to include in the filter; default is None.
+    :param queue_names: list of queue names to include in the filter; default is None.
     :return: the list of filters.
     """
     filters = [{"Name": f"tag:{CLUSTER_NAME_TAG}", "Values": [cluster_name]}]
 
     if node_type:
         filters.append({"Name": f"tag:{NODE_TYPE_TAG}", "Values": list(node_type)})
+
+    if queue_names:
+        filters.append({"Name": f"tag:{QUEUE_NAME_TAG}", "Values": list(queue_names)})
 
     if instance_state:
         filters.append({"Name": "instance-state-name", "Values": list(instance_state)})

--- a/test/unit/head_node_checks/test_check_cluster_ready.py
+++ b/test/unit/head_node_checks/test_check_cluster_ready.py
@@ -9,7 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
+from unittest.mock import patch, mock_open
 
 import pytest
 from assertpy import assert_that
@@ -158,3 +158,235 @@ def test_check_cluster_ready(boto3_stubber, compute_nodes, login_nodes, ddb_reco
         assert_that(str(exc.value)).is_equal_to(expected_error)
     else:
         check_cluster_ready("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION")
+
+
+def _mocked_request_describe_instances_with_queue(
+    cluster_name: str, node_type: str, queue_names: [str], instance_ids: [str]
+):
+    """Mock EC2 describe_instances with optional queue filter."""
+    filters = [
+        {"Name": "tag:parallelcluster:cluster-name", "Values": [cluster_name]},
+        {"Name": "tag:parallelcluster:node-type", "Values": [node_type]},
+    ]
+    if queue_names:
+        filters.append({"Name": "tag:parallelcluster:queue-name", "Values": queue_names})
+    filters.append({"Name": "instance-state-name", "Values": ["running"]})
+
+    return MockedBoto3Request(
+        method="describe_instances",
+        response={"Reservations": [{"Instances": [{"InstanceId": iid} for iid in instance_ids]}]},
+        expected_params={"Filters": filters, "MaxResults": 100},
+        generate_error=False,
+        error_code=None,
+    )
+
+
+@patch("check_cluster_ready.json.load")
+@patch("check_cluster_ready.os.path.exists")
+@patch("builtins.open", new_callable=mock_open)
+def test_queue_filtering_single_modified(mock_file, mock_exists, mock_json_load, boto3_stubber):
+    """Test that only nodes in modified queue are checked."""
+    # Setup: change-set indicates queue1 was modified
+    change_set = {
+        "changeSet": [
+            {"parameter": "Scheduling.SlurmQueues[queue1].ComputeResources[0].InstanceType", "requestedValue": "c5.xlarge"}
+        ]
+    }
+    mock_exists.return_value = True
+    mock_json_load.return_value = change_set
+
+    compute_nodes_queue1 = ["i-queue1-node1", "i-queue1-node2"]
+    login_nodes = ["i-login1"]
+    ddb_records = {
+        "i-queue1-node1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+        "i-queue1-node2": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+        "i-login1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+    }
+
+    # Mock EC2: only queue1 compute nodes and login nodes should be queried
+    boto3_stubber(
+        "ec2",
+        [
+            _mocked_request_describe_instances_with_queue("CLUSTER_NAME", "Compute", ["queue1"], compute_nodes_queue1),
+            _mocked_request_describe_instances_with_queue("CLUSTER_NAME", "LoginNode", None, login_nodes),
+        ],
+    )
+
+    boto3_stubber("dynamodb", [
+        _mocked_request_batch_get_items("TABLE_NAME", compute_nodes_queue1, ddb_records),
+        _mocked_request_batch_get_items("TABLE_NAME", login_nodes, ddb_records),
+    ])
+
+    from check_cluster_ready import check_deployed_config_version
+    check_deployed_config_version("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", "/fake/shared")
+
+
+@patch("check_cluster_ready.json.load")
+@patch("check_cluster_ready.os.path.exists")
+@patch("builtins.open", new_callable=mock_open)
+def test_queue_addition_new_queue(mock_file, mock_exists, mock_json_load, boto3_stubber):
+    """Test adding a new queue with no nodes yet."""
+    change_set = {
+        "changeSet": [
+            {"parameter": "Scheduling.SlurmQueues[new-queue].ComputeResources[0].InstanceType", "requestedValue": "c5.xlarge"}
+        ]
+    }
+    mock_exists.return_value = True
+    mock_json_load.return_value = change_set
+
+    # No compute nodes in new queue yet, but login nodes exist
+    login_nodes = ["i-login1"]
+    ddb_records = {"i-login1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}}}
+
+    boto3_stubber(
+        "ec2",
+        [
+            _mocked_request_describe_instances_with_queue("CLUSTER_NAME", "Compute", ["new-queue"], []),
+            _mocked_request_describe_instances_with_queue("CLUSTER_NAME", "LoginNode", None, login_nodes),
+        ],
+    )
+
+    boto3_stubber("dynamodb", [_mocked_request_batch_get_items("TABLE_NAME", login_nodes, ddb_records)])
+
+    from check_cluster_ready import check_deployed_config_version
+    check_deployed_config_version("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", "/fake/shared")
+
+
+@patch("check_cluster_ready.os.path.exists")
+def test_no_change_set_fallback(mock_exists, boto3_stubber):
+    """Test fallback to checking all nodes when change-set.json is missing."""
+    mock_exists.return_value = False  # change-set.json doesn't exist
+
+    all_nodes = ["i-compute1", "i-compute2", "i-login1"]
+    ddb_records = {
+        "i-compute1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+        "i-compute2": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+        "i-login1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+    }
+
+    # Should check all Compute + LoginNode without queue filter
+    boto3_stubber("ec2", [_mocked_request_describe_instances("CLUSTER_NAME", ["Compute", "LoginNode"], all_nodes)])
+    boto3_stubber("dynamodb", [_mocked_request_batch_get_items("TABLE_NAME", all_nodes, ddb_records)])
+
+    from check_cluster_ready import check_deployed_config_version
+    check_deployed_config_version("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", "/fake/shared")
+
+
+@patch("check_cluster_ready.json.load")
+@patch("check_cluster_ready.os.path.exists")
+@patch("builtins.open", new_callable=mock_open)
+def test_malformed_change_set_fallback(mock_file, mock_exists, mock_json_load, boto3_stubber):
+    """Test fallback when change-set.json is malformed."""
+    mock_exists.return_value = True
+    mock_json_load.side_effect = ValueError("Invalid JSON")  # Simulate JSON parse error
+
+    all_nodes = ["i-compute1", "i-login1"]
+    ddb_records = {
+        "i-compute1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+        "i-login1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+    }
+
+    # Should fallback to checking all nodes
+    boto3_stubber("ec2", [_mocked_request_describe_instances("CLUSTER_NAME", ["Compute", "LoginNode"], all_nodes)])
+    boto3_stubber("dynamodb", [_mocked_request_batch_get_items("TABLE_NAME", all_nodes, ddb_records)])
+
+    from check_cluster_ready import check_deployed_config_version
+    check_deployed_config_version("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", "/fake/shared")
+
+
+@patch("check_cluster_ready.json.load")
+@patch("check_cluster_ready.os.path.exists")
+@patch("builtins.open", new_callable=mock_open)
+def test_login_nodes_always_checked(mock_file, mock_exists, mock_json_load, boto3_stubber):
+    """Test that LoginNode is always checked separately from queues."""
+    change_set = {
+        "changeSet": [
+            {"parameter": "Scheduling.SlurmQueues[queue1].ComputeResources[0].MaxCount", "requestedValue": "10"}
+        ]
+    }
+    mock_exists.return_value = True
+    mock_json_load.return_value = change_set
+
+    compute_nodes = ["i-queue1-compute1"]
+    login_nodes = ["i-login1", "i-login2"]
+    ddb_records = {
+        "i-queue1-compute1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+        "i-login1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+        "i-login2": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+    }
+
+    boto3_stubber(
+        "ec2",
+        [
+            _mocked_request_describe_instances_with_queue("CLUSTER_NAME", "Compute", ["queue1"], compute_nodes),
+            _mocked_request_describe_instances_with_queue("CLUSTER_NAME", "LoginNode", None, login_nodes),
+        ],
+    )
+
+    boto3_stubber("dynamodb", [
+        _mocked_request_batch_get_items("TABLE_NAME", compute_nodes, ddb_records),
+        _mocked_request_batch_get_items("TABLE_NAME", login_nodes, ddb_records),
+    ])
+
+    from check_cluster_ready import check_deployed_config_version
+    check_deployed_config_version("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", "/fake/shared")
+
+
+@patch("check_cluster_ready.json.load")
+@patch("check_cluster_ready.os.path.exists")
+@patch("builtins.open", new_callable=mock_open)
+def test_mixed_queue_changes(mock_file, mock_exists, mock_json_load, boto3_stubber):
+    """Test multiple queues modified simultaneously."""
+    change_set = {
+        "changeSet": [
+            {"parameter": "Scheduling.SlurmQueues[queue1].ComputeResources[0].InstanceType", "requestedValue": "c5.xlarge"},
+            {"parameter": "Scheduling.SlurmQueues[queue2].ComputeResources[0].MaxCount", "requestedValue": "5"},
+        ]
+    }
+    mock_exists.return_value = True
+    mock_json_load.return_value = change_set
+
+    # Nodes in both queues should be checked
+    compute_nodes_queue1 = ["i-q1-node1"]
+    compute_nodes_queue2 = ["i-q2-node1", "i-q2-node2"]
+    login_nodes = ["i-login1"]
+
+    ddb_records = {
+        "i-q1-node1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+        "i-q2-node1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+        "i-q2-node2": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+        "i-login1": {"cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"}},
+    }
+
+    # Note: EC2 filter will include both queues in Values list
+    boto3_stubber(
+        "ec2",
+        [
+            MockedBoto3Request(
+                method="describe_instances",
+                response={"Reservations": [
+                    {"Instances": [{"InstanceId": iid} for iid in compute_nodes_queue1 + compute_nodes_queue2]}
+                ]},
+                expected_params={
+                    "Filters": [
+                        {"Name": "tag:parallelcluster:cluster-name", "Values": ["CLUSTER_NAME"]},
+                        {"Name": "tag:parallelcluster:node-type", "Values": ["Compute"]},
+                        {"Name": "tag:parallelcluster:queue-name", "Values": ["queue1", "queue2"]},
+                        {"Name": "instance-state-name", "Values": ["running"]},
+                    ],
+                    "MaxResults": 100,
+                },
+                generate_error=False,
+                error_code=None,
+            ),
+            _mocked_request_describe_instances_with_queue("CLUSTER_NAME", "LoginNode", None, login_nodes),
+        ],
+    )
+
+    boto3_stubber("dynamodb", [
+        _mocked_request_batch_get_items("TABLE_NAME", compute_nodes_queue1 + compute_nodes_queue2, ddb_records),
+        _mocked_request_batch_get_items("TABLE_NAME", login_nodes, ddb_records),
+    ])
+
+    from check_cluster_ready import check_deployed_config_version
+    check_deployed_config_version("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", "/fake/shared")


### PR DESCRIPTION
## Summary

Fixes HeadNodeWaitCondition timeout when adding new SLURM queues to clusters with running jobs.

When adding a new queue via `pcluster update-cluster`, the HeadNode readiness check currently validates `cluster_config_version` for **all compute nodes**, including those in unmodified queues. This causes timeout if existing nodes have running jobs since they retain the old config version.

This PR optimizes the check to only validate nodes in modified queues by reading `change-set.json`.

## Changes

- **check_cluster_ready.py**: Add `_read_change_set()` to parse modified queues and filter readiness checks
- **ec2_utils.py**: Add `queue_names` parameter to `list_cluster_instance_ids_iterator()`
- **constants.py**: Add `QUEUE_NAME_TAG` constant
- **test_check_cluster_ready.py**: Add 6 new test cases covering queue filtering scenarios

## Implementation Details

### Queue Filtering Logic
1. Read `change-set.json` (already generated by ParallelCluster)
2. Extract modified queue names via regex: `Scheduling.SlurmQueues[queue_name].*`
3. Check only compute nodes in modified queues + LoginNodes
4. **Fallback**: If change-set unavailable/invalid → check all nodes (backward compatible)

### Edge Cases Handled
- Missing change-set.json → fallback to all nodes
- Malformed JSON → log warning, fallback
- No queue changes → check all nodes
- LoginNodes always checked separately (no queue tags)
- New queue with no nodes yet → empty result, skip

## Testing

All 12 test cases pass (6 existing + 6 new):
- ✅ Queue filtering for single modified queue
- ✅ Adding new queue with no nodes
- ✅ Fallback when change-set missing
- ✅ Fallback when change-set malformed
- ✅ LoginNode always checked separately
- ✅ Multiple queues modified simultaneously

## Backward Compatibility

✅ **Fully backward compatible**:
- No CLI interface changes
- No new dependencies
- Graceful fallback if change-set unavailable
- Uses existing ParallelCluster infrastructure

## Related Issue

Fixes aws/aws-parallelcluster#7203

## Checklist

- [x] Tests added and passing (12/12)
- [x] Backward compatibility maintained
- [x] Logging enhanced (queue filtering details)
- [x] Regex follows AWS queue naming convention: `^[a-z][a-z0-9-]*$`
- [x] Code follows existing patterns (Ruby cookbook already uses change-set.json)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>