### PR TITLE
DRAFT Enforce NFSv4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 3.16.0
 ------
 
+**CHANGES**
+- Switch NFS server to NFSv4-only mode. Disable NFSv2 and NFSv3 in the NFS server configuration and mask
+  `rpcbind.service` and `rpcbind.socket` to prevent from starting the auxiliary services that
+  are not needed by NFSv4 (`rpc-statd`, `nfs-mountd`).
+
 **BUG FIXES**
 - Fix Xdcv segfault caused by DCV attempting GL initialization when GPU acceleration is not supported.
 
@@ -45,6 +50,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade amazon-efs-utils to version 2.4.0 (from v2.1.0) for Amazon Linux AMI's.
 
 **BUG FIXES**
+- Fix Xdcv segfault on RHEL9 and Rocky9 caused by DCV attempting GL initialization when GPU acceleration is not supported.
 - Fix a failure when creating a cluster with GPU instances and with DCV enabled but without internet access.
 - Fix build-image failure during ubuntu-desktop installation on a Ubuntu parent image with outdated OS packages.
 - Fix the CloudWatch agent configuration to ensure proper parsing of timestamps across all log files.

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -5,6 +5,17 @@ default['cluster']['proxy'] = 'NONE'
 # For performance, set NFS threads to min(256, max(8, num_cores * 4))
 default['cluster']['nfs']['threads'] = [[node['cpu']['cores'].to_i * 4, 8].max, 256].min
 
+# NFS version configuration — these are attributes of the upstream `nfs` cookbook (cookbooks/nfs),
+# not PCluster-owned attributes. We override their defaults here to enforce NFSv4-only mode.
+# The upstream defaults are nil (defer to kernel), which leaves v2 and v3 enabled.
+default['nfs']['v4'] = 'yes'
+default['nfs']['v3'] = 'no'
+default['nfs']['v2'] = 'no'
+# PCluster-owned attribute: mask rpcbind.service and rpcbind.socket so systemd does not start
+# the auxiliary services (rpc-statd, nfs-mountd) that are only needed for NFSv2/v3.
+# Set to false if rpcbind is needed by other services on the node.
+default['cluster']['nfs']['mask-nfsv2-nfsv3-services'] = true
+
 # Kernel release version used to select Lustre version
 # This is a mechanism used to mock kernel release on docker system-tests, see kitchen.docker.yml:
 # when kernel_release is defined, it will be used, otherwise the release version will be taken from ohai.

--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_alinux2.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_alinux2.rb
@@ -24,6 +24,7 @@ default_action :setup
 action :setup do
   action_install_nfs4
   action_disable_start_at_boot
+  action_mask_nfsv2_nfsv3_services
 end
 
 action_class do

--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_alinux2023.rb
@@ -26,6 +26,7 @@ default_action :setup
 action :setup do
   action_install_nfs4
   action_disable_start_at_boot
+  action_mask_nfsv2_nfsv3_services
 end
 
 action_class do

--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_alinux2023.rb
@@ -32,7 +32,7 @@ end
 action_class do
   def override_server_template
     edit_resource(:template, node['nfs']['config']['server_template']) do
-      source 'nfs/default-nfs-kernel-server.conf.erb'
+      source 'nfs/nfs-ubuntu22+.conf.erb'
       cookbook 'aws-parallelcluster-environment'
     end
   end

--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_redhat8.rb
@@ -26,6 +26,7 @@ default_action :setup
 action :setup do
   action_install_nfs4
   action_disable_start_at_boot
+  action_mask_nfsv2_nfsv3_services
 end
 
 action_class do

--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_rocky8.rb
@@ -26,6 +26,7 @@ default_action :setup
 action :setup do
   action_install_nfs4
   action_disable_start_at_boot
+  action_mask_nfsv2_nfsv3_services
 end
 
 action_class do

--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_ubuntu22+.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/nfs_ubuntu22+.rb
@@ -29,6 +29,7 @@ action :setup do
   action_install_nfs
   action_install_nfs4
   action_disable_start_at_boot
+  action_mask_nfsv2_nfsv3_services
 end
 
 action_class do

--- a/cookbooks/aws-parallelcluster-environment/resources/nfs/partial/_install_nfs4_and_disable.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/nfs/partial/_install_nfs4_and_disable.rb
@@ -23,3 +23,15 @@ action :disable_start_at_boot do
     action :disable
   end unless on_docker?
 end
+
+action :mask_nfsv2_nfsv3_services do
+  # Mask rpcbind so systemd does not start it (or rpc-statd/nfs-mountd that depend on it)
+  # as transitive dependencies of nfs-server.service. Both units are masked because
+  # rpcbind is socket-activated. See nfs.systemd(7), "Masking unwanted services".
+  %w(rpcbind.service rpcbind.socket).each do |svc|
+    service svc do
+      action :mask
+      only_if { !on_docker? && node['cluster']['nfs']['mask-nfsv2-nfsv3-services'] }
+    end
+  end
+end


### PR DESCRIPTION
**DO NOT MERGE YET: This is just a draft, validated on Ubuntu, but facing issues on AL23 and it's missing proper unit tests**

### Description of changes

Enforce NFSv4-only mode on the NFS server across all supported operating systems.
In particular:
1. Override upstream `nfs` cookbook defaults to enable NFSv4 and disable NFSv2/NFSv3.
1. Add `default['cluster']['nfs']['mask-nfsv2-nfsv3-services']` (default `true`) to mask `rpcbind.service` and `rpcbind.socket`, preventing `rpc-statd` and `nfs-mountd` from starting as transitive deps of `nfs-server.service`.  This is done because NFsv4 does not require those services. This is exposed as a Chef attribute so customers who need NFSv2/v3 can set it to `false` to unmask those services.

### Tests
- TODO

### References
This change fixes:
1.  https://github.com/aws/aws-parallelcluster/issues/6622 because we are enforcing now NFSv4-only.
2.  https://github.com/aws/aws-parallelcluster/issues/6949 because we are masking the services not required by NFSv4, which were responsible for the intermittent ports collision.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
