### PR TITLE
[Test] Handle exceptions from non-blocking blocks

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
@@ -20,7 +20,7 @@ control 'tag:install_lustre_client_installed' do
       end
 
       describe yum.repo('aws-fsx') do
-        before { retry_helpers.wait_for_command("yum -v repolist all 2>/dev/null | grep -q 'aws-fsx'") }
+        before { retry_helpers.wait_for_command("yum -v repolist all 2>/dev/null | grep -q 'aws-fsx'") rescue nil } # rubocop:disable Style/RescueModifier
         it { should exist }
         it { should be_enabled }
         its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
@@ -49,7 +49,7 @@ control 'tag:install_lustre_client_installed' do
       end
 
       describe yum.repo('aws-fsx') do
-        before { retry_helpers.wait_for_command("yum -v repolist all 2>/dev/null | grep -q 'aws-fsx'") }
+        before { retry_helpers.wait_for_command("yum -v repolist all 2>/dev/null | grep -q 'aws-fsx'") rescue nil } # rubocop:disable Style/RescueModifier
         it { should exist }
         it { should be_enabled }
         its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }
@@ -83,7 +83,7 @@ control 'tag:install_lustre_client_installed' do
 
   if os_properties.alinux2?
     describe yum.repo('amzn2extra-lustre') do
-      before { retry_helpers.wait_for_command("yum -v repolist all 2>/dev/null | grep -q 'amzn2extra-lustre'") }
+      before { retry_helpers.wait_for_command("yum -v repolist all 2>/dev/null | grep -q 'amzn2extra-lustre'") rescue nil } # rubocop:disable Style/RescueModifier
       it { should exist }
       it { should be_enabled }
     end


### PR DESCRIPTION
### Description of changes
The rescue nil means the before block still attempts to warm up the yum cache, but if it fails, the test proceeds anyway and lets InSpec's own internal `yum -v repolist all` call handle it.



Our tests fails with below 
```

2026-03-06 00:34:13.640000  Stdout: [38;5;9m  Ã—  tag:install_lustre_client_installed: Verify that lustre client is installed (1 failed)[0m
2026-03-06 00:34:13.640000  Stdout: [38;5;41m     âœ”  System Package kmod-lustre-client is expected to be installed[0m
2026-03-06 00:34:13.640000  Stdout: [38;5;41m     âœ”  System Package lustre-client is expected to be installed[0m
2026-03-06 00:34:13.640000  Stdout: [38;5;41m     âœ”  System Package kmod-lustre-client version is expected to cmp >= "2.12"[0m
2026-03-06 00:34:13.640000  Stdout: [38;5;41m     âœ”  System Package lustre-client version is expected to cmp >= "2.12"[0m
2026-03-06 00:34:13.640000  Stdout: [38;5;9m     Ã—  YumRepo aws-fsx is expected to exist
2026-03-06 00:34:13.640000  Stdout:      Command `yum -v repolist all` timed out after  seconds[0m
2026-03-06 00:34:13.640000  Stdout: [38;5;41m     âœ”  YumRepo aws-fsx is expected to be enabled[0m
2026-03-06 00:34:13.640000  Stdout: [38;5;41m     âœ”  YumRepo aws-fsx baseurl is expected to include "fsx-lustre-client-repo.s3.amazonaws.com"[0m
2026-03-06 00:34:13.640000  Stdout: [38;5;41m  âœ”  tag:install_lustre_lnet_kernel_module_enabled: Verify that lnet kernel module is enabled[0m
2026-03-06 00:34:13.640000  Stdout: [38;5;41m     âœ”  Kernel Module lnet is expected to be loaded[0m
2026-03-06 00:34:13.640000  Stdout: [38;5;41m     âœ”  Kernel Module lnet is expected not to be disabled[0m
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
