### PR TITLE
[DCV] Fix Xdcv crashes caused by DCV misconfiguration that attempts GL initialization when GPU acceleration is not supported.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.16.0
+------
+
+**BUG FIXES**
+- Fix Xdcv segfault caused by DCV attempting GL initialization when GPU acceleration is not supported.
+
 3.15.0
 ------
 

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
@@ -188,10 +188,21 @@ end
 
 action :configure do
   if dcv_supported? && (node['cluster']['node_type'] == "HeadNode" || node['cluster']['node_type'] == "LoginNode")
-    if dcv_gpu_accel_supported?
+    gpu_accel = dcv_gpu_accel_supported?
+    if gpu_accel
       # Enable graphic acceleration in dcv conf file for graphic instances.
       allow_gpu_acceleration
     else
+      # On non-GPU instances, disable the NVIDIA EGL config files to prevent
+      # Xdcv from crashing during GLX initialization (SIGABRT in libnvidia-egl-gbm.so).
+      # The AMI ships NVIDIA libraries for GPU instance types, but on non-GPU instances
+      # there is no hardware to back them and Xdcv crashes when it discovers them via EGL.
+      execute 'disable nvidia egl platform on non-gpu instances' do
+        command "find /usr/share/egl/egl_external_platform.d /etc/egl/egl_external_platform.d -name '*nvidia*' -exec mv {} {}.disabled \\; 2>/dev/null; true"
+        user 'root'
+        only_if { nvidia_installed? }
+      end
+
       bash 'set default systemd runlevel to graphical.target' do
         user 'root'
         code <<-SETUPX
@@ -234,6 +245,7 @@ action :configure do
       owner 'root'
       group 'root'
       mode '0755'
+      variables(gpu_accel_supported: gpu_accel)
     end
 
     # Create directory for the external authenticator to store access file created by the users

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -931,6 +931,12 @@ describe 'dcv:configure' do
         it 'starts Amazon DCV server' do
           is_expected.to enable_service('dcvserver').with_action(%i(enable start))
         end
+
+        it 'passes gpu_accel_supported=true to dcv.conf template' do
+          is_expected.to create_template('/etc/dcv/dcv.conf').with(
+            variables: { gpu_accel_supported: true }
+          )
+        end
       end
 
       context "when g2 instance" do
@@ -1000,6 +1006,50 @@ describe 'dcv:configure' do
             .with_user('root')
             .with_code(/systemctl set-default graphical.target/)
             .with_code(/systemctl isolate graphical.target &/)
+        end
+
+        it 'passes gpu_accel_supported=false to dcv.conf template' do
+          is_expected.to create_template('/etc/dcv/dcv.conf').with(
+            variables: { gpu_accel_supported: false }
+          )
+        end
+
+        it 'disables NVIDIA EGL platform config files to prevent Xdcv GLX crash' do
+          is_expected.to run_execute('disable nvidia egl platform on non-gpu instances')
+            .with_user('root')
+            .with_command(/find.*egl_external_platform.*nvidia.*disabled/)
+        end
+      end
+
+      context "when dcv_gpu_accel not supported and nvidia not installed" do
+        cached(:chef_run) do
+          stubs_for_resource('dcv') do |res|
+            allow(res).to receive(:dcv_supported?).and_return(true)
+            allow(res).to receive(:dcv_gpu_accel_supported?).and_return(false)
+            allow(res).to receive(:dcv_package).and_return(dcv_package)
+            allow(res).to receive(:dcv_gl).and_return(dcv_gl)
+          end
+          runner = runner(platform: platform, version: version, step_into: ['dcv']) do |node|
+            node.override['ec2']['instance_type'] = 'any'
+            node.override['cluster']['sources_dir'] = sources_dir
+            node.override['cluster']['node_type'] = 'HeadNode'
+            node.override['cluster']['dcv']['gl']['version'] = dcv_gl_version
+            node.override['cluster']['base_os'] = base_os
+            node.override['cluster']['dcv']['version'] = dcv_version
+            node.override['cluster']['dcv']['authenticator']['certificate'] = certificate
+            node.override['cluster']['dcv']['authenticator']['private_key'] = private_key
+            node.override['cluster']['dcv']['authenticator']['user'] = user
+            node.override['cluster']['dcv']['authenticator']['user_home'] = user_home
+          end
+          allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+          allow_any_instance_of(Object).to receive(:graphic_instance?).and_return(false)
+          allow_any_instance_of(Object).to receive(:nvidia_installed?).and_return(false)
+          ConvergeDcv.configure(runner)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'does not disable NVIDIA EGL platform config files when nvidia is not installed' do
+          is_expected.not_to run_execute('disable nvidia egl platform on non-gpu instances')
         end
       end
     end

--- a/cookbooks/aws-parallelcluster-platform/templates/dcv/dcv.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/dcv/dcv.conf.erb
@@ -41,7 +41,13 @@
 # 'dcv-gl' feature (a specific license will be required).
 # Allowed values: 'always-on', 'always-off', 'default-on', 'default-off'.
 # If not specified, the default value is 'default-on'.
+<% if @gpu_accel_supported %>
 #enable-gl-in-virtual-sessions = "default-on"
+<% else %>
+# Explicitly disable dcv-gl on instances where GPU acceleration is not supported
+# (e.g. g5g) to prevent Xdcv segfaults during GLX initialization.
+enable-gl-in-virtual-sessions = "always-off"
+<% end %>
 
 # Property "virtual-session-source-profile" specifies whether the shell that
 # runs the session starter script should source the user profile.
@@ -99,7 +105,10 @@ virtual-session-source-profile = true
 # second that are sent to the client. A higher value consumes more bandwidth
 # and resources. By default it is set to 25. Set to 0 for no limit
 #target-fps = 30
-<% unless node['cluster']['dcv']['is_graphic_instance'] %>
+<% unless @gpu_accel_supported %>
+# On instances that do not support GPU acceleration, DCV must use
+# software-only encoders because there is no GPU that can be used
+# for hardware encoding.
 display-encoders=['turbojpeg', 'lz4', 'ffmpeg']
 <% end %>
 

--- a/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
@@ -238,6 +238,11 @@ control 'tag:config_dcv_correctly_configured' do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode 0755 }
+
+    unless instance.graphic? && instance.nvidia_installed? && instance.dcv_gpu_accel_supported?
+      its('content') { should match /enable-gl-in-virtual-sessions\s*=\s*"always-off"/ }
+      its('content') { should match /display-encoders=\['turbojpeg', 'lz4', 'ffmpeg'\]/ }
+    end
   end
 
   describe directory('/var/spool/parallelcluster/pcluster_dcv_authenticator') do


### PR DESCRIPTION
### Description of changes
Fix Xdcv crashes caused by DCV misconfiguration that attempts GL initialization when GPU acceleration is not supported.

**1. Disable dcv-gl on instances where GPU acceleration is not supported**
DCV-GL should always be disabled on instance types that do not support GPU acceleration, such as g5g or instance types w/o GPU.
`enable-gl-in-virtual-sessions` was left at its default value (`default-on`) even on instance types that don't support GPU acceleration. On RHEL9 and Rocky9 this caused Xdcv to segfault during GLX initialization. On other OSes the misconfiguration was handled more gracefully w/o crashes, but we see that DCV is trying to setup DVC-GL, which is in any case not correct for those instance types. 
We now explicitly set `enable-gl-in-virtual-sessions = "always-off"` in `dcv.conf` when GPU acceleration is not supported.

**2. Restrict display encoders to software-only on non-GPU instances**
Instance types that do not support GPU acceleration should not use hardware encoding, but software encoding.
`display-encoders`, which is the dcv.conf parameter controlling this aspect was controlled by the `cluster.dcv.is_graphic_instance` attribute, which was never actually set (it was accidentally removed in https://github.com/aws/aws-parallelcluster-cookbook/commit/04893c21). As a result, the software-only encoder list was never applied. We now correctly set the value for this setting.

**3. Disable NVIDIA EGL platform config files on non-GPU instances**
DCV should never try to initialize NVIDIA libraries on instance types that do not support GPU acceleration.
However, pcluster bakes into the AMI the NVIDIA libraries, hence on non-GPU instances these libraries are present on disk but have no hardware to back them. When Xdcv initializes the virtual session, the EGL loader discovers the NVIDIA EGL config files and attempts to load NVIDIA EGL libraries, causing the crash because there is no GPU. We now mask those files, so the EGL loader falls back cleanly to `swrast` software rendering.
Apparently this defects affects only the first virtual session. It seems that after the first crash, DCV is smart enough to directly fall back to the correct rendering. However, we want to fix this setup to prevent crashes on the first session.

### Tests
* PR checks (include tests covering this change)
* ONGOING `test_dcv_configuration` executed on all OSs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
