### PR TITLE
[Networking] Move NFS lockd and rquotad ports outside the ephemeral ports range.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.16.0
+------
+
+**CHANGES**
+- Move the NFS service `lockd` to port 32763 (from 32768) and `rquotad` to port 32764 (from 32769),
+  to reduce the risk of port collision within the ephemeral ports range.
+
 3.15.0
 ------
 

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -2,6 +2,10 @@ default['cluster']['stack_name'] = nil
 
 default['cluster']['proxy'] = 'NONE'
 
+# Override NFS service ports that fall within the Linux ephemeral port range (32768-60999)
+default['nfs']['port']['lockd'] = 32_763
+default['nfs']['port']['rquotad'] = 32_764
+
 # For performance, set NFS threads to min(256, max(8, num_cores * 4))
 default['cluster']['nfs']['threads'] = [[node['cpu']['cores'].to_i * 4, 8].max, 256].min
 

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/nfs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/nfs_spec.rb
@@ -18,6 +18,33 @@ class ConvergeNfs
   end
 end
 
+describe 'nfs:port_overrides' do
+  # Verify that NFS service ports inside the Linux ephemeral port range (32768-60999)
+  # are overridden to safe values. Only lockd and rquotad need overriding.
+  cached(:chef_run) { ChefSpec::SoloRunner.new.converge('aws-parallelcluster-environment') }
+  cached(:node) { chef_run.node }
+
+  it "overrides nfs port for lockd to 32763" do
+    expect(node['nfs']['port']['lockd']).to eq(32_763)
+  end
+
+  it "overrides nfs port for rquotad to 32764" do
+    expect(node['nfs']['port']['rquotad']).to eq(32_764)
+  end
+
+  it "keeps nfs port for statd at upstream default 32765" do
+    expect(node['nfs']['port']['statd']).to eq(32_765)
+  end
+
+  it "keeps nfs port for statd_out at upstream default 32766" do
+    expect(node['nfs']['port']['statd_out']).to eq(32_766)
+  end
+
+  it "keeps nfs port for mountd at upstream default 32767" do
+    expect(node['nfs']['port']['mountd']).to eq(32_767)
+  end
+end
+
 describe 'nfs:setup' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do


### PR DESCRIPTION
### Description of changes
Move NFS lockd and rquotad ports outside the ephemeral ports range.

The upstream NFS cookbook assigns lockd to port 32768 and rquotad to 32769, both inside the Linux ephemeral port range (32768-60999).
During boot, another process can grab these ports via ephemeral allocation before NFS starts, causing EADDRINUSE and cluster creation failure.

In this change, we move lockd to 32763 and rquotad to 32764, which are outside the ephemeral port range and adjacent to the other NFS services (statd 32765, statd_out 32766, mountd 32767) which remain unchanged.

### Tests
* PR checks (added unit test covering the changes).
* ONGOING `test_essential_features` on all supported OSs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
