### PR TITLE
Only delete rollback marker if head node

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/update.rb
@@ -31,7 +31,8 @@ if is_custom_node?
   include_recipe 'aws-parallelcluster-computefleet::update_parallelcluster_node'
 end
 
-# Clean up update failure marker on success
+# Clean up update failure marker on success (only on HeadNode, which owns the marker lifecycle)
 file "#{node['cluster']['shared_dir']}/update_failed_marker" do
   action :delete
+  only_if { node['cluster']['node_type'] == 'HeadNode' }
 end

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/update_spec.rb
@@ -72,7 +72,11 @@ describe 'aws-parallelcluster-entrypoints::update' do
               end
 
               it "deletes the update failed marker on success" do
-                is_expected.to delete_file("#{node['cluster']['shared_dir']}/update_failed_marker")
+                if node_type == 'HeadNode'
+                  is_expected.to delete_file("#{node['cluster']['shared_dir']}/update_failed_marker")
+                else
+                  is_expected.not_to delete_file("#{node['cluster']['shared_dir']}/update_failed_marker")
+                end
               end
             end
           end


### PR DESCRIPTION
### Description of changes
* Only delete rollback marker if head node
* The `update_failed_marker` is written to shared storage (`/opt/parallelcluster/shared/`) by the head node's `UpdateFailureHandler` when an update fails to distinguish between an update failure and a rollback failure
*  `update.rb` deletes the marker on success, and compute nodes run the same `update.rb` recipe. 
* This introduce a race condition where compute nodes delete `update_failed_marker` before head node rollback fails
* Compute nodes should not interact with the marker

### Tests
* Ran test_update_rollback_failure

### References
* Fix to: https://github.com/aws/aws-parallelcluster-cookbook/pull/3144

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
