### PR TITLE
[Docs] Add changelog entry related to removal of deprecated Slurm parameter AccountingStorageUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Fix Xdcv segfault caused by DCV attempting GL initialization when GPU acceleration is not supported.
 - Fix cluster creation failure caused by Slurm accounting bootstrap failing when ClusterName is overridden 
 via custom Slurm settings or the cluster name contains upper-case letters.
+- Remove deprecated parameter `AccountingStorageUser` from Slurm configuration that was causing harmless error messages.
 
 3.15.0
 ------


### PR DESCRIPTION
### Description of changes
Add changelog entry related to removal of deprecated Slurm parameter AccountingStorageUser 

See https://github.com/aws/aws-parallelcluster-cookbook

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.