### PR TITLE
Upgrade dependencies for GDRcopy, EFA, Slurm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - Rdma-core: rdma-core-61.0-1
   - Open MPI: openmpi40-aws-4.1.7-2 and openmpi50-aws-5.0.9
 - Upgrade NVIDIA driver to version 580.105.08 (from 570.172.08) for all OSs except Amazon Linux 2.
-- Upgrade GDRCopy to version 2.5.1 (from 2.4.4).
+- Upgrade GDRCopy to version 2.5.2 (from 2.4.4).
 - Upgrade DCV to version 2025.0-20103 (from 2024.0-19030).
 - Upgrade CUDA Toolkit to version 13.0.2 (from 12.8.1) for all OSs except Amazon Linux 2.
 - Upgrade NVIDIA Fabric manager to 580.105.08 for all OSs except Amazon Linux 2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Mitigate the risk of transient build-image failures in RHEL and Rocky caused by out-of-sync repo mirrors.
 - Upgrade Slurm to version 25.11.3 (from 24.11.7).
 - Upgrade Pmix to 5.0.10 (from 5.0.6).
-- Upgrade EFA installer to 1.46.0 (from 1.44.0).
-  - Efa-driver: efa-2.17.3-1
+- Upgrade EFA installer to 1.47.0 (from 1.44.0).
+  - Efa-driver: efa-3.0.0
   - Efa-config: efa-config-1.18-1
   - Efa-profile: efa-profile-1.7-1
-  - Libfabric-aws: libfabric-aws-2.3.1-1
-  - Rdma-core: rdma-core-60.0-1
-  - Open MPI: openmpi40-aws-4.1.7-2 and openmpi50-aws-5.0.8-11
+  - Libfabric-aws: libfabric-aws-2.4.0-1
+  - Rdma-core: rdma-core-61.0-1
+  - Open MPI: openmpi40-aws-4.1.7-2 and openmpi50-aws-5.0.9
 - Upgrade NVIDIA driver to version 580.105.08 (from 570.172.08) for all OSs except Amazon Linux 2.
 - Upgrade GDRCopy to version 2.5.1 (from 2.4.4).
 - Upgrade DCV to version 2025.0-20103 (from 2024.0-19030).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Stop cleaning up shared DNA files after a successful head node update or rollback.
 - Disable dnf-makecache.timer to improve MPI collective performance on RHEL/Rocky at scale.
 - Mitigate the risk of transient build-image failures in RHEL and Rocky caused by out-of-sync repo mirrors.
-- Upgrade Slurm to version 25.11.3 (from 24.11.7).
+- Upgrade Slurm to version 25.11.4 (from 24.11.7).
 - Upgrade Pmix to 5.0.10 (from 5.0.6).
 - Upgrade EFA installer to 1.47.0 (from 1.44.0).
   - Efa-driver: efa-3.0.0

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -70,8 +70,8 @@ default['cluster']['internal_initial_shared_dir'] = "#{node['cluster']['base_dir
 
 default['cluster']['head_node_private_ip'] = nil
 
-default['cluster']['efa']['version'] = '1.46.0'
-default['cluster']['efa']['sha256'] = '8302bd7849afb95c903a875d7dcb6f85b3d7629e9a8b67d020031cfc6f4d0ee1'
+default['cluster']['efa']['version'] = '1.47.0'
+default['cluster']['efa']['sha256'] = '2df4201e046833c7dc8160907bee7f52b76ff80ed147376a2d0ed8a0dd66b2db'
 
 default['cluster']['efs']['version'] = '2.4.0'
 default['cluster']['efs']['sha256'] = '9b60c039c162388091d6fab6e9c6cfc5832f34b26b6d05b0a68b333147d78a25'

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efa_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 # parallelcluster default source dir defined in attributes
 source_dir = '/opt/parallelcluster/sources'
-efa_version = '1.46.0'
-efa_checksum = '8302bd7849afb95c903a875d7dcb6f85b3d7629e9a8b67d020031cfc6f4d0ee1'
+efa_version = '1.47.0'
+efa_checksum = '2df4201e046833c7dc8160907bee7f52b76ff80ed147376a2d0ed8a0dd66b2db'
 
 class ConvergeEfa
   def self.setup(chef_run, efa_version: nil, efa_checksum: nil)

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -25,8 +25,8 @@ end
 default['cluster']['nvidia']['dcgm_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_dcgm"
 
 # GDRCopy
-default['cluster']['nvidia']['gdrcopy']['version'] = '2.5.1'
-default['cluster']['nvidia']['gdrcopy']['sha256'] = 'c6d5ebb7dabb89d798f27609511735595004da73af28d93ac041bb5290c4cbec'
+default['cluster']['nvidia']['gdrcopy']['version'] = '2.5.2'
+default['cluster']['nvidia']['gdrcopy']['sha256'] = '32bc7b2c198dd97ec251de0ff4823252c95e31a4c79a5f843c82514c9af2052b'
 default['cluster']['nvidia']['gdrcopy']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/gdr_copy/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"
 
 # nvidia-imex

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -1,8 +1,8 @@
 # Slurm
-default['cluster']['slurm']['version'] = '25-11-3-1'
+default['cluster']['slurm']['version'] = '25-11-4-1'
 default['cluster']['slurm']['commit'] = ''
 default['cluster']['slurm']['branch'] = ''
-default['cluster']['slurm']['sha256'] = 'c50afba037851c5631f64f56daed888c0944dfdaff2507d66995d46c8b14e115'
+default['cluster']['slurm']['sha256'] = '15f5a172812868349031d57104323f23d62f1c28537f21d1992c572dffdd93c2'
 default['cluster']['slurm']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/slurm"
 # Munge
 default['cluster']['munge']['munge_version'] = '0.5.18'


### PR DESCRIPTION
### Description of changes
Upgrade EFA from to 1.47.0
Upgrade Slurm to 25.11.4
Upgrade GDRCopy to 2.5.2

### Tests
Build image on Ubuntu2404 in us-east-1 has passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
