### PR TITLE
Clear update checkpoint on update failure

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/templates/check_update/pcluster-check-update.sh.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/check_update/pcluster-check-update.sh.erb
@@ -49,10 +49,15 @@ if [ "$CURRENT_UPDATE" != "$LAST_APPLIED" ]; then
         exit 1
     }
     
-    # Run the update action
+    # Run the update action; on failure clear checkpoint so the next timer tick retries
     log "Executing update script: $UPDATE_SCRIPT"
-    "$UPDATE_SCRIPT"
-    log "Update script completed"
+    if "$UPDATE_SCRIPT"; then
+        log "Update script completed successfully"
+    else
+        log "[ERROR] Update script failed. Clearing checkpoint to allow retry."
+        timeout $FS_TIMEOUT sh -c "echo '' > \"$LOCAL_CHECKPOINT\"" || true
+        exit 1
+    fi
 else
     log "No update needed: trigger and checkpoint match ('$CURRENT_UPDATE')"
 fi


### PR DESCRIPTION
### Description of changes
* Clear update checkpoint on update failure
* Leads to the following update sequences: 
  * Update fails on compute node
    1. Trigger = v2, checkpoint = v1 → diff detected
    2. Checkpoint written to v2
    3. Update runs → fails
    4. Checkpoint cleared to ''
    5. Next timer tick (60s): trigger = v2, checkpoint = '' → diff detected → retries 

  * Update fails on compute node and head node triggers rollback
    1. Trigger = v2, checkpoint = v1 → diff detected
    2. Checkpoint written to v2
    3. Update runs → fails
    4. Checkpoint cleared to ''
    5. Head node rolls back trigger to v1
    6. Next timer tick: trigger = v1, checkpoint = '' → diff detected → rollback runs 

  * Update succeeds on compute node but head node triggers rollback:
    1. Trigger = v2, checkpoint = v2 (success, no clearing)
    2. Head node rolls back trigger to v1
    3. Next timer tick: trigger = v1, checkpoint = v2 → diff detected → rollback runs 


### Tests
* Ran all update integration tests
* Triggered a transient update failure on compute node to check that it properly retries

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
