### PR TITLE
[Accounting] Fix slurm accounting bootstrap regression introduced in 3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Fix Xdcv segfault caused by DCV attempting GL initialization when GPU acceleration is not supported.
+- Fix Slurm accounting bootstrap failure when ClusterName is overridden via custom Slurm settings.
 
 3.15.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **BUG FIXES**
 - Fix Xdcv segfault caused by DCV attempting GL initialization when GPU acceleration is not supported.
-- Fix Slurm accounting bootstrap failure when ClusterName is overridden via custom Slurm settings.
+- Fix cluster creation failure caused by Slurm accounting bootstrap failing when ClusterName is overridden 
+via custom Slurm settings or the cluster name contains upper-case letters.
 
 3.15.0
 ------

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -247,3 +247,14 @@ end
 def get_login_node_pool_config(config, pool_name)
   config['LoginNodes']['Pools'].select { |pool| pool['Name'] == pool_name }.first
 end
+
+#
+# Return the cluster name used for Slurm accounting registration.
+# Normally this matches the stack name, but users can override ClusterName via custom Slurm settings.
+#
+def get_slurm_accounting_cluster_name
+  cluster_name = shell_out!(
+    "#{node['cluster']['slurm']['install_dir']}/bin/scontrol show config | awk '/^ClusterName/{print $3}'"
+  ).stdout.strip
+  cluster_name.empty? ? node['cluster']['stack_name'] : cluster_name
+end

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
@@ -22,7 +22,7 @@ execute "wait for cluster registration" do
   # ClusterName via custom Slurm settings. Read the effective value from the running slurmctld config.
   command lazy {
     cluster_name = get_slurm_accounting_cluster_name
-    "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{cluster_name} format=cluster | grep -Fx '#{cluster_name}'"
+    "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{cluster_name} format=cluster | grep -Fxi '#{cluster_name}'"
   }
   retries 30
   retry_delay 10

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb
@@ -18,7 +18,12 @@
 return if kitchen_test? || (node['cluster']['node_type'] == "ExternalSlurmDbd")
 
 execute "wait for cluster registration" do
-  command "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{node['cluster']['stack_name']} format=cluster | grep -Fx '#{node['cluster']['stack_name']}'"
+  # The cluster name used for accounting may differ from the stack name if the user has overridden
+  # ClusterName via custom Slurm settings. Read the effective value from the running slurmctld config.
+  command lazy {
+    cluster_name = get_slurm_accounting_cluster_name
+    "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{cluster_name} format=cluster | grep -Fx '#{cluster_name}'"
+  }
   retries 30
   retry_delay 10
 end
@@ -26,9 +31,11 @@ end
 bash "bootstrap slurm database" do
   user 'root'
   group 'root'
-  code <<-BOOTSTRAP
+  code lazy {
+    cluster_name = get_slurm_accounting_cluster_name
+    <<-BOOTSTRAP
     SACCTMGR_CMD=#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr
-    CLUSTER_NAME=#{node['cluster']['stack_name']}
+    CLUSTER_NAME=#{cluster_name}
     DEF_ACCOUNT=pcdefault
     SLURM_USER=#{node['cluster']['slurm']['user']}
     DEF_USER=#{node['cluster']['cluster_user']}
@@ -45,5 +52,6 @@ bash "bootstrap slurm database" do
         $SACCTMGR_CMD -iQ add user $DEF_USER Account=$DEF_ACCOUNT AdminLevel=Admin
 
     exit 0
-  BOOTSTRAP
+    BOOTSTRAP
+  }
 end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/libraries/get_slurm_accounting_cluster_name_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/libraries/get_slurm_accounting_cluster_name_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'get_slurm_accounting_cluster_name' do
+  let(:slurm_install_dir) { '/opt/slurm' }
+  let(:stack_name) { 'my-stack' }
+  let(:node) do
+    { 'cluster' => { 'slurm' => { 'install_dir' => slurm_install_dir }, 'stack_name' => stack_name } }
+  end
+  let(:scontrol_cmd) { "#{slurm_install_dir}/bin/scontrol show config | awk '/^ClusterName/{print $3}'" }
+
+  context 'when ClusterName is not overridden in custom Slurm settings' do
+    it 'returns the stack name as fallback' do
+      allow_any_instance_of(Object).to receive(:shell_out!).with(scontrol_cmd).and_return(double(stdout: ""))
+      expect(get_slurm_accounting_cluster_name).to eq(stack_name)
+    end
+  end
+
+  context 'when ClusterName is overridden in custom Slurm settings' do
+    it 'returns the custom cluster name' do
+      allow_any_instance_of(Object).to receive(:shell_out!).with(scontrol_cmd).and_return(double(stdout: "my-custom-cluster\n"))
+      expect(get_slurm_accounting_cluster_name).to eq('my-custom-cluster')
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/bootstrap_slurm_accounting_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/bootstrap_slurm_accounting_spec.rb
@@ -18,7 +18,7 @@ describe 'aws-parallelcluster-slurm::bootstrap_slurm_accounting' do
         is_expected.to run_execute("wait for cluster registration")
         command = chef_run.execute("wait for cluster registration").command
         expect(command).to include("cluster=#{accounting_cluster_name}")
-        expect(command).to include("grep -Fx '#{accounting_cluster_name}'")
+        expect(command).to include("grep -Fxi '#{accounting_cluster_name}'")
       end
 
       it "bootstraps the Slurm database using the name returned by get_slurm_accounting_cluster_name" do

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/bootstrap_slurm_accounting_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/bootstrap_slurm_accounting_spec.rb
@@ -3,20 +3,28 @@ require 'spec_helper'
 describe 'aws-parallelcluster-slurm::bootstrap_slurm_accounting' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
+      let(:accounting_cluster_name) { 'My-Custom-ClusterName' }
+
+      before do
+        allow_any_instance_of(Object).to receive(:get_slurm_accounting_cluster_name).and_return(accounting_cluster_name)
+      end
+
       cached(:chef_run) do
-        runner = runner(platform: platform, version: version)
-        runner.converge(described_recipe)
+        runner(platform: platform, version: version).converge(described_recipe)
       end
       cached(:node) { chef_run.node }
 
-      it "waits for cluster registration" do
-        is_expected.to run_execute("wait for cluster registration").with(
-          command: "#{node['cluster']['slurm']['install_dir']}/bin/sacctmgr show clusters -Pn cluster=#{node['cluster']['stack_name']} format=cluster | grep -Fx '#{node['cluster']['stack_name']}'"
-        )
+      it "waits for cluster registration using the name returned by get_slurm_accounting_cluster_name" do
+        is_expected.to run_execute("wait for cluster registration")
+        command = chef_run.execute("wait for cluster registration").command
+        expect(command).to include("cluster=#{accounting_cluster_name}")
+        expect(command).to include("grep -Fx '#{accounting_cluster_name}'")
       end
 
-      it "bootstraps the Slurm database with users" do
+      it "bootstraps the Slurm database using the name returned by get_slurm_accounting_cluster_name" do
         is_expected.to run_bash("bootstrap slurm database")
+        code = chef_run.bash("bootstrap slurm database").code
+        expect(code).to include("CLUSTER_NAME=#{accounting_cluster_name}")
       end
     end
   end


### PR DESCRIPTION
### Description of changes
Fix slurm accounting bootstrap regression introduced in 3.15.0.

#### Problem
In 3.15.0 we introduced [this line](https://github.com/aws/aws-parallelcluster-cookbook/blob/release-3.15/cookbooks/aws-parallelcluster-slurm/recipes/config/bootstrap_slurm_accounting.rb#L21) as part of [this PR](https://github.com/aws/aws-parallelcluster-cookbook/pull/3132) to wait for the cluster to be registered in the accounting database by slurm. 
This check fails for the migration procedure because it expects the cluster to be registered in the database with its cluster stack name. This is not compatible with the procedure, which relies specifically on using the old cluster name for accounting to insist on the same accounting tables.

#### Solution
When a custom cluster name is provided by the user, SLURM will register the cluster with the accounting using that name. The fix consists in honoring that name in the bootstrapping check.
Also, the check must match the registered name with a case-insensitively because a cluster with name containing upper-case letters is always registered in the database with lower-case.

**Fix 1 -- Fix slurm accounting bootstrap to honor custom ClusterName**
The bootstrap_slurm_accounting recipe was hardcoding the stack name as the cluster name for all sacctmgr operations. When a user overrides ClusterName via custom Slurm settings, slurm registers the cluster under the custom name, causing the bootstrap to fail waiting for a cluster that doesn't exist under that name.
With this fix the effective cluster name is read from the slurmctld config, falling back to stack_name if empty.

**Fix 2 -- Make the check for cluster registration with accounting case-insensitive**
    
Slurm normalizes ClusterName to lowercase internally, so when the user specifies a name with upper-case letters, sacctmgr returns the lowercased version. The previous exact match (grep -Fx) would fail to find it, causing cluster creation to time out. Switch to grep -Fxi to match case-insensitively.

**NOTE**
To prevent this type of regression in future we will extend our end2end tests to use custom cluster names with upper case letters. For now that use case has been validated manually. Will soon work on a PR to extend the test.


### Tests
1. Manual testing for fix 1: verified that cluster creation and update succeeds when using a custom cluster name.
2. Manual testing for fix 2: verified that cluster creation succeeds when using a cluster name that contains upper case letters.
3. end2end test succeeded:
```
test-suites:
  schedulers:
    test_slurm_accounting.py::test_slurm_accounting:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5.xlarge"]
          oss: ["alinux2023"]
          schedulers: ["slurm"]
    test_slurm_accounting.py::test_slurm_accounting_external_dbd:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5.xlarge"]
          oss: ["alinux2023"]
          schedulers: ["slurm"]
```

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
