### PR TITLE
[Security] Disable algif_aead kernel module on Ubuntu  to address CVE-2026-31431.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **CHANGES**
-- There were no changes for this version.
+- Disable `algif_aead` kernel module on Ubuntu to address [CVE-2026-31431](https://nvd.nist.gov/vuln/detail/CVE-2026-31431).
 
 3.15.0
 ------

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -85,6 +85,12 @@ default['cluster']['instance_types_data_version'] = nil
 default['cluster']['change_set_s3_key'] = nil
 default['cluster']['instance_types_data_s3_key'] = nil
 
+# Kernel modules to disable
+default['cluster']['disable_kernel_modules'] = []
+if platform?('ubuntu')
+  default['cluster']['disable_kernel_modules'] = %w(algif_aead)
+end
+
 # Intel MPI
 default['cluster']['intelmpi']['version'] = '2021.17'
 default['cluster']['intelmpi']['full_version'] = '2021.17.2.94'

--- a/cookbooks/aws-parallelcluster-platform/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install.rb
@@ -24,6 +24,7 @@ unless alinux2023_on_docker? # Running this recipe on Alinux 2023 docker generat
   include_recipe "openssh"
 end
 include_recipe "aws-parallelcluster-platform::disable_selinux"
+include_recipe "aws-parallelcluster-platform::disable_kernel_modules"
 include_recipe "aws-parallelcluster-platform::license_readme"
 include_recipe "aws-parallelcluster-platform::gc_thresh_values"
 include_recipe "aws-parallelcluster-platform::supervisord_install"

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/disable_kernel_modules.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/disable_kernel_modules.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: aws-parallelcluster-platform
+# Recipe:: disable_kernel_modules
+#
+# Copyright:: 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Disable kernel modules defined in node['cluster']['disable_kernel_modules'].
+# The :disable action creates a fake install entry in /etc/modprobe.d that prevents
+# the module from being loaded.
+
+node['cluster']['disable_kernel_modules'].each do |mod_name|
+  kernel_module mod_name do
+    action :disable
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_kernel_modules_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_kernel_modules_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-platform::disable_kernel_modules' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      context "when disable_kernel_modules attribute is set" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['disable_kernel_modules'] = %w(algif_aead test_module)
+          end
+          runner.converge(described_recipe)
+        end
+
+        %w(algif_aead test_module).each do |mod_name|
+          it "disables kernel module #{mod_name}" do
+            is_expected.to disable_kernel_module(mod_name)
+          end
+        end
+      end
+
+      context "when disable_kernel_modules attribute is empty" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['disable_kernel_modules'] = []
+          end
+          runner.converge(described_recipe)
+        end
+
+        it "does not disable any kernel module" do
+          expect(chef_run.find_resources(:kernel_module)).to be_empty
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
Disable algif_aead kernel module on Ubuntu  to address https://nvd.nist.gov/vuln/detail/CVE-2026-31431.

To this aim we introduced a new `disable_kernel_modules` recipe that disables kernel modules listed in the `node['cluster']['disable_kernel_modules']`, so that the disablement can be easily adapted for customer/tests needs through Chef attributes.

This approach is reported as mitigation in https://ubuntu.com/blog/copy-fail-vulnerability-fixes-available

### Tests
1. Unit tests executed in this PR
3. SUCCESS build image on all OSs
4. SUCCESS e2e test `test_essential_features` on Ubu2404

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.