### PR TITLE
[Workaround Only, Will Revert] Add Topology parameter to NodeName lines for block topology nodes

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/config_renderer.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/config_renderer.py
@@ -16,12 +16,21 @@ log = logging.getLogger()
 class ComputeResourceRenderer:
     """Renders a PCluster ComputeResource Config as a Slurm NodeName config, gres config or node_set element."""
 
-    def __init__(self, queue_name: str, compute_resource_config: Dict, no_gpu, memory_ratio, instance_types_info: Dict):
+    def __init__(
+        self,
+        queue_name: str,
+        compute_resource_config: Dict,
+        no_gpu,
+        memory_ratio,
+        instance_types_info: Dict,
+        topology_block_name: str = None,
+    ):
         self.queue_name = queue_name
         self.has_gpu = not no_gpu
         self.static_nodes = compute_resource_config["MinCount"]
         self.dynamic_nodes = compute_resource_config["MaxCount"] - self.static_nodes
         self.name = compute_resource_config["Name"]
+        self.topology_block_name = topology_block_name
         self.disable_multithreading = compute_resource_config["DisableSimultaneousMultithreading"]
         self.custom_settings = compute_resource_config.get("CustomSlurmSettings", {})
         self.spot_price = compute_resource_config.get("SpotPrice", None)
@@ -82,6 +91,9 @@ class ComputeResourceRenderer:
         if self.has_gpu and self.gpu_count > 0:
             definitions += f" Gres=gpu:{self.gpu_type}:{self.gpu_count}"
 
+        if self.topology_block_name:
+            definitions += f" Topology=default:{self.topology_block_name}"
+
         return definitions
 
     def _features(self, dynamic=False):
@@ -134,13 +146,29 @@ class ComputeResourceRenderer:
 class QueueRenderer:
     """Renders a PCluster Queue Config as a Slurm partition config or as gres config."""
 
-    def __init__(self, queue_config, no_gpu, memory_ratio, instance_types_info, conf_type="partition", default=False):
+    def __init__(
+        self,
+        queue_config,
+        no_gpu,
+        memory_ratio,
+        instance_types_info,
+        conf_type="partition",
+        default=False,
+        topology_block_mapping=None,
+    ):
         self.name = queue_config["Name"]
         self.is_default = default
         self.conf_type = conf_type
         self.custom_settings = queue_config.get("CustomSlurmSettings", {})
         self.compute_renderers = [
-            ComputeResourceRenderer(self.name, compute_resource_config, no_gpu, memory_ratio, instance_types_info)
+            ComputeResourceRenderer(
+                self.name,
+                compute_resource_config,
+                no_gpu,
+                memory_ratio,
+                instance_types_info,
+                topology_block_name=(topology_block_mapping or {}).get((self.name, compute_resource_config["Name"])),
+            )
             for compute_resource_config in queue_config["ComputeResources"]
         ]
         self.job_exclusive_allocation = queue_config.get("JobExclusiveAllocation")

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/pcluster_slurm_config_generator.py
@@ -40,6 +40,60 @@ class CriticalError(Exception):
     pass
 
 
+def _build_topology_block_mapping(slurm_conf_dir):
+    """
+    Build a mapping of (queue_name, compute_resource_name) -> block_name from topology.conf.
+
+    Returns an empty dict if topology.conf does not exist.
+    """
+    topology_conf_path = path.join(slurm_conf_dir, "topology.conf")
+    mapping = {}
+
+    if not path.exists(topology_conf_path):
+        return mapping
+
+    try:
+        with open(topology_conf_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if not line.startswith("BlockName="):
+                    continue
+
+                block_name = None
+                nodes_spec = None
+                for token in line.split():
+                    if token.startswith("BlockName="):
+                        block_name = token.split("=", 1)[1]
+                    elif token.startswith("Nodes="):
+                        nodes_spec = token.split("=", 1)[1]
+
+                if not block_name or not nodes_spec:
+                    continue
+
+                # Extract queue_name and compute_resource_name from node spec
+                # Node spec format: {queue_name}-st-{compute_resource_name}-[1-N]
+                #                or {queue_name}-dy-{compute_resource_name}-[1-N]
+                # Remove the trailing -[1-N] part
+                node_prefix = re.sub(r"-\[.*\]$", "", nodes_spec)
+                # Split by "-st-" or "-dy-" to get queue_name and compute_resource_name
+                parts = re.split(r"-(st|dy)-", node_prefix, maxsplit=1)
+                if len(parts) == 3:
+                    queue_name, _node_type, compute_resource_name = parts
+                    mapping[(queue_name, compute_resource_name)] = block_name
+                    log.info(
+                        "Topology mapping: (%s, %s) -> %s",
+                        queue_name,
+                        compute_resource_name,
+                        block_name,
+                    )
+    except Exception as e:
+        log.warning("Failed to parse topology.conf for block mapping: %s", e)
+
+    return mapping
+
+
 def generate_slurm_config_files(
     output_directory,
     template_directory,
@@ -81,6 +135,13 @@ def generate_slurm_config_files(
     # Initialize partition-nodelist mapping
     partition_nodelist_mapping = {}
 
+    # TODO: Revert this changes after SchedMd fix the bug
+    # Build topology block mapping from topology.conf (if it exists)
+    # This is a workaround for a Slurm 25.11.2 bug where nodes are incorrectly removed from
+    # topology blocks when they enter power-down state. Setting Topology=default:<BlockName>
+    # on the NodeName line prevents this issue.
+    topology_block_mapping = _build_topology_block_mapping(output_directory)
+
     # Generate slurm_parallelcluster_{QueueName}_partitions.conf and slurm_parallelcluster_{QueueName}_gres.conf
     is_default_queue = True  # The first queue in the queues list is the default queue
     for queue in queues:
@@ -92,6 +153,7 @@ def generate_slurm_config_files(
                 instance_types_data,
                 conf_type=file_type,
                 default=is_default_queue,
+                topology_block_mapping=topology_block_mapping if file_type == "partition" else None,
             )
             _generate_queue_config(
                 queue["Name"],


### PR DESCRIPTION
### Description of changes
Workaround for Slurm 25.11.2 bug where topology_p_add_rm_node incorrectly removes nodes from topology blocks when they enter power-down state. By setting `Topology=default:<BlockName>` on NodeName lines, the node's `topology_str` is no longer NULL, preventing the buggy code path.

SchedMD has confirmed this is a known issue with a fix in review.

## Changes we are doing

The change in this PR is to read the topology.conf that ParallelCluster creates and stores at `/opt/slurm/etc/` and parse it to get Block Mappings.
So if this file exists we read it to find the BlockName so that we can add `Topology=default:<BlockName>` to the slurm node definition

## Why not create the topology.conf through pcluster_slurm_config_generator.py or merge the configuration in file?
This is a temporary workaround for the bug that we found with slurm and we do not change the generation of separate topology.conf file since in future when we want to expand to use different topology plugin we can easily expand the existing resource we have in our cookbook.

### Tests
* Running

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
