### PR TITLE
[NVSwitch] Using vendor ID and class ID of PCI device to find the number of NVSwitch/Bridges

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/libraries/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-platform/libraries/nvidia.rb
@@ -1,3 +1,15 @@
+# PCI Vendor IDs
+NVIDIA_VENDOR_ID = '10de'.freeze
+MELLANOX_VENDOR_ID = '15b3'.freeze
+
+# PCI Class IDs
+GPU_3D_CONTROLLER_CLASS_ID = '0302'.freeze      # 3D Controllers (GPU without display)
+NVSWITCH_BRIDGE_CLASS_ID = '0680'.freeze        # NVSwitch/Bridges
+INFINIBAND_CONTROLLER_CLASS_ID = '0207'.freeze  # Infiniband controller (Mellanox CX-7 on P6/B300)
+
+# PCI Device IDs
+GB200_DEVICE_ID = '2941'.freeze # P6e (GB200) instance
+
 def nvidia_enabled?
   ['yes', true, 'true'].include?(node['cluster']['nvidia']['enabled'])
 end
@@ -20,22 +32,46 @@ def is_process_running(process_name)
 end
 
 #
-# Get Count of GPUs in instance
+# Get device counts using lspci -d vendor_id:device_id:class_id
 #
-def get_nvswitch_count(device_id)
-  shell_out("lspci -d #{device_id} | wc -l").stdout.strip.to_i
+
+# Generic function to count PCI devices matching vendor_id:device_id:class_id
+# Format: lspci -d [vendor]:[device]:[class]
+# Use empty string to match any value for that field
+def get_pci_device_count(vendor_id, device_id = '', class_id = '')
+  pci_device_filter = "#{vendor_id}:#{device_id}:#{class_id}"
+  count = shell_out("lspci -d #{pci_device_filter} | wc -l").stdout.strip.to_i
+  Chef::Log.info("PCI device count for filter '#{pci_device_filter}': #{count}")
+  count
 end
 
-def get_device_ids
-  #  A100 (P4), H100(P5), B200(P6), B300(p6-b300) and GB200(p6e) systems have NVSwitches
-  # NVSwitch device id is 10de:1af1 for P4 instance
-  # NVSwitch device id is 10de:22a3 for P5 instance
-  # NVSwitch device id is 10de:2901 for P6 instance
-  # NVSwitch device id is 10de:2941 for P6e instance
-  # NVSwitch device id is 10de:3182 for P6-b300 instance
-  { 'a100' => '10de:1af1', 'h100' => '10de:22a3', 'b200' => '10de:2901', 'gb200' => '10de:2941', 'b300' => '10de:3182' }
+# Count NVIDIA GPUs (3D controllers)
+def get_gpu_count
+  get_pci_device_count(NVIDIA_VENDOR_ID, '', GPU_3D_CONTROLLER_CLASS_ID)
+end
+
+# Count NVIDIA NVSwitches (Bridges)
+def get_nvswitch_count
+  get_pci_device_count(NVIDIA_VENDOR_ID, '', NVSWITCH_BRIDGE_CLASS_ID)
+end
+
+# Count Mellanox Infiniband controllers (CX-7 bridges on P6/B300)
+def get_mellanox_bridge_count
+  get_pci_device_count(MELLANOX_VENDOR_ID, '', INFINIBAND_CONTROLLER_CLASS_ID)
+end
+
+# Count GB200 devices by specific device ID
+def get_gb200_count
+  get_pci_device_count(NVIDIA_VENDOR_ID, GB200_DEVICE_ID)
+end
+
+def enable_fabric_manager?
+  return false if get_gpu_count <= 1
+
+  # Enable if NVSwitch bridges or Mellanox Infiniband controllers are detected
+  (get_nvswitch_count > 1) || (get_mellanox_bridge_count > 1)
 end
 
 def is_gb200_node?
-  get_nvswitch_count(get_device_ids['gb200']) > 1
+  get_gb200_count > 1
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
@@ -30,8 +30,8 @@ action :setup do
 end
 
 action :configure do
-  # Start nvidia fabric manager on NVSwitch enabled systems, except for GB200 which does not need it
-  if get_nvswitches > 1 && !is_gb200_node?
+  # Start nvidia fabric manager on NVSwitch enabled systems, except for GB200 which does not need it.
+  if enable_fabric_manager? && !is_gb200_node?
     service "#{fabric_manager_package}" do
       action %i(start enable)
       supports status: true
@@ -58,12 +58,4 @@ end
 
 def fabric_manager_version
   _nvidia_driver_version
-end
-
-# Get number of nv switches
-def get_nvswitches
-  # We sum the count for all these deviceIds as output of lscpi command will be >0
-  # for only one device ID based on the instance type
-  nvswitch_device_ids = get_device_ids.values
-  nvswitch_device_ids.sum { |id| get_nvswitch_count(id) }
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
@@ -217,20 +217,20 @@ describe 'fabric_manager:setup' do
 end
 
 describe 'fabric_manager:configure' do
-  let(:output_of_shell) { double('shell_out') }
   cached(:nvidia_driver_version) { 'nvidia_driver_version' }
   [true, false].each do |is_gb200|
     for_all_oses do |platform, version|
       context "on #{platform}#{version} on #{is_gb200} gb200 node" do
-        cached(:fabric_manager_version) { nvidia_driver_version }
         cached(:fabric_manager_package) { platform == 'amazon' && version == '2' ? 'nvidia-fabric-manager' : 'nvidia-fabricmanager' }
-        context('when nvswithes are > 1') do
+        cached(:fabric_manager_version) { nvidia_driver_version }
+
+        context('when fabric manager is required (multiple GPUs with bridges)') do
           cached(:chef_run) do
             stubs_for_provider('fabric_manager') do |res|
-              allow(res).to receive(:get_nvswitches).and_return(2)
-              allow(res).to receive(:get_device_ids).and_return({ 'gb200' => 'test' })
-              allow(res).to receive(:is_gb200_node?).and_return(is_gb200)
-              allow(res).to receive(:shell_out).and_return(output_of_shell)
+              allow(res).to receive(:get_pci_device_count).with('10de', '', '0302').and_return(8)
+              allow(res).to receive(:get_pci_device_count).with('10de', '', '0680').and_return(6)
+              allow(res).to receive(:get_pci_device_count).with('15b3', '', '0207').and_return(0)
+              allow(res).to receive(:get_pci_device_count).with('10de', '2941').and_return(is_gb200 ? 2 : 0)
             end
             runner = runner(platform: platform, version: version, step_into: ['fabric_manager'])
             ConvergeFabricManager.configure(runner)
@@ -243,8 +243,6 @@ describe 'fabric_manager:configure' do
           if is_gb200
             it 'does not start nvidia-fabricmanager service' do
               is_expected.not_to start_service("#{fabric_manager_package}")
-                .with_action(%i(start enable))
-                .with_supports({ status: true })
             end
           else
             it 'starts nvidia-fabricmanager service' do
@@ -255,13 +253,13 @@ describe 'fabric_manager:configure' do
           end
         end
 
-        context('when nvswithes are not > 1') do
+        context('when fabric manager is not required (single GPU or no bridges)') do
           cached(:chef_run) do
             stubs_for_provider('fabric_manager[configure]') do |res|
-              allow(res).to receive(:get_nvswitches).and_return(1)
-              allow(res).to receive(:get_device_ids).and_return({ 'gb200' => 'test' })
-              allow(res).to receive(:is_gb200_node?).and_return(is_gb200)
-              allow(res).to receive(:shell_out).and_return(output_of_shell)
+              allow(res).to receive(:get_pci_device_count).with('10de', '', '0302').and_return(1)
+              allow(res).to receive(:get_pci_device_count).with('10de', '', '0680').and_return(0)
+              allow(res).to receive(:get_pci_device_count).with('15b3', '', '0207').and_return(0)
+              allow(res).to receive(:get_pci_device_count).with('10de', '2941').and_return(0)
             end
             runner = runner(platform: platform, version: version, step_into: ['fabric_manager'])
             ConvergeFabricManager.configure(runner)
@@ -276,39 +274,44 @@ describe 'fabric_manager:configure' do
   end
 end
 
-describe 'fabric_manager:get_nvswitches' do
-  cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['fabric_manager'])
-  end
+describe 'fabric_manager:enable_fabric_manager?' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:fabric_manager_package) { platform == 'amazon' && version == '2' ? 'nvidia-fabric-manager' : 'nvidia-fabricmanager' }
 
-  let(:output_of_shell) { double('shell_out') }
-  cached(:resource) do
-    ConvergeFabricManager.setup(chef_run)
-    chef_run.find_resource('fabric_manager', 'setup')
-  end
+      context 'when multiple GPUs with NVSwitches' do
+        cached(:chef_run) do
+          stubs_for_provider('fabric_manager') do |res|
+            allow(res).to receive(:get_pci_device_count).with('10de', '', '0302').and_return(8)
+            allow(res).to receive(:get_pci_device_count).with('10de', '', '0680').and_return(6)
+            allow(res).to receive(:get_pci_device_count).with('15b3', '', '0207').and_return(0)
+            allow(res).to receive(:get_pci_device_count).with('10de', '2941').and_return(0)
+          end
+          runner = runner(platform: platform, version: version, step_into: ['fabric_manager'])
+          ConvergeFabricManager.configure(runner)
+        end
 
-  before do
-    allow(resource).to receive(:shell_out).and_return(output_of_shell)
-  end
+        it 'enables fabric manager service' do
+          is_expected.to start_service(fabric_manager_package)
+        end
+      end
 
-  context 'when count of NVSwitches > 1' do
-    it 'correctly counts multiple NVSwitches' do
-      allow(output_of_shell).to receive(:stdout).and_return("2\n", "0\n", "0\n")
-      expect(resource.get_nvswitches).to eq(2)
-    end
-  end
+      context 'when single GPU' do
+        cached(:chef_run) do
+          stubs_for_provider('fabric_manager') do |res|
+            allow(res).to receive(:get_pci_device_count).with('10de', '', '0302').and_return(1)
+            allow(res).to receive(:get_pci_device_count).with('10de', '', '0680').and_return(0)
+            allow(res).to receive(:get_pci_device_count).with('15b3', '', '0207').and_return(0)
+            allow(res).to receive(:get_pci_device_count).with('10de', '2941').and_return(0)
+          end
+          runner = runner(platform: platform, version: version, step_into: ['fabric_manager'])
+          ConvergeFabricManager.configure(runner)
+        end
 
-  context 'when count of NVSwitches == 0' do
-    it 'returns zero when no NVSwitches are found' do
-      allow(output_of_shell).to receive(:stdout).and_return("0\n")
-      expect(resource.get_nvswitches).to eq(0)
-    end
-  end
-
-  context 'when count of NVSwitches gives unexpected output' do
-    it 'handles non-numeric output' do
-      allow(output_of_shell).to receive(:stdout).and_return("error\n")
-      expect(resource.get_nvswitches).to eq(0)
+        it 'does not enable fabric manager service' do
+          is_expected.not_to start_service(fabric_manager_package)
+        end
+      end
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
@@ -352,12 +352,11 @@ describe 'nvidia_imex:configure' do
         end
 
         %w(HeadNode LoginNode ComputeFleet).each do |node_type|
-          context "when get_nvswitch_count > 1 on #{node_type} node" do
+          context "when is_gb200_node? is true on #{node_type} node" do
             cached(:chef_run) do
               stubs_for_provider('nvidia_imex[configure]') do |pro|
                 allow(pro).to receive(:imex_installed?).and_return(true)
-                allow(pro).to receive(:get_device_ids).and_return({ 'gb200' => 'test' })
-                allow(pro).to receive(:get_nvswitch_count).with('test').and_return(4)
+                allow(pro).to receive(:is_gb200_node?).and_return(true)
                 allow(pro).to receive(:enable_force_configuration?).and_return(force_indicator)
               end
               runner(platform: platform, version: version, step_into: ['nvidia_imex'])
@@ -394,12 +393,11 @@ describe 'nvidia_imex:configure' do
           end
         end
 
-        context "when get_nvswitch_count <= 1" do
+        context "when is_gb200_node? is false" do
           cached(:chef_run) do
             stubs_for_provider('nvidia_imex[configure]') do |pro|
               allow(pro).to receive(:imex_installed?).and_return(true)
-              allow(pro).to receive(:get_device_ids).and_return({ 'gb200' => 'test' })
-              allow(pro).to receive(:get_nvswitch_count).with('test').and_return(1)
+              allow(pro).to receive(:is_gb200_node?).and_return(false)
               allow(pro).to receive(:enable_force_configuration?).and_return(force_indicator)
             end
             runner = runner(platform: platform, version: version, step_into: ['nvidia_imex'])


### PR DESCRIPTION
### Description of changes

[NVSwitch] Using vendor ID  and class ID of PCI device to find the number of NVSwitches/Bridges for an EC2 instance


* We do not need to know the entire device ID (Vendor_ID:Gpu_ID:ClassID) to find the number of GPU's or the Number of NVSwitches/Bridges
    - Vendor ID is same for a particular manufacturer (ie NVIDIA, AMD, etc)
    - We use the VendorID and ClassID (type of device) for identifying whether we want to enable Fabric Manager.
* We still need the GB200 device ID as this instance does not require Fabric Manager and our logic use the entire device ID to identify this instance type
* update unit tests

Without this change the future instances whose device IDs were not known or added in our recipes would not have the fabric manager started. This change would allow the starting of Fabric manager for any future eligible instances (which have more than 1 GPU's).


Logs from p5e.48xlarge 

```
Recipe: aws-parallelcluster-platform::nvidia_config
  * fabric_manager[Configure fabric manager] action configure[2026-02-10T17:22:02+00:00] INFO: Processing fabric_manager[Configure fabric manager] action configure (aws-parallelcluster-platform::nvidia_config line 18)
[2026-02-10T17:22:02+00:00] INFO: PCI device count for filter '10de::0302': 8
[2026-02-10T17:22:02+00:00] INFO: PCI device count for filter '10de::0680': 4
[2026-02-10T17:22:02+00:00] INFO: PCI device count for filter '10de:2941:': 0

    * service[nvidia-fabricmanager] action start[2026-02-10T17:22:02+00:00] INFO: Processing service[nvidia-fabricmanager] action start (aws-parallelcluster-platform::nvidia_config line 35)
[2026-02-10T17:22:08+00:00] INFO: service[nvidia-fabricmanager] started

      - start service service[nvidia-fabricmanager]
 
```

### Tests
* Success integ tests 
   -  tested with below instances and `p5e.48xlarge` and `p6-b300.48xlarge` (same Bridge as p6-b200.48xlarge)
```
  health_checks:
    test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
      dimensions:
        - regions: [ "us-east-1"]
          instances: [ "g4dn.2xlarge", "g5g.4xlarge", "p4d.24xlarge" ]
          oss: [{{ OS_X86_5 }}]
          schedulers: ["slurm"]

```

### References
* https://phoenixnap.com/kb/lspci-command and https://man7.org/linux/man-pages/man5/pci.ids.5.html on lspci command and some details on the different IDs (ie. Vendor ID, Device ID and Class ID )
* Database to find PCI devices using Vendor ID, Device ID and Class ID (https://devicehunt.com/ and https://pci-ids.ucw.cz/)


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
