### PR TITLE
[Update] Start clustermgtd on update-compute-fleet failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade mysql-community-client to version 8.4.8 (from 8.0.39) for all OSs except Amazon Linux 2.
 - Upgrade Intel MPI Library to 2021.17.2 (from 2021.16.0).
 - Upgrade Cinc Client to version 18.8.54 (from 18.7.10).
-- Always start clustermgtd on cluster update failure, regardless the failure condition.
+- Always start clustermgtd on cluster update and compute fleet status update failure, regardless the failure condition.
 
 **BUG FIXES**
 - Fix timestamp formats in CloudWatch log configuration to let CloudWatch parse the correct timestamps.

--- a/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
+++ b/cookbooks/aws-parallelcluster-computefleet/files/clusterstatusmgtd/clusterstatusmgtd.py
@@ -389,7 +389,7 @@ class ClusterStatusManager:
             "sudo cinc-client "
             "--local-mode "
             "--config /etc/chef/client.rb "
-            "--log_level auto "
+            "--log_level info "
             f"--logfile {cinc_log_file} "
             "--force-formatter "
             "--no-color "

--- a/cookbooks/aws-parallelcluster-computefleet/templates/clusterstatusmgtd/99-parallelcluster-clusterstatusmgtd.erb
+++ b/cookbooks/aws-parallelcluster-computefleet/templates/clusterstatusmgtd/99-parallelcluster-clusterstatusmgtd.erb
@@ -1,3 +1,3 @@
-Cmnd_Alias CINC_COMMAND = /usr/bin/cinc-client --local-mode --config /etc/chef/client.rb --log_level auto --logfile /var/log/chef-client.log --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist  aws-parallelcluster-entrypoints\:\:update_computefleet_status
+Cmnd_Alias CINC_COMMAND = /usr/bin/cinc-client --local-mode --config /etc/chef/client.rb --log_level info --logfile /var/log/chef-client.log --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist  aws-parallelcluster-entrypoints\:\:update_computefleet_status
 
 <%= node['cluster']['cluster_admin_user'] %> ALL = (root) NOPASSWD: CINC_COMMAND

--- a/cookbooks/aws-parallelcluster-computefleet/test/controls/clusterstatusmgtd_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/test/controls/clusterstatusmgtd_spec.rb
@@ -47,7 +47,8 @@ control 'tag:config_clusterstatusmgtd' do
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0600' }
-    its('content') { should match %r{Cmnd_Alias CINC_COMMAND = /usr/bin/cinc-client .*\n\npcluster-admin ALL = \(root\) NOPASSWD: CINC_COMMAND.*} }
+    its('content') { should match %r{Cmnd_Alias CINC_COMMAND = /usr/bin/cinc-client --local-mode --config /etc/chef/client\.rb --log_level info --logfile /var/log/chef-client\.log --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna\.json --override-runlist  aws-parallelcluster-entrypoints\\:\\:update_computefleet_status} }
+    its('content') { should match /#{node['cluster']['cluster_admin_user']} ALL = \(root\) NOPASSWD: CINC_COMMAND/ }
   end
 
   describe file('/var/log/parallelcluster/clusterstatusmgtd') do

--- a/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
@@ -18,16 +18,22 @@ require_relative 'command_runner'
 module ErrorHandlers
   # Chef exception handler for cluster update failures.
   #
-  # This handler is triggered when the update recipe fails. It performs recovery actions
-  # to restore the cluster to a consistent state:
-  # 1. Logs information about the update failure including which resources succeeded before failure
-  # 2. Cleans up DNA files shared with compute nodes
-  # 3. Starts clustermgtd
+  # This handler is triggered when either the update or update-compute-fleet recipe fails.
+  # It performs recovery actions to restore the cluster to a consistent state:
+  # 1. Logs information about the update failure including which resources succeeded before failure.
+  # 2. Cleans up DNA files shared with compute nodes, if cleanup_dna_files=true.
+  # 3. Starts clustermgtd, if start_clustermgtd=true.
   #
   # Only runs on HeadNode - compute and login nodes skip this handler.
   class UpdateFailureHandler < Chef::Handler
+    def initialize(config = {})
+      @cleanup_dna_files = config.fetch(:cleanup_dna_files, false)
+      @start_clustermgtd = config.fetch(:start_clustermgtd, false)
+      super()
+    end
+
     def report
-      Chef::Log.info("#{log_prefix} Started")
+      Chef::Log.info("#{log_prefix} Started with parameters @cleanup_dna_files=#{@cleanup_dna_files}, @start_clustermgtd=#{@start_clustermgtd}")
 
       unless node_type == 'HeadNode'
         Chef::Log.info("#{log_prefix} Node type is #{node_type}, recovery from update failure only executes on the HeadNode")
@@ -54,8 +60,8 @@ module ErrorHandlers
 
     def run_recovery
       Chef::Log.info("#{log_prefix} Running recovery commands")
-      cleanup_dna_files
-      start_clustermgtd
+      cleanup_dna_files if @cleanup_dna_files
+      start_clustermgtd if @start_clustermgtd
     end
 
     def cleanup_dna_files

--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 chef_handler 'ErrorHandlers::UpdateFailureHandler' do
+  arguments cleanup_dna_files: true, start_clustermgtd: true
   type exception: true
 end
 

--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/update_computefleet_status.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/update_computefleet_status.rb
@@ -12,5 +12,10 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+chef_handler 'ErrorHandlers::UpdateFailureHandler' do
+  arguments start_clustermgtd: true
+  type exception: true
+end
+
 include_recipe 'aws-parallelcluster-shared::setup_envars'
 include_recipe 'aws-parallelcluster-computefleet::update_computefleet_status'

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
@@ -15,7 +15,7 @@ require_relative '../../spec_helper'
 require_relative '../../../libraries/update_failure_handler'
 
 describe ErrorHandlers::UpdateFailureHandler do
-  let(:handler) { described_class.new }
+  let(:handler) { described_class.new(cleanup_dna_files: true, start_clustermgtd: true) }
   let(:exception) { StandardError.new('Test error') }
   let(:resource1) { double('resource1', to_s: 'file[/tmp/test]') }
   let(:updated_resources) { [resource1] }
@@ -99,10 +99,28 @@ describe ErrorHandlers::UpdateFailureHandler do
   end
 
   describe '#run_recovery' do
-    it 'cleans up DNA files and starts clustermgtd unconditionally' do
-      expect(handler).to receive(:cleanup_dna_files).ordered
-      expect(handler).to receive(:start_clustermgtd).ordered
-      handler.run_recovery
+    { cleanup_dna_files: :cleanup_dna_files, start_clustermgtd: :start_clustermgtd }.each do |flag, method|
+      [true, false].each do |enabled|
+        context "when #{flag} is #{enabled}" do
+          let(:handler) { described_class.new(flag => enabled) }
+
+          before do
+            allow(handler).to receive(:run_status).and_return(run_status)
+            allow(handler).to receive(:action_collection).and_return(action_collection)
+            allow(handler).to receive(:command_runner).and_return(command_runner)
+            allow(Chef::Log).to receive(:info)
+          end
+
+          it "#{enabled ? 'calls' : 'does not call'} #{method}" do
+            if enabled
+              expect(handler).to receive(method)
+            else
+              expect(handler).not_to receive(method)
+            end
+            handler.run_recovery
+          end
+        end
+      end
     end
   end
 

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_computefleet_status_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_computefleet_status_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Copyright:: 2026 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'ostruct'
+
+describe 'aws-parallelcluster-entrypoints::update_computefleet_status' do
+  before do
+    @included_recipes = []
+    %w(
+      aws-parallelcluster-shared::setup_envars
+      aws-parallelcluster-computefleet::update_computefleet_status
+    ).each do |recipe_name|
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with(recipe_name) do
+        @included_recipes << recipe_name
+      end
+    end
+  end
+
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      for_all_node_types do |node_type|
+        context "when #{node_type}" do
+          cached(:chef_run) do
+            runner = runner(platform: platform, version: version) do |node|
+              allow_any_instance_of(Object).to receive(:fetch_config).and_return(OpenStruct.new)
+
+              node.override['cluster']['node_type'] = node_type
+              node.override['cluster']['scheduler'] = 'slurm'
+            end
+            runner.converge(described_recipe)
+          end
+          cached(:node) { chef_run.node }
+
+          expected_recipes = %w(
+            aws-parallelcluster-shared::setup_envars
+            aws-parallelcluster-computefleet::update_computefleet_status
+          )
+
+          it "includes the recipes in the right order" do
+            chef_run
+            expect(@included_recipes).to eq(expected_recipes)
+          end
+
+          it "enables the update failure handler" do
+            expect(chef_run).to enable_chef_handler('ErrorHandlers::UpdateFailureHandler').with(
+              arguments: { start_clustermgtd: true },
+              type: { exception: true }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_spec.rb
@@ -65,7 +65,10 @@ describe 'aws-parallelcluster-entrypoints::update' do
               end
 
               it "enables the update failure handler" do
-                expect(chef_run).to enable_chef_handler('ErrorHandlers::UpdateFailureHandler').with(type: { exception: true })
+                expect(chef_run).to enable_chef_handler('ErrorHandlers::UpdateFailureHandler').with(
+                  arguments: { cleanup_dna_files: true, start_clustermgtd: true },
+                  type: { exception: true }
+                )
               end
             end
           end

--- a/test/unit/clusterstatusmgtd/test_clusterstatusmgtd.py
+++ b/test/unit/clusterstatusmgtd/test_clusterstatusmgtd.py
@@ -384,7 +384,7 @@ class TestClusterStatusManager:
             "sudo cinc-client "
             "--local-mode "
             "--config /etc/chef/client.rb "
-            "--log_level auto "
+            "--log_level info "
             f"--logfile {cinc_log_file} "
             "--force-formatter "
             "--no-color "


### PR DESCRIPTION
### Description of changes
Start clustermgtd when update-compute-fleet fails, to reduce the risk of having clustermgt not running.
This is the same strategy we already applied to cluster updates.

To avoid code duplication, we adapted and reuse the existing `UpdateFailureHandler` so that it can handle the failure on both cluster updates and compute fleet status updates, applying different recovery strategies.

We also needed to set the log level of `clusterstatusmgtd` from auto to info so that custom logs can be displayed in `chef-client.log`. To change the log level we also needed to change it in the corresponding allowed Cinc command in sudoers config for the daemon.

#### UX
After injecting a synthetic failure in the recipe `update_computefleet_status_head_node.rb`, we see that the handler is able to restart clustermgtd
```
Running handlers:
[2026-02-10T05:03:26+00:00] ERROR: Running exception handlers
[2026-02-10T05:03:26+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Started with parameters @cleanup_dna_files=false, @start_clustermgtd=true
[2026-02-10T05:03:26+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Update failed on HeadNode due to: bash[update compute fleet] (aws-parallelcluster-slurm::update_computefleet_status_head_node line 18) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '126'
---- Begin output of "bash"  ----
STDOUT: clustermgtd: stopped
STDERR: + /opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/supervisorctl stop clustermgtd
+ /opt/parallelcluster/scripts/slurm/slurm_fleet_status_manager -cf /opt/parallelcluster/shared/computefleet-status.json
bash: line 3: /opt/parallelcluster/scripts/slurm/slurm_fleet_status_manager: Permission denied
---- End output of "bash"  ----
Ran "bash"  returned 126
[2026-02-10T05:03:26+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Resources that have been successfully executed before the failure:
[2026-02-10T05:03:26+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - ruby_block[Configure environment variable for recipes context: PATH]
[2026-02-10T05:03:26+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - ruby_block[load cluster configuration]
[2026-02-10T05:03:26+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Running recovery commands
[2026-02-10T05:03:26+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Executing: start clustermgtd
[2026-02-10T05:03:26+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Running command (attempt 1/11): /opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/supervisorctl start clustermgtd
[2026-02-10T05:03:28+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stdout: clustermgtd: started

[2026-02-10T05:03:28+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stderr:
[2026-02-10T05:03:28+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Successfully executed: start clustermgtd
[2026-02-10T05:03:28+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Completed successfully
  - ErrorHandlers::UpdateFailureHandler
Running handlers complete
[2026-02-10T05:03:28+00:00] ERROR: Exception handlers complete
...
[root@ip-27-6-32-233 ~]# /opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/supervisorctl status
cfn-hup                          RUNNING   pid 3931, uptime 0:38:54
clustermgtd                      RUNNING   pid 7293, uptime 0:00:23
clusterstatusmgtd                RUNNING   pid 6850, uptime 0:04:30
```

**Limits of this solution + future improvements**
In this solution we control the different recovery strategies with boolean flags. This is ok for the current scenario. because we have only two recovery strategies (restart clustermgtd, cleanup dna files). To be more flexible and future proof we should apply the *Stategy pattern*. I preferred not to do now because it would require more boilerplate and refactoring that would introduce unnecessary complexity for such a simple case.

### Tests
* Manually verified that by injecting a failure in compute-fleet status update, clustermgtd is started by the error handler (see UX above)
* SUCCEEDED `test_update_rollback_failure` which has been extended in https://github.com/aws/aws-parallelcluster/pull/7225 to cover this specific change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
