### PR TITLE
Use al2023 for dcgm dependency

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/nvidia_dcgm_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/nvidia_dcgm_alinux2023.rb
@@ -24,5 +24,5 @@ def _nvidia_dcgm_enabled
 end
 
 def platform
-  'rhel9'
+  'amzn2023'
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_dcgm_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_dcgm_spec.rb
@@ -79,6 +79,20 @@ end
 describe 'nvidia_dcgm:_nvidia_dcgm_enabled' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
+      cached(:expected_platform) do
+        platforms = {
+          'amazon2' => 'rhel7',
+          'amazon2023' => 'amzn2023',
+          'ubuntu22.04' => 'ubuntu2204',
+          'ubuntu24.04' => 'ubuntu2404',
+          'redhat8' => 'rhel8',
+          'redhat9' => 'rhel9',
+          'rocky8' => 'rhel8',
+          'rocky9' => 'rhel9',
+        }
+        platforms["#{platform}#{version}"]
+      end
+
       context 'when on arm and nvidia enabled' do
         cached(:chef_run) do
           allow_any_instance_of(Object).to receive(:arm_instance?).and_return(true)
@@ -97,6 +111,10 @@ describe 'nvidia_dcgm:_nvidia_dcgm_enabled' do
           it "is enabled" do
             expect(resource._nvidia_dcgm_enabled).to eq(true)
           end
+
+          it "returns correct platform for download URL" do
+            expect(resource.platform).to eq(expected_platform)
+          end
         end
       end
 
@@ -114,6 +132,10 @@ describe 'nvidia_dcgm:_nvidia_dcgm_enabled' do
 
           it "is enabled" do
             expect(resource._nvidia_dcgm_enabled).to eq(true)
+          end
+
+          it "returns correct platform for download URL" do
+            expect(resource.platform).to eq(expected_platform)
           end
         end
 


### PR DESCRIPTION
### Description of changes
* Use proper dcgm dependency for al2023
* Support for AL2023 was introduced in [4.3.0](https://docs.nvidia.com/datacenter/dcgm/latest/release-notes/changelog.html#id10) which is why we were previously using rhel9
* We have already been uploading the amzn2023 dependecies to our s3 buckets but have not been using them

### Tests
* Ran second stage build for AL2023 AMI and ran `test_essential_features`

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
