### PR TITLE
Remove AccountingStorageUser from slurm.conf

### DIFF
--- a/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster.conf
+++ b/cookbooks/aws-parallelcluster-slurm/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster.conf
@@ -22,7 +22,6 @@ SelectTypeParameters=CR_CPU
 {#      #}AccountingStorageHost={{ scaling_config.ExternalSlurmdbd.Host }}
 {#      #}AccountingStoragePort={{ scaling_config.ExternalSlurmdbd.Port }}
 {#  #}{% endif %}
-{#  #}AccountingStorageUser={{ slurmdbd_user }}
 {#  #}JobAcctGatherType=jobacct_gather/cgroup
 {% endif %}
 

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_externaldbd.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_externaldbd.conf
@@ -10,7 +10,6 @@ SelectTypeParameters=CR_CPU
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost=test.slurmdbd.host
 AccountingStoragePort=12345
-AccountingStorageUser=slurm
 JobAcctGatherType=jobacct_gather/cgroup
 
 include <DIR>/pcluster/slurm_parallelcluster_efa_partition.conf

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_slurm_accounting.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_slurm_accounting.conf
@@ -10,7 +10,6 @@ SelectTypeParameters=CR_CPU
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost=ip-1-0-0-0
 AccountingStoragePort=6819
-AccountingStorageUser=slurm
 JobAcctGatherType=jobacct_gather/cgroup
 
 include <DIR>/pcluster/slurm_parallelcluster_efa_partition.conf

--- a/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_slurm_accounting_dbname.conf
+++ b/test/unit/slurm/test_slurm_config_generator/test_generate_slurm_config_files_slurm_accounting/expected_outputs/slurm_parallelcluster_slurm_accounting_dbname.conf
@@ -10,7 +10,6 @@ SelectTypeParameters=CR_CPU
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost=ip-1-0-0-0
 AccountingStoragePort=6819
-AccountingStorageUser=slurm
 JobAcctGatherType=jobacct_gather/cgroup
 
 include <DIR>/pcluster/slurm_parallelcluster_efa_partition.conf


### PR DESCRIPTION
### Description of changes
AccountingStorageUser is defunct from slurm.conf with 25.11. We need to remove the parameter.

In slurmctld.log of test_slurm_accounting, we see the logs:
```
[2026-03-26T23:36:05.722] cred/munge: init: Munge credential signature plugin loaded
[2026-03-26T23:36:05.722] select/cons_tres: init: select/cons_tres loaded
[2026-03-26T23:36:05.724] accounting_storage/slurmdbd: init: Accounting storage SLURMDBD plugin loaded
[2026-03-26T23:36:05.731] accounting_storage/slurmdbd: _load_dbd_state: recovered 0 pending RPCs
[2026-03-26T23:36:05.731] accounting_storage/slurmdbd: clusteracct_storage_p_register_ctld: Registering slurmctld at port 6820 with slurmdbd
[2026-03-26T23:36:07.138] error: The option "AccountingStorageUser" is defunct, please remove it from slurm.conf.
[2026-03-26T23:36:07.139] No memory enforcing mechanism configured.
```

### Tests
The following tests have passed
```
{%- import 'common.jinja2' as common with context -%}
{{- common.OSS_COMMERCIAL_X86.append("rocky8") or "" -}}
{{- common.OSS_COMMERCIAL_X86.append("rocky9") or "" -}}
---
test-suites:
  schedulers:
    test_slurm_accounting.py::test_slurm_accounting:
      dimensions:
        - regions: ["ap-south-1"]
          instances:  {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2023"]
          schedulers: ["slurm"]
    test_slurm_accounting.py::test_slurm_accounting_external_dbd:
      dimensions:
        - regions: [ "ap-south-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2404"]
          schedulers: ["slurm"]
```

### References
Integration tests change to prevent other defunct parameters https://github.com/aws/aws-parallelcluster/pull/7342

Github issue: https://github.com/aws/aws-parallelcluster/issues/7319

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
