### PR TITLE
[Debugging] Enable xtrace on a bash command to wait for head node updates to facilitate troubleshooting

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
@@ -183,6 +183,7 @@ action_class do # rubocop:disable Metrics/BlockLength
       retries 30
       retry_delay 15
       timeout 5
+      flags "-x"
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fetch_config_spec.rb
@@ -150,7 +150,8 @@ describe 'fetch_config:run' do
           code: "[[ \"$(cat #{config_version_file})\" == \"cluster_config_version\" ]] || exit 1",
           retries: 30,
           retry_delay: 15,
-          timeout: 5
+          timeout: 5,
+          flags: "-x"
         )
       end
 


### PR DESCRIPTION
### Description of changes
Enable xtrace on a bash command to wait for head node updates to facilitate troubleshooting.
enabling xtrace allows to know what is the content of the file when it is checked.

Notice that it is expected for xtrace to output the second string escaped. This happens because bash's xtrace shows the pattern-matching interpretation of the literal string on the RHS of == in [[ ]]. To prevent this we need to slightly change this code but it is not worth it.

```
    * bash[Wait cluster config files to be updated by the head node] action run[2026-02-05T22:33:14+00:00] INFO: Processing bash[Wait cluster config files to be updated by the head node] action run (aws-parallelcluster-platform::update line 181)

      [execute] ++ cat /opt/parallelcluster/shared/cluster-config-version
                + [[ 61LOetsQ_2n4o5sIoEMzK0TsUey9ids2 == \6\1\L\O\e\t\s\Q\_\2\n\4\o\5\s\I\o\E\M\z\K\0\T\s\U\e\y\9\i\d\s\2 ]]
```

### Tests
Manually verified that the flag outputs as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
