### PR TITLE
[Discard] Increase the sleep time between slurmctld restarting and scontrol configure when update HeadNode

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -270,11 +270,60 @@ execute "check slurmctld status" do
   retry_delay 2
 end
 
+# Debug: Print topology info BEFORE scontrol reconfigure
+ruby_block "debug_topology_before_reconfigure" do
+  block do
+    Chef::Log.info("=== DEBUG: Topology info BEFORE scontrol reconfigure ===")
+
+    # Print scontrol show topology
+    topology_output = shell_out("#{node['cluster']['slurm']['install_dir']}/bin/scontrol show topology").stdout
+    Chef::Log.info("scontrol show topology output:\n#{topology_output}")
+
+    # Print slurm_parallelcluster_topology.conf content
+    topology_conf_path = "#{node['cluster']['slurm']['install_dir']}/etc/slurm_parallelcluster_topology.conf"
+    if ::File.exist?(topology_conf_path)
+      topology_conf_content = ::File.read(topology_conf_path)
+      Chef::Log.info("#{topology_conf_path} content:\n#{topology_conf_content}")
+    else
+      Chef::Log.info("#{topology_conf_path} does not exist")
+    end
+
+    # Also print topology.conf content
+    topology_conf_path2 = "#{node['cluster']['slurm']['install_dir']}/etc/topology.conf"
+    if ::File.exist?(topology_conf_path2)
+      topology_conf_content2 = ::File.read(topology_conf_path2)
+      Chef::Log.info("#{topology_conf_path2} content:\n#{topology_conf_content2}")
+    else
+      Chef::Log.info("#{topology_conf_path2} does not exist")
+    end
+
+    Chef::Log.info("=== END DEBUG: Topology info BEFORE scontrol reconfigure ===")
+  end
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && !are_bulk_custom_slurm_settings_updated? }
+end
+
 execute SCONTROL_RECONFIGURE_RESOURCE_NAME do
   command "#{node['cluster']['slurm']['install_dir']}/bin/scontrol reconfigure"
   retries 3
   retry_delay 5
   timeout node['cluster']['slurm']['reconfigure_timeout']
+  not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && !are_bulk_custom_slurm_settings_updated? }
+end
+
+# Debug: Print topology info AFTER scontrol reconfigure (wait a few seconds first)
+ruby_block "debug_topology_after_reconfigure" do
+  block do
+    Chef::Log.info("=== DEBUG: Waiting 10 seconds after scontrol reconfigure ===")
+    sleep(10)
+
+    Chef::Log.info("=== DEBUG: Topology info AFTER scontrol reconfigure ===")
+
+    # Print scontrol show topology
+    topology_output = shell_out("#{node['cluster']['slurm']['install_dir']}/bin/scontrol show topology").stdout
+    Chef::Log.info("scontrol show topology output:\n#{topology_output}")
+
+    Chef::Log.info("=== END DEBUG: Topology info AFTER scontrol reconfigure ===")
+  end
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && !are_bulk_custom_slurm_settings_updated? }
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -260,7 +260,7 @@ service 'slurmctld' do
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && !are_bulk_custom_slurm_settings_updated? }
 end
 
-chef_sleep '15'
+chef_sleep '60'
 
 # The slurmctld service does not return an error code to `systemctl start slurmctld`, so
 # we must explicitly check the status of the service to capture failures

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -260,7 +260,7 @@ service 'slurmctld' do
   not_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && !are_queues_updated? && !are_bulk_custom_slurm_settings_updated? }
 end
 
-chef_sleep '5'
+chef_sleep '15'
 
 # The slurmctld service does not return an error code to `systemctl start slurmctld`, so
 # we must explicitly check the status of the service to capture failures


### PR DESCRIPTION
### Description of changes
* Increase the sleep time between slurmctld restarting and scontrol configure from 5s to 15s when update HeadNode for fix the issue that the output of `scontrol show topology` not aligned with topology.conf.

### Tests
* This PR can not fix the issue we encountered, closing the PR

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
