### PR TITLE
Move netplan+networkd configuration to before ubuntu-desktop installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Fix timestamp formats in CloudWatch log configuration to let CloudWatch parse the correct timestamps.
 - Fix an issue that was blocking the logging of slurm health check events.
 - Fix cluster creation failure without Internet access when GPU instances and DCV are used.
+- Fix build-image failure on Ubuntu with outdated os packages. Using the latest Ubuntu base AMI and/or enabling os packages update is recommended for most stable build-image process.
 
 3.14.2
 ------

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_ubuntu_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_ubuntu_common.rb
@@ -37,6 +37,21 @@ action_class do
   def pre_install
     apt_update
 
+    # ubuntu-desktop comes with NetworkManager. On a cloud instance NetworkManager is unnecessary and causes delay.
+    # Instruct Netplan to use networkd for better performance,
+    # and avoid network disruption when installing ubuntu-desktop.
+    bash 'Instruct Netplan to use networkd' do
+      code <<-NETPLAN
+        set -e
+        cat > /etc/netplan/95-parallelcluster-force-networkd.yaml << 'EOF'
+network:
+  version: 2
+  renderer: networkd
+EOF
+        netplan apply
+      NETPLAN
+    end unless on_docker?
+
     bash 'install pre-req' do
       cwd Chef::Config[:file_cache_path]
       # Must install whoopsie separately before installing ubuntu-desktop to avoid whoopsie crash pop-up
@@ -136,21 +151,5 @@ action_class do
       retries 10
       retry_delay 5
     end
-  end
-
-  def post_install
-    # ubuntu-desktop comes with NetworkManager. On a cloud instance NetworkManager is unnecessary and causes delay.
-    # Instruct Netplan to use networkd for better performance
-    bash 'Instruct Netplan to use networkd' do
-      code <<-NETPLAN
-        set -e
-        cat > /etc/netplan/95-parallelcluster-force-networkd.yaml << 'EOF'
-network:
-  version: 2
-  renderer: networkd
-EOF
-        netplan apply
-      NETPLAN
-    end unless on_docker?
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -471,6 +471,9 @@ describe 'dcv:setup' do
           case platform
           when 'ubuntu'
             is_expected.to periodic_apt_update('')
+            is_expected.to run_bash('Instruct Netplan to use networkd')
+              .with_code(%r{cat > /etc/netplan/95-parallelcluster-force-networkd.yaml})
+              .with_code(/netplan apply/)
             is_expected.to run_bash('install pre-req').with_cwd(Chef::Config[:file_cache_path]).with_retries(10).with_retry_delay(5)
                                                       .with_code(/apt -y install whoopsie/)
                                                       .with_code(/apt -y install ubuntu-desktop && apt -y install mesa-utils || (dpkg --configure -a && exit 1)/)


### PR DESCRIPTION
### Description of changes
This commit fixes build-image failure caused by ubuntu-desktop installation on older Ubuntu 24

Installing ubuntu-desktop on older Ubuntu 24 triggers systemd upgrades and other network reconfigurations which disrupt SSM agent connection, failing build-image.

Instructing netplan to always use networkd (therefore not switching to NetowrkManager when installing ubuntu-desktop) keeps the networking working.

### Tests
* With this fix, build-image with "Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 24.04) 20251212" succeeds
* Without this fix, build-image with "Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 24.04) 20251212" fails 

### References
* Integration tests PR to reenable DCV installation on Ubuntu https://github.com/aws/aws-parallelcluster/pull/7238

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
