### PR TITLE
Slurm accounting should not be case sensitive

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
@@ -18,7 +18,7 @@
 return if kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")
 
 execute "wait for cluster registration" do
-  command "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{node['cluster']['stack_name']} format=cluster | grep -Fx '#{node['cluster']['stack_name']}'"
+  command "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{node['cluster']['stack_name']} format=cluster | grep -Fxi '#{node['cluster']['stack_name']}'"
   retries 30
   retry_delay 10
 end


### PR DESCRIPTION


### Description of changes
Prior to 3.15.0 the slurm accounting bootstrap was not case sensitive. The split from https://github.com/aws/aws-parallelcluster-cookbook/pull/3132 made it case sensitive causing the bootstrap to fail when the stack has capital letters in it. 

Bootstrap would fail with 

"Mixlib::ShellOut::ShellCommandFailed: execute[wait for cluster registration] (aws-parallelcluster-slurm::bootstrap_slurm_accounting line 20) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'"

with the change to the grep command the return is the expected [0]

/opt/slurm/bin/sacctmgr show clusters -Pn cluster=AL2023-Arctos format=cluster | grep -Fx AL2023-Arctos echo $?
1

/opt/slurm/bin/sacctmgr show clusters -Pn cluster=AL2023-Arctos format=cluster | grep -Fxi AL2023-Arctos al2023-arctos
echo $?
0


### Tests
attempting to deploy with a stackname with uppercase letters caused fail. Rerunning with all lowercase stackname was successful 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
