### PR TITLE
[Update] Start clustermgtd before cluster readiness checks during cluster updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade mysql-community-client to version 8.4.8 (from 8.0.39) for all OSs except Amazon Linux 2.
 - Upgrade Intel MPI Library to 2021.17.2 (from 2021.16.0).
 - Upgrade Cinc Client to version 18.8.54 (from 18.7.10).
+- Start clustermgtd before cluster readiness checks during cluster updates,
+  to maximize the time clustermgtd can operate on the cluster.
 - Always start clustermgtd on cluster update failure, regardless the failure condition.
 
 **BUG FIXES**

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -280,11 +280,11 @@ end
 
 chef_sleep '15'
 
-wait_cluster_ready if cluster_readiness_check_on_update_enabled?
-
 execute 'start clustermgtd' do
   command "#{cookbook_virtualenv_path}/bin/supervisorctl start clustermgtd"
 end
+
+wait_cluster_ready if cluster_readiness_check_on_update_enabled?
 
 # The updated cfnconfig will be used by post update custom scripts
 template "#{node['cluster']['etc_dir']}/cfnconfig" do

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
@@ -84,6 +84,42 @@ describe 'aws-parallelcluster-slurm::update_head_node' do
               timeout: reconfigure_timeout
             )
           end
+          it 'executes resources in the correct order' do
+            # NOTE: The most important aspect in the sequence is that clustermgtd is stopped while executing:
+            #   1. update_munge_key
+            #   2. restart of slurmctld
+            #   3. scontrol reconfigure
+            resource_names = chef_run.resource_collection.map(&:name)
+
+            expected_sequence = [
+              'stop clustermgtd',
+              chef_run.node['cluster']['update']['trigger_file'],
+              'update_shared_storages',
+              'replace slurm queue nodes',
+              'Update or Cleanup Slurm Topology',
+              'generate_pcluster_slurm_configs',
+              'generate_pcluster_custom_slurm_settings_include_files',
+              'Override Custom Slurm Settings with remote file',
+              'generate_pcluster_fleet_config',
+              'update node replacement timeout',
+              'Update Slurm Accounting',
+              "#{scripts_dir}/slurm/check_login_nodes_stopped.sh",
+              "#{scripts_dir}/slurm/update_munge_key.sh",
+              'update_munge_key',
+              'update Slurm database password',
+              'slurmctld',
+              '5',
+              'check slurmctld status',
+              'reload config for running nodes',
+              '15',
+              'start clustermgtd',
+              'Check cluster readiness',
+              '/etc/parallelcluster/cfnconfig',
+              'Cleanup',
+            ]
+
+            expect(resource_names).to eq(expected_sequence)
+          end
         end
       end
 


### PR DESCRIPTION
### Description of changes
Start clustermgtd before cluster readiness checks during cluster updates, to maximize the time clustermgtd can operate on the cluster.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
