### PR TITLE
[UpdateWorkflow] Tolerate nodes that bootstrap during cluster readiness check. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Fix an issue that was blocking the logging of slurm health check events.
 - Fix cluster creation failure without Internet access when GPU instances and DCV are used.
 - Fix build-image failure during ubuntu-desktop installation on a Ubuntu parent image with outdated OS packages.
+- Prevent cluster update failures caused by nodes that completed their bootstrap during the update workflow.
 - Prevent unexpected execution of cluster update failure recovery on AWS Batch.
 
 3.14.2

--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_checks/check_cluster_ready.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import logging
+from datetime import datetime
 
 import click
 from common.constants import CLUSTER_CONFIG_DDB_ID
@@ -23,15 +24,21 @@ logging.basicConfig(level=logging.INFO)
 
 BATCH_SIZE = 500
 
+# Must match the strftime format used in dynamo.rb and helpers.rb: "%Y-%m-%dT%H:%M:%S.%3N+00:00"
+TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
 
-def _check_cluster_config_items(instance_ids: [str], items: [{}], expected_config_version: str):
+
+def _check_cluster_config_items(
+    instance_ids: [str], items: [{}], expected_config_version: str, cutoff_time: datetime = None
+):
     missing = []
     incomplete = []
     wrong = []
+    wrong_tolerated = []
 
     if not instance_ids:
         logger.warning("No instances to check cluster config version for")
-        return missing, incomplete, wrong
+        return missing, incomplete, wrong, wrong_tolerated
 
     # Transform DDB items to make it easier to search.
     # Example: the original items:
@@ -40,7 +47,7 @@ def _check_cluster_config_items(instance_ids: [str], items: [{}], expected_confi
     #     "Data": {
     #       "M": {
     #         "cluster_config_version": { "HoqyEZYBkMig3gSxaMARUv0NGcG0rrso" },
-    #         "lastUpdateTime": { "2024-01-16 18:59:18 UTC" }
+    #         "lastUpdateTime": { "2024-01-16T18:59:18.000+00:00" }
     #       }
     #     }
     #   }
@@ -51,7 +58,7 @@ def _check_cluster_config_items(instance_ids: [str], items: [{}], expected_confi
     # {
     #   "CLUSTER_CONFIG.i-123456789": {
     #     "cluster_config_version": { "HoqyEZYBkMig3gSxaMARUv0NGcG0rrso" },
-    #     "lastUpdateTime": { "2024-01-16 18:59:18 UTC" }
+    #     "lastUpdateTime": { "2024-01-16T18:59:18.000+00:00" }
     #   }
     # }
     items_by_id = {item["Id"]["S"]: item["Data"]["M"] for item in items}
@@ -63,16 +70,51 @@ def _check_cluster_config_items(instance_ids: [str], items: [{}], expected_confi
             missing.append(instance_id)
             continue
         cluster_config_version = data.get("cluster_config_version", {}).get("S")
-        if cluster_config_version is None:
+
+        if cluster_config_version is None:  # Incomplete records
             incomplete.append(instance_id)
             continue
-        if cluster_config_version != expected_config_version:
-            wrong.append((instance_id, cluster_config_version))
 
-    return missing, incomplete, wrong
+        if cluster_config_version != expected_config_version:  # Wrong records
+            if completed_bootstrap_after(data, cutoff_time):  # Wrong records, tolerated
+                wrong_tolerated.append(instance_id)
+            else:  # Wrong records, not tolerated
+                wrong.append((instance_id, cluster_config_version))
+
+    return missing, incomplete, wrong, wrong_tolerated
 
 
-def check_deployed_config_version(cluster_name: str, table_name: str, expected_config_version: str, region: str):
+def completed_bootstrap_after(data: dict, cutoff_time: datetime) -> bool:
+    # If no cut-off time is provided, cannot say whether the node was bootstrapped before or after the cut-off time.
+    if not cutoff_time:
+        return False
+
+    # We only tolerate nodes that completed the bootstrap after the cut-off, not the update.
+    # Nodes that completed the update after the cut-off are still required to apply the update.
+    status = data.get("status", {}).get("S")
+    if status != "DEPLOYED_BOOTSTRAP":
+        return False
+
+    # If there is no last update time, cannot say whether the node was bootstrapped before or after the cut-off time.
+    last_update_time_str = data.get("lastUpdateTime", {}).get("S")
+    if not last_update_time_str:
+        return False
+
+    try:
+        last_update_time = datetime.strptime(last_update_time_str, TIMESTAMP_FORMAT)
+        return last_update_time >= cutoff_time
+    except (ValueError, TypeError):
+        logger.warning(
+            "Cannot parse lastUpdateTime '%s', assuming record was updated before the cut off time '%s'",
+            last_update_time_str,
+            cutoff_time,
+        )
+        return False
+
+
+def check_deployed_config_version(
+    cluster_name: str, table_name: str, expected_config_version: str, region: str, cutoff_time_dt: datetime = None
+):
     """
     Verify that every compute/login node in the cluster has deployed the expected config version.
 
@@ -85,6 +127,8 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
     :param table_name: DDB table to read the deployed config version from.
     :param expected_config_version: expected config version.
     :param region: AWS region name (eg: us-east-1).
+    :param cutoff_time_dt: optional UTC timestamp; nodes with wrong records that completed bootstrap
+           after this time are ignored.
     :return: None
     """
     logger.info(
@@ -92,6 +136,13 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
         cluster_name,
         expected_config_version,
     )
+
+    if cutoff_time_dt:
+        cutoff_str = cutoff_time_dt.isoformat(timespec="milliseconds")
+        logger.info("Cutoff time: %s", cutoff_str)
+    else:
+        cutoff_str = "None"
+        logger.info("No check start time provided, all nodes with wrong config version will be reported")
 
     for instance_ids in list_cluster_instance_ids_iterator(
         cluster_name=cluster_name,
@@ -110,15 +161,20 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
         items = get_cluster_config_records(table_name, instance_ids, region)
         logger.info("Retrieved %s DDB item(s):\n\t%s", len(items), "\n\t".join([str(i) for i in items]))
 
-        missing, incomplete, wrong = _check_cluster_config_items(instance_ids, items, expected_config_version)
+        missing, incomplete, wrong, wrong_tolerated = _check_cluster_config_items(
+            instance_ids, items, expected_config_version, cutoff_time_dt
+        )
+
+        wrong_tolerated_label = f"wrong records tolerated, bootstrapped after cut-off time ({cutoff_str})"
 
         if incomplete or wrong:
             raise CheckFailedError(
                 f"Check failed due to the following erroneous records "
-                f"(missing records are not counted for the failure):\n"
+                f"(missing records and {wrong_tolerated_label} are not counted for the failure):\n"
                 f"  * missing records ({len(missing)}): {missing}\n"
                 f"  * incomplete records ({len(incomplete)}): {incomplete}\n"
-                f"  * wrong records ({len(wrong)}): {wrong}"
+                f"  * wrong records ({len(wrong)}): {wrong}\n"
+                f"  * {wrong_tolerated_label} ({len(wrong_tolerated)}): {wrong_tolerated}"
             )
         if missing:
             logger.warning(
@@ -126,6 +182,13 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
                 "  *  missing records (%s): %s",
                 len(missing),
                 missing,
+            )
+        if wrong_tolerated:
+            logger.warning(
+                "Ignoring the following nodes that completed bootstrap during the check:\n  *  %s (%s): %s",
+                wrong_tolerated_label,
+                len(wrong_tolerated),
+                wrong_tolerated,
             )
         logger.info("Verified cluster configuration for cluster node(s) %s", instance_ids)
 
@@ -135,17 +198,33 @@ def check_deployed_config_version(cluster_name: str, table_name: str, expected_c
 @click.option("--table-name", required=True, help="Name of the DDB table.")
 @click.option("--config-version", required=True, help="Expected cluster config version.")
 @click.option("--region", required=True, help="Name of AWS region.")
-def check_cluster_ready(cluster_name: str, table_name: str, config_version: str, region: str):
+@click.option(
+    "--cutoff-time",
+    required=False,
+    default=None,
+    help="Tolerance time as UTC timestamp (ISO 8601 format, e.g. '2026-03-12T21:16:11.000+00:00'). "
+    "Nodes that completed bootstrap after this time are ignored.",
+)
+def check_cluster_ready(cluster_name: str, table_name: str, config_version: str, region: str, cutoff_time: str):
     logger.info(
-        "Checking cluster readiness with arguments: cluster_name=%s, table_name=%s, config_version=%s, region=%s",
+        "Checking cluster readiness with arguments: "
+        "cluster_name=%s, table_name=%s, config_version=%s, region=%s, cutoff_time=%s",
         cluster_name,
         table_name,
         config_version,
         region,
+        cutoff_time,
     )
 
+    cutoff_time_dt = None
+    if cutoff_time:
+        try:
+            cutoff_time_dt = datetime.strptime(cutoff_time, TIMESTAMP_FORMAT)
+        except ValueError:
+            logger.warning("Cannot parse cutoff-time '%s', ignoring it", cutoff_time)
+
     try:
-        check_deployed_config_version(cluster_name, table_name, config_version, region)
+        check_deployed_config_version(cluster_name, table_name, config_version, region, cutoff_time_dt)
     except CheckFailedError as e:
         logger.error("Some cluster readiness checks failed: %s", e)
         raise e

--- a/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
@@ -17,7 +17,8 @@
 
 DDB_CONFIG_STATUS = {
   # The node successfully deployed the cluster configuration.
-  DEPLOYED: "DEPLOYED",
+  DEPLOYED_BOOTSTRAP: "DEPLOYED_BOOTSTRAP",
+  DEPLOYED_UPDATE: "DEPLOYED_UPDATE",
 }.freeze
 
 def save_instance_config_version_to_dynamodb(status)
@@ -28,7 +29,8 @@ def save_instance_config_version_to_dynamodb(status)
     item_id = "CLUSTER_CONFIG.#{node['ec2']['instance_id']}"
     node_type = node['cluster']['node_type']
     config_version = node['cluster']['cluster_config_version']
-    last_update_time = Time.now.utc
+    # Must match TIMESTAMP_FORMAT in check_cluster_ready.py
+    last_update_time = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S.%3N+00:00")
 
     item_data = "{\"cluster_config_version\": {\"S\": \"#{config_version}\"}, \"status\": {\"S\": \"#{status}\"}, \"node_type\": {\"S\": \"#{node_type}\"}, \"lastUpdateTime\": {\"S\": \"#{last_update_time}\"}}"
     item = "{\"Id\": {\"S\": \"#{item_id}\"}, \"Data\": {\"M\": #{item_data}}}"

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -166,12 +166,15 @@ end
 
 def wait_cluster_ready
   return if on_docker? || kitchen_test? && !node['interact_with_ddb']
+  # Must match TIMESTAMP_FORMAT in check_cluster_ready.py
+  check_start_time = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S.%3N+00:00")
   execute "Check cluster readiness" do
     command "#{cookbook_virtualenv_path}/bin/python #{node['cluster']['scripts_dir']}/head_node_checks/check_cluster_ready.py" \
               " --cluster-name #{node['cluster']['stack_name']}" \
               " --table-name parallelcluster-#{node['cluster']['stack_name']}" \
               " --config-version #{node['cluster']['cluster_config_version']}" \
-              " --region #{node['cluster']['region']}"
+              " --region #{node['cluster']['region']}" \
+              " --cutoff-time '#{check_start_time}'"
     timeout 30
     retries 10
     retry_delay 90

--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_compute.rb
@@ -60,4 +60,4 @@ execute 'resume_node' do
   only_if { is_static_node?(node.run_state['slurm_compute_nodename']) }
 end
 
-save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED])
+save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED_BOOTSTRAP])

--- a/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_login_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/finalize/finalize_login_node.rb
@@ -15,4 +15,4 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED])
+save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED_BOOTSTRAP])

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_compute.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_compute.rb
@@ -24,4 +24,4 @@ ruby_block "update_shared_storages" do
   only_if { are_mount_or_unmount_required? && storage_change_supports_live_update? }
 end
 
-save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED])
+save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED_UPDATE])

--- a/cookbooks/aws-parallelcluster-slurm/recipes/update/update_login_node.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/update/update_login_node.rb
@@ -24,4 +24,4 @@ ruby_block "update_shared_storages" do
   only_if { are_mount_or_unmount_required? && storage_change_supports_live_update? }
 end
 
-save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED])
+save_instance_config_version_to_dynamodb(DDB_CONFIG_STATUS[:DEPLOYED_UPDATE])

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_compute_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_compute_spec.rb
@@ -21,7 +21,7 @@ describe 'aws-parallelcluster-slurm::finalize_compute' do
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
     cluster_config_version = "MOCK_CLUSTER_CONFIG_VERSION"
-    time_now = "2024-01-16 15:30:45 UTC"
+    time_now = "2024-01-16T15:30:45.000+00:00"
 
     context "on #{platform}#{version}" do
       cached(:chef_run) do
@@ -42,7 +42,7 @@ describe 'aws-parallelcluster-slurm::finalize_compute' do
         runner.converge(described_recipe)
       end
 
-      status = "DEPLOYED"
+      status = "DEPLOYED_BOOTSTRAP"
       it "saves the cluster config version to dynamodb with status #{status}" do
         expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
           " --table-name parallelcluster-#{cluster_name}"\

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_head_node_spec.rb
@@ -20,11 +20,13 @@ describe 'aws-parallelcluster-slurm::finalize_head_node' do
     region = "MOCK_REGION"
     cluster_config_version = "MOCK_CLUSTER_CONFIG_VERSION"
     scripts_dir = "/MOCK_SCRIPTS_DIR"
+    time_now = "2024-01-16T15:30:45.000+00:00"
 
     context "on #{platform}#{version}" do
       cached(:chef_run) do
         runner = runner(platform: platform, version: version) do |node|
           allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
+          allow(Time).to receive(:now).and_return(Time.parse(time_now))
           RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
           node.override['cluster']['stack_name'] = cluster_name
@@ -44,7 +46,8 @@ describe 'aws-parallelcluster-slurm::finalize_head_node' do
           " --cluster-name #{cluster_name}" \
           " --table-name parallelcluster-#{cluster_name}" \
           " --config-version #{cluster_config_version}" \
-          " --region #{region}"
+          " --region #{region}" \
+          " --cutoff-time '#{time_now}'"
         is_expected.to run_execute("Check cluster readiness").with(
           command: expected_command,
           timeout: 30,

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_login_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_login_node_spec.rb
@@ -21,7 +21,7 @@ describe 'aws-parallelcluster-slurm::finalize_login_node' do
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
     cluster_config_version = "MOCK_CLUSTER_CONFIG_VERSION"
-    time_now = "2024-01-16 15:30:45 UTC"
+    time_now = "2024-01-16T15:30:45.000+00:00"
 
     context "on #{platform}#{version}" do
       cached(:chef_run) do
@@ -42,7 +42,7 @@ describe 'aws-parallelcluster-slurm::finalize_login_node' do
         runner.converge(described_recipe)
       end
 
-      status = "DEPLOYED"
+      status = "DEPLOYED_BOOTSTRAP"
       it "saves the cluster config version to dynamodb with status #{status}" do
         expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
           " --table-name parallelcluster-#{cluster_name}"\

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_compute_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_compute_spec.rb
@@ -21,7 +21,7 @@ describe 'aws-parallelcluster-slurm::update_compute' do
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
     cluster_config_version = "MOCK_CLUSTER_CONFIG_VERSION"
-    time_now = "2024-01-16 15:30:45 UTC"
+    time_now = "2024-01-16T15:30:45.000+00:00"
 
     context "on #{platform}#{version}" do
       [true, false].each do |are_mount_or_unmount_required|
@@ -56,7 +56,7 @@ describe 'aws-parallelcluster-slurm::update_compute' do
                 end
               end
 
-              status = "DEPLOYED"
+              status = "DEPLOYED_UPDATE"
               it "saves the cluster config version to dynamodb with status #{status}" do
                 expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
                   " --table-name parallelcluster-#{cluster_name}"\

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_head_node_spec.rb
@@ -9,6 +9,7 @@ describe 'aws-parallelcluster-slurm::update_head_node' do
     scripts_dir = "/MOCK_SCRIPTS_DIR"
     slurm_install_dir = "/MOCK_SLURM_INSTALL_DIR"
     reconfigure_timeout = 600
+    time_now = "2024-01-16T15:30:45.000+00:00"
 
     context "on #{platform}#{version}" do
       [true, false].each do |are_mount_or_unmount_required|
@@ -19,6 +20,7 @@ describe 'aws-parallelcluster-slurm::update_head_node' do
               allow_any_instance_of(Object).to receive(:dig).and_return(true)
               allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
               allow_any_instance_of(Object).to receive(:cluster_readiness_check_on_update_enabled?).and_return(true)
+              allow(Time).to receive(:now).and_return(Time.parse(time_now))
               RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
               node.override['cluster']['stack_name'] = cluster_name
@@ -63,7 +65,8 @@ describe 'aws-parallelcluster-slurm::update_head_node' do
               " --cluster-name #{cluster_name}" \
               " --table-name parallelcluster-#{cluster_name}" \
               " --config-version #{cluster_config_version}" \
-              " --region #{region}"
+              " --region #{region}" \
+              " --cutoff-time '#{time_now}'"
             is_expected.to run_execute("Check cluster readiness").with(
               command: expected_command,
               timeout: 30,

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_login_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_login_node_spec.rb
@@ -21,7 +21,7 @@ describe 'aws-parallelcluster-slurm::update_login_node' do
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
     cluster_config_version = "MOCK_CLUSTER_CONFIG_VERSION"
-    time_now = "2024-01-16 15:30:45 UTC"
+    time_now = "2024-01-16T15:30:45.000+00:00"
 
     context "on #{platform}#{version}" do
       [true, false].each do |are_mount_or_unmount_required|
@@ -56,7 +56,7 @@ describe 'aws-parallelcluster-slurm::update_login_node' do
                 end
               end
 
-              status = "DEPLOYED"
+              status = "DEPLOYED_UPDATE"
               it "saves the cluster config version to dynamodb with status #{status}" do
                 expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
                   " --table-name parallelcluster-#{cluster_name}"\

--- a/test/unit/head_node_checks/test_check_cluster_ready.py
+++ b/test/unit/head_node_checks/test_check_cluster_ready.py
@@ -9,6 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -23,7 +24,11 @@ patch("retrying.retry", do_nothing_decorator).start()
 patch("click.command", do_nothing_decorator).start()
 patch("click.option", do_nothing_decorator).start()
 
-from check_cluster_ready import check_cluster_ready  # noqa: E402
+from check_cluster_ready import (  # noqa: E402
+    _check_cluster_config_items,
+    check_cluster_ready,
+    completed_bootstrap_after,
+)
 
 
 @pytest.fixture()
@@ -93,10 +98,12 @@ def _mocked_request_batch_get_items(table_name: str, compute_nodes: [str], ddb_r
                 "i-cmp123456789": {"UNEXPECTED_KEY_A": {"S": "UNEXPECTED_KEY_VALUE_A"}},
                 "i-lgn123456789": {"UNEXPECTED_KEY_B": {"S": "UNEXPECTED_KEY_VALUE_B"}},
             },
-            "Check failed due to the following erroneous records (missing records are not counted for the failure):\n"
+            "Check failed due to the following erroneous records (missing records and wrong records tolerated, "
+            "bootstrapped after cut-off time (None) are not counted for the failure):\n"
             "  * missing records (0): []\n"
             "  * incomplete records (2): ['i-cmp123456789', 'i-lgn123456789']\n"
-            "  * wrong records (0): []",
+            "  * wrong records (0): []\n"
+            "  * wrong records tolerated, bootstrapped after cut-off time (None) (0): []",
             id="Check with malformed DDB records",
         ),
         pytest.param(
@@ -106,11 +113,13 @@ def _mocked_request_batch_get_items(table_name: str, compute_nodes: [str], ddb_r
                 "i-cmp123456789": {"cluster_config_version": {"S": "WRONG_CLUSTER_CONFIG_VERSION_A"}},
                 "i-lgn123456789": {"cluster_config_version": {"S": "WRONG_CLUSTER_CONFIG_VERSION_B"}},
             },
-            "Check failed due to the following erroneous records (missing records are not counted for the failure):\n"
+            "Check failed due to the following erroneous records (missing records and wrong records tolerated, "
+            "bootstrapped after cut-off time (None) are not counted for the failure):\n"
             "  * missing records (0): []\n"
             "  * incomplete records (0): []\n"
             "  * wrong records (2): [('i-cmp123456789', 'WRONG_CLUSTER_CONFIG_VERSION_A'), "
-            "('i-lgn123456789', 'WRONG_CLUSTER_CONFIG_VERSION_B')]",
+            "('i-lgn123456789', 'WRONG_CLUSTER_CONFIG_VERSION_B')]\n"
+            "  * wrong records tolerated, bootstrapped after cut-off time (None) (0): []",
             id="Check with wrong cluster config version",
         ),
         pytest.param(
@@ -124,11 +133,13 @@ def _mocked_request_batch_get_items(table_name: str, compute_nodes: [str], ddb_r
                 "i-cmp1234567893": {"cluster_config_version": {"S": "WRONG_CLUSTER_CONFIG_VERSION_A"}},
                 "i-lgn1234567893": {"cluster_config_version": {"S": "WRONG_CLUSTER_CONFIG_VERSION_B"}},
             },
-            "Check failed due to the following erroneous records (missing records are not counted for the failure):\n"
+            "Check failed due to the following erroneous records (missing records and wrong records tolerated, b"
+            "ootstrapped after cut-off time (None) are not counted for the failure):\n"
             "  * missing records (2): ['i-cmp1234567894', 'i-lgn1234567894']\n"
             "  * incomplete records (2): ['i-cmp1234567892', 'i-lgn1234567892']\n"
             "  * wrong records (2): [('i-cmp1234567893', 'WRONG_CLUSTER_CONFIG_VERSION_A'), "
-            "('i-lgn1234567893', 'WRONG_CLUSTER_CONFIG_VERSION_B')]",
+            "('i-lgn1234567893', 'WRONG_CLUSTER_CONFIG_VERSION_B')]\n"
+            "  * wrong records tolerated, bootstrapped after cut-off time (None) (0): []",
             id="Check with mixed errors",
         ),
         pytest.param(
@@ -154,7 +165,411 @@ def test_check_cluster_ready(boto3_stubber, compute_nodes, login_nodes, ddb_reco
 
     if expected_error is not None:
         with pytest.raises(CheckFailedError) as exc:
-            check_cluster_ready("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION")
+            check_cluster_ready("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", None)
         assert_that(str(exc.value)).is_equal_to(expected_error)
     else:
-        check_cluster_ready("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION")
+        check_cluster_ready("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", None)
+
+
+CUTOFF = datetime(2026, 3, 11, 11, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    "data, cutoff, expected",
+    [
+        pytest.param(
+            {"status": {"S": "DEPLOYED_BOOTSTRAP"}, "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"}},
+            CUTOFF,
+            True,
+            id="Bootstrap status updated after cutoff",
+        ),
+        pytest.param(
+            {"status": {"S": "DEPLOYED_BOOTSTRAP"}, "lastUpdateTime": {"S": "2026-03-11T10:00:00.000+00:00"}},
+            CUTOFF,
+            False,
+            id="Bootstrap status updated before cutoff",
+        ),
+        pytest.param(
+            {"status": {"S": "DEPLOYED_BOOTSTRAP"}, "lastUpdateTime": {"S": "2026-03-11T11:00:00.000+00:00"}},
+            CUTOFF,
+            True,
+            id="Bootstrap status updated at exact cutoff",
+        ),
+        pytest.param(
+            {"status": {"S": "DEPLOYED_UPDATE"}, "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"}},
+            CUTOFF,
+            False,
+            id="Update status updated after cutoff is not tolerated",
+        ),
+        pytest.param(
+            {"status": {"S": "DEPLOYED_BOOTSTRAP"}},
+            CUTOFF,
+            False,
+            id="Bootstrap status with no lastUpdateTime",
+        ),
+        pytest.param(
+            {"lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"}},
+            CUTOFF,
+            False,
+            id="No status field",
+        ),
+        pytest.param(
+            {},
+            CUTOFF,
+            False,
+            id="Empty data",
+        ),
+        pytest.param(
+            {"status": {"S": "DEPLOYED_BOOTSTRAP"}, "lastUpdateTime": {"S": "not-a-timestamp"}},
+            CUTOFF,
+            False,
+            id="Bootstrap status with unparseable timestamp",
+        ),
+        pytest.param(
+            {"status": {"S": "DEPLOYED_BOOTSTRAP"}, "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"}},
+            None,
+            False,
+            id="No cutoff time provided",
+        ),
+    ],
+)
+def test_completed_bootstrap_after(data, cutoff, expected):
+    assert_that(completed_bootstrap_after(data, cutoff)).is_equal_to(expected)
+
+
+@pytest.mark.parametrize(
+    "instance_ids, items, expected_missing, expected_incomplete, expected_wrong, expected_wrong_tolerated",
+    [
+        pytest.param(
+            ["i-001"],
+            [
+                {
+                    "Id": {"S": "CLUSTER_CONFIG.i-001"},
+                    "Data": {
+                        "M": {
+                            "cluster_config_version": {"S": "OLD_VERSION"},
+                            "status": {"S": "DEPLOYED_BOOTSTRAP"},
+                            "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+                        }
+                    },
+                }
+            ],
+            [],
+            [],
+            [],
+            ["i-001"],
+            id="Wrong version bootstrap after cutoff is tolerated",
+        ),
+        pytest.param(
+            ["i-001"],
+            [
+                {
+                    "Id": {"S": "CLUSTER_CONFIG.i-001"},
+                    "Data": {
+                        "M": {
+                            "cluster_config_version": {"S": "OLD_VERSION"},
+                            "status": {"S": "DEPLOYED_BOOTSTRAP"},
+                            "lastUpdateTime": {"S": "2026-03-11T10:00:00.000+00:00"},
+                        }
+                    },
+                }
+            ],
+            [],
+            [],
+            [("i-001", "OLD_VERSION")],
+            [],
+            id="Wrong version bootstrap before cutoff is wrong",
+        ),
+        pytest.param(
+            ["i-001"],
+            [
+                {
+                    "Id": {"S": "CLUSTER_CONFIG.i-001"},
+                    "Data": {
+                        "M": {
+                            "cluster_config_version": {"S": "OLD_VERSION"},
+                            "status": {"S": "DEPLOYED_UPDATE"},
+                            "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+                        }
+                    },
+                }
+            ],
+            [],
+            [],
+            [("i-001", "OLD_VERSION")],
+            [],
+            id="Wrong version update after cutoff is still wrong",
+        ),
+        pytest.param(
+            ["i-001"],
+            [
+                {
+                    "Id": {"S": "CLUSTER_CONFIG.i-001"},
+                    "Data": {
+                        "M": {
+                            "cluster_config_version": {"S": "OLD_VERSION"},
+                        }
+                    },
+                }
+            ],
+            [],
+            [],
+            [("i-001", "OLD_VERSION")],
+            [],
+            id="Wrong version no status or lastUpdateTime is wrong",
+        ),
+        pytest.param(
+            ["i-correct", "i-wrong-old", "i-wrong-new", "i-wrong-update", "i-missing", "i-incomplete"],
+            [
+                {
+                    "Id": {"S": "CLUSTER_CONFIG.i-correct"},
+                    "Data": {
+                        "M": {
+                            "cluster_config_version": {"S": "EXPECTED_VERSION"},
+                            "status": {"S": "DEPLOYED_UPDATE"},
+                            "lastUpdateTime": {"S": "2026-03-11T10:00:00.000+00:00"},
+                        }
+                    },
+                },
+                {
+                    "Id": {"S": "CLUSTER_CONFIG.i-wrong-old"},
+                    "Data": {
+                        "M": {
+                            "cluster_config_version": {"S": "OLD_VERSION"},
+                            "status": {"S": "DEPLOYED_BOOTSTRAP"},
+                            "lastUpdateTime": {"S": "2026-03-11T10:00:00.000+00:00"},
+                        }
+                    },
+                },
+                {
+                    "Id": {"S": "CLUSTER_CONFIG.i-wrong-new"},
+                    "Data": {
+                        "M": {
+                            "cluster_config_version": {"S": "OLD_VERSION"},
+                            "status": {"S": "DEPLOYED_BOOTSTRAP"},
+                            "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+                        }
+                    },
+                },
+                {
+                    "Id": {"S": "CLUSTER_CONFIG.i-wrong-update"},
+                    "Data": {
+                        "M": {
+                            "cluster_config_version": {"S": "OLD_VERSION"},
+                            "status": {"S": "DEPLOYED_UPDATE"},
+                            "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+                        }
+                    },
+                },
+                {
+                    "Id": {"S": "CLUSTER_CONFIG.i-incomplete"},
+                    "Data": {
+                        "M": {
+                            "some_other_key": {"S": "value"},
+                        }
+                    },
+                },
+            ],
+            ["i-missing"],
+            ["i-incomplete"],
+            [("i-wrong-old", "OLD_VERSION"), ("i-wrong-update", "OLD_VERSION")],
+            ["i-wrong-new"],
+            id="Mixed with cutoff",
+        ),
+    ],
+)
+def test_check_cluster_config_items_with_cutoff(
+    instance_ids, items, expected_missing, expected_incomplete, expected_wrong, expected_wrong_tolerated
+):
+    missing, incomplete, wrong, wrong_tolerated = _check_cluster_config_items(
+        instance_ids, items, "EXPECTED_VERSION", CUTOFF
+    )
+    assert_that(missing).is_equal_to(expected_missing)
+    assert_that(incomplete).is_equal_to(expected_incomplete)
+    assert_that(wrong).is_equal_to(expected_wrong)
+    assert_that(wrong_tolerated).is_equal_to(expected_wrong_tolerated)
+
+
+@pytest.mark.parametrize(
+    "ddb_records, cutoff_time_str, should_fail",
+    [
+        pytest.param(
+            {
+                "i-001": {
+                    "cluster_config_version": {"S": "OLD_VERSION"},
+                    "status": {"S": "DEPLOYED_BOOTSTRAP"},
+                    "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+                },
+            },
+            "2026-03-11T11:00:00.000+00:00",
+            False,
+            id="Wrong version bootstrap after cutoff passes",
+        ),
+        pytest.param(
+            {
+                "i-001": {
+                    "cluster_config_version": {"S": "OLD_VERSION"},
+                    "status": {"S": "DEPLOYED_BOOTSTRAP"},
+                    "lastUpdateTime": {"S": "2026-03-11T10:00:00.000+00:00"},
+                },
+            },
+            "2026-03-11T11:00:00.000+00:00",
+            True,
+            id="Wrong version bootstrap before cutoff fails",
+        ),
+        pytest.param(
+            {
+                "i-001": {
+                    "cluster_config_version": {"S": "OLD_VERSION"},
+                    "status": {"S": "DEPLOYED_UPDATE"},
+                    "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+                },
+            },
+            "2026-03-11T11:00:00.000+00:00",
+            True,
+            id="Wrong version update after cutoff still fails",
+        ),
+        pytest.param(
+            {
+                "i-tolerated": {
+                    "cluster_config_version": {"S": "OLD_VERSION"},
+                    "status": {"S": "DEPLOYED_BOOTSTRAP"},
+                    "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+                },
+            },
+            "2026-03-11T11:00:00.000+00:00",
+            False,
+            id="Only tolerated records passes with warning",
+        ),
+        pytest.param(
+            {
+                "i-wrong": {
+                    "cluster_config_version": {"S": "OLD_VERSION"},
+                    "status": {"S": "DEPLOYED_BOOTSTRAP"},
+                    "lastUpdateTime": {"S": "2026-03-11T10:00:00.000+00:00"},
+                },
+                "i-tolerated": {
+                    "cluster_config_version": {"S": "OLD_VERSION"},
+                    "status": {"S": "DEPLOYED_BOOTSTRAP"},
+                    "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+                },
+            },
+            "2026-03-11T11:00:00.000+00:00",
+            True,
+            id="Wrong + tolerated still fails",
+        ),
+        pytest.param(
+            {
+                "i-wrong-update": {
+                    "cluster_config_version": {"S": "OLD_VERSION"},
+                    "status": {"S": "DEPLOYED_UPDATE"},
+                    "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+                },
+                "i-tolerated": {
+                    "cluster_config_version": {"S": "OLD_VERSION"},
+                    "status": {"S": "DEPLOYED_BOOTSTRAP"},
+                    "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+                },
+            },
+            "2026-03-11T11:00:00.000+00:00",
+            True,
+            id="Wrong update + tolerated still fails",
+        ),
+    ],
+)
+def test_check_cluster_ready_with_cutoff(boto3_stubber, ddb_records, cutoff_time_str, should_fail):
+    nodes = list(ddb_records.keys())
+    boto3_stubber("ec2", [_mocked_request_describe_instances("CLUSTER_NAME", ["Compute", "LoginNode"], nodes)])
+    boto3_stubber("dynamodb", [_mocked_request_batch_get_items("TABLE_NAME", nodes, ddb_records)])
+
+    if should_fail:
+        with pytest.raises(CheckFailedError):
+            check_cluster_ready("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", cutoff_time_str)
+    else:
+        check_cluster_ready("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", cutoff_time_str)
+
+
+def test_check_cluster_ready_missing_and_tolerated_passes(boto3_stubber):
+    """Missing + tolerated (no wrong) should pass with warnings."""
+    all_nodes = ["i-missing", "i-tolerated"]
+    ddb_records = {
+        "i-tolerated": {
+            "cluster_config_version": {"S": "OLD_VERSION"},
+            "status": {"S": "DEPLOYED_BOOTSTRAP"},
+            "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+        },
+    }
+    boto3_stubber("ec2", [_mocked_request_describe_instances("CLUSTER_NAME", ["Compute", "LoginNode"], all_nodes)])
+    boto3_stubber("dynamodb", [_mocked_request_batch_get_items("TABLE_NAME", all_nodes, ddb_records)])
+
+    # Should not raise
+    check_cluster_ready(
+        "CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", "2026-03-11T11:00:00.000+00:00"
+    )
+
+
+def test_check_cluster_ready_missing_and_wrong_fails(boto3_stubber):
+    """Missing + wrong (no tolerated) should fail."""
+    all_nodes = ["i-missing", "i-wrong"]
+    ddb_records = {
+        "i-wrong": {
+            "cluster_config_version": {"S": "OLD_VERSION"},
+            "status": {"S": "DEPLOYED_BOOTSTRAP"},
+            "lastUpdateTime": {"S": "2026-03-11T10:00:00.000+00:00"},
+        },
+    }
+    boto3_stubber("ec2", [_mocked_request_describe_instances("CLUSTER_NAME", ["Compute", "LoginNode"], all_nodes)])
+    boto3_stubber("dynamodb", [_mocked_request_batch_get_items("TABLE_NAME", all_nodes, ddb_records)])
+
+    with pytest.raises(CheckFailedError):
+        check_cluster_ready(
+            "CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", "2026-03-11T11:00:00.000+00:00"
+        )
+
+
+def test_check_cluster_ready_missing_wrong_and_tolerated_fails(boto3_stubber):
+    """Missing + wrong + tolerated should fail."""
+    all_nodes = ["i-missing", "i-wrong", "i-tolerated"]
+    ddb_records = {
+        "i-wrong": {
+            "cluster_config_version": {"S": "OLD_VERSION"},
+            "status": {"S": "DEPLOYED_BOOTSTRAP"},
+            "lastUpdateTime": {"S": "2026-03-11T10:00:00.000+00:00"},
+        },
+        "i-tolerated": {
+            "cluster_config_version": {"S": "OLD_VERSION"},
+            "status": {"S": "DEPLOYED_BOOTSTRAP"},
+            "lastUpdateTime": {"S": "2026-03-11T12:00:00.000+00:00"},
+        },
+    }
+    boto3_stubber("ec2", [_mocked_request_describe_instances("CLUSTER_NAME", ["Compute", "LoginNode"], all_nodes)])
+    boto3_stubber("dynamodb", [_mocked_request_batch_get_items("TABLE_NAME", all_nodes, ddb_records)])
+
+    with pytest.raises(CheckFailedError):
+        check_cluster_ready(
+            "CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", "2026-03-11T11:00:00.000+00:00"
+        )
+
+
+def test_check_cluster_config_items_empty_instance_ids():
+    """Empty instance_ids should return all empty lists (early return with warning)."""
+    missing, incomplete, wrong, wrong_tolerated = _check_cluster_config_items([], [], "EXPECTED_VERSION", CUTOFF)
+    assert_that(missing).is_equal_to([])
+    assert_that(incomplete).is_equal_to([])
+    assert_that(wrong).is_equal_to([])
+    assert_that(wrong_tolerated).is_equal_to([])
+
+
+def test_check_cluster_ready_unparseable_cutoff_time(boto3_stubber):
+    """Unparseable cutoff-time should be ignored (treated as None) and check should pass."""
+    ddb_records = {
+        "i-001": {
+            "cluster_config_version": {"S": "EXPECTED_CONFIG_VERSION"},
+        },
+    }
+    nodes = list(ddb_records.keys())
+    boto3_stubber("ec2", [_mocked_request_describe_instances("CLUSTER_NAME", ["Compute", "LoginNode"], nodes)])
+    boto3_stubber("dynamodb", [_mocked_request_batch_get_items("TABLE_NAME", nodes, ddb_records)])
+
+    # Should not raise; the bad cutoff-time is silently ignored
+    check_cluster_ready("CLUSTER_NAME", "TABLE_NAME", "EXPECTED_CONFIG_VERSION", "REGION", "not-a-valid-timestamp")


### PR DESCRIPTION
### Description of changes
Tolerate nodes that bootstrap during cluster readiness check. Nodes that ran the update recipe and still have the wrong version continue to fail the check.

Implementation details:
1. Split DDB config status into `DEPLOYED_BOOTSTRAP` and `DEPLOYED_UPDATE` to distinguish initial node bootstrap from update completion. This is not only useful for the readiness check, but also facilitates the troubleshooting of issues making it clear if the recorded config was deployed as part of a bootstrap or as part of an update.
1. Pass a cutoff time (captured before the check starts) to the readiness check script so that nodes with the wrong config version are tolerated if they completed their initial bootstrap after the cutoff.  
1. Standardize DDB timestamp format to ISO-like %Y-%m-%dT%H:%M:%S%Z.


### Outcome of the readiness check

| missing | wrong (bootstrapped before cutoff) | wrong (updated before cutoff) | wrong, but tolerated (bootstrapped after cutoff) | outcome | notes |
|---------|------------------------------------|-------------------------------|--------------------------------------------------|---------|-------|
| 0 | 0 | 0 | 0 | ✅ SUCCESS | |
| >0 | 0 | 0 | 0 | ✅ SUCCESS | warning: missing records |
| 0 | 0 | 0 | >0 | ✅ SUCCESS | warning: wrong but tolerated records |
| >0 | 0 | 0 | >0 | ✅ SUCCESS | warning: missing records, wrong but tolerated records |
| 0 | >0 | 0 | 0 | ❌ FAIL | |
| 0 | 0 | >0 | 0 | ❌ FAIL | |
| 0 | >0 | >0 | 0 | ❌ FAIL | |
| >0 | >0 | 0 | 0 | ❌ FAIL | |
| >0 | 0 | >0 | 0 | ❌ FAIL | |
| >0 | >0 | >0 | 0 | ❌ FAIL | |
| 0 | >0 | 0 | >0 | ❌ FAIL | |
| 0 | 0 | >0 | >0 | ❌ FAIL | |
| 0 | >0 | >0 | >0 | ❌ FAIL | |
| >0 | >0 | 0 | >0 | ❌ FAIL | |
| >0 | 0 | >0 | >0 | ❌ FAIL | |
| >0 | >0 | >0 | >0 | ❌ FAIL | |


#### User Experience

#### Output when the check succeeds

```
INFO:__main__:Checking cluster readiness with arguments: cluster_name=update-fixed-3, table_name=parallelcluster-update-fixed-3, config_version=YXWRBeMafp15s0eOpIqIeUe3q7W4jjZ0_X, region=us-east-1, cutoff_time=2026-03-12T22:00:21+00:00
INFO:__main__:Checking that cluster configuration deployed on cluster nodes for cluster update-fixed-3 is YXWRBeMafp15s0eOpIqIeUe3q7W4jjZ0_X
INFO:__main__:Cutoff time: 2026-03-12T22:00:21.000+00:00
INFO:botocore.credentials:Found credentials from IAM Role: update-fixed-3-RoleHeadNode-W9PNz0qLBKTl
INFO:__main__:Found batch of 3 cluster node(s): ['i-0e859f82bd40cf609', 'i-04d7932190569d488', 'i-0179cb81604681fe7']
INFO:__main__:Retrieved 2 DDB item(s):
        {'Id': {'S': 'CLUSTER_CONFIG.i-0e859f82bd40cf609'}, 'Data': {'M': {'node_type': {'S': 'LoginNode'}, 'cluster_config_version': {'S': 'YXWRBeMafp15s0eOpIqIeUe3q7W4jjZ0'}, 'status': {'S': 'DEPLOYED_BOOTSTRAP'}, 'lastUpdateTime': {'S': '2026-03-12T22:00:22.119+00:00'}}}}
        {'Id': {'S': 'CLUSTER_CONFIG.i-0179cb81604681fe7'}, 'Data': {'M': {'node_type': {'S': 'ComputeFleet'}, 'cluster_config_version': {'S': 'YXWRBeMafp15s0eOpIqIeUe3q7W4jjZ0'}, 'status': {'S': 'DEPLOYED_BOOTSTRAP'}, 'lastUpdateTime': {'S': '2026-03-12T22:02:46.317+00:00'}}}}
WARNING:__main__:Ignoring the following missing records due them being recently bootstrapped:
  *  missing records (1): ['i-04d7932190569d488']
WARNING:__main__:Ignoring the following nodes that completed bootstrap during the check:
  *  wrong records tolerated, bootstrapped after cut-off time (2026-03-12T22:00:21.000+00:00) (2): ['i-0e859f82bd40cf609', 'i-0179cb81604681fe7']
INFO:__main__:Verified cluster configuration for cluster node(s) ['i-0e859f82bd40cf609', 'i-04d7932190569d488', 'i-0179cb81604681fe7']
INFO:__main__:All checks succeeded!
```

#### Output when the check fails
It is expected to fail in this case because the node `i-0e859f82bd40cf609` completed the bootstrap before the cutoff time so the check expect it to deploy the updated config

```
INFO:__main__:Checking cluster readiness with arguments: cluster_name=update-fixed-3, table_name=parallelcluster-update-fixed-3, config_version=YXWRBeMafp15s0eOpIqIeUe3q7W4jjZ0_X, region=us-east-1, cutoff_time=2026-03-12T22:02:00+00:00
INFO:__main__:Checking that cluster configuration deployed on cluster nodes for cluster update-fixed-3 is YXWRBeMafp15s0eOpIqIeUe3q7W4jjZ0_X
INFO:__main__:Cutoff time: 2026-03-12T22:02:00.000+00:00
INFO:botocore.credentials:Found credentials from IAM Role: update-fixed-3-RoleHeadNode-W9PNz0qLBKTl
INFO:__main__:Found batch of 4 cluster node(s): ['i-07e1a1ddafb896dc5', 'i-0e859f82bd40cf609', 'i-04d7932190569d488', 'i-0179cb81604681fe7']
INFO:__main__:Retrieved 2 DDB item(s):
        {'Id': {'S': 'CLUSTER_CONFIG.i-0e859f82bd40cf609'}, 'Data': {'M': {'node_type': {'S': 'LoginNode'}, 'cluster_config_version': {'S': 'YXWRBeMafp15s0eOpIqIeUe3q7W4jjZ0'}, 'status': {'S': 'DEPLOYED_BOOTSTRAP'}, 'lastUpdateTime': {'S': '2026-03-12T22:00:22.119+00:00'}}}}
        {'Id': {'S': 'CLUSTER_CONFIG.i-0179cb81604681fe7'}, 'Data': {'M': {'node_type': {'S': 'ComputeFleet'}, 'cluster_config_version': {'S': 'YXWRBeMafp15s0eOpIqIeUe3q7W4jjZ0'}, 'status': {'S': 'DEPLOYED_BOOTSTRAP'}, 'lastUpdateTime': {'S': '2026-03-12T22:02:46.317+00:00'}}}}
ERROR:__main__:Some cluster readiness checks failed: Check failed due to the following erroneous records (missing records and wrong records tolerated, bootstrapped after cut-off time (2026-03-12T22:02:00.000+00:00) are not counted for the failure):
  * missing records (2): ['i-07e1a1ddafb896dc5', 'i-04d7932190569d488']
  * incomplete records (0): []
  * wrong records (1): [('i-0e859f82bd40cf609', 'YXWRBeMafp15s0eOpIqIeUe3q7W4jjZ0')]
  * wrong records tolerated, bootstrapped after cut-off time (2026-03-12T22:02:00.000+00:00) (1): ['i-0179cb81604681fe7']
```

### Tests
* SUCCESS Manual testing, validated the combination of cases (see table above)
* SUCCESS test_update_slurm
* SUCCESS test_dynamic_file_systems_update
* SUCCESS test_dynamic_file_systems_update_rollback
* SUCCESS est_login_nodes_update
* SUCCESS test_update_rollback_failure
* SUCCEEDED THE RELEVANT PORTION of  test_update_race_conditions.
The test failed, but it succeeded the portion relevant to this fix. Before this fix the cluster stack used to fail the update, while now it succeeds it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
