### PR TITLE
Upgrade amazon-efs-utils to version 2.4.0 (from v2.1.0) for Amazon Linux AMI's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade mysql-community-client to version 8.4.8 (from 8.0.39) for all OSs except Amazon Linux 2.
 - Upgrade Intel MPI Library to 2021.17.2 (from 2021.16.0).
 - Upgrade Cinc Client to version 18.8.54 (from 18.7.10).
+- Upgrade amazon-efs-utils to version 2.4.0 (from v2.1.0) for Amazon Linux AMI's.
 - Always start clustermgtd on cluster update and compute fleet status update failure, regardless the failure condition.
 
 **BUG FIXES**

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -75,9 +75,6 @@ default['cluster']['efa']['sha256'] = '8302bd7849afb95c903a875d7dcb6f85b3d7629e9
 
 default['cluster']['efs']['version'] = '2.4.0'
 default['cluster']['efs']['sha256'] = '9b60c039c162388091d6fab6e9c6cfc5832f34b26b6d05b0a68b333147d78a25'
-if platform?('amazon') && node['platform_version'].to_i == 2
-  default['cluster']['efs']['version'] = '2.1.0'
-end
 
 default['cluster']['cfn_bootstrap']['version'] = '2.0-38'
 

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -75,7 +75,7 @@ default['cluster']['efa']['sha256'] = '8302bd7849afb95c903a875d7dcb6f85b3d7629e9
 
 default['cluster']['efs']['version'] = '2.4.0'
 default['cluster']['efs']['sha256'] = '9b60c039c162388091d6fab6e9c6cfc5832f34b26b6d05b0a68b333147d78a25'
-if platform?('amazon')
+if platform?('amazon') && node['platform_version'].to_i == 2
   default['cluster']['efs']['version'] = '2.1.0'
 end
 


### PR DESCRIPTION
### Description of changes
* Previously, the efs-utils version override applied to all Amazon Linux platforms (AL2 and AL2023), keeping both at 2.1.0. Now upgrade them to use the default 2.4.0 version that other OSes already use.

### Tests
* build-image passed on both AL2 and AL2023
```
{%- import 'common.jinja2' as common with context -%}
{{- common.OSS_COMMERCIAL_X86.append("rocky8") or "" -}}
{{- common.OSS_COMMERCIAL_X86.append("rocky9") or "" -}}
---
test-suites:
  storage:
    test_efs.py::test_efs_compute_az:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_efs.py::test_efs_same_az:
      dimensions:
        - regions: [ "us-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: [ "slurm" ]
    test_efs.py::test_multiple_efs:
      dimensions:
        - regions: [ "us-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: [ "slurm" ]
    test_efs.py::test_efs_access_point:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
