### PR TITLE
Fix DynamoDB retry behavior and error message on compute node bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ via custom Slurm settings or the cluster name contains upper-case letters.
 - Remove deprecated parameter `AccountingStorageUser` from Slurm configuration that was causing harmless error messages.
 - Fix DCV prerequisite installation potentially blocking on interactive prompts by exporting `DEBIAN_FRONTEND=noninteractive` to child processes.
 - Fix slurmrestd failing to start on AL2023 because the http-parser library was not discoverable by the dynamic linker.
-- Fix compute node bootstrap failing without a clear error when the compute subnet cannot reach DynamoDB (e.g. when a DynamoDB VPC gateway endpoint is missing).
+- Fix compute node bootstrap hanging without a clear error when the compute subnet cannot reach DynamoDB.
 
 3.15.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ via custom Slurm settings or the cluster name contains upper-case letters.
 - Remove deprecated parameter `AccountingStorageUser` from Slurm configuration that was causing harmless error messages.
 - Fix DCV prerequisite installation potentially blocking on interactive prompts by exporting `DEBIAN_FRONTEND=noninteractive` to child processes.
 - Fix slurmrestd failing to start on AL2023 because the http-parser library was not discoverable by the dynamic linker.
+- Fail fast and log a descriptive error when a compute node cannot reach DynamoDB during bootstrap, so the root cause
+  (e.g. a missing DynamoDB VPC endpoint) is visible in the Chef logs before Slurm's ResumeTimeout terminates the instance.
 
 3.15.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ via custom Slurm settings or the cluster name contains upper-case letters.
 - Remove deprecated parameter `AccountingStorageUser` from Slurm configuration that was causing harmless error messages.
 - Fix DCV prerequisite installation potentially blocking on interactive prompts by exporting `DEBIAN_FRONTEND=noninteractive` to child processes.
 - Fix slurmrestd failing to start on AL2023 because the http-parser library was not discoverable by the dynamic linker.
-- Fail fast and log a descriptive error when a compute node cannot reach DynamoDB during bootstrap, so the root cause
-  (e.g. a missing DynamoDB VPC endpoint) is visible in the Chef logs before Slurm's ResumeTimeout terminates the instance.
+- Fix compute node bootstrap failing without a clear error when the compute subnet cannot reach DynamoDB (e.g. when a DynamoDB VPC gateway endpoint is missing).
 
 3.15.0
 ------

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -28,6 +28,10 @@ end
 # Retrieve compute and head node info from dynamo db (Slurm only)
 #
 def dynamodb_info(aws_connection_timeout_seconds: 10, aws_read_timeout_seconds: 30, shell_timeout_seconds: 60)
+  ddb_hint = "This usually means the compute node cannot reach DynamoDB. " \
+             "If the compute subnet has no internet egress (NAT/IGW), ensure a DynamoDB VPC gateway endpoint " \
+             "is configured and attached to the subnet's route table."
+
   cmd = Mixlib::ShellOut.new("#{cookbook_virtualenv_path}/bin/aws dynamodb " \
                       "--region #{node['cluster']['region']} query --table-name #{node['cluster']['slurm_ddb_table']} " \
                       "--index-name InstanceId --key-condition-expression 'InstanceId = :instanceid' " \
@@ -37,14 +41,18 @@ def dynamodb_info(aws_connection_timeout_seconds: 10, aws_read_timeout_seconds: 
                       "--cli-read-timeout #{aws_read_timeout_seconds} " \
                       "--output text --query 'Items[0].[Id.S]'",
                              user: 'root',
-                             timeout: shell_timeout_seconds).run_command
+                             timeout: shell_timeout_seconds)
+
+  begin
+    cmd.run_command
+  rescue Mixlib::ShellOut::CommandTimeout
+    raise "Failed to query DynamoDB for compute node info: the aws cli call did not return in time " \
+          "and was terminated. #{ddb_hint}"
+  end
 
   if cmd.error?
     raise "Failed to query DynamoDB for compute node info. " \
-          "exit_code=#{cmd.exitstatus}, stderr=#{cmd.stderr.strip}. " \
-          "This usually means the compute node cannot reach DynamoDB. " \
-          "If the compute subnet has no internet egress (NAT/IGW), ensure a DynamoDB VPC gateway endpoint " \
-          "is configured and attached to the subnet's route table."
+          "exit_code=#{cmd.exitstatus}, stderr=#{cmd.stderr.strip}. #{ddb_hint}"
   end
 
   output = cmd.stdout.strip

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -28,10 +28,6 @@ end
 # Retrieve compute and head node info from dynamo db (Slurm only)
 #
 def dynamodb_info(aws_connection_timeout_seconds: 10, aws_read_timeout_seconds: 30, shell_timeout_seconds: 60)
-  ddb_hint = "This usually means the compute node cannot reach DynamoDB. " \
-             "If the compute subnet has no internet egress (NAT/IGW), ensure a DynamoDB VPC gateway endpoint " \
-             "is configured and attached to the subnet's route table."
-
   cmd = Mixlib::ShellOut.new("#{cookbook_virtualenv_path}/bin/aws dynamodb " \
                       "--region #{node['cluster']['region']} query --table-name #{node['cluster']['slurm_ddb_table']} " \
                       "--index-name InstanceId --key-condition-expression 'InstanceId = :instanceid' " \
@@ -47,23 +43,19 @@ def dynamodb_info(aws_connection_timeout_seconds: 10, aws_read_timeout_seconds: 
     cmd.run_command
   rescue Mixlib::ShellOut::CommandTimeout
     raise "Failed to query DynamoDB for compute node info: the aws cli call did not return in time " \
-          "and was terminated. #{ddb_hint}"
-  end
-
-  if cmd.error?
-    raise "Failed to query DynamoDB for compute node info. " \
-          "exit_code=#{cmd.exitstatus}, stderr=#{cmd.stderr.strip}. #{ddb_hint}"
+          "and was terminated. This usually means the compute node cannot reach DynamoDB. " \
+          "If the compute subnet has no internet egress (NAT/IGW), ensure a DynamoDB VPC gateway endpoint " \
+          "is configured and attached to the subnet's route table."
   end
 
   output = cmd.stdout.strip
-  if output.nil? || output.empty? || output == "None"
-    raise "DynamoDB query returned no compute node info for instance #{node['ec2']['instance_id']} " \
-          "in table #{node['cluster']['slurm_ddb_table']}. " \
-          "The instance may not be registered; check clustermgtd logs on the head node."
-  end
+  raise "Failed when retrieving Compute info from DynamoDB" if output.nil? || output.empty? || output == "None"
 
-  Chef::Log.info("Retrieved Slurm nodename is: #{output}")
-  output
+  slurm_nodename = output
+
+  Chef::Log.info("Retrieved Slurm nodename is: #{slurm_nodename}")
+
+  slurm_nodename
 end
 
 #

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -27,8 +27,8 @@ end
 #
 # Retrieve compute and head node info from dynamo db (Slurm only)
 #
-def dynamodb_info(aws_connection_timeout_seconds: 30, aws_read_timeout_seconds: 60, shell_timout_seconds: 300)
-  output = Mixlib::ShellOut.new("#{cookbook_virtualenv_path}/bin/aws dynamodb " \
+def dynamodb_info(aws_connection_timeout_seconds: 10, aws_read_timeout_seconds: 30, shell_timeout_seconds: 60)
+  cmd = Mixlib::ShellOut.new("#{cookbook_virtualenv_path}/bin/aws dynamodb " \
                       "--region #{node['cluster']['region']} query --table-name #{node['cluster']['slurm_ddb_table']} " \
                       "--index-name InstanceId --key-condition-expression 'InstanceId = :instanceid' " \
                       "--expression-attribute-values '{\":instanceid\": {\"S\":\"#{node['ec2']['instance_id']}\"}}' " \
@@ -36,16 +36,26 @@ def dynamodb_info(aws_connection_timeout_seconds: 30, aws_read_timeout_seconds: 
                       "--cli-connect-timeout #{aws_connection_timeout_seconds} " \
                       "--cli-read-timeout #{aws_read_timeout_seconds} " \
                       "--output text --query 'Items[0].[Id.S]'",
-                                user: 'root',
-                                timeout: shell_timout_seconds).run_command.stdout.strip
+                             user: 'root',
+                             timeout: shell_timeout_seconds).run_command
 
-  raise "Failed when retrieving Compute info from DynamoDB" if output.nil? || output.empty? || output == "None"
+  if cmd.error?
+    raise "Failed to query DynamoDB for compute node info. " \
+          "exit_code=#{cmd.exitstatus}, stderr=#{cmd.stderr.strip}. " \
+          "This usually means the compute node cannot reach DynamoDB. " \
+          "If the compute subnet has no internet egress (NAT/IGW), ensure a DynamoDB VPC gateway endpoint " \
+          "is configured and attached to the subnet's route table."
+  end
 
-  slurm_nodename = output
+  output = cmd.stdout.strip
+  if output.nil? || output.empty? || output == "None"
+    raise "DynamoDB query returned no compute node info for instance #{node['ec2']['instance_id']} " \
+          "in table #{node['cluster']['slurm_ddb_table']}. " \
+          "The instance may not be registered; check clustermgtd logs on the head node."
+  end
 
-  Chef::Log.info("Retrieved Slurm nodename is: #{slurm_nodename}")
-
-  slurm_nodename
+  Chef::Log.info("Retrieved Slurm nodename is: #{output}")
+  output
 end
 
 #

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
@@ -31,7 +31,7 @@ end
 if node['cluster']['node_type'] == "ComputeFleet"
 
   ruby_block "retrieve compute node info" do
-    retries 30
+    retries 10
     retry_delay 10
     block do
       slurm_nodename = dynamodb_info

--- a/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/init.rb
@@ -31,7 +31,7 @@ end
 if node['cluster']['node_type'] == "ComputeFleet"
 
   ruby_block "retrieve compute node info" do
-    retries 10
+    retries 5
     retry_delay 10
     block do
       slurm_nodename = dynamodb_info


### PR DESCRIPTION
### Description of changes

When a compute node cannot reach DynamoDB during bootstrap (for example, a private subnet is missing the DynamoDB VPC gateway endpoint), Chef's `ruby_block[retrieve compute node info]` retries silently with no useful diagnostic information. The default configuration (30 retries × ~5 min per attempt) also exceeds Slurm's default ResumeTimeout (2100s), so the instance is terminated before Chef can emit a final error.

This change:

- **Tightens timeouts and retries** so Chef fails fast within ResumeTimeout:
  - `retries`: 30 → 5
  - `aws_connection_timeout_seconds`: 30 → 10
  - `aws_read_timeout_seconds`: 60 → 30
  - `shell_timeout_seconds`: 300 → 60
  - Worst-case total time: ~5–6 minutes (under the 35 minutes `ResumeTimeout` default).
- **Improves the failure message** to include the CLI exit code and stderr, plus a hint about the most common cause (missing DynamoDB VPC endpoint on a private subnet).
- Fixes a pre-existing typo: `shell_timout_seconds` → `shell_timeout_seconds`.

Related bug: https://github.com/aws/aws-parallelcluster-node/pull/702

### Tests
- E2E on a cluster whose compute subnet has no DynamoDB VPC endpoint and no NAT:
  - Chef fails within 6 minutes instead of looping silently for >2 hours.
  - `/var/log/chef-client.log` on the compute node contains the new error message with CLI stderr and the VPC-endpoint hint.
```
2026-05-06T20:24:56.000Z [2026-05-06T20:24:56+00:00] INFO: Retrying execution of ruby_block[retrieve compute node info], 1 attempt left
2026-05-06T20:26:10.000Z [2026-05-06T20:26:10+00:00] INFO: Retrying execution of ruby_block[retrieve compute node info], 0 attempt left
2026-05-06T20:26:10.000Z     
    ================================================================================
    Error executing action `run` on resource 'ruby_block[retrieve compute node info]'
    ================================================================================
    
    RuntimeError
    ------------
    Failed to query DynamoDB for compute node info: the aws cli call did not return in time and was terminated. This usually means the compute node cannot reach DynamoDB. If the compute subnet has no internet egress (NAT/IGW), ensure a DynamoDB VPC gateway endpoint is configured and attached to the subnet's route table.
```


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
