### PR TITLE
Update munge version to 0.5.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.14.2
+------
+**CHANGES**
+- Upgrade munge to version 0.5.18 (from 0.5.16).
+
 3.14.1
 ------
 

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -5,8 +5,8 @@ default['cluster']['slurm']['branch'] = ''
 default['cluster']['slurm']['sha256'] = 'f0912d85a9a9b417fd23ca4997c8d3dfed89b3b70b15aad4da54f2812d30d48c'
 default['cluster']['slurm']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/slurm"
 # Munge
-default['cluster']['munge']['munge_version'] = '0.5.16'
-default['cluster']['munge']['sha256'] = 'fa27205d6d29ce015b0d967df8f3421067d7058878e75d0d5ec3d91f4d32bb57'
+default['cluster']['munge']['munge_version'] = '0.5.18'
+default['cluster']['munge']['sha256'] = '67722a4fbf46d206fa01061cd8832a04693d8a5d2699540b86528016de7efb55'
 default['cluster']['munge']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/munge"
 # LibJwt
 default['cluster']['jwt']['version'] = '1.18.4'


### PR DESCRIPTION
### Description of changes
* Update munge version to 0.5.18

### Tests
* Will run `global_second_stage_build_and_test_branch_3_14`

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
