### PR TITLE
Update munge version to 0.5.18 (#3113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,10 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 3.14.2
 ------
+
 **CHANGES**
-- Upgrade munge to version 0.5.18 (from 0.5.16).
+- Upgrade munge to version 0.5.18 (from 0.5.16) to address [CVE-2026-25506](https://github.com/dun/munge/security/advisories/GHSA-r9cr-jf4v-75gh).
+- Upgrade NodeJS version in installer to version 22.22.0 (from 20.18.3).
 
 3.14.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **CHANGES**
 - Upgrade munge to version 0.5.18 (from 0.5.16) to address [CVE-2026-25506](https://github.com/dun/munge/security/advisories/GHSA-r9cr-jf4v-75gh).
-- Upgrade NodeJS version in installer to version 22.22.0 (from 20.18.3).
 
 3.14.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Fix an issue that was blocking the logging of slurm health check events.
 - Fix cluster creation failure without Internet access when GPU instances and DCV are used.
 
+3.14.2
+------
+**CHANGES**
+- Upgrade munge to version 0.5.18 (from 0.5.16).
+
 3.14.1
 ------
 

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -6,7 +6,7 @@ default['cluster']['slurm']['sha256'] = '719783317e46b6241ab5c8f1e3f91e1e34fda63
 default['cluster']['slurm']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/slurm"
 # Munge
 default['cluster']['munge']['munge_version'] = '0.5.18'
-default['cluster']['munge']['sha256'] = '67722a4fbf46d206fa01061cd8832a04693d8a5d2699540b86528016de7efb55'
+default['cluster']['munge']['sha256'] = '39c3ec6ef5604bfa206e8aa10fc05d5119040f6de4a554bc0fb98ca1aed838dc'
 default['cluster']['munge']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/munge"
 # LibJwt
 default['cluster']['jwt']['version'] = '1.18.4'

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -5,12 +5,8 @@ default['cluster']['slurm']['branch'] = ''
 default['cluster']['slurm']['sha256'] = '719783317e46b6241ab5c8f1e3f91e1e34fda63b5a1cd21403fa7696ec8d517c'
 default['cluster']['slurm']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/slurm"
 # Munge
-default['cluster']['munge']['munge_version'] = '0.5.17'
-default['cluster']['munge']['sha256'] = '4d6a1b9665d8a1119fb90678e6bcf446012340dc59dbcc90a10e2ab2e4724f08'
-if platform?('amazon') && node['platform_version'] == "2"
-  default['cluster']['munge']['munge_version'] = '0.5.16'
-  default['cluster']['munge']['sha256'] = 'fa27205d6d29ce015b0d967df8f3421067d7058878e75d0d5ec3d91f4d32bb57'
-end
+default['cluster']['munge']['munge_version'] = '0.5.18'
+default['cluster']['munge']['sha256'] = '67722a4fbf46d206fa01061cd8832a04693d8a5d2699540b86528016de7efb55'
 default['cluster']['munge']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/munge"
 # LibJwt
 default['cluster']['jwt']['version'] = '1.18.4'

--- a/cookbooks/aws-parallelcluster-slurm/resources/munge/partial/_munge_actions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/munge/partial/_munge_actions.rb
@@ -20,8 +20,8 @@ unified_mode true
 default_action :setup
 
 munge_version = node['cluster']['munge']['munge_version']
-munge_url = "#{node['cluster']['munge']['base_url']}/munge-#{munge_version}.tar.gz"
-munge_tarball = "#{node['cluster']['sources_dir']}/munge-#{munge_version}.tar.gz"
+munge_url = "#{node['cluster']['munge']['base_url']}/munge-#{munge_version}.tar.xz"
+munge_tarball = "#{node['cluster']['sources_dir']}/munge-#{munge_version}.tar.xz"
 munge_user = node['cluster']['munge']['user']
 munge_user_id = node['cluster']['munge']['user_id']
 munge_group = node['cluster']['munge']['group']
@@ -81,8 +81,7 @@ action :compile_and_install do
     code <<-MUNGE
       set -e
       tar xf #{munge_tarball}
-      cd munge-munge-#{munge_version}
-      ./bootstrap
+      cd munge-#{munge_version}
       ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=#{munge_libdir}
       CORES=$(grep processor /proc/cpuinfo | wc -l)
       make -j $CORES


### PR DESCRIPTION
### Description of changes
* Update munge version to 0.5.18 (#3113)
* Cherry-pick: https://github.com/aws/aws-parallelcluster-cookbook/pull/3119
* Cherry-pick: https://github.com/aws/aws-parallelcluster-cookbook/pull/3116
### Tests
* Ran second_stage_build_and_test for 3.14.2

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
