### PR TITLE
[Update] Keep clustermgtd running on fleet update + always restart it on cluster update failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Intel MPI Library to 2021.17.2 (from 2021.16.0).
 - Upgrade Cinc Client to version 18.8.54 (from 18.7.10).
 - Always start clustermgtd on cluster update failure, regardless the failure condition.
+- Keep clustermgtd running during compute-fleet status updates.
 
 **BUG FIXES**
 - Fix timestamp formats in CloudWatch log configuration to let CloudWatch parse the correct timestamps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade mysql-community-client to version 8.4.8 (from 8.0.39) for all OSs except Amazon Linux 2.
 - Upgrade Intel MPI Library to 2021.17.2 (from 2021.16.0).
 - Upgrade Cinc Client to version 18.8.54 (from 18.7.10).
+- Always start clustermgtd on cluster update failure, regardless the failure condition.
 
 **BUG FIXES**
 - Fix timestamp formats in CloudWatch log configuration to let CloudWatch parse the correct timestamps.

--- a/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
@@ -22,7 +22,7 @@ module ErrorHandlers
   # to restore the cluster to a consistent state:
   # 1. Logs information about the update failure including which resources succeeded before failure
   # 2. Cleans up DNA files shared with compute nodes
-  # 3. Starts clustermgtd if scontrol reconfigure succeeded
+  # 3. Starts clustermgtd
   #
   # Only runs on HeadNode - compute and login nodes skip this handler.
   class UpdateFailureHandler < Chef::Handler
@@ -54,20 +54,8 @@ module ErrorHandlers
 
     def run_recovery
       Chef::Log.info("#{log_prefix} Running recovery commands")
-
-      # Cleanup DNA files
       cleanup_dna_files
-
-      # Start clustermgtd if scontrol reconfigure succeeded
-      # Must match SCONTROL_RECONFIGURE_RESOURCE_NAME in aws-parallelcluster-slurm/libraries/update.rb
-      scontrol_reconfigure_resource_name = 'reload config for running nodes'
-      Chef::Log.info("#{log_prefix} Resource '#{scontrol_reconfigure_resource_name}' has execution status: #{resource_status(scontrol_reconfigure_resource_name)}")
-      if resource_succeeded?(scontrol_reconfigure_resource_name)
-        Chef::Log.info("#{log_prefix} scontrol reconfigure succeeded, starting clustermgtd")
-        start_clustermgtd
-      else
-        Chef::Log.info("#{log_prefix} scontrol reconfigure did not succeed, skipping clustermgtd start")
-      end
+      start_clustermgtd
     end
 
     def cleanup_dna_files

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
@@ -38,7 +38,6 @@ describe ErrorHandlers::UpdateFailureHandler do
   end
   let(:node_type) { 'HeadNode' }
   let(:run_status) { double('run_status', exception: exception, updated_resources: updated_resources, node: node) }
-  let(:scontrol_resource_name) { 'reload config for running nodes' }
   let(:command_runner) { instance_double(ErrorHandlers::CommandRunner) }
 
   before do
@@ -100,27 +99,10 @@ describe ErrorHandlers::UpdateFailureHandler do
   end
 
   describe '#run_recovery' do
-    context 'when scontrol reconfigure succeeded' do
-      let(:reload_resource) { double('reload_resource', resource_name: :execute, name: scontrol_resource_name) }
-      let(:action_record) { double('action_record', new_resource: reload_resource, status: :updated) }
-
-      before do
-        allow(action_collection).to receive(:filtered_collection).and_return([action_record])
-      end
-
-      it 'cleans up DNA files and starts clustermgtd' do
-        expect(handler).to receive(:cleanup_dna_files)
-        expect(handler).to receive(:start_clustermgtd)
-        handler.run_recovery
-      end
-    end
-
-    context 'when scontrol reconfigure did not succeed' do
-      it 'cleans up DNA files but does not start clustermgtd' do
-        expect(handler).to receive(:cleanup_dna_files)
-        expect(handler).not_to receive(:start_clustermgtd)
-        handler.run_recovery
-      end
+    it 'cleans up DNA files and starts clustermgtd unconditionally' do
+      expect(handler).to receive(:cleanup_dna_files).ordered
+      expect(handler).to receive(:start_clustermgtd).ordered
+      handler.run_recovery
     end
   end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_computefleet_status_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_computefleet_status_head_node.rb
@@ -19,8 +19,6 @@ bash 'update compute fleet' do
   user 'root'
   code <<-UPDATE_COMPUTE_FLEET
       set -xe
-      #{cookbook_virtualenv_path}/bin/supervisorctl stop clustermgtd
       #{node['cluster']['scripts_dir']}/slurm/slurm_fleet_status_manager -cf #{node['cluster']['computefleet_status_path']}
-      #{cookbook_virtualenv_path}/bin/supervisorctl start clustermgtd
   UPDATE_COMPUTE_FLEET
 end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_computefleet_status_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_computefleet_status_head_node_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Copyright:: 2026 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::update_computefleet_status_head_node' do
+  for_all_oses do |platform, version|
+    scripts_dir = "/MOCK_SCRIPTS_DIR"
+    computefleet_status_path = "/MOCK_COMPUTEFLEET_STATUS_PATH"
+
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner = runner(platform: platform, version: version) do |node|
+          node.override['cluster']['scripts_dir'] = scripts_dir
+          node.override['cluster']['computefleet_status_path'] = computefleet_status_path
+        end
+        runner.converge(described_recipe)
+      end
+
+      it 'runs the update compute fleet bash resource with correct configuration' do
+        is_expected.to run_bash('update compute fleet').with(
+          user: 'root',
+          code: "      set -xe\n      #{scripts_dir}/slurm/slurm_fleet_status_manager -cf #{computefleet_status_path}\n"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
Reduce the risk of having clustermgtd not running by:
1. keeping clustermgtd running during stop/start of compute-fleet.
2. always start clustermgtd on cluster update failure, regardless the specific point of failure. Before this change we used to restart it only if the update failed at a specific point.

### Q&A
1. **This PR is a cherry pick of 2 out of 3 commits from https://github.com/aws/aws-parallelcluster-cookbook/pull/3102. Why??**
This PR contains the safe commits from that original PR. We want to decouple those 2 out of 3 improvements so that the troubleshooting of the 3rd improvement  does not block those.

### UX

clustermgtd gets restarted on update recipe failure (both update and rollback):

```
Running handlers:
[2026-01-28T17:50:42+00:00] ERROR: Running exception handlers
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Started
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Update failed on HeadNode due to: ruby_block[synthetic failure] (aws-parallelcluster-slurm::update_head_node line 258) had an error: RuntimeError: SYNTHETIC ERROR INJECTED BY MGIACOMO
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Resources that have been successfully executed before the failure:
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - ruby_block[Configure environment variable for recipes context: PATH]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - fetch_dna_files[Fetch ComputeFleet's Dna files]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - fetch_config[Fetch and load cluster configs]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - file[/opt/parallelcluster/shared/update_trigger]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - ruby_block[replace slurm queue nodes]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - execute[generate_pcluster_slurm_configs]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - execute[generate_pcluster_fleet_config]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - execute[stop clustermgtd]
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Running recovery commands
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Executing: cleanup DNA files
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Running command (attempt 1/11): /opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/python /opt/parallelcluster/scripts/share_compute_fleet_dna.py --region us-east-1 --cleanup
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stdout:
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stderr: INFO:__main__:Cleaning up /opt/parallelcluster/shared/dna/LaunchTemplateB1b67670b4d707d5-dna.json
INFO:__main__:Cleaning up /opt/parallelcluster/shared/dna/extra.json
INFO:__main__:All dna.json files have been shared!

[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Successfully executed: cleanup DNA files
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Executing: start clustermgtd
[2026-01-28T17:50:42+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Running command (attempt 1/11): /opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/supervisorctl start clustermgtd
[2026-01-28T17:50:44+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stdout: clustermgtd: started

[2026-01-28T17:50:44+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stderr:
[2026-01-28T17:50:44+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Successfully executed: start clustermgtd
[2026-01-28T17:50:44+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Completed successfully
  - ErrorHandlers::UpdateFailureHandler
Running handlers complete
[2026-01-28T17:50:44+00:00] ERROR: Exception handlers complete
```

### Tests
* The risks have been deeply assessed during design.
* Manually verified that clustermgtd is always restarted on whatever update failure. 
* Manually verified that those changes do not introduce race conditions by executing multiple fleet/cluster updates and checking there are no errors reported by clustermgtd nor unexpected launches/terminations.
* Unit tests (updated to cover the current changes)
* [SUCCESS] Integ tests: 
  * `test_update_slurm`
  * `test_update_rollback_failure`
  * `test_queue_parameters_update`
  * `test_dynamic_file_systems_update`

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
