### PR TITLE
Do not delete dna json at end of update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Replace cfn-hup in compute nodes with systemd timer to support in place updates in order to improve MPI collective performance at scale.
   This new mechanism relies on shared storage to sync updates between the head node and compute nodes.
+- Stop cleaning up shared DNA files after a successful head node update.
 - Disable dnf-makecache.timer to improve MPI collective performance on RHEL/Rocky at scale.
 - Mitigate the risk of transient build-image failures in RHEL and Rocky caused by out-of-sync repo mirrors.
 - Upgrade Slurm to version 25.11.3 (from 24.11.7).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Replace cfn-hup in compute nodes with systemd timer to support in place updates in order to improve MPI collective performance at scale.
   This new mechanism relies on shared storage to sync updates between the head node and compute nodes.
-- Stop cleaning up shared DNA files after a successful head node update.
+- Stop cleaning up shared DNA files after a successful head node update or rollback.
 - Disable dnf-makecache.timer to improve MPI collective performance on RHEL/Rocky at scale.
 - Mitigate the risk of transient build-image failures in RHEL and Rocky caused by out-of-sync repo mirrors.
 - Upgrade Slurm to version 25.11.3 (from 24.11.7).

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_head_node.rb
@@ -299,7 +299,3 @@ template "#{node['cluster']['etc_dir']}/cfnconfig" do
   cookbook 'aws-parallelcluster-environment'
   mode '0644'
 end
-
-fetch_dna_files 'Cleanup' do
-  action :cleanup
-end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
@@ -72,6 +72,10 @@ describe 'aws-parallelcluster-slurm::update_head_node' do
             )
           end
 
+          it 'does not cleanup DNA files after update' do
+            is_expected.not_to run_execute("Cleanup dna.json and extra.json from #{chef_run.node['cluster']['shared_dir']}/dna")
+          end
+
           it 'starts clustermgtd unconditionally' do
             is_expected.to run_execute('start clustermgtd').with(
               command: "#{cookbook_venv_path}/bin/supervisorctl start clustermgtd"


### PR DESCRIPTION
### Description of changes
* Do not delete dna json at end of update
* This prevents the issue where compute nodes get stuck waiting for the DNA files because when the update succeeds, HN deletes DNA file, but there still may be CN that need those to complete their update.

* This change is safe for the following reasons:
  * After the update is complete, the dna.json file are not used. Compute nodes only read them when cfn-hup-update-action.sh runs. They are never re-read if they linger.
  * Stale DNA files from a previous update would not be picked up by a future update because share_compute_fleet_dna.py overwrites them with fresh data at the start of every update (fetch_dna_files 'Share' runs early in the recipe). So stale files get replaced before any compute node reads them.

### Tests
* Ran all the test_update integ tests
* Ran `test_update_race_conditions` and validated that recipes were executed in the correct order.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
