### PR TITLE
[Logging] Fix the timestamp format used by CW Agent to parse timestamp for chef-client.log.

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
+++ b/cookbooks/aws-parallelcluster-environment/files/cloudwatch/cloudwatch_agent_config.json
@@ -4,7 +4,8 @@
     "default": "%Y-%m-%d %H:%M:%S,%f",
     "default_seconds": "%Y-%m-%d %H:%M:%S",
     "iso8610": "%Y-%m-%dT%H:%M:%S.%f",
-    "iso8610_seconds": "%Y-%m-%dT%H:%M:%S"
+    "iso8610_seconds": "%Y-%m-%dT%H:%M:%S",
+    "chef": "[%Y-%m-%dT%H:%M:%S"
   },
   "log_configs": [
     {
@@ -81,7 +82,7 @@
       "feature_conditions": []
     },
     {
-      "timestamp_format_key": "iso8610_seconds",
+      "timestamp_format_key": "chef",
       "file_path": "/var/log/chef-client.log",
       "log_stream_name": "chef-client",
       "schedulers": [


### PR DESCRIPTION
### Description of changes
Fix the timestamp format used by CW Agent to parse timestamp for chef-client.log.

In https://github.com/aws/aws-parallelcluster-cookbook/pull/3071 we changed the format from `[%Y-%m-%dT%H:%M:%S"` to `%Y-%m-%dT%H:%M:%S`, so basically we removed the bracket from the format.
In this PR we are restoring the original format.

The bracket in the timestamp format prevents the CW Agent from getting confused when log lines include timestamps with the format ISO8610.

We figured out the issue because we recently added a log line that includes a ISO8610 timestamp and we noticed the problem in the sorting of logs.

A changelog entry is not required because the removal of the bracket in the timestamp format was not released yet.

### Tests
Manual verification (see below report).

#### Before
Before the fix, CW logs was not showing the logs from the readiness check for retries after the first one:

```
* execute[Check cluster readiness] action run[2026-03-17T21:21:34+00:00] INFO: Processing execute[Check cluster readiness] action run (aws-parallelcluster-slurm::update_head_node line 171)

    [execute] INFO:__main__:Checking cluster readiness with arguments: cluster_name=update-fixed-11, table_name=parallelcluster-update-fixed-11, config_version=aYzuF4u.91cIvD3rkdt8pWiZE2Zi.F8q, region=us-east-1, cutoff_time=2026-03-17T21:21:11.828+00:00
             ...
[2026-03-17T21:21:36+00:00] INFO: Retrying execution of execute[Check cluster readiness], 9 attempts left
[2026-03-17T21:23:07+00:00] INFO: Retrying execution of execute[Check cluster readiness], 8 attempts left
[2026-03-17T21:24:38+00:00] INFO: Retrying execution of execute[Check cluster readiness], 7 attempts left
[2026-03-17T21:26:09+00:00] INFO: Retrying execution of execute[Check cluster readiness], 6 attempts left
[2026-03-17T21:27:40+00:00] INFO: Retrying execution of execute[Check cluster readiness], 5 attempts left
[2026-03-17T21:29:11+00:00] INFO: Retrying execution of execute[Check cluster readiness], 4 attempts left
[2026-03-17T21:30:42+00:00] INFO: Retrying execution of execute[Check cluster readiness], 3 attempts left
[2026-03-17T21:32:13+00:00] INFO: Retrying execution of execute[Check cluster readiness], 2 attempts left
```

#### After this fix
After the fix, CW logs shows the logs from the readiness check for all retries (reported only couple of iterations ofr brevity:

```
* execute[Check cluster readiness] action run[2026-03-17T22:04:01+00:00] INFO: Processing execute[Check cluster readiness] action run (aws-parallelcluster-slurm::update_head_node line 171)

    [execute] INFO:__main__:Checking cluster readiness with arguments: cluster_name=update-fixed-12, table_name=parallelcluster-update-fixed-12, config_version=Pncp070ZAhUgjvQC2OSJDz2ojWEuxDXY, region=us-east-1, cutoff_time=2026-03-17T22:03:37.065+00:00
              INFO:__main__:Checking that cluster configuration deployed on cluster nodes for cluster update-fixed-12 is Pncp070ZAhUgjvQC2OSJDz2ojWEuxDXY
              INFO:__main__:Cutoff time: 2026-03-17T22:03:37.065+00:00
             ...
              common.exceptions.CheckFailedError: Check failed due to the following erroneous records (missing records and wrong records tolerated, bootstrapped after cut-off time (2026-03-17T22:03:37.065+00:00) are not counted for the failure):
                * missing records (0): []
                * incomplete records (0): []
                * wrong records (2): [('i-0931a09d641809129', 'rZigYqxKgIyQbeFaUk8nLJCQvuojXh_2'), ('i-059dbb92d79b6c02d', 'rZigYqxKgIyQbeFaUk8nLJCQvuojXh_2')]
                * wrong records tolerated, bootstrapped after cut-off time (2026-03-17T22:03:37.065+00:00) (0): []
[2026-03-17T22:04:02+00:00] INFO: Retrying execution of execute[Check cluster readiness], 9 attempts left
    [execute] INFO:__main__:Checking cluster readiness with arguments: cluster_name=update-fixed-12, table_name=parallelcluster-update-fixed-12, config_version=Pncp070ZAhUgjvQC2OSJDz2ojWEuxDXY, region=us-east-1, cutoff_time=2026-03-17T22:03:37.065+00:00
              INFO:__main__:Checking that cluster configuration deployed on cluster nodes for cluster update-fixed-12 is Pncp070ZAhUgjvQC2OSJDz2ojWEuxDXY
              INFO:__main__:Cutoff time: 2026-03-17T22:03:37.065+00:00
             ...
              common.exceptions.CheckFailedError: Check failed due to the following erroneous records (missing records and wrong records tolerated, bootstrapped after cut-off time (2026-03-17T22:03:37.065+00:00) are not counted for the failure):
                * missing records (0): []
                * incomplete records (0): []
                * wrong records (1): [('i-0931a09d641809129', 'rZigYqxKgIyQbeFaUk8nLJCQvuojXh_2')]
                * wrong records tolerated, bootstrapped after cut-off time (2026-03-17T22:03:37.065+00:00) (0): []

... SAME OUTOUT FOR OTHER ITERATIONS...

[2026-03-17T22:16:10+00:00] INFO: Retrying execution of execute[Check cluster readiness], 1 attempt left
    [execute] INFO:__main__:Checking cluster readiness with arguments: cluster_name=update-fixed-12, table_name=parallelcluster-update-fixed-12, config_version=Pncp070ZAhUgjvQC2OSJDz2ojWEuxDXY, region=us-east-1, cutoff_time=2026-03-17T22:03:37.065+00:00
              INFO:__main__:Checking that cluster configuration deployed on cluster nodes for cluster update-fixed-12 is Pncp070ZAhUgjvQC2OSJDz2ojWEuxDXY
              INFO:__main__:Cutoff time: 2026-03-17T22:03:37.065+00:00
             ...
              INFO:__main__:Verified cluster configuration for cluster node(s) ['i-0e984577de88465a1', 'i-07410dede2d538fe5', 'i-00ef811022850d1b9', 'i-0931a09d641809129', 'i-059dbb92d79b6c02d']
              INFO:__main__:All checks succeeded!
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
