### PR TITLE
Downgrade cfn-boostrap to 2.0-33 (from 2.0-38) to test in regions without the new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade CUDA Toolkit to version 13.0.2 (from 12.8.1) for all OSs except Amazon Linux 2.
 - Upgrade NVIDIA Fabric manager to 580.105.08 for all OSs except Amazon Linux 2.
 - Upgrade Python to 3.14.2 (from 3.12.11) for all OSs except Amazon Linux 2.
-- Upgrade aws-cfn-bootstrap to version 2.0-38 (from 2.0-33).
 - Upgrade DCGM to version 4.5.1 (from 4.4.1) for all OSs except Amazon Linux 2.
 - Upgrade Munge to version 0.5.17 (from 0.5.16) for all OSs except Amazon Linux 2.
 - Upgrade mysql-community-client to version 8.4.8 (from 8.0.39) for all OSs except Amazon Linux 2.

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -76,7 +76,7 @@ default['cluster']['efa']['sha256'] = '2df4201e046833c7dc8160907bee7f52b76ff80ed
 default['cluster']['efs']['version'] = '2.4.0'
 default['cluster']['efs']['sha256'] = '9b60c039c162388091d6fab6e9c6cfc5832f34b26b6d05b0a68b333147d78a25'
 
-default['cluster']['cfn_bootstrap']['version'] = '2.0-38'
+default['cluster']['cfn_bootstrap']['version'] = '2.0-33'
 
 # TODO: Move to platform cookbook
 default['cluster']['spack_shared_dir'] = "#{node['cluster']['shared_dir']}/spack"


### PR DESCRIPTION
### Description of changes
Downgrade cfn-boostrap to 2.0-33 (from 2.0-38) to test in regions without the new version

### Tests
Testing will be done after the PR is merged

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
