### PR TITLE
[NVSwitch] Add B300 device ID for enabling Fabric Manager

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/libraries/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-platform/libraries/nvidia.rb
@@ -27,12 +27,13 @@ def get_nvswitch_count(device_id)
 end
 
 def get_device_ids
-  #  A100 (P4), H100(P5), B200(P6) and GB200(p6e) systems have NVSwitches
+  #  A100 (P4), H100(P5), B200(P6), B300(p6-b300) and GB200(p6e) systems have NVSwitches
   # NVSwitch device id is 10de:1af1 for P4 instance
   # NVSwitch device id is 10de:22a3 for P5 instance
   # NVSwitch device id is 10de:2901 for P6 instance
   # NVSwitch device id is 10de:2941 for P6e instance
-  { 'a100' => '10de:1af1', 'h100' => '10de:22a3', 'b200' => '10de:2901', 'gb200' => '10de:2941' }
+  # NVSwitch device id is 10de:3182 for P6-b300 instance
+  { 'a100' => '10de:1af1', 'h100' => '10de:22a3', 'b200' => '10de:2901', 'gb200' => '10de:2941', 'b300' => '10de:3182' }
 end
 
 def is_gb200_node?


### PR DESCRIPTION
### Description of changes
* Add B300 device ID for enabling Fabric Manager

### Tests
* Manually tested command `lspci -d 10de:3182`
* Tested by creating a cluster with b300

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
