### PR TITLE
[Slurm 25.11] Enable expedited requeue by default

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -25,11 +25,10 @@ LaunchParameters=enable_nss_slurm
 <% end -%>
 #
 # CLOUD CONFIGS OPTIONS
-<% if node['cluster']['use_private_hostname'] == 'true' or node['cluster']['dns_domain'].nil? or node['cluster']['dns_domain'].empty? -%>
 SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,node_reg_mem_percent=<%= node['cluster']['slurm_node_reg_mem_percent'] %>,enable_expedited_requeue
+<% if node['cluster']['use_private_hostname'] == 'true' or node['cluster']['dns_domain'].nil? or node['cluster']['dns_domain'].empty? -%>
 TreeWidth=65533
 <% else -%>
-SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,node_reg_mem_percent=<%= node['cluster']['slurm_node_reg_mem_percent'] %>,enable_expedited_requeue
 TreeWidth=30
 <% end -%>
 SuspendProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_suspend

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/slurm.conf.erb
@@ -26,10 +26,10 @@ LaunchParameters=enable_nss_slurm
 #
 # CLOUD CONFIGS OPTIONS
 <% if node['cluster']['use_private_hostname'] == 'true' or node['cluster']['dns_domain'].nil? or node['cluster']['dns_domain'].empty? -%>
-SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,node_reg_mem_percent=<%= node['cluster']['slurm_node_reg_mem_percent'] %>
+SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,node_reg_mem_percent=<%= node['cluster']['slurm_node_reg_mem_percent'] %>,enable_expedited_requeue
 TreeWidth=65533
 <% else -%>
-SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,node_reg_mem_percent=<%= node['cluster']['slurm_node_reg_mem_percent'] %>
+SlurmctldParameters=idle_on_node_suspend,power_save_min_interval=30,node_reg_mem_percent=<%= node['cluster']['slurm_node_reg_mem_percent'] %>,enable_expedited_requeue
 TreeWidth=30
 <% end -%>
 SuspendProgram=<%= node['cluster']['scripts_dir'] %>/slurm/slurm_suspend

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/slurm_config_spec.rb
@@ -64,3 +64,13 @@ control 'tag:config_slurm_correctly_installed_on_compute_node' do
     end
   end
 end
+
+control 'tag:config_slurm_expedited_requeue_enabled' do
+  title 'Check that expedited requeue is enabled by default in slurm.conf'
+
+  only_if { instance.head_node? && node['cluster']['scheduler'] == 'slurm' && !os_properties.on_docker? }
+
+  describe file("#{node['cluster']['slurm']['install_dir']}/etc/slurm.conf") do
+    its('content') { should match /SlurmctldParameters=.*enable_expedited_requeue/ }
+  end
+end


### PR DESCRIPTION
### Description of changes
* Enable expedited requeue by default

### Tests
* Kitchen tests passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
