### PR TITLE
Split slurm accounting configuration into two parts 

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
@@ -19,7 +19,7 @@ execute "wait for cluster registration" do
   command "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{node['cluster']['stack_name']} format=cluster | grep -x '#{node['cluster']['stack_name']}'"
   retries 30
   retry_delay 10
-end unless kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")
+end
 
 bash "bootstrap slurm database" do
   user 'root'
@@ -44,4 +44,4 @@ bash "bootstrap slurm database" do
 
     exit 0
   BOOTSTRAP
-end unless kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-slurm
+# Recipe:: bootstrap_slurm_accounting
+#
+# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+execute "wait for cluster registration" do
+  command "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{node['cluster']['stack_name']} format=cluster | grep -x '#{node['cluster']['stack_name']}'"
+  retries 30
+  retry_delay 10
+end unless kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")
+
+bash "bootstrap slurm database" do
+  user 'root'
+  group 'root'
+  code <<-BOOTSTRAP
+    SACCTMGR_CMD=#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr
+    CLUSTER_NAME=#{node['cluster']['stack_name']}
+    DEF_ACCOUNT=pcdefault
+    SLURM_USER=#{node['cluster']['slurm']['user']}
+    DEF_USER=#{node['cluster']['cluster_user']}
+
+    # Add account-cluster association to database if it is not present yet
+    [[ $($SACCTMGR_CMD list associations -Pn cluster=$CLUSTER_NAME account=$DEF_ACCOUNT format=account | grep $DEF_ACCOUNT) ]] || \
+        $SACCTMGR_CMD -iQ add account $DEF_ACCOUNT Cluster=$CLUSTER_NAME \
+            Description="ParallelCluster default account" Organization="none"
+
+    # Add user-account associations to database if they are not present yet
+    [[ $($SACCTMGR_CMD list associations -Pn cluster=$CLUSTER_NAME account=$DEF_ACCOUNT user=$SLURM_USER format=user | grep $SLURM_USER) ]] || \
+        $SACCTMGR_CMD -iQ add user $SLURM_USER Account=$DEF_ACCOUNT AdminLevel=Admin
+    [[ $($SACCTMGR_CMD list associations -Pn cluster=$CLUSTER_NAME account=$DEF_ACCOUNT user=$DEF_USER format=user | grep $DEF_USER) ]] || \
+        $SACCTMGR_CMD -iQ add user $DEF_USER Account=$DEF_ACCOUNT AdminLevel=Admin
+
+    exit 0
+  BOOTSTRAP
+end unless kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
@@ -4,7 +4,7 @@
 # Cookbook:: aws-parallelcluster-slurm
 # Recipe:: bootstrap_slurm_accounting
 #
-# Copyright:: 2013-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright:: 2026 Amazon.com, Inc. and its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -15,8 +15,10 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+return if kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")
+
 execute "wait for cluster registration" do
-  command "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{node['cluster']['stack_name']} format=cluster | grep -x '#{node['cluster']['stack_name']}'"
+  command "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{node['cluster']['stack_name']} format=cluster | grep -Fx '#{node['cluster']['stack_name']}'"
   retries 30
   retry_delay 10
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
@@ -220,7 +220,7 @@ execute "check slurmctld status" do
   command "systemctl is-active --quiet slurmctld.service"
   retries 5
   retry_delay 2
-end
+end unless redhat_on_docker?
 
 ruby_block "Bootstrap Slurm Accounting Users" do
   block do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
@@ -204,8 +204,8 @@ ruby_block "Configure Slurm Accounting" do
   block do
     run_context.include_recipe "aws-parallelcluster-slurm::config_slurm_accounting"
   end
-  not_if { node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
-end unless on_docker?
+  not_if { on_docker? || node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
+end
 
 service "slurmctld" do
   supports restart: false
@@ -226,6 +226,5 @@ ruby_block "Bootstrap Slurm Accounting Users" do
   block do
     run_context.include_recipe "aws-parallelcluster-slurm::bootstrap_slurm_accounting"
   end
-  not_if { node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
-  not_if { kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd") }
-end unless on_docker?
+  not_if { on_docker? || node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_head_node.rb
@@ -220,4 +220,12 @@ execute "check slurmctld status" do
   command "systemctl is-active --quiet slurmctld.service"
   retries 5
   retry_delay 2
-end unless redhat_on_docker?
+end
+
+ruby_block "Bootstrap Slurm Accounting Users" do
+  block do
+    run_context.include_recipe "aws-parallelcluster-slurm::bootstrap_slurm_accounting"
+  end
+  not_if { node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
+  not_if { kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd") }
+end unless on_docker?

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_accounting.rb
@@ -76,10 +76,6 @@ service "slurmdbd" do
   action action
 end unless on_docker?
 
-file "/var/spool/slurm.state/clustername" do
-  action "delete"
-end
-
 if node['cluster']['slurmdbd_service_enabled'] == "true"
   # After starting slurmdbd the database may not be fully responsive yet and
   # its bootstrapping may fail. We need to wait for sacctmgr to successfully
@@ -90,36 +86,5 @@ if node['cluster']['slurmdbd_service_enabled'] == "true"
     command "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn"
     retries node['cluster']['slurmdbd_response_retries']
     retry_delay 10
-  end unless kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")
-
-  bash "bootstrap slurm database" do
-    user 'root'
-    group 'root'
-    code <<-BOOTSTRAP
-      SACCTMGR_CMD=#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr
-      CLUSTER_NAME=#{node['cluster']['stack_name']}
-      DEF_ACCOUNT=pcdefault
-      SLURM_USER=#{node['cluster']['slurm']['user']}
-      DEF_USER=#{node['cluster']['cluster_user']}
-
-      # Add cluster to database if it is not present yet
-      [[ $($SACCTMGR_CMD show clusters -Pn cluster=$CLUSTER_NAME | grep $CLUSTER_NAME) ]] || \
-          $SACCTMGR_CMD -iQ add cluster $CLUSTER_NAME
-
-      # Add account-cluster association to database if it is not present yet
-      [[ $($SACCTMGR_CMD list associations -Pn cluster=$CLUSTER_NAME account=$DEF_ACCOUNT format=account | grep $DEF_ACCOUNT) ]] || \
-          $SACCTMGR_CMD -iQ add account $DEF_ACCOUNT Cluster=$CLUSTER_NAME \
-              Description="ParallelCluster default account" Organization="none"
-
-      # Add user-account associations to database if they are not present yet
-      [[ $($SACCTMGR_CMD list associations -Pn cluster=$CLUSTER_NAME account=$DEF_ACCOUNT user=$SLURM_USER format=user | grep $SLURM_USER) ]] || \
-          $SACCTMGR_CMD -iQ add user $SLURM_USER Account=$DEF_ACCOUNT AdminLevel=Admin
-      [[ $($SACCTMGR_CMD list associations -Pn cluster=$CLUSTER_NAME account=$DEF_ACCOUNT user=$DEF_USER format=user | grep $DEF_USER) ]] || \
-          $SACCTMGR_CMD -iQ add user $DEF_USER Account=$DEF_ACCOUNT AdminLevel=Admin
-
-      # sacctmgr might throw errors if the DEF_ACCOUNT is not associated to a cluster already defined on the database.
-      # This is not important for the scope of this script, so we return 0.
-      exit 0
-    BOOTSTRAP
   end unless kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")
 end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/clear_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/clear_slurm_accounting.rb
@@ -23,7 +23,3 @@ service "slurmdbd" do
   supports restart: false
   action %i(disable stop)
 end
-
-file '/var/spool/slurm.state/clustername' do
-  action :delete
-end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -215,8 +215,8 @@ ruby_block "Update Slurm Accounting" do
       run_context.include_recipe "aws-parallelcluster-slurm::config_slurm_accounting"
     end
   end
-  only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_slurm_database_updated? }
-end unless on_docker?
+  only_if { !on_docker? && ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_slurm_database_updated? }
+end
 
 # Cover the following two scenarios:
 # - a cluster without login nodes is updated to have login nodes;
@@ -274,8 +274,7 @@ ruby_block "Bootstrap Slurm Accounting Users" do
   block do
     run_context.include_recipe "aws-parallelcluster-slurm::bootstrap_slurm_accounting"
   end
-  only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_slurm_database_updated? }
-  not_if { kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd") }
+  only_if { !on_docker? && ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_slurm_database_updated? }
 end
 
 execute SCONTROL_RECONFIGURE_RESOURCE_NAME do

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -207,7 +207,7 @@ replace_or_add "update node replacement timeout" do
   replace_only true
 end
 
-ruby_block "Configure Slurm Accounting" do
+ruby_block "Update Slurm Accounting" do
   block do
     if node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil?
       run_context.include_recipe "aws-parallelcluster-slurm::clear_slurm_accounting"
@@ -274,7 +274,7 @@ ruby_block "Bootstrap Slurm Accounting Users" do
   block do
     run_context.include_recipe "aws-parallelcluster-slurm::bootstrap_slurm_accounting"
   end
-  only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_slurm_database_updated? && !node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
+  only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_slurm_database_updated? }
   not_if { kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd") }
 end
 

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -207,7 +207,7 @@ replace_or_add "update node replacement timeout" do
   replace_only true
 end
 
-ruby_block "Update Slurm Accounting" do
+ruby_block "Configure Slurm Accounting" do
   block do
     if node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil?
       run_context.include_recipe "aws-parallelcluster-slurm::clear_slurm_accounting"
@@ -268,6 +268,14 @@ execute "check slurmctld status" do
   command "systemctl is-active --quiet slurmctld.service"
   retries 5
   retry_delay 2
+end
+
+ruby_block "Bootstrap Slurm Accounting Users" do
+  block do
+    run_context.include_recipe "aws-parallelcluster-slurm::bootstrap_slurm_accounting"
+  end
+  only_if { ::File.exist?(node['cluster']['previous_cluster_config_path']) && is_slurm_database_updated? && !node['cluster']['config'].dig(:Scheduling, :SlurmSettings, :Database).nil? }
+  not_if { kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd") }
 end
 
 execute SCONTROL_RECONFIGURE_RESOURCE_NAME do

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/bootstrap_slurm_accounting_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/bootstrap_slurm_accounting_spec.rb
@@ -11,7 +11,7 @@ describe 'aws-parallelcluster-slurm::bootstrap_slurm_accounting' do
 
       it "waits for cluster registration" do
         is_expected.to run_execute("wait for cluster registration").with(
-          command: "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{node['cluster']['stack_name']} format=cluster | grep -x '#{node['cluster']['stack_name']}'"
+          command: "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{node['cluster']['stack_name']} format=cluster | grep -Fx '#{node['cluster']['stack_name']}'"
         )
       end
 

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/bootstrap_slurm_accounting_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/bootstrap_slurm_accounting_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::bootstrap_slurm_accounting' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner = runner(platform: platform, version: version)
+        runner.converge(described_recipe)
+      end
+      cached(:node) { chef_run.node }
+
+      it "waits for cluster registration" do
+        is_expected.to run_execute("wait for cluster registration").with(
+          command: "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{node['cluster']['stack_name']} format=cluster | grep -x '#{node['cluster']['stack_name']}'"
+        )
+      end
+
+      it "bootstraps the Slurm database with users" do
+        is_expected.to run_bash("bootstrap slurm database")
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/clear_slurm_accounting_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/clear_slurm_accounting_spec.rb
@@ -19,10 +19,6 @@ describe 'aws-parallelcluster-slurm::clear_slurm_accounting' do
       it 'deletes the Slurm database password update script' do
         is_expected.to delete_file("#{node['cluster']['scripts_dir']}/slurm/update_slurm_database_password.sh")
       end
-
-      it 'Removes existing cluster name state file' do
-        is_expected.to delete_file('/var/spool/slurm.state/clustername')
-      end
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurm_accounting_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurm_accounting_spec.rb
@@ -71,9 +71,6 @@ describe 'aws-parallelcluster-slurm::config_slurm_accounting' do
             )
           end
           if enable_service == "true"
-            it 'Removes existing cluster name state file' do
-              is_expected.to delete_file('/var/spool/slurm.state/clustername')
-            end
             it 'starts the slurm database daemon' do
               is_expected.to enable_service("slurmdbd")
               is_expected.to start_service("slurmdbd")
@@ -82,10 +79,6 @@ describe 'aws-parallelcluster-slurm::config_slurm_accounting' do
               is_expected.to run_execute("wait for slurm database").with(
                 command: "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn"
               )
-            end
-
-            it "bootstraps the Slurm database idempotently" do
-              is_expected.to run_bash("bootstrap slurm database")
             end
           else
             it 'disables the slurm database daemon' do


### PR DESCRIPTION
### Description of changes

* Slurm 25.11+ includes a [fix](https://github.com/SchedMD/slurm/commit/6086f2c3) that allows slurmctld to preserve its ClusterID when registering with slurmdbd. This should resolve cluster ID mismatch issues when enabling accounting on an existing cluster.
* Despite the Slurm fix, preserving the `/var/spool/slurm.state/clustername` file (which contains the ClusterID) still resulted in a cluster ID mismatch error. 
* The bootstrap script used `sacctmgr add cluster`, which always assigns a new ClusterID and cannot accept the existing ID as a parameter. This created a mismatch between:
  - slurmctld's ClusterID (from the state file)
  - slurmdbd's ClusterID (newly generated by sacctmgr)
* To solve this, I removed `sacctmgr add cluster` and rely on slurmctld's automatic registration to preserve the ClusterID.
* This created a new problem: the bootstrap script ran before slurmctld could register the cluster, leaving no cluster in the database to add users to.
* To fix this, I split Slurm accounting configuration into two phases:

  1. **Configure and start slurmdbd** - prepares the accounting database service
  2. **Restart slurmctld** - automatically registers the cluster with preserved ClusterID
  3. **Bootstrap users** - adds accounts and users to the now-registered cluster

This ordering ensures slurmctld registers the cluster (with correct ClusterID) before the bootstrap script attempts to add users.

### Tests
* Ran `test_slurm_accounting`, `test_slurm_accounting_external_dbd`, and `test_slurm`
* I tested that 2 clusters can use the same db
* I tested that a cluster can be updated to use a different db

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
