### PR TITLE
[develop] Improve curl retry for pcluster package downloads

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/recipes/install.rb
@@ -40,7 +40,12 @@ if !node['cluster']['custom_awsbatchcli_package'].nil? && !node['cluster']['cust
       else
         custom_package_url=#{node['cluster']['custom_awsbatchcli_package']}
       fi
-      curl --retry 3 -L -o aws-parallelcluster.tgz ${custom_package_url}
+      delays=(1 2 4 8 16 32 64 128 256)
+      for i in {0..8}; do
+        curl -v -L -o aws-parallelcluster.tgz ${custom_package_url} && break
+        echo "Curl attempt $((i+1)) failed, retrying in ${delays[$i]}s..."
+        sleep ${delays[$i]}
+      done
       mkdir aws-parallelcluster-awsbatch-cli
       tar -xzf aws-parallelcluster.tgz --directory aws-parallelcluster-awsbatch-cli
       cd aws-parallelcluster-awsbatch-cli/*aws-parallelcluster*

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
@@ -67,7 +67,12 @@ bash "install custom aws-parallelcluster-node" do
     else
       custom_package_url=#{node['cluster']['custom_node_package']}
     fi
-    curl --retry 3 -L -o aws-parallelcluster-node.tgz ${custom_package_url}
+    delays=(1 2 4 8 16 32 64 128 256)
+    for i in {0..8}; do
+      curl -v -L -o aws-parallelcluster-node.tgz ${custom_package_url} && break
+      echo "Curl attempt $((i+1)) failed, retrying in ${delays[$i]}s..."
+      sleep ${delays[$i]}
+    done
     rm -fr aws-parallelcluster-custom-node
     mkdir aws-parallelcluster-custom-node
     tar -xzf aws-parallelcluster-node.tgz --directory aws-parallelcluster-custom-node

--- a/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
@@ -49,7 +49,12 @@ describe 'aws-parallelcluster-computefleet::custom_parallelcluster_node' do
   else
     custom_package_url=#{custom_node_s3_url}
   fi
-  curl --retry 3 -L -o aws-parallelcluster-node.tgz ${custom_package_url}
+  delays=(1 2 4 8 16 32 64 128 256)
+  for i in {0..8}; do
+    curl -v -L -o aws-parallelcluster-node.tgz ${custom_package_url} && break
+    echo "Curl attempt $((i+1)) failed, retrying in ${delays[$i]}s..."
+    sleep ${delays[$i]}
+  done
   rm -fr aws-parallelcluster-custom-node
   mkdir aws-parallelcluster-custom-node
   tar -xzf aws-parallelcluster-node.tgz --directory aws-parallelcluster-custom-node


### PR DESCRIPTION
### Description of changes
* Improve curl retry for GitHub package downloads
Same as https://github.com/aws/aws-parallelcluster/pull/7180/changes and https://github.com/aws/aws-parallelcluster/pull/7183/commits

### Tests
* [ONGOING] Build Image Integ test 
```
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
      - instances:
        - g4dn.2xlarge
        oss:
        - alinux2023
        regions:
        - cn-north-1
        schedulers:
        - slurm

```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
