### PR TITLE
[AwsBatch] Add Chef attribute to skip awsbatch installation during build image

### DIFF
--- a/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_config_spec.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_config_spec.rb
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 control 'tag:config_awsbatch_cli_commands_available' do
-  only_if { node['cluster']['scheduler'] == 'awsbatch' && !os_properties.redhat8? && !os_properties.rocky8? }
+  only_if { node['cluster']['scheduler'] == 'awsbatch' && !os_properties.redhat8? && !os_properties.rocky8? && !node['cluster']['skip_awsbatch_cli_install'] }
 
   # Test that batch commands can be accessed without absolute path
   %w(awsbkill awsbqueues awsbsub awsbhosts awsbout awsbstat).each do |cli_commmand|

--- a/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_install_spec.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_install_spec.rb
@@ -11,7 +11,7 @@
 
 control 'custom_awsbatchcli_package_installed' do
   title "custom aws-parallelcluster-awsbatch-cli should have been installed in the virtualenv"
-  only_if { !os_properties.redhat_on_docker? }
+  only_if { !os_properties.redhat_on_docker? && !node['cluster']['skip_awsbatch_cli_install'] }
 
   describe command("#{node['cluster']['awsbatch_virtualenv_path']}/bin/pip freeze | grep aws-parallelcluster-awsbatch-cli") do
     its('exit_status') { should eq(0) }

--- a/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_virtualenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-awsbatch/test/controls/awsbatch_virtualenv_spec.rb
@@ -15,7 +15,7 @@ pyenv_dir = "#{base_dir}/pyenv"
 control 'tag:install_awsbatch_virtualenv_created' do
   python_version = os_properties.alinux2? ? '3.9.23' : '3.14.2'
   title "awsbatch virtualenv should be created on #{python_version}"
-  only_if { !os_properties.redhat? }
+  only_if { !os_properties.redhat? && !node['cluster']['skip_awsbatch_cli_install'] }
 
   describe directory("#{pyenv_dir}/versions/#{python_version}/envs/awsbatch_virtualenv") do
     it { should exist }

--- a/cookbooks/aws-parallelcluster-entrypoints/attributes/entrypoints.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/attributes/entrypoints.rb
@@ -18,3 +18,6 @@ default['conditions']['ami_bootstrapped'] = ami_bootstrapped?
 
 # Official ami build
 default['cluster']['is_official_ami_build'] = false
+
+# Skip awsbatch CLI install (for air-gapped environments without PyPI access)
+default['cluster']['skip_awsbatch_cli_install'] = false

--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/install.rb
@@ -22,7 +22,7 @@ include_recipe 'aws-parallelcluster-platform::install'
 include_recipe 'aws-parallelcluster-environment::install'
 include_recipe 'aws-parallelcluster-computefleet::install'
 include_recipe 'aws-parallelcluster-slurm::install'
-include_recipe 'aws-parallelcluster-awsbatch::install'
+include_recipe 'aws-parallelcluster-awsbatch::install' unless node['cluster']['skip_awsbatch_cli_install']
 
 # == WORKSTATIONS
 # DCV recipe installs Gnome, X and their dependencies so it must be installed as latest to not break the environment

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/install_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/install_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-entrypoints::install' do
+  all_recipes = %w(
+    aws-parallelcluster-shared::setup_envars
+    aws-parallelcluster-platform::install
+    aws-parallelcluster-environment::install
+    aws-parallelcluster-computefleet::install
+    aws-parallelcluster-slurm::install
+    aws-parallelcluster-awsbatch::install
+  )
+
+  before do
+    @included_recipes = []
+    all_recipes.each do |recipe_name|
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with(recipe_name) do
+        @included_recipes << recipe_name
+      end
+    end
+  end
+
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      context "when ami is already bootstrapped" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['conditions']['ami_bootstrapped'] = true
+          end
+          runner.converge(described_recipe)
+        end
+
+        it "does not include any recipes" do
+          chef_run
+          expect(@included_recipes).to be_empty
+        end
+      end
+
+      context "when ami is not bootstrapped" do
+        context "when skip_awsbatch_cli_install is false" do
+          cached(:chef_run) do
+            runner = runner(platform: platform, version: version) do |node|
+              node.override['conditions']['ami_bootstrapped'] = false
+              node.override['cluster']['skip_awsbatch_cli_install'] = false
+            end
+            runner.converge(described_recipe)
+          end
+
+          it "includes all recipes in the right order" do
+            chef_run
+            expect(@included_recipes).to eq(all_recipes)
+          end
+        end
+
+        context "when skip_awsbatch_cli_install is true" do
+          cached(:chef_run) do
+            runner = runner(platform: platform, version: version) do |node|
+              node.override['conditions']['ami_bootstrapped'] = false
+              node.override['cluster']['skip_awsbatch_cli_install'] = true
+            end
+            runner.converge(described_recipe)
+          end
+
+          it "includes all recipes except awsbatch in the right order" do
+            chef_run
+            expect(@included_recipes).to eq(all_recipes - %w(aws-parallelcluster-awsbatch::install))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
* Add Chef attribute to skip awsbatch installation during build image


### Tests
* Unit test
* BUILD image success

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
