### PR TITLE
[Changelog] Remove Wrong Munge Version in 3.15.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Python to 3.14.2 (from 3.12.11) for all OSs except Amazon Linux 2.
 - Upgrade aws-cfn-bootstrap to version 2.0-38 (from 2.0-33).
 - Upgrade DCGM to version 4.5.1 (from 4.4.1) for all OSs except Amazon Linux 2.
-- Upgrade Munge to version 0.5.17 (from 0.5.16) for all OSs except Amazon Linux 2.
 - Upgrade mysql-community-client to version 8.4.8 (from 8.0.39) for all OSs except Amazon Linux 2.
 - Upgrade Intel MPI Library to 2021.17.2 (from 2021.16.0).
 - Upgrade Cinc Client to version 18.8.54 (from 18.7.10).


### PR DESCRIPTION
### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
