### PR TITLE
Improve MPI collective performance with small packet sizes on RHEL/Rocky at scale by disabling dnf-makecache timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **CHANGES**
-- Replace cfn-hup in compute nodes with systemd timer to support in place updates in order to improve performance.
+- Replace cfn-hup in compute nodes with systemd timer to support in place updates in order to improve MPI collective performance at scale.
   This new mechanism relies on shared storage to sync updates between the head node and compute nodes.
+- Disable dnf-makecache.timer to improve MPI collective performance on RHEL/Rocky at scale.
 - Mitigate the risk of transient build-image failures in RHEL and Rocky caused by out-of-sync repo mirrors.
 - Upgrade Slurm to version 25.11.3 (from 24.11.7).
 - Upgrade Pmix to 5.0.10 (from 5.0.6).

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/disable_services.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/disable_services.rb
@@ -28,6 +28,15 @@ service 'log4j-cve-2021-44228-hotpatch' do
   action %i(disable stop mask)
 end unless on_docker?
 
+# Disable dnf-makecache timer to reduce system jitter.
+# dnf-makecache periodically refreshes repo metadata, triggering heavy rpm/dnf
+# operations. At scale (500+ nodes), the randomized timer ensures at least one
+# node is always running a cache refresh, causing barrier straggler effects.
+# Cluster nodes do not need periodic repo cache updates.
+service 'dnf-makecache.timer' do
+  action %i(disable stop)
+end unless on_docker?
+
 # Disable services if node['cluster']['disable_services'] is provided
 if node['cluster']['disable_services']
   node['cluster']['disable_services'].split().each do |service_name|

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
@@ -24,6 +24,11 @@ describe 'aws-parallelcluster-platform::disable_services' do
         is_expected.to mask_service('log4j-cve-2021-44228-hotpatch')
       end
 
+      it 'disables dnf-makecache timer' do
+        is_expected.to disable_service('dnf-makecache.timer')
+        is_expected.to stop_service('dnf-makecache.timer')
+      end
+
       DISABLE_SERVICE_NAME.split().each do |service_name|
         it "disables #{service_name}" do
           is_expected.to disable_service(service_name)

--- a/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
@@ -45,3 +45,14 @@ control 'tag:testami_tag:config_services_disabled_on_amazon_family' do
     its(:stdout) { should match /LoadState=masked/ }
   end
 end
+
+control 'tag:testami_tag:config_dnf_makecache_timer_disabled' do
+  title 'Test that dnf-makecache timer is disabled and stopped to reduce HPC jitter'
+
+  only_if { !os_properties.on_docker? }
+
+  describe service('dnf-makecache.timer') do
+    it { should_not be_enabled }
+    it { should_not be_running }
+  end
+end


### PR DESCRIPTION
### Description of changes
RHEL/Rocky instances run dnf-makecache.timer hourly with a randomized 60-minute delay, refreshing package metadata for 6+ RHUI repos. Each refresh consumes a few seconds of CPU. At 500+ nodes, usually at least one node is always mid-refresh, creating straggler effects in MPI barrier synchronization. This timer does not exist on Amazon Linux or Ubuntu.

Disable the timer during AMI build. Cluster nodes do not need periodic repo cache updates. Manual dnf operations still work on demand.


### Tests
* OSU benchmark result is now similar between RHEL and Amazon Linux on 500 nodes


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
