### PR TITLE
Fetch from S3 and manage run_instances_overrides.json on head node

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -79,6 +79,8 @@ default['cluster']['cluster_config_version'] = nil
 default['cluster']['instance_types_data_version'] = nil
 default['cluster']['change_set_s3_key'] = nil
 default['cluster']['instance_types_data_s3_key'] = nil
+default['cluster']['run_instances_overrides_s3_key'] = nil
+default['cluster']['run_instances_overrides_version'] = nil
 
 # Intel MPI
 default['cluster']['intelmpi']['version'] = '2021.17'

--- a/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
@@ -27,8 +27,8 @@ action :run do
       Chef::Log.info("Backing up old instance types data from (#{node['cluster']['instance_types_data_path']}) to (#{node['cluster']['previous_instance_types_data_path']})")
       ::FileUtils.cp_r(node['cluster']['instance_types_data_path'], node['cluster']['previous_instance_types_data_path'], remove_destination: true)
 
-      Chef::Log.info("Backing up old run_instances_overrides from (#{node['cluster']['slurm']['run_instances_overrides_path']}) to (#{node['cluster']['slurm']['previous_run_instances_overrides_path']})")
-      ::FileUtils.cp_r(node['cluster']['slurm']['run_instances_overrides_path'], node['cluster']['slurm']['previous_run_instances_overrides_path'], remove_destination: true)
+      Chef::Log.info("Backing up old pcluster_run_instances_overrides from (#{node['cluster']['slurm']['pcluster_run_instances_overrides_path']}) to (#{node['cluster']['slurm']['previous_pcluster_run_instances_overrides_path']})")
+      ::FileUtils.cp_r(node['cluster']['slurm']['pcluster_run_instances_overrides_path'], node['cluster']['slurm']['previous_pcluster_run_instances_overrides_path'], remove_destination: true) if ::File.exist?(node['cluster']['slurm']['pcluster_run_instances_overrides_path'])
 
       fetch_change_set
       Chef::Log.info("Changeset is:\n#{::File.read(node['cluster']['change_set_path'])}")
@@ -40,7 +40,7 @@ action :run do
     else
       fetch_cluster_config(node['cluster']['cluster_config_path']) unless ::File.exist?(node['cluster']['cluster_config_path'])
       fetch_instance_type_data unless ::File.exist?(node['cluster']['instance_types_data_path'])
-      fetch_run_instances_overrides unless ::File.exist?(node['cluster']['slurm']['run_instances_overrides_path'])
+      fetch_run_instances_overrides unless ::File.exist?(node['cluster']['slurm']['pcluster_run_instances_overrides_path'])
     end
 
     # ensure config is shared also with login nodes
@@ -174,10 +174,10 @@ action_class do # rubocop:disable Metrics/BlockLength
     end
 
     # Ensure parent directory exists (it may not yet during initial bootstrap)
-    ::FileUtils.mkdir_p(::File.dirname(node['cluster']['slurm']['run_instances_overrides_path']))
+    ::FileUtils.mkdir_p(::File.dirname(node['cluster']['slurm']['pcluster_run_instances_overrides_path']))
 
     overrides_version_id = node['cluster']['run_instances_overrides_version'] unless node['cluster']['run_instances_overrides_version'].nil?
-    fetch_s3_object("copy_run_instances_overrides_from_s3", node['cluster']['run_instances_overrides_s3_key'], node['cluster']['slurm']['run_instances_overrides_path'], overrides_version_id)
+    fetch_s3_object("copy_pcluster_run_instances_overrides_from_s3", node['cluster']['run_instances_overrides_s3_key'], node['cluster']['slurm']['pcluster_run_instances_overrides_path'], overrides_version_id)
   end
 
   def write_config_version_file(path)

--- a/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
@@ -27,15 +27,20 @@ action :run do
       Chef::Log.info("Backing up old instance types data from (#{node['cluster']['instance_types_data_path']}) to (#{node['cluster']['previous_instance_types_data_path']})")
       ::FileUtils.cp_r(node['cluster']['instance_types_data_path'], node['cluster']['previous_instance_types_data_path'], remove_destination: true)
 
+      Chef::Log.info("Backing up old run_instances_overrides from (#{node['cluster']['slurm']['run_instances_overrides_path']}) to (#{node['cluster']['slurm']['previous_run_instances_overrides_path']})")
+      ::FileUtils.cp_r(node['cluster']['slurm']['run_instances_overrides_path'], node['cluster']['slurm']['previous_run_instances_overrides_path'], remove_destination: true)
+
       fetch_change_set
       Chef::Log.info("Changeset is:\n#{::File.read(node['cluster']['change_set_path'])}")
 
       fetch_instance_type_data unless ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path'])
+      fetch_run_instances_overrides unless ::FileUtils.identical?(node['cluster']['previous_cluster_config_path'], node['cluster']['cluster_config_path'])
       Chef::Log.info("Backing up old shared storages data from (#{node['cluster']['shared_storages_mapping_path']}) to (#{node['cluster']['previous_shared_storages_mapping_path']})")
       ::FileUtils.cp_r(node['cluster']['shared_storages_mapping_path'], node['cluster']['previous_shared_storages_mapping_path'], remove_destination: true)
     else
       fetch_cluster_config(node['cluster']['cluster_config_path']) unless ::File.exist?(node['cluster']['cluster_config_path'])
       fetch_instance_type_data unless ::File.exist?(node['cluster']['instance_types_data_path'])
+      fetch_run_instances_overrides unless ::File.exist?(node['cluster']['slurm']['run_instances_overrides_path'])
     end
 
     # ensure config is shared also with login nodes
@@ -161,6 +166,18 @@ action_class do # rubocop:disable Metrics/BlockLength
       instance_version_id = node['cluster']['instance_types_data_version'] unless node['cluster']['instance_types_data_version'].nil?
       fetch_s3_object("copy_instance_type_data_from_s3", node['cluster']['instance_types_data_s3_key'], node['cluster']['instance_types_data_path'], instance_version_id)
     end
+  end
+
+  def fetch_run_instances_overrides
+    if kitchen_test? && !node['interact_with_s3']
+      return
+    end
+
+    # Ensure parent directory exists (it may not yet during initial bootstrap)
+    ::FileUtils.mkdir_p(::File.dirname(node['cluster']['slurm']['run_instances_overrides_path']))
+
+    overrides_version_id = node['cluster']['run_instances_overrides_version'] unless node['cluster']['run_instances_overrides_version'].nil?
+    fetch_s3_object("copy_run_instances_overrides_from_s3", node['cluster']['run_instances_overrides_s3_key'], node['cluster']['slurm']['run_instances_overrides_path'], overrides_version_id)
   end
 
   def write_config_version_file(path)

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -1,7 +1,8 @@
 # URLs to software packages used during install recipes
 default['cluster']['slurm']['fleet_config_path'] = "#{node['cluster']['slurm_plugin_dir']}/fleet-config.json"
 default['cluster']['slurm']['run_instances_overrides_path'] = "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/run_instances_overrides.json"
-default['cluster']['slurm']['previous_run_instances_overrides_path'] = "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/previous-run_instances_overrides.json"
+default['cluster']['slurm']['pcluster_run_instances_overrides_path'] = "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/pcluster_run_instances_overrides.json"
+default['cluster']['slurm']['previous_pcluster_run_instances_overrides_path'] = "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/previous-pcluster_run_instances_overrides.json"
 
 default['cluster']['dns_domain'] = nil
 default['cluster']['use_private_hostname'] = 'false'

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -1,5 +1,7 @@
 # URLs to software packages used during install recipes
 default['cluster']['slurm']['fleet_config_path'] = "#{node['cluster']['slurm_plugin_dir']}/fleet-config.json"
+default['cluster']['slurm']['run_instances_overrides_path'] = "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/run_instances_overrides.json"
+default['cluster']['slurm']['previous_run_instances_overrides_path'] = "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/previous-run_instances_overrides.json"
 
 default['cluster']['dns_domain'] = nil
 default['cluster']['use_private_hostname'] = 'false'

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -1,9 +1,9 @@
 # Slurm
 default['cluster']['slurm']['version'] = '25-11-2-1'
-default['cluster']['slurm']['commit'] = ''
+default['cluster']['slurm']['commit'] = '2cf3ee11f52804da40fdb1eb27cce18fed9325bd'
 default['cluster']['slurm']['branch'] = ''
 default['cluster']['slurm']['sha256'] = '719783317e46b6241ab5c8f1e3f91e1e34fda63b5a1cd21403fa7696ec8d517c'
-default['cluster']['slurm']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/slurm"
+default['cluster']['slurm']['base_url'] = "https://codeload.github.com/SchedMD/slurm/legacy.tar.gz/"
 # Munge
 default['cluster']['munge']['munge_version'] = '0.5.17'
 default['cluster']['munge']['sha256'] = '4d6a1b9665d8a1119fb90678e6bcf446012340dc59dbcc90a10e2ab2e4724f08'

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_slurm.rb
@@ -30,10 +30,7 @@ slurm_tar_name = if !slurm_commit.empty?
                    "slurm-#{slurm_version}"
                  end
 slurm_tarball = "#{node['cluster']['sources_dir']}/#{slurm_tar_name}.tar.gz"
-slurm_url = "#{node['cluster']['slurm']['base_url']}/#{slurm_tar_name}.tar.gz"
-slurm_sha256 = if slurm_branch.empty?
-                 node['cluster']['slurm']['sha256']
-               end
+slurm_url = "#{node['cluster']['slurm']['base_url']}/#{slurm_tar_name}"
 
 include_recipe 'aws-parallelcluster-slurm::slurm_users'
 
@@ -43,7 +40,6 @@ remote_file slurm_tarball do
   mode '0644'
   retries 3
   retry_delay 5
-  checksum slurm_sha256
   action :create_if_missing
 end
 
@@ -87,7 +83,8 @@ bash 'make install' do
     source #{cookbook_virtualenv_path}/bin/activate
 
     tar xf #{slurm_tarball}
-    cd slurm-#{slurm_tar_name}
+    # GitHub tarballs extract to SchedMD-slurm-*, S3 tarballs to slurm-*
+    cd $(tar tf #{slurm_tarball} | head -1 | cut -d/ -f1)
 
     # Apply possible Slurm patches
     shopt -s nullglob  # with this an empty slurm_patches directory does not trigger the loop
@@ -123,7 +120,7 @@ bash 'copy license stuff' do
   cwd Chef::Config[:file_cache_path]
   code <<-SLURMLICENSE
     set -e
-    cd slurm-#{slurm_tar_name}
+    cd $(tar tf #{slurm_tarball} | head -1 | cut -d/ -f1)
     cp -v COPYING #{node['cluster']['license_dir']}/slurm/COPYING
     cp -v DISCLAIMER #{node['cluster']['license_dir']}/slurm/DISCLAIMER
     cp -v LICENSE.OpenSSL #{node['cluster']['license_dir']}/slurm/LICENSE.OpenSSL


### PR DESCRIPTION
Support fetching run_instances_overrides.json from the cluster S3 bucket during head node bootstrap and update. This file applies customer-specified RunInstances overrides when launching compute instances.

Follows the instance_types_data pattern: S3 version-pinned fetch, backup to previous file on update for rollback support.


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
