### PR TITLE
[Update] Reduce the risk of clustermgtd being stopped on cluster update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Intel MPI Library to 2021.17.2 (from 2021.16.0).
 - Upgrade Cinc Client to version 18.8.54 (from 18.7.10).
 - Always start clustermgtd on cluster update failure, regardless the failure condition.
+- Keep clustermgtd stopped during cluster updates only during munge key updates, slurmctld restart and slurm reconfigure.
 
 **BUG FIXES**
 - Fix timestamp formats in CloudWatch log configuration to let CloudWatch parse the correct timestamps.

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -207,17 +207,6 @@ replace_or_add "update node replacement timeout" do
   replace_only true
 end
 
-ruby_block "Update Slurm Accounting" do
-  block do
-    if node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil?
-      run_context.include_recipe "aws-parallelcluster-slurm::clear_slurm_accounting"
-    else
-      run_context.include_recipe "aws-parallelcluster-slurm::config_slurm_accounting"
-    end
-  end
-  only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_slurm_database_updated? }
-end unless on_docker?
-
 # Cover the following two scenarios:
 # - a cluster without login nodes is updated to have login nodes;
 # - a cluster with login nodes is updated to use another pool name.
@@ -242,8 +231,6 @@ template "#{node['cluster']['scripts_dir']}/slurm/update_munge_key.sh" do
   only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_custom_munge_key_updated? }
 end
 
-update_munge_head_node
-
 # The previous execute "generate_pcluster_slurm_configs" block resource may have overridden the slurmdbd password in
 # slurm_parallelcluster_slurmdbd.conf with a default value, so if it has run and Slurm accounting
 # is enabled we must pull the database password from Secrets Manager once again.
@@ -254,6 +241,19 @@ execute "update Slurm database password" do
   # This horrible only_if guard is needed to cover all cases that trigger "generate_pcluster_slurm_settings", in the case Slurm accounting is being used
   only_if { !(::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated?) && !node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
 end
+
+update_munge_head_node
+
+ruby_block "Update Slurm Accounting" do
+  block do
+    if node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil?
+      run_context.include_recipe "aws-parallelcluster-slurm::clear_slurm_accounting"
+    else
+      run_context.include_recipe "aws-parallelcluster-slurm::config_slurm_accounting"
+    end
+  end
+  only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_slurm_database_updated? }
+end unless on_docker?
 
 service 'slurmctld' do
   action :restart
@@ -280,11 +280,11 @@ end
 
 chef_sleep '15'
 
-wait_cluster_ready if cluster_readiness_check_on_update_enabled?
-
 execute 'start clustermgtd' do
   command "#{cookbook_virtualenv_path}/bin/supervisorctl start clustermgtd"
 end
+
+wait_cluster_ready if cluster_readiness_check_on_update_enabled?
 
 # The updated cfnconfig will be used by post update custom scripts
 template "#{node['cluster']['etc_dir']}/cfnconfig" do

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
@@ -84,6 +84,43 @@ describe 'aws-parallelcluster-slurm::update_head_node' do
               timeout: reconfigure_timeout
             )
           end
+
+          it 'executes resources in the correct order' do
+            # NOTE: The most important aspect in the sequence is that clustermgtd is stopped while executing:
+            #   1. update_munge_key
+            #   2. restart of slurmctld
+            #   3. scontrol reconfigure
+            resource_names = chef_run.resource_collection.map(&:name)
+
+            expected_sequence = [
+              'stop clustermgtd',
+              chef_run.node['cluster']['update']['trigger_file'],
+              'update_shared_storages',
+              'replace slurm queue nodes',
+              'Update or Cleanup Slurm Topology',
+              'generate_pcluster_slurm_configs',
+              'generate_pcluster_custom_slurm_settings_include_files',
+              'Override Custom Slurm Settings with remote file',
+              'generate_pcluster_fleet_config',
+              'update node replacement timeout',
+              "#{scripts_dir}/slurm/check_login_nodes_stopped.sh",
+              "#{scripts_dir}/slurm/update_munge_key.sh",
+              'update Slurm database password',
+              'update_munge_key',
+              'Update Slurm Accounting',
+              'slurmctld',
+              '5',
+              'check slurmctld status',
+              'reload config for running nodes',
+              '15',
+              'start clustermgtd',
+              'Check cluster readiness',
+              '/etc/parallelcluster/cfnconfig',
+              'Cleanup',
+            ]
+
+            expect(resource_names).to eq(expected_sequence)
+          end
         end
       end
 


### PR DESCRIPTION
### Description of changes
Reduce the risk of clustermgtd being stopped on cluster update
We keep clustermgtd stopped only during update actions that have high risk of race conditions, that are munge key updates, slurm accounting updates, restart of slurmctld and scontrol reconfigure. Also, in case of update failure, we restart clustermgtd whatever the point of failure faced during the update.

### Q&A
2. **How will we cover this change with integ tests?**
We will introduce/extend integ tests to verify no race conditions are triggered as part of the next sprint. 
For sake of this PR we consider enough to verify that it introduces no regressions.
3. **Why keeping clustermgtd stopped during slurm accounting updates?**
This is not required because of conflicts with clustermgtd, but because the slurm accounting updates includes the restart of slurmdbd, that, in case munge key is updated, must occur after the munge key updates ([docs](https://slurm.schedmd.com/quickstart_admin.html)).

### Tests
* The risks have been deeply assessed during design.
* Unit tests (updated to cover the current changes)
* [PENDING] Integ tests: 
  * `test_update_slurm`
  * `test_custom_munge_key`
  * `test_dynamic_file_systems_update_rollback`
  * `test_update_rollback_failure`
  *  `test_login_nodes_update`
  * `test_queue_parameters_update`
  * `test_dynamic_file_systems_update`

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
