### PR TITLE
Fix build image failures when installing GDR copy

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -27,7 +27,7 @@ default['cluster']['nvidia']['dcgm_base_url'] = "#{node['cluster']['artifacts_s3
 # GDRCopy
 default['cluster']['nvidia']['gdrcopy']['version'] = '2.5.1'
 default['cluster']['nvidia']['gdrcopy']['sha256'] = 'c6d5ebb7dabb89d798f27609511735595004da73af28d93ac041bb5290c4cbec'
-default['cluster']['nvidia']['gdrcopy']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/gdr_copy/v#{node['cluster']['nvidia']['gdrcopy_version']}.tar.gz"
+default['cluster']['nvidia']['gdrcopy']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/gdr_copy/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"
 
 # nvidia-imex
 default['cluster']['nvidia']['imex']['force_configuration'] = false


### PR DESCRIPTION
### Description of changes
* This commit fixes a bug from https://github.com/aws/aws-parallelcluster-cookbook/pull/3134

### Tests
* Build image is successful

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
