### PR TITLE
[Update Workflow] Prevent unexpected execution of cluster update failure recovery on AWS Batch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Fix an issue that was blocking the logging of slurm health check events.
 - Fix cluster creation failure without Internet access when GPU instances and DCV are used.
 - Fix build-image failure during ubuntu-desktop installation on a Ubuntu parent image with outdated OS packages.
+- Prevent unexpected execution of cluster update failure recovery on AWS Batch.
 
 3.14.2
 ------

--- a/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
@@ -35,8 +35,8 @@ module ErrorHandlers
     def report
       Chef::Log.info("#{log_prefix} Started with parameters @cleanup_dna_files=#{@cleanup_dna_files}, @start_clustermgtd=#{@start_clustermgtd}")
 
-      unless node_type == 'HeadNode'
-        Chef::Log.info("#{log_prefix} Node type is #{node_type}, recovery from update failure only executes on the HeadNode")
+      unless node_type == 'HeadNode' && scheduler == 'slurm'
+        Chef::Log.info("#{log_prefix} Node type is #{node_type} and scheduler is #{scheduler}, recovery from update failure only executes on the HeadNode with slurm scheduler")
         return
       end
 
@@ -80,6 +80,10 @@ module ErrorHandlers
 
     def node_type
       cluster_attributes['node_type']
+    end
+
+    def scheduler
+      cluster_attributes['scheduler']
     end
 
     def cookbook_virtualenv_path

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
@@ -29,6 +29,7 @@ describe ErrorHandlers::UpdateFailureHandler do
     {
       'cluster' => {
         'node_type' => node_type,
+        'scheduler' => scheduler,
         'system_pyenv_root' => pyenv_root,
         'python-version' => python_version,
         'scripts_dir' => scripts_dir,
@@ -37,6 +38,7 @@ describe ErrorHandlers::UpdateFailureHandler do
     }
   end
   let(:node_type) { 'HeadNode' }
+  let(:scheduler) { 'slurm' }
   let(:run_status) { double('run_status', exception: exception, updated_resources: updated_resources, node: node) }
   let(:command_runner) { instance_double(ErrorHandlers::CommandRunner) }
 
@@ -54,6 +56,12 @@ describe ErrorHandlers::UpdateFailureHandler do
     end
   end
 
+  describe '#scheduler' do
+    it 'returns the scheduler from cluster attributes' do
+      expect(handler.scheduler).to eq('slurm')
+    end
+  end
+
   describe '#cookbook_virtualenv_path' do
     it 'constructs the correct virtualenv path' do
       expect(handler.cookbook_virtualenv_path).to eq(virtualenv_path)
@@ -61,7 +69,7 @@ describe ErrorHandlers::UpdateFailureHandler do
   end
 
   describe '#report' do
-    context 'when node type is HeadNode' do
+    context 'when node type is HeadNode and scheduler is slurm' do
       it 'writes error report and runs recovery commands' do
         expect(handler).to receive(:write_error_report)
         expect(handler).to receive(:run_recovery)
@@ -83,7 +91,32 @@ describe ErrorHandlers::UpdateFailureHandler do
         expect(handler).not_to receive(:write_error_report)
         expect(handler).not_to receive(:run_recovery)
         allow(Chef::Log).to receive(:info)
-        expect(Chef::Log).to receive(:info).with(/Node type is ComputeFleet/)
+        expect(Chef::Log).to receive(:info).with(/Node type is ComputeFleet and scheduler is slurm, recovery from update failure only executes on the HeadNode with slurm scheduler/)
+        handler.report
+      end
+    end
+
+    context 'when scheduler is not slurm' do
+      let(:scheduler) { 'awsbatch' }
+
+      it 'skips recovery and returns early' do
+        expect(handler).not_to receive(:write_error_report)
+        expect(handler).not_to receive(:run_recovery)
+        allow(Chef::Log).to receive(:info)
+        expect(Chef::Log).to receive(:info).with(/Node type is HeadNode and scheduler is awsbatch, recovery from update failure only executes on the HeadNode with slurm scheduler/)
+        handler.report
+      end
+    end
+
+    context 'when node type is not HeadNode and scheduler is not slurm' do
+      let(:node_type) { 'ComputeFleet' }
+      let(:scheduler) { 'awsbatch' }
+
+      it 'skips recovery and returns early' do
+        expect(handler).not_to receive(:write_error_report)
+        expect(handler).not_to receive(:run_recovery)
+        allow(Chef::Log).to receive(:info)
+        expect(Chef::Log).to receive(:info).with(/Node type is ComputeFleet and scheduler is awsbatch, recovery from update failure only executes on the HeadNode with slurm scheduler/)
         handler.report
       end
     end


### PR DESCRIPTION
### Description of changes
Prevent unexpected execution of cluster update failure recovery on AWS Batch.
The UpdateFailureHandler now returns immediately if the scheduler is AWS Batch, as it only supports recovery on Slurm.

### UX
When cluster update fails with scheduler awsbatch, the error handler does not execute any recovery, as expected:

```
* ruby_block[synthetic_failure] action run[2026-02-26T04:17:19+00:00] INFO: Processing ruby_block[synthetic_failure] action run (aws-parallelcluster-entrypoints::update line 22)
...
Running handlers:
[2026-02-26T04:17:19+00:00] ERROR: Running exception handlers
[2026-02-26T04:17:19+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Started with parameters @cleanup_dna_files=true, @start_clustermgtd=true
[2026-02-26T04:17:19+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Node type is HeadNode and scheduler is awsbatch, recovery from update failure only executes on the HeadNode with slurm scheduler
  - ErrorHandlers::UpdateFailureHandler
Running handlers complete
[2026-02-26T04:17:19+00:00] ERROR: Exception handlers complete
```


No regression on update failure in SLURM

```
ruby_block[synthetic_failure] action run (aws-parallelcluster-entrypoints::update line 23)
...
Running handlers:
[2026-02-26T04:17:07+00:00] ERROR: Running exception handlers
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Started with parameters @cleanup_dna_files=true, @start_clustermgtd=true
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Update failed on HeadNode due to: ruby_block[synthetic_failure] (aws-parallelcluster-entrypoints::update line 23) had an error: RuntimeError: Synthetic failure injected for testing
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Resources that have been successfully executed before the failure:
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler:   - ruby_block[Configure environment variable for recipes context: PATH]
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Running recovery commands
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Executing: cleanup DNA files
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Running command (attempt 1/11): /opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/python /opt/parallelcluster/scripts/share_compute_fleet_dna.py --region us-east-1 --cleanup
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stdout:
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stderr: INFO:__main__:All dna.json files have been shared!

[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Successfully executed: cleanup DNA files
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Executing: start clustermgtd
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Running command (attempt 1/11): /opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/supervisorctl start clustermgtd
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stdout: clustermgtd: ERROR (already started)

[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Command stderr:
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Successfully executed: start clustermgtd
[2026-02-26T04:17:07+00:00] INFO: ErrorHandlers::UpdateFailureHandler: Completed successfully
  - ErrorHandlers::UpdateFailureHandler
Running handlers complete
[2026-02-26T04:17:07+00:00] ERROR: Exception handlers complete
Infra Phase failed. 1 resources updated in 05 seconds
```

### Tests
1. [SUCCESS] Unit tests (added to this PR)
1. [SUCCESS] Manual validation: on update failure, the update handler is executed as expected on Slurm and it is skipped on awsbatch. See UX above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
