### PR TITLE
[DCV] Fix DCV prerequisite installation potentially blocking on interactive prompts by exporting `DEBIAN_FRONTEND=noninteractive` to child processes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Fix cluster creation failure caused by Slurm accounting bootstrap failing when ClusterName is overridden 
 via custom Slurm settings or the cluster name contains upper-case letters.
 - Remove deprecated parameter `AccountingStorageUser` from Slurm configuration that was causing harmless error messages.
+- Fix DCV prerequisite installation potentially blocking on interactive prompts by exporting `DEBIAN_FRONTEND=noninteractive` to child processes.
 
 3.15.0
 ------

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_ubuntu_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_ubuntu_common.rb
@@ -59,7 +59,7 @@ EOF
       # Run dpkg --configure -a if there is a `dpkg interrupted` issue when installing ubuntu-desktop
       code <<-PREREQ
         set -e
-        DEBIAN_FRONTEND=noninteractive
+        export DEBIAN_FRONTEND=noninteractive
         apt -y install whoopsie
         apt -y install ubuntu-desktop && apt -y install mesa-utils || (dpkg --configure -a && exit 1)
         apt -y purge ifupdown

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -475,6 +475,7 @@ describe 'dcv:setup' do
               .with_code(%r{cat > /etc/netplan/95-parallelcluster-force-networkd.yaml})
               .with_code(/netplan apply/)
             is_expected.to run_bash('install pre-req').with_cwd(Chef::Config[:file_cache_path]).with_retries(10).with_retry_delay(5)
+                                                      .with_code(/export DEBIAN_FRONTEND=noninteractive/)
                                                       .with_code(/apt -y install whoopsie/)
                                                       .with_code(/apt -y install ubuntu-desktop && apt -y install mesa-utils || (dpkg --configure -a && exit 1)/)
                                                       .with_code(/apt -y purge ifupdown/)


### PR DESCRIPTION
### Description of changes
Fix DCV prerequisite installation potentially blocking on interactive prompts by exporting `DEBIAN_FRONTEND=noninteractive` to child processes.

**Why DEBIAN_FRONTEND=noninteractive?**
Before installing DCV pre-requisites, we set `DEBIAN_FRONTEND=noninteractive` so that the installation of ubuntu-desktop and other requirements does not block on user input. 

**What is the problem?**
There are cases where such setup is not honored and the installation blocks on user input.
An example is when Snap Store is not available, the installation of firefox (installed by ubuntu-desktop) is blocked on user input and the build-image eventually fails because the installation remains stuck.

**Why exporting is the solution?**
By exporting the envar, its value is injected in every child processes spawned by the installation of ubuntu-desktop.

**Why now?**
The recent outage on Snap Store (https://sqmagazine.co.uk/313-team-claims-ddos-extortion-attack-on-canonical/) causes Snap Store connectivity failure during the installation of ubuntu-desktop. On such failure the installation blocked prompting the user to choose how to react the failure (retry/abort/skip).

**What would happen in case of Snap Store failure with the current change?**
The installation would not block on the user input, but will retry the installation in the background every minute for 30 minutes. If connectivity is not recovered, the installation would fail in any case.

### Tests
* ONGOING `test_build_image` on Ubu22 and Ubu24
* Manually verified by running `apt-get -y install firefox` in an env where I injected Snap Store connectivity failure:
    * when the envar is not exported, the terminal blocks on user prompt.
    * when the envar is exported, the terminal does not prompt the user

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
