### PR TITLE
[Update] Always restart clustermgtd on update failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade NVIDIA Fabric manager to 580.105.08 for all OSs except Amazon Linux 2.
 - Upgrade Python to 3.14.2 (from 3.12.11) for all OSs except Amazon Linux 2.
 - Upgrade aws-cfn-bootstrap to version 2.0-38 (from 2.0-33).
+- Always start clustermgtd on cluster update failure, regardless the failure condition. 
 
 **BUG FIXES**
 - Fix timestamp formats in CloudWatch log configuration to let CloudWatch parse the correct timestamps.

--- a/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
@@ -22,7 +22,7 @@ module ErrorHandlers
   # to restore the cluster to a consistent state:
   # 1. Logs information about the update failure including which resources succeeded before failure
   # 2. Cleans up DNA files shared with compute nodes
-  # 3. Starts clustermgtd if scontrol reconfigure succeeded
+  # 3. Starts clustermgtd
   #
   # Only runs on HeadNode - compute and login nodes skip this handler.
   class UpdateFailureHandler < Chef::Handler
@@ -54,20 +54,8 @@ module ErrorHandlers
 
     def run_recovery
       Chef::Log.info("#{log_prefix} Running recovery commands")
-
-      # Cleanup DNA files
       cleanup_dna_files
-
-      # Start clustermgtd if scontrol reconfigure succeeded
-      # Must match SCONTROL_RECONFIGURE_RESOURCE_NAME in aws-parallelcluster-slurm/libraries/update.rb
-      scontrol_reconfigure_resource_name = 'reload config for running nodes'
-      Chef::Log.info("#{log_prefix} Resource '#{scontrol_reconfigure_resource_name}' has execution status: #{resource_status(scontrol_reconfigure_resource_name)}")
-      if resource_succeeded?(scontrol_reconfigure_resource_name)
-        Chef::Log.info("#{log_prefix} scontrol reconfigure succeeded, starting clustermgtd")
-        start_clustermgtd
-      else
-        Chef::Log.info("#{log_prefix} scontrol reconfigure did not succeed, skipping clustermgtd start")
-      end
+      start_clustermgtd
     end
 
     def cleanup_dna_files

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
@@ -38,7 +38,6 @@ describe ErrorHandlers::UpdateFailureHandler do
   end
   let(:node_type) { 'HeadNode' }
   let(:run_status) { double('run_status', exception: exception, updated_resources: updated_resources, node: node) }
-  let(:scontrol_resource_name) { 'reload config for running nodes' }
   let(:command_runner) { instance_double(ErrorHandlers::CommandRunner) }
 
   before do
@@ -100,27 +99,10 @@ describe ErrorHandlers::UpdateFailureHandler do
   end
 
   describe '#run_recovery' do
-    context 'when scontrol reconfigure succeeded' do
-      let(:reload_resource) { double('reload_resource', resource_name: :execute, name: scontrol_resource_name) }
-      let(:action_record) { double('action_record', new_resource: reload_resource, status: :updated) }
-
-      before do
-        allow(action_collection).to receive(:filtered_collection).and_return([action_record])
-      end
-
-      it 'cleans up DNA files and starts clustermgtd' do
-        expect(handler).to receive(:cleanup_dna_files)
-        expect(handler).to receive(:start_clustermgtd)
-        handler.run_recovery
-      end
-    end
-
-    context 'when scontrol reconfigure did not succeed' do
-      it 'cleans up DNA files but does not start clustermgtd' do
-        expect(handler).to receive(:cleanup_dna_files)
-        expect(handler).not_to receive(:start_clustermgtd)
-        handler.run_recovery
-      end
+    it 'cleans up DNA files and starts clustermgtd unconditionally' do
+      expect(handler).to receive(:cleanup_dna_files).ordered
+      expect(handler).to receive(:start_clustermgtd).ordered
+      handler.run_recovery
     end
   end
 


### PR DESCRIPTION
### Description of changes
Always restart clustermgtd on update failure, regardless the point of failure.

Before this change, clustermgtd was restarted only if the update recipe failed the cluster readiness check.

This change is meant to reduce the chances of having clustermgtd stopped after a failed update.

### UX

clustermgtd gets restarted on update recipe failure (both update and rollback):

```
Running handlers:
[2026-01-28T17:50:42+00:00] ERROR: Running exception handlers
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Started
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Update failed on HeadNode due to: ruby_block[synthetic failure] (aws-parallelcluster-slurm::update_head_node line 258) had an error: RuntimeError: SYNTHETIC ERROR INJECTED BY MGIACOMO
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Resources that have been successfully executed before the failure:
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - ruby_block[Configure environment variable for recipes context: PATH]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - fetch_dna_files[Fetch ComputeFleet's Dna files]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - fetch_config[Fetch and load cluster configs]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - file[/opt/parallelcluster/shared/update_trigger]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - ruby_block[replace slurm queue nodes]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - execute[generate_pcluster_slurm_configs]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - execute[generate_pcluster_fleet_config]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - execute[stop clustermgtd]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Running recovery commands
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Executing: cleanup DNA files
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Running command (attempt 1/11): /opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/python /opt/parallelcluster/scripts/share_compute_fleet_dna.py --region us-east-1 --cleanup
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stdout:
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stderr: INFO:__main__:Cleaning up /opt/parallelcluster/shared/dna/LaunchTemplateB1b67670b4d707d5-dna.json
INFO:__main__:Cleaning up /opt/parallelcluster/shared/dna/extra.json
INFO:__main__:All dna.json files have been shared!

[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Successfully executed: cleanup DNA files
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Executing: start clustermgtd
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Running command (attempt 1/11): /opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/supervisorctl start clustermgtd
[2026-01-28T17:50:44+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stdout: clustermgtd: started

[2026-01-28T17:50:44+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stderr:
[2026-01-28T17:50:44+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Successfully executed: start clustermgtd
[2026-01-28T17:50:44+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Completed successfully
  - ErrorHandlers::UpdateFailureHandler
Running handlers complete
[2026-01-28T17:50:44+00:00] ERROR: Exception handlers complete
```

### Tests
* The risks have been deeply assessed during design.
* Manually verified that clustermgtd is always restarted on whatever update failure. In particular I simulated a failure by injecting synthetic exceptions into the update recipe while clustermgtd was stgopped. The alarm introduced in https://github.com/aws/aws-parallelcluster/pull/7209 never goes red because the overall downtime of clustermgtd is less than a minute from update start to rollback completion.
* Unit tests (updated to cover the current changes)
* [SUCCEEDED] Integ tests:  `test_update_rollback_failure`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
