### PR TITLE
[DevSettings] Add possibility to skip cluster readiness check or ignore its failures, both on create and update workflow.

### DIFF
--- a/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
@@ -12,8 +12,11 @@ default['cluster']['etc_dir'] = '/etc/parallelcluster'
 # Cluster Updates
 default['cluster']['update']['trigger_file'] = "#{node['cluster']['shared_dir']}/update_trigger"
 default['cluster']['update']['checkpoint_file'] = "#{node['cluster']['scripts_dir']}/update_checkpoint"
-default['cluster']['update']['cluster_readiness_check_enabled'] = 'true'
 default['cluster']['in_place_update_on_fleet_enabled'] = 'true'
+
+# Cluster readiness checks
+default['cluster']['cluster_readiness_check_enabled'] = 'true'
+default['cluster']['cluster_readiness_check_ignore_failure'] = 'false'
 
 # Slurm_plugin_dir is used by slurm cookbook and custom_actions recipe
 default['cluster']['slurm_plugin_dir'] = "#{node['cluster']['etc_dir']}/slurm_plugin"

--- a/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
@@ -115,8 +115,15 @@ def cfnhup_enabled?
 end
 
 def cluster_readiness_check_on_update_enabled?
-  node['cluster']['update']['cluster_readiness_check_enabled'] == 'true' ||
-    node['cluster']['in_place_update_on_fleet_enabled'] == 'true'
+  cluster_readiness_check_enabled? && node['cluster']['in_place_update_on_fleet_enabled'] == 'true'
+end
+
+def cluster_readiness_check_enabled?
+  node['cluster']['cluster_readiness_check_enabled'].to_s.downcase == 'true'
+end
+
+def cluster_readiness_check_ignore_failure?
+  node['cluster']['cluster_readiness_check_ignore_failure'].to_s.downcase == 'true'
 end
 
 # Executes a block with retry logic for handling transient failures.

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/libraries/helpers_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/libraries/helpers_spec.rb
@@ -35,12 +35,50 @@ describe 'cluster_readiness_check_on_update_enabled?' do
 
   [true, false].each do |cluster_readiness_check_enabled|
     [true, false].each do |in_place_update_on_fleet_enabled|
-      expected = cluster_readiness_check_enabled || in_place_update_on_fleet_enabled
+      expected = cluster_readiness_check_enabled && in_place_update_on_fleet_enabled
       it "returns #{expected} when cluster_readiness_check_enabled is #{cluster_readiness_check_enabled} and in_place_update_on_fleet_enabled is #{in_place_update_on_fleet_enabled}" do
-        node.override['cluster']['update']['cluster_readiness_check_enabled'] = cluster_readiness_check_enabled.to_s
+        node.override['cluster']['cluster_readiness_check_enabled'] = cluster_readiness_check_enabled.to_s
         node.override['cluster']['in_place_update_on_fleet_enabled'] = in_place_update_on_fleet_enabled.to_s
         expect(cluster_readiness_check_on_update_enabled?).to be expected
       end
+    end
+  end
+end
+
+describe 'cluster_readiness_check_enabled?' do
+  let(:node) { Chef::Node.new }
+
+  %w(true TRUE True).each do |value|
+    it "returns true when cluster_readiness_check_enabled is '#{value}'" do
+      node.override['cluster']['cluster_readiness_check_enabled'] = value
+      expect(cluster_readiness_check_enabled?).to be true
+    end
+  end
+
+  %w(false FALSE invalid).each do |value|
+    it "returns false when cluster_readiness_check_enabled is '#{value}'" do
+      node.override['cluster']['cluster_readiness_check_enabled'] = value
+      expect(cluster_readiness_check_enabled?).to be false
+    end
+  end
+end
+
+describe 'cluster_readiness_check_ignore_failure?' do
+  let(:node) { Chef::Node.new }
+
+  %w(true True TRUE).each do |value|
+    expected = true
+    it "returns #{expected} when cluster_readiness_check_ignore_failure is '#{value}'" do
+      node.override['cluster']['cluster_readiness_check_ignore_failure'] = value
+      expect(cluster_readiness_check_ignore_failure?).to be true
+    end
+  end
+
+  %w(false False FALSE invalid).each do |value|
+    expected = false
+    it "returns #{expected} when cluster_readiness_check_ignore_failure is '#{value}'" do
+      node.override['cluster']['cluster_readiness_check_ignore_failure'] = value
+      expect(cluster_readiness_check_ignore_failure?).to be expected
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -175,6 +175,8 @@ def wait_cluster_ready
     timeout 30
     retries 10
     retry_delay 90
+    ignore_failure cluster_readiness_check_ignore_failure?
+    only_if { cluster_readiness_check_enabled? }
   end
 end
 


### PR DESCRIPTION
This PR is related to https://github.com/aws/aws-parallelcluster/pull/7259

### Description of changes
 Add possibility to skip cluster readiness check or ignore its failures, both on create and update workflow.
* To skip the readiness check, set `cluster.cluster_readiness_check_enabled` to false.
* To execute readiness check, but ignore its failure, set `cluster.cluster_readiness_check_ignore_failure` to true.

Also fixed the condition that skips the readiness check on update. 

Before this change we could disable readiness check on update only if we disabled in-place updates as well. However, that was not correct because we should be able to skip the readiness check while still keep in-place updates enabled. 
After this change, the user can skip the readiness check while still keep the in-place updates enabled.

**Note** we will not add a changelog entry because it is a dev settings.

### Tests
* PR checks (unit tests have been adapted to cover the current chnages)
* Manual validation with cluster create/update (we will; not create an integ test for this use case)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
