### PR TITLE
Fix nvidia-fabric-manager service name mismatch on AL2

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
@@ -32,7 +32,7 @@ end
 action :configure do
   # Start nvidia fabric manager on NVSwitch enabled systems, except for GB200 which does not need it.
   if enable_fabric_manager? && !is_gb200_node?
-    service "#{fabric_manager_package}" do
+    service fabric_manager_service do
       action %i(start enable)
       supports status: true
     end
@@ -53,6 +53,14 @@ def _nvidia_driver_version
 end
 
 def fabric_manager_package
+  'nvidia-fabricmanager'
+end
+
+# The systemd service name for fabric manager.
+# On AL2, the RPM package is named 'nvidia-fabric-manager' but the
+# systemd service unit is 'nvidia-fabricmanager' (no hyphen between
+# 'fabric' and 'manager'), matching all other platforms.
+def fabric_manager_service
   'nvidia-fabricmanager'
 end
 

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
@@ -218,6 +218,7 @@ end
 
 describe 'fabric_manager:configure' do
   cached(:nvidia_driver_version) { 'nvidia_driver_version' }
+  cached(:fabric_manager_service) { 'nvidia-fabricmanager' }
   [true, false].each do |is_gb200|
     for_all_oses do |platform, version|
       context "on #{platform}#{version} on #{is_gb200} gb200 node" do
@@ -242,11 +243,11 @@ describe 'fabric_manager:configure' do
 
           if is_gb200
             it 'does not start nvidia-fabricmanager service' do
-              is_expected.not_to start_service("#{fabric_manager_package}")
+              is_expected.not_to start_service(fabric_manager_service)
             end
           else
             it 'starts nvidia-fabricmanager service' do
-              is_expected.to start_service("#{fabric_manager_package}")
+              is_expected.to start_service(fabric_manager_service)
                 .with_action(%i(start enable))
                 .with_supports({ status: true })
             end
@@ -266,7 +267,7 @@ describe 'fabric_manager:configure' do
           end
 
           it "doesn't start nvidia-fabricmanager service" do
-            is_expected.not_to start_service("#{fabric_manager_package}")
+            is_expected.not_to start_service(fabric_manager_service)
           end
         end
       end
@@ -275,10 +276,9 @@ describe 'fabric_manager:configure' do
 end
 
 describe 'fabric_manager:enable_fabric_manager?' do
+  cached(:fabric_manager_service) { 'nvidia-fabricmanager' }
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
-      cached(:fabric_manager_package) { platform == 'amazon' && version == '2' ? 'nvidia-fabric-manager' : 'nvidia-fabricmanager' }
-
       context 'when multiple GPUs with NVSwitches' do
         cached(:chef_run) do
           stubs_for_provider('fabric_manager') do |res|
@@ -292,7 +292,7 @@ describe 'fabric_manager:enable_fabric_manager?' do
         end
 
         it 'enables fabric manager service' do
-          is_expected.to start_service(fabric_manager_package)
+          is_expected.to start_service(fabric_manager_service)
         end
       end
 
@@ -309,7 +309,7 @@ describe 'fabric_manager:enable_fabric_manager?' do
         end
 
         it 'does not enable fabric manager service' do
-          is_expected.not_to start_service(fabric_manager_package)
+          is_expected.not_to start_service(fabric_manager_service)
         end
       end
     end


### PR DESCRIPTION
### Description of changes
On Amazon Linux 2, the fabric manager RPM package is named 'nvidia-fabric-manager' but the systemd service unit is 'nvidia-fabricmanager' (no hyphen between fabric and manager).

Commits 6dbbf681 and 4e8a0f29 changed the service name in the :configure action from a hardcoded 'nvidia-fabricmanager' to the dynamic fabric_manager_package method, which returns 'nvidia-fabric-manager' on AL2. This caused systemctl to fail with "Unit not found" on p4d + AL2 since GBN 1849 (Jan 28).

Fix: introduce a fabric_manager_service method that always returns 'nvidia-fabricmanager' (the actual systemd unit name), decoupling the service name from the package name.


### Tests
* Ongoing

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
