### PR TITLE
[GH System tests] `Downgrade Docker` if the runner has docker v29.x.

### DIFF
--- a/.github/workflows/dokken-system-tests.yml
+++ b/.github/workflows/dokken-system-tests.yml
@@ -80,24 +80,31 @@ jobs:
           omnitruckUrl: omnitruck.cinc.sh
           project: cinc-workstation
       - name: Downgrade Docker for kitchen-dokken 2.20.8 compatibility
-        if: steps.changed-files-excluding-tests.outputs.any_changed == 'true' && needs.check-labels.outputs.skip_system_tests != 'true'
+        if: steps.changed-files-excluding-tests.outputs.any_changed == 'true' && needs.check-labels.outputs.skip_system_tests != 'true' && !startsWith(matrix.os, 'alinux')
         run: |
           # kitchen-dokken 2.20.8 sends Cmd as string and platform as "os/arch" string
           # Docker 29.x (rolled out Feb 9 2026) rejects these — downgrade to 28.x
           # https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260201.15
-          echo "Current Docker: $(docker --version)"
-          # Ensure Docker official repo is configured
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-          # List available versions for debugging
-          apt-cache madison docker-ce | head -20
-          # Find latest 28.x version (format is 5:28.x.y-1~ubuntu...)
-          VERSION_STRING=$(apt-cache madison docker-ce | awk -F'|' '{print $2}' | tr -d ' ' | grep '^5:28\.' | head -1)
-          echo "Installing Docker version: $VERSION_STRING"
-          sudo apt-get install -y --allow-downgrades docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING
-          echo "New Docker: $(docker --version)"
+          DOCKER_VERSION=$(docker version --format '{{.Server.Version}}')
+          echo "Current Docker: $DOCKER_VERSION"
+          DOCKER_MAJOR=$(echo "$DOCKER_VERSION" | cut -d. -f1)
+          if [[ "$DOCKER_MAJOR" -ge 29 ]]; then
+            echo "Docker ${DOCKER_VERSION} (major >= 29) detected — downgrading to 28.x"
+            # Ensure Docker official repo is configured
+            sudo install -m 0755 -d /etc/apt/keyrings
+            sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+            echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+            sudo apt-get update
+            # List available versions for debugging
+            apt-cache madison docker-ce | head -20
+            # Find latest 28.x version (format is 5:28.x.y-1~ubuntu...)
+            VERSION_STRING=$(apt-cache madison docker-ce | awk -F'|' '{print $2}' | tr -d ' ' | grep '^5:28\.' | head -1)
+            echo "Installing Docker version: $VERSION_STRING"
+            sudo apt-get install -y --allow-downgrades docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING
+            echo "New Docker: $(docker --version)"
+          else
+            echo "Docker version is not 29.x — skipping downgrade"
+          fi
       - name: Kitchen Test Install
         if: steps.changed-files-excluding-tests.outputs.any_changed == 'true' && needs.check-labels.outputs.skip_system_tests != 'true'
         uses: actionshub/test-kitchen@main


### PR DESCRIPTION
### Description of changes
* Downgrade Docker if the runner has docker v29.x. Other wise skip the Downgrade step.
* Skip the `Downgrade Docker` so that we are aware of when to revert the workaround https://github.com/aws/aws-parallelcluster-cookbook/pull/3124
* We do not block the PR merge on failure of AL2 and AL2023 system tests since they fail with CW installation or not availability of GLIBC ruby -> https://github.com/aws/aws-parallelcluster-cookbook/actions/runs/22190525744/job/64176702663


### Tests
* System tests in this PR

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
