### PR TITLE
[GH System Test] Pinning kitchen-dokken in order to tackle upgrade of docker engine in GH runners

### DIFF
--- a/.github/workflows/dokken-system-tests.yml
+++ b/.github/workflows/dokken-system-tests.yml
@@ -79,6 +79,25 @@ jobs:
         with:
           omnitruckUrl: omnitruck.cinc.sh
           project: cinc-workstation
+      - name: Downgrade Docker for kitchen-dokken 2.20.8 compatibility
+        if: steps.changed-files-excluding-tests.outputs.any_changed == 'true' && needs.check-labels.outputs.skip_system_tests != 'true'
+        run: |
+          # kitchen-dokken 2.20.8 sends Cmd as string and platform as "os/arch" string
+          # Docker 29.x (rolled out Feb 9 2026) rejects these — downgrade to 28.x
+          # https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260201.15
+          echo "Current Docker: $(docker --version)"
+          # Ensure Docker official repo is configured
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          # List available versions for debugging
+          apt-cache madison docker-ce | head -20
+          # Find latest 28.x version (format is 5:28.x.y-1~ubuntu...)
+          VERSION_STRING=$(apt-cache madison docker-ce | awk -F'|' '{print $2}' | tr -d ' ' | grep '^5:28\.' | head -1)
+          echo "Installing Docker version: $VERSION_STRING"
+          sudo apt-get install -y --allow-downgrades docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING
+          echo "New Docker: $(docker --version)"
       - name: Kitchen Test Install
         if: steps.changed-files-excluding-tests.outputs.any_changed == 'true' && needs.check-labels.outputs.skip_system_tests != 'true'
         uses: actionshub/test-kitchen@main

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -1,7 +1,6 @@
 ---
 driver:
   name: dokken
-  platform: linux/amd64
   pull_platform_image: false # Use the local images, prevent pull of docker images from Docker Hub,
   chef_version: 18.7.10
   chef_image: cincproject/cinc


### PR DESCRIPTION
## Fix Docker system tests broken by Docker 29.x on GitHub runners

### Problem

Starting February 9th, 2026, GitHub Actions runner images updated Docker Engine from 28.x to 29.x. https://github.com/actions/runner-images/issues/13474  
Docker 29.x introduced stricter API validation that broke `kitchen-dokken 2.20.8` (bundled with cinc-workstation):

- **`platform` field**: kitchen-dokken sends the string `"linux/amd64"`, but Docker 29.x requires a JSON object `{"os":"linux","architecture":"amd64"}` → `failed to parse platform: invalid character 'l'` -> https://github.com/test-kitchen/kitchen-dokken/pull/356 and https://github.com/test-kitchen/kitchen-dokken/issues/288
- **`Cmd` field**: kitchen-dokken sends a plain string, but Docker 29.x requires an array of strings `["sh", "-c", "..."]` → `cannot unmarshal string into Go struct field CreateRequest.Config.Cmd of type []string` -> https://github.com/test-kitchen/kitchen-dokken/pull/368

These bugs are fixed in kitchen-dokken >= 2.21.1, but those versions require Ruby >= 3.2, while cinc-workstation bundles Ruby 3.1.7. Upgrading the gem is not feasible due to Ruby version constraints, hardcoded version pins in `/usr/bin/kitchen`, and dependency conflicts with other bundled gems.

### Changes

**`dokken-system-tests.yml`:**
- Added a step to downgrade Docker Engine to 28.x before running tests, restoring compatibility with kitchen-dokken 2.20.8


**`kitchen.docker.yml`:**
- Removed the global `platform: linux/amd64` driver config to avoid the platform parse error on any Docker version
- Added `pull_platform_image: true` for `rhel8` and `rhel9` platforms, since their images come from `registry.access.redhat.com` and need to be pulled (unlike `dokken/*` images which are built locally)

## NEED to revert once cinc-workstation ships a version with Ruby >= 3.2 and kitchen-dokken >= 2.21.4.


### Tests
* GH Actions

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
