### PR TITLE
[DCV] Fix DCV configuration (display-encoders)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Improve resilience of EBS volume attachment during cluster creation by retrying on transient IMDS connectivity failures.
 
 **BUG FIXES**
-- Fix Xdcv segfault caused by DCV attempting GL initialization when GPU acceleration is not supported.
 - Fix cluster creation failure caused by Slurm accounting bootstrap failing when ClusterName is overridden 
 via custom Slurm settings or the cluster name contains upper-case letters.
 - Remove deprecated parameter `AccountingStorageUser` from Slurm configuration that was causing harmless error messages.
+- Fix DCV configuration by letting DCV server decide the display-encoders for the instance type.
 - Fix DCV prerequisite installation potentially blocking on interactive prompts by exporting `DEBIAN_FRONTEND=noninteractive` to child processes.
+- Fix Xdcv segfault caused by DCV attempting GL initialization when GPU acceleration is not supported.
 - Fix slurmrestd failing to start on AL2023 because the http-parser library was not discoverable by the dynamic linker.
 - Fix compute node bootstrap hanging without a clear error when the compute subnet cannot reach DynamoDB.
 

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
@@ -188,8 +188,8 @@ end
 
 action :configure do
   if dcv_supported? && (node['cluster']['node_type'] == "HeadNode" || node['cluster']['node_type'] == "LoginNode")
-    gpu_accel = dcv_gpu_accel_supported?
-    if gpu_accel
+    is_dcv_gl_supported = dcv_gpu_accel_supported?
+    if is_dcv_gl_supported
       # Enable graphic acceleration in dcv conf file for graphic instances.
       allow_gpu_acceleration
     else
@@ -245,7 +245,7 @@ action :configure do
       owner 'root'
       group 'root'
       mode '0755'
-      variables(gpu_accel_supported: gpu_accel)
+      variables(is_dcv_gl_supported: is_dcv_gl_supported)
     end
 
     # Create directory for the external authenticator to store access file created by the users

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -933,9 +933,9 @@ describe 'dcv:configure' do
           is_expected.to enable_service('dcvserver').with_action(%i(enable start))
         end
 
-        it 'passes gpu_accel_supported=true to dcv.conf template' do
+        it 'passes is_dcv_gl_supported=true to dcv.conf template' do
           is_expected.to create_template('/etc/dcv/dcv.conf').with(
-            variables: { gpu_accel_supported: true }
+            variables: { is_dcv_gl_supported: true }
           )
         end
       end
@@ -1009,9 +1009,9 @@ describe 'dcv:configure' do
             .with_code(/systemctl isolate graphical.target &/)
         end
 
-        it 'passes gpu_accel_supported=false to dcv.conf template' do
+        it 'passes is_dcv_gl_supported=false to dcv.conf template' do
           is_expected.to create_template('/etc/dcv/dcv.conf').with(
-            variables: { gpu_accel_supported: false }
+            variables: { is_dcv_gl_supported: false }
           )
         end
 

--- a/cookbooks/aws-parallelcluster-platform/templates/dcv/dcv.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/dcv/dcv.conf.erb
@@ -41,7 +41,7 @@
 # 'dcv-gl' feature (a specific license will be required).
 # Allowed values: 'always-on', 'always-off', 'default-on', 'default-off'.
 # If not specified, the default value is 'default-on'.
-<% if @gpu_accel_supported %>
+<% if @is_dcv_gl_supported %>
 #enable-gl-in-virtual-sessions = "default-on"
 <% else %>
 # Explicitly disable dcv-gl on instances where GPU acceleration is not supported
@@ -105,13 +105,6 @@ virtual-session-source-profile = true
 # second that are sent to the client. A higher value consumes more bandwidth
 # and resources. By default it is set to 25. Set to 0 for no limit
 #target-fps = 30
-<% unless @gpu_accel_supported %>
-# On instances that do not support GPU acceleration, DCV must use
-# software-only encoders because there is no GPU that can be used
-# for hardware encoding.
-display-encoders=['turbojpeg', 'lz4', 'ffmpeg']
-<% end %>
-
 
 ###############################################################################
 ## Section "connectivity" contains the properties of the dcv connection

--- a/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
@@ -241,7 +241,6 @@ control 'tag:config_dcv_correctly_configured' do
 
     unless instance.graphic? && instance.nvidia_installed? && instance.dcv_gpu_accel_supported?
       its('content') { should match /enable-gl-in-virtual-sessions\s*=\s*"always-off"/ }
-      its('content') { should match /display-encoders=\['turbojpeg', 'lz4', 'ffmpeg'\]/ }
     end
   end
 


### PR DESCRIPTION
### Description of changes
Fix DCV configuration by letting DCV decide the best display-encoders. In particular, DCV can now use hardware encoders for g5g instance types.

Also renamed some parameters to make it clear that there may exist instance type that support gpu acceleration without supporting dcv gl acceleration, .e.g g5g.

### Tests
SUCCESS
```
test-suites:
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
      - instances:
        - g5g.2xlarge
        - g4dn.2xlarge
        oss:
        - ubuntu2404
        regions:
        - use1-az1
        schedulers:
        - slurm
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
