### PR TITLE
[Storage] Add retry to IMDS metadata retrieval during EBS volume attach detach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 3.16.0
 ------
 
+**ENHANCEMENTS**
+- Improve resilience of EBS volume attachment during cluster creation by retrying on transient IMDS connectivity failures.
+
 **BUG FIXES**
 - Fix Xdcv segfault caused by DCV attempting GL initialization when GPU acceleration is not supported.
 - Fix cluster creation failure caused by Slurm accounting bootstrap failing when ClusterName is overridden 

--- a/cookbooks/aws-parallelcluster-environment/files/default/ec2_udev_rules/manageVolume.py
+++ b/cookbooks/aws-parallelcluster-environment/files/default/ec2_udev_rules/manageVolume.py
@@ -17,6 +17,7 @@ import time
 import boto3
 import requests
 from botocore.config import Config
+from retrying import retry
 
 METADATA_REQUEST_TIMEOUT = 60
 
@@ -201,12 +202,18 @@ def parse_proxy_config():
     return proxy_config
 
 
+@retry(
+    stop_max_attempt_number=3,
+    wait_fixed=5000,
+)
 def get_metadata_value(token, metadata_path):
-    return requests.get(
+    response = requests.get(
         metadata_path,
         headers=token,
         timeout=METADATA_REQUEST_TIMEOUT,
-    ).text
+    )
+    response.raise_for_status()
+    return response.text
 
 
 def handle_volume(volume_id, attach, detach):


### PR DESCRIPTION
### Description of changes
Add retry to IMDS metadata retrieval during EBS volume attach/detach to improve resiliency against transient networking glitches.

### Tests
SUCCESS `test_raid_performance_mode` (the test that was originally impacted by the IMDS glitch)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
