### PR TITLE
Do not delete dna json at end of rollback failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Replace cfn-hup in compute nodes with systemd timer to support in place updates in order to improve MPI collective performance at scale.
   This new mechanism relies on shared storage to sync updates between the head node and compute nodes.
-- Stop cleaning up shared DNA files after a successful head node update or rollback.
+- Stop cleaning up shared DNA files after a successful head node update, a successful rollback, or a failed rollback.
 - Disable dnf-makecache.timer to improve MPI collective performance on RHEL/Rocky at scale.
 - Mitigate the risk of transient build-image failures in RHEL and Rocky caused by out-of-sync repo mirrors.
 - Upgrade Slurm to version 25.11.3 (from 24.11.7).

--- a/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
@@ -60,21 +60,29 @@ module ErrorHandlers
 
     def run_recovery
       Chef::Log.info("#{log_prefix} Running recovery commands")
-      cleanup_dna_files if @cleanup_dna_files
       start_clustermgtd if @start_clustermgtd
+      cleanup_dna_files if @cleanup_dna_files
     end
 
     def cleanup_dna_files
       marker = "#{cluster_attributes['shared_dir']}/update_failed_marker"
-      if ::File.exist?(marker)
-        # Marker exists from previous update failure — this is a rollback failure, keep DNA files
-        Chef::Log.info("#{log_prefix} Rollback failure detected, keeping DNA files for bootstrapping nodes")
-        ::File.delete(marker)
-      else
-        # No marker — this is an update failure, clean up DNA files and write marker
+      begin
+        if ::File.exist?(marker)
+          # Marker exists from previous update failure — this is a rollback failure, keep DNA files
+          Chef::Log.info("#{log_prefix} Rollback failure detected (marker found at #{marker}), keeping DNA files")
+          ::File.delete(marker)
+        else
+          # No marker — this is an update failure, clean up DNA files and write marker
+          Chef::Log.info("#{log_prefix} Update failure detected (no marker at #{marker}), cleaning up DNA files")
+          command = "#{cookbook_virtualenv_path}/bin/python #{cluster_attributes['scripts_dir']}/share_compute_fleet_dna.py --region #{cluster_attributes['region']} --cleanup"
+          command_runner.run_with_retries(command, description: "cleanup DNA files")
+          ::File.write(marker, '')
+        end
+      rescue => e
+        # If marker I/O fails, fall back to deleting DNA files
+        Chef::Log.warn("#{log_prefix} Error during marker check (#{e.message}), falling back to cleaning up DNA files")
         command = "#{cookbook_virtualenv_path}/bin/python #{cluster_attributes['scripts_dir']}/share_compute_fleet_dna.py --region #{cluster_attributes['region']} --cleanup"
         command_runner.run_with_retries(command, description: "cleanup DNA files")
-        ::File.write(marker, '')
       end
     end
 

--- a/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/libraries/update_failure_handler.rb
@@ -65,8 +65,17 @@ module ErrorHandlers
     end
 
     def cleanup_dna_files
-      command = "#{cookbook_virtualenv_path}/bin/python #{cluster_attributes['scripts_dir']}/share_compute_fleet_dna.py --region #{cluster_attributes['region']} --cleanup"
-      command_runner.run_with_retries(command, description: "cleanup DNA files")
+      marker = "#{cluster_attributes['shared_dir']}/update_failed_marker"
+      if ::File.exist?(marker)
+        # Marker exists from previous update failure — this is a rollback failure, keep DNA files
+        Chef::Log.info("#{log_prefix} Rollback failure detected, keeping DNA files for bootstrapping nodes")
+        ::File.delete(marker)
+      else
+        # No marker — this is an update failure, clean up DNA files and write marker
+        command = "#{cookbook_virtualenv_path}/bin/python #{cluster_attributes['scripts_dir']}/share_compute_fleet_dna.py --region #{cluster_attributes['region']} --cleanup"
+        command_runner.run_with_retries(command, description: "cleanup DNA files")
+        ::File.write(marker, '')
+      end
     end
 
     def start_clustermgtd

--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
@@ -26,13 +26,12 @@ include_recipe 'aws-parallelcluster-environment::update'
 
 include_recipe 'aws-parallelcluster-slurm::update' if node['cluster']['scheduler'] == 'slurm'
 
-# Clean up update failure marker on success
-file "#{node['cluster']['shared_dir']}/update_failed_marker" do
-  action :delete
-  only_if { ::File.exist?("#{node['cluster']['shared_dir']}/update_failed_marker") }
-end
-
 # Update node package - useful for development purposes only
 if is_custom_node?
   include_recipe 'aws-parallelcluster-computefleet::update_parallelcluster_node'
+end
+
+# Clean up update failure marker on success
+file "#{node['cluster']['shared_dir']}/update_failed_marker" do
+  action :delete
 end

--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
@@ -26,6 +26,12 @@ include_recipe 'aws-parallelcluster-environment::update'
 
 include_recipe 'aws-parallelcluster-slurm::update' if node['cluster']['scheduler'] == 'slurm'
 
+# Clean up update failure marker on success
+file "#{node['cluster']['shared_dir']}/update_failed_marker" do
+  action :delete
+  only_if { ::File.exist?("#{node['cluster']['shared_dir']}/update_failed_marker") }
+end
+
 # Update node package - useful for development purposes only
 if is_custom_node?
   include_recipe 'aws-parallelcluster-computefleet::update_parallelcluster_node'

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
@@ -25,6 +25,7 @@ describe ErrorHandlers::UpdateFailureHandler do
   let(:scripts_dir) { '/opt/parallelcluster/scripts' }
   let(:region) { 'us-east-1' }
   let(:virtualenv_path) { "#{pyenv_root}/versions/#{python_version}/envs/cookbook_virtualenv" }
+  let(:shared_dir) { '/opt/parallelcluster/shared' }
   let(:node) do
     {
       'cluster' => {
@@ -34,6 +35,7 @@ describe ErrorHandlers::UpdateFailureHandler do
         'python-version' => python_version,
         'scripts_dir' => scripts_dir,
         'region' => region,
+        'shared_dir' => shared_dir,
       },
     }
   end
@@ -158,10 +160,46 @@ describe ErrorHandlers::UpdateFailureHandler do
   end
 
   describe '#cleanup_dna_files' do
-    it 'runs the cleanup command with correct arguments' do
-      expected_command = "#{virtualenv_path}/bin/python #{scripts_dir}/share_compute_fleet_dna.py --region #{region} --cleanup"
-      expect(command_runner).to receive(:run_with_retries).with(expected_command, description: "cleanup DNA files")
-      handler.cleanup_dna_files
+    let(:marker) { "#{shared_dir}/update_failed_marker" }
+
+    context 'when marker does not exist (update failure)' do
+      before do
+        allow(::File).to receive(:exist?).with(marker).and_return(false)
+        allow(::File).to receive(:write)
+      end
+
+      it 'runs the cleanup command' do
+        expected_command = "#{virtualenv_path}/bin/python #{scripts_dir}/share_compute_fleet_dna.py --region #{region} --cleanup"
+        expect(command_runner).to receive(:run_with_retries).with(expected_command, description: "cleanup DNA files")
+        handler.cleanup_dna_files
+      end
+
+      it 'writes the marker file' do
+        expect(::File).to receive(:write).with(marker, '')
+        handler.cleanup_dna_files
+      end
+    end
+
+    context 'when marker exists (rollback failure)' do
+      before do
+        allow(::File).to receive(:exist?).with(marker).and_return(true)
+        allow(::File).to receive(:delete)
+      end
+
+      it 'does not run the cleanup command' do
+        expect(command_runner).not_to receive(:run_with_retries)
+        handler.cleanup_dna_files
+      end
+
+      it 'deletes the marker file' do
+        expect(::File).to receive(:delete).with(marker)
+        handler.cleanup_dna_files
+      end
+
+      it 'logs rollback failure detected' do
+        expect(Chef::Log).to receive(:info).with(/Rollback failure detected, keeping DNA files/)
+        handler.cleanup_dna_files
+      end
     end
   end
 

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/libraries/update_failure_handler_spec.rb
@@ -178,6 +178,11 @@ describe ErrorHandlers::UpdateFailureHandler do
         expect(::File).to receive(:write).with(marker, '')
         handler.cleanup_dna_files
       end
+
+      it 'logs update failure detected with marker path' do
+        expect(Chef::Log).to receive(:info).with(/Update failure detected.*#{Regexp.escape(marker)}/)
+        handler.cleanup_dna_files
+      end
     end
 
     context 'when marker exists (rollback failure)' do
@@ -196,8 +201,25 @@ describe ErrorHandlers::UpdateFailureHandler do
         handler.cleanup_dna_files
       end
 
-      it 'logs rollback failure detected' do
-        expect(Chef::Log).to receive(:info).with(/Rollback failure detected, keeping DNA files/)
+      it 'logs rollback failure detected with marker path' do
+        expect(Chef::Log).to receive(:info).with(/Rollback failure detected.*#{Regexp.escape(marker)}/)
+        handler.cleanup_dna_files
+      end
+    end
+
+    context 'when marker check raises an error' do
+      before do
+        allow(::File).to receive(:exist?).with(marker).and_raise(Errno::EIO.new("I/O error"))
+      end
+
+      it 'falls back to cleaning up DNA files' do
+        expected_command = "#{virtualenv_path}/bin/python #{scripts_dir}/share_compute_fleet_dna.py --region #{region} --cleanup"
+        expect(command_runner).to receive(:run_with_retries).with(expected_command, description: "cleanup DNA files")
+        handler.cleanup_dna_files
+      end
+
+      it 'logs a warning' do
+        expect(Chef::Log).to receive(:warn).with(/Error during marker check/)
         handler.cleanup_dna_files
       end
     end

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_spec.rb
@@ -72,7 +72,7 @@ describe 'aws-parallelcluster-entrypoints::update' do
               end
 
               it "deletes the update failed marker on success" do
-                expect(chef_run).to delete_file("#{node['cluster']['shared_dir']}/update_failed_marker")
+                is_expected.to delete_file("#{node['cluster']['shared_dir']}/update_failed_marker")
               end
             end
           end

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_spec.rb
@@ -70,6 +70,10 @@ describe 'aws-parallelcluster-entrypoints::update' do
                   type: { exception: true }
                 )
               end
+
+              it "deletes the update failed marker on success" do
+                expect(chef_run).to delete_file("#{node['cluster']['shared_dir']}/update_failed_marker")
+              end
             end
           end
         end


### PR DESCRIPTION
### Description of changes
* Do not delete dna json at end of rollback failure
* This is so bootstrapping nodes that finish bootstrapping after the rollback fails do not get stuck waiting for dna json
* Add a marker that is used to determine if we are in an update failed state or a rollback failed.
* Here is the flow: 
  * Update fails, rollback fails:
    1. Update fails > no marker > delete dna, write marker
    2. Rollback fails > marker exists > keep dna, delete marker

  * Update fails, rollback succeeds:
    1. Update fails > no marker > delete dna, write marker
    2. Rollback succeeds > success path deletes marker

  * Update succeeds:
    1. Update succeeds > success path deletes marker if it exists (It should not exist)
### Tests
* Ran all test_update integration tests
* Manually tested state of marker and dna json

### References
* Changes to test: https://github.com/aws/aws-parallelcluster/pull/7288

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
