### PR TITLE
Upgrade Munge, DCGM, IntelMPI and MYSQl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade NVIDIA Fabric manager to 580.105.08 for all OSs except Amazon Linux 2.
 - Upgrade Python to 3.14.2 (from 3.12.11) for all OSs except Amazon Linux 2.
 - Upgrade aws-cfn-bootstrap to version 2.0-38 (from 2.0-33).
+- Upgrade DCGM to version 4.5.1 (from 4.4.1) for all OSs except Amazon Linux 2.
+- Upgrade Munge to version 0.5.17 (from 0.5.16) for all OSs except Amazon Linux 2.
+- Upgrade mysql-community-client to version 8.4.8 (from 8.0.39) for all OSs except Amazon Linux 2.
+- Upgrade Intel MPI Library to 2021.17.2 (from 2021.16.0).
+- Upgrade Cinc Client to version 18.8.54 (from 18.7.10).
 
 **BUG FIXES**
 - Fix timestamp formats in CloudWatch log configuration to let CloudWatch parse the correct timestamps.

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -17,11 +17,12 @@ default['cluster']['enroot']['persistent_dir'] = '/var/enroot'
 # NVidia
 default['cluster']['nvidia']['enabled'] = 'no'
 default['cluster']['nvidia']['driver_version'] = '580.105.08'
-default['cluster']['nvidia']['dcgm_version'] = '4.4.1-1'
+default['cluster']['nvidia']['dcgm_version'] = '4.5.1-1'
 if platform?('amazon') && node['platform_version'] == "2"
   default['cluster']['nvidia']['driver_version'] = '550.127.08'
   default['cluster']['nvidia']['dcgm_version'] = '3.3.6-1'
 end
+default['cluster']['nvidia']['dcgm_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_dcgm"
 
 # nvidia-imex
 default['cluster']['nvidia']['imex']['force_configuration'] = false

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -78,3 +78,8 @@ default['cluster']['cluster_config_version'] = nil
 default['cluster']['instance_types_data_version'] = nil
 default['cluster']['change_set_s3_key'] = nil
 default['cluster']['instance_types_data_s3_key'] = nil
+
+# Intel MPI
+default['cluster']['intelmpi']['version'] = '2021.17'
+default['cluster']['intelmpi']['full_version'] = '2021.17.2.94'
+default['cluster']['intelmpi']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/impi"

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/intel_mpi.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/intel_mpi.rb
@@ -16,20 +16,19 @@
 # limitations under the License.
 
 intelmpi_supported = !arm_instance?
-intelmpi_version = '2021.16'
 
 node.default['conditions']['intel_mpi_supported'] = intelmpi_supported
-node.default['cluster']['intelmpi']['version'] = intelmpi_version
 
 node_attributes "dump node attributes"
 
 return unless intelmpi_supported
 
-intelmpi_full_version = "#{intelmpi_version}.0.443"
+intelmpi_version = node['cluster']['intelmpi']['version']
+intelmpi_full_version = node['cluster']['intelmpi']['full_version']
 intelmpi_installation_path = "/opt/intel/mpi/#{intelmpi_version}"
 intelmpi_installer = "intel-mpi-#{intelmpi_full_version}_offline.sh"
 intelmpi_installer_path = "#{node['cluster']['sources_dir']}/#{intelmpi_installer}"
-intelmpi_installer_url = "#{node['cluster']['artifacts_s3_url']}/impi/#{intelmpi_installer}"
+intelmpi_installer_url = "#{node['cluster']['intelmpi']['base_url']}/#{intelmpi_installer}"
 intelmpi_qt_version = '6.5.3'
 
 # Prerequisite for module install

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_debian.rb
@@ -20,7 +20,7 @@ action :install_package do
                        end
   packages_urls_list.each do |package|
     remote_file "#{node['cluster']['sources_dir']}/#{package}-#{package_version}.deb" do
-      source "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_dcgm/#{platform}/#{package}_#{package_version}_#{arch_suffix}.deb"
+      source "#{node['cluster']['nvidia']['dcgm_base_url']}/#{platform}/#{package}_#{package_version}_#{arch_suffix}.deb"
       mode '0644'
       retries 3
       retry_delay 5

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_rhel.rb
@@ -22,7 +22,7 @@ action :install_package do
   end
   packages_urls_list.each do |package|
     remote_file "#{node['cluster']['sources_dir']}/#{package}-#{package_version}.rpm" do
-      source "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_dcgm/#{platform}/#{package}-#{package_version}#{package_url_separator}#{arch_suffix}.rpm"
+      source "#{node['cluster']['nvidia']['dcgm_base_url']}/#{platform}/#{package}-#{package_version}#{package_url_separator}#{arch_suffix}.rpm"
       mode '0644'
       retries 3
       retry_delay 5

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/intel_mpi_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/intel_mpi_spec.rb
@@ -3,10 +3,16 @@ require 'spec_helper'
 describe 'aws-parallelcluster-platform::intel_mpi' do
   cached(:source_dir) { 'source_dir_for_tests' }
   cached(:aws_region) { 'region_for_tests' }
+  cached(:intelmpi_version) { 'VERSION' }
+  cached(:intelmpi_full_version) { 'VERSION.0' }
+  cached(:intelmpi_base_url) { "https://#{aws_region}-aws-parallelcluster.s3.#{aws_region}.test_aws_domain/archives/impi" }
   cached(:chef_run) do
     runner = ChefSpec::Runner.new do |node|
       node.override['cluster']['sources_dir'] = source_dir
       node.override['cluster']['region'] = aws_region
+      node.override['cluster']['intelmpi']['version'] = intelmpi_version
+      node.override['cluster']['intelmpi']['full_version'] = intelmpi_full_version
+      node.override['cluster']['intelmpi']['base_url'] = intelmpi_base_url
     end
     runner.converge(described_recipe)
   end
@@ -20,8 +26,8 @@ describe 'aws-parallelcluster-platform::intel_mpi' do
   end
 
   it 'fetches intel mpi installer script' do
-    is_expected.to create_remote_file("#{source_dir}/intel-mpi-2021.16.0.443_offline.sh").with(
-      source: "https://#{aws_region}-aws-parallelcluster.s3.#{aws_region}.test_aws_domain/archives/impi/intel-mpi-2021.16.0.443_offline.sh",
+    is_expected.to create_remote_file("#{source_dir}/intel-mpi-#{intelmpi_full_version}_offline.sh").with(
+      source: "#{intelmpi_base_url}/intel-mpi-#{intelmpi_full_version}_offline.sh",
       mode: '0744',
       retries: 3,
       retry_delay: 5
@@ -31,25 +37,26 @@ describe 'aws-parallelcluster-platform::intel_mpi' do
   it 'installs intel mpi' do
     is_expected.to run_bash('install intel mpi').with(
       cwd: source_dir,
-      creates: '/opt/intel/mpi/2021.16'
-    ).with_code(%r{chmod +x intel-mpi-2021.16.0.443_offline.sh --remove-extracted-files yes -a --silent --eula accept --install-dir /opt/intel})
-                                                .with_code(/rm -f intel-mpi-2021.16.0.443_offline.sh/)
+      creates: "/opt/intel/mpi/#{intelmpi_version}"
+    ).with_code(/chmod \+x intel-mpi-#{intelmpi_full_version}_offline.sh/)
+                                                .with_code(%r{--remove-extracted-files yes -a --silent --eula accept --install-dir /opt/intel})
+                                                .with_code(/rm -f intel-mpi-#{intelmpi_full_version}_offline.sh/)
   end
 
   it 'appends intel module file dir to modules config' do
     is_expected.to append_to_config_modules('append intel modules file dir to modules conf')
-      .with_line('/opt/intel/mpi/2021.16/etc/modulefiles/')
+      .with_line("/opt/intel/mpi/#{intelmpi_version}/etc/modulefiles/")
   end
 
   it 'renames intel mpi module' do
     is_expected.to run_execute('rename intel mpi modules file name').with(
-      command: "mv /opt/intel/mpi/2021.16/etc/modulefiles/mpi /opt/intel/mpi/2021.16/etc/modulefiles/intelmpi",
-      creates: '/opt/intel/mpi/2021.16/etc/modulefiles/intelmpi'
+      command: "mv /opt/intel/mpi/#{intelmpi_version}/etc/modulefiles/mpi /opt/intel/mpi/#{intelmpi_version}/etc/modulefiles/intelmpi",
+      creates: "/opt/intel/mpi/#{intelmpi_version}/etc/modulefiles/intelmpi"
     )
   end
 
   it 'adds Qt source file' do
-    is_expected.to create_template("/opt/intel/mpi/2021.16/qt_source_code.txt").with(
+    is_expected.to create_template("/opt/intel/mpi/#{intelmpi_version}/qt_source_code.txt").with(
       source: 'intel_mpi/qt_source_code.erb',
       owner: 'root',
       group: 'root',

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -16,3 +16,10 @@ if platform?('amazon') && node['platform_version'] == "2"
   default['cluster']['jwt']['sha256'] = '617778f9687682220abf9b7daacbe72bab7c2985479f8bee4db9648bd2440687'
 end
 default['cluster']['jwt']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/jwt"
+## MySql
+default['cluster']['mysql']['source_version'] = '8.4.8'
+if platform?('amazon') && node['platform_version'] == "2"
+  default['cluster']['mysql']['source_version'] = '8.0.39'
+end
+default['cluster']['mysql']['version'] = "#{node['cluster']['mysql']['source_version']}-1"
+default['cluster']['mysql']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/mysql"

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -5,8 +5,12 @@ default['cluster']['slurm']['branch'] = ''
 default['cluster']['slurm']['sha256'] = 'f0912d85a9a9b417fd23ca4997c8d3dfed89b3b70b15aad4da54f2812d30d48c'
 default['cluster']['slurm']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/slurm"
 # Munge
-default['cluster']['munge']['munge_version'] = '0.5.16'
-default['cluster']['munge']['sha256'] = 'fa27205d6d29ce015b0d967df8f3421067d7058878e75d0d5ec3d91f4d32bb57'
+default['cluster']['munge']['munge_version'] = '0.5.17'
+default['cluster']['munge']['sha256'] = '4d6a1b9665d8a1119fb90678e6bcf446012340dc59dbcc90a10e2ab2e4724f08'
+if platform?('amazon') && node['platform_version'] == "2"
+  default['cluster']['munge']['munge_version'] = '0.5.16'
+  default['cluster']['munge']['sha256'] = 'fa27205d6d29ce015b0d967df8f3421067d7058878e75d0d5ec3d91f4d32bb57'
+end
 default['cluster']['munge']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/munge"
 # LibJwt
 default['cluster']['jwt']['version'] = '1.18.4'

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/partial/_common.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/partial/_common.rb
@@ -25,7 +25,7 @@ action :create_source_link do
   file "#{node['cluster']['sources_dir']}/mysql_source_code.txt" do
     content %(You can get MySQL source code here:
 
-#{package_source(node['cluster']['artifacts_s3_url'])}
+#{package_source}
 )
     owner 'root'
     group 'root'
@@ -35,26 +35,22 @@ end
 
 action_class do
   def package_version
-    "8.0.39-1"
+    node['cluster']['mysql']['version']
   end
 
   def package_source_version
-    "8.0.39"
+    node['cluster']['mysql']['source_version']
   end
 
   def package_filename
     "mysql-community-client-#{package_version}.tar.gz"
   end
 
-  def package_root(s3_url)
-    "#{s3_url}/mysql"
+  def package_archive
+    "#{node['cluster']['mysql']['base_url']}/#{package_platform}/#{package_filename}"
   end
 
-  def package_archive(s3_url)
-    "#{package_root(s3_url)}/#{package_platform}/#{package_filename}"
-  end
-
-  def package_source(s3_url)
-    "#{s3_url}/source/mysql-#{package_source_version}.tar.gz"
+  def package_source
+    "#{node['cluster']['mysql']['base_url']}/source/mysql-#{package_source_version}.tar.gz"
   end
 end

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/partial/_setup_rhel_based.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/partial/_setup_rhel_based.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 action :setup do
-  mysql_archive_url = package_archive(node['cluster']['artifacts_s3_url'])
+  mysql_archive_url = package_archive
   mysql_tar_file = "/tmp/#{package_filename}"
 
   log "Downloading MySQL packages archive from #{mysql_archive_url}"

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/resources/mysql_client_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/resources/mysql_client_spec.rb
@@ -23,10 +23,11 @@ describe 'mysql_client:setup' do
     %w(x86_64 aarch64).each do |architecture|
       context "on #{platform}#{version} #{architecture}" do
         cached(:source_dir) { 'SOURCE_DIR' }
-        cached(:package_source_version) { '8.0.39' }
-        cached(:package_version) { '8.0.39-1' }
+        cached(:package_source_version) { 'VERSION' }
+        cached(:package_version) { 'VERSION-1' }
         cached(:package_filename) { "mysql-community-client-#{package_version}.tar.gz" }
         cached(:s3_url) { 's3://url' }
+        cached(:mysql_base_url) { "#{s3_url}/mysql" }
         cached(:package_platform) do
           platform_version = if version.to_i == 2
                                7
@@ -47,7 +48,7 @@ describe 'mysql_client:setup' do
             pending "unsupported architecture #{architecture}"
           end
         end
-        cached(:package_archive) { "#{s3_url}/mysql/#{package_platform}/#{package_filename}" }
+        cached(:package_archive) { "#{mysql_base_url}/#{package_platform}/#{package_filename}" }
         cached(:tarfile) { "/tmp/mysql-community-client-#{package_version}.tar.gz" }
         cached(:repository_packages) do
           if platform == 'ubuntu'
@@ -65,6 +66,9 @@ describe 'mysql_client:setup' do
             node.automatic['kernel']['machine'] = architecture
             node.override['cluster']['sources_dir'] = source_dir
             node.override['cluster']['artifacts_s3_url'] = s3_url
+            node.override['cluster']['mysql']['version'] = package_version
+            node.override['cluster']['mysql']['source_version'] = package_source_version
+            node.override['cluster']['mysql']['base_url'] = mysql_base_url
           end
           ConvergeMysqlClient.setup(runner)
         end
@@ -117,7 +121,7 @@ describe 'mysql_client:setup' do
           is_expected.to create_file("#{source_dir}/mysql_source_code.txt")
             .with(content: %(You can get MySQL source code here:
 
-#{"#{s3_url}/source/mysql-#{package_source_version}.tar.gz"}
+#{"#{mysql_base_url}/source/mysql-#{package_source_version}.tar.gz"}
 ))
             .with(owner: 'root')
             .with(group: 'root')

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/mysql_client_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/mysql_client_spec.rb
@@ -31,7 +31,7 @@ control 'tag:install_mysql_client_installed' do
   mysql_packages.each do |pkg|
     describe package(pkg) do
       it { should be_installed }
-      its('version') { should match /^8.0.39-/ } unless ubuntu
+      its('version') { should match /^#{node['cluster']['mysql']['source_version']}-/ } unless ubuntu
     end
   end
 end
@@ -47,7 +47,7 @@ control 'tag:install_mysql_client_source_code_created' do
     its('content') do
       should eq %(You can get MySQL source code here:
 
-https://#{node['cluster']['region']}-aws-parallelcluster.s3.#{node['cluster']['region']}.amazonaws.com/archives/source/mysql-8.0.39.tar.gz
+https://#{node['cluster']['region']}-aws-parallelcluster.s3.#{node['cluster']['region']}.amazonaws.com/archives/mysql/source/mysql-#{node['cluster']['mysql']['source_version']}.tar.gz
 )
     end
   end


### PR DESCRIPTION
### Description of changes
 - Upgrade DCGM to version 4.5.1 (from 4.4.1) for all OSs except Amazon Linux 2.
- Upgrade Munge to version 0.5.17 (from 0.5.16) for all OSs except Amazon Linux 2.
- Upgrade mysql-community-client to version 8.4.8 (from 8.0.39) for all OSs except Amazon Linux 2.
- Upgrade Intel MPI Library to 2021.17.2 (from 2021.16.0).
- Upgrade cinc in https://github.com/aws/aws-parallelcluster/pull/7218
- Added ExtraChefAttribute to be able to override the Base URL's for dependecies

### Tests
* Build Image without ExtraChefAttributes
* Build Image with below ExtraChefAttributes
```
{"cluster":{"intelmpi":{"base_url":"https://registrationcenter-download.intel.com/akdlm/IRC_NAS/86923909-82e5-4c1a-9499-b4263e800a33"},"munge":{"base_url":"https://github.com/dun/munge/archive"},"nvidia":{"dcgm_base_url":"https://developer.download.nvidia.com/compute/cuda/repos"},"mysql":{"base_url":"https://public-s3-bucket.s3.us-east-1.amazonaws.com/archives/mysql"}}}

```
* Integ Build image tests 
```
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
        - regions: ["cnn1-az1"]
          instances: ["g4dn.2xlarge"]
          schedulers: ["slurm"]
          oss: ["alinux2023"]
        - regions: ["us-gov-west-1"]
          instances: ["g4dn.2xlarge"]
          schedulers: ["slurm"]
          oss: ["alinux2023"]
```
* Integ tests for the dependecies
```
test-suites:
  basic:
    test_essential_features.py::test_essential_features:
      dimensions:
        - regions: [{{ US_EAST_1_INSTANCE_TYPE_0_xlarge_CAPACITY_RESERVATION_8_INSTANCES_2_HOURS_NOPG_OS_X86_1 }}]
          instances: [{{ US_EAST_1_INSTANCE_TYPE_0 }}.xlarge]
          oss: [{{ DCV_OS_X86_1 }}]
          schedulers: ["slurm"]
  health_checks:
    test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
      dimensions:
        - regions: [{{ US_WEST_2_GPU_INSTANCE_TYPE_0_CAPACITY_RESERVATION_3_INSTANCES_2_HOURS_NOPG_OS_X86_5 }}]
          instances: [{{ US_WEST_2_GPU_INSTANCE_TYPE_0 }}]
          oss: [{{ OS_X86_5 }}]
          schedulers: ["slurm"]
  schedulers:
    test_slurm_accounting.py::test_slurm_accounting:
      dimensions:
        - regions: ["ap-south-1"]
          instances:  {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [{{ OS_X86_1 }}]
          schedulers: ["slurm"]
    test_slurm_accounting.py::test_slurm_accounting_external_dbd:
      dimensions:
        - regions: [ "ap-south-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [{{ OS_X86_3 }}]
          schedulers: ["slurm"]
    test_custom_munge_key.py::test_custom_munge_key:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [{{ OS_X86_0 }}]
          schedulers: ["slurm"]
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
