### PR TITLE
[NVIDIA] Upgrade NVIDIA to 580.126.18 from 580.105.08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **CHANGES**
 - Disable `algif_aead` kernel module on Ubuntu to address [CVE-2026-31431](https://nvd.nist.gov/vuln/detail/CVE-2026-31431).
+- Upgrade NVIDIA driver to version 580.126.20 (from 580.105.08) for all OSs except Amazon Linux 2 to address CVE-2025-33219.
+- Upgrade NVIDIA Fabric manager to 580.126.20 (from 580.105.08) for all OSs except Amazon Linux 2.
+- Upgrade NVIDIA IMEX to 580.126.20 (from 580.105.08) for all OSs except Amazon Linux 2.
 
 3.15.0
 ------

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -29,7 +29,7 @@
 - [chevron; version 0.14.0](#chevron-version-0140)
 - [libjwt; version 1.18.4 (1.17.0 on AL2)](#libjwt-version-1184-1170-on-al2)
 - [Amazon DCV; version 2025.0-20103](#amazon-dcv-version-20250-20103)
-- [Nvidia Driver; version 580.105.08 (550.127.08 on AL2)](#nvidia-driver-version-58010508-55012708-on-al2)
+- [Nvidia Driver; version 580.126.20 (550.127.08 on AL2)](#nvidia-driver-version-58012618-55012708-on-al2)
 - [Cuda Samples; version 13.0 (12.4 on AL2)](#cuda-samples-version-130-124-on-al2)
 - [Nvidia CUDA; version 13.0.2 (12.4.1 on AL2)](#nvidia-cuda-version-1302-1241-on-al2)
 - [NVIDIA Fabric Manager (grouped with 2 other entries sharing this license)](#nvidia-fabric-manager-grouped-with-2-other-entries-sharing-this-license)
@@ -7188,7 +7188,7 @@ individual or entity that is not a party to this EULA.
 
 ---
 
-## Nvidia Driver; version 580.105.08 (550.127.08 on AL2)
+## Nvidia Driver; version 580.126.20 (550.127.08 on AL2)
 
 <https://www.nvidia.com/download/index.aspx?lang=en-us>
 
@@ -7197,7 +7197,7 @@ individual or entity that is not a party to this EULA.
     * Package Nvidia Driver's source code may be found at:
       https://us-east-1-aws-parallelcluster.s3.us-
 east-1.amazonaws.com/archives/dependencies/nvidia_driver/NVIDIA-
-Linux-x86_64-580.105.08.run
+Linux-x86_64-580.126.20.run
       (AL2 continues to use NVIDIA-Linux-x86_64-550.127.08.run)
 
 NVIDIA Driver License Agreement
@@ -9338,8 +9338,8 @@ conditions:
 
 **Entries covered by the license text below:**
 
-- **NVIDIA Fabric Manager; version 580.105.08 (matches Nvidia Driver; 550.127.08 on AL2)** — <https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/>
-- **NVIDIA IMEX; version 580.105.08 (matches Nvidia Driver; 550.127.08 on AL2)** — <https://docs.nvidia.com/multi-node-nvlink-systems/imex-guide/>
+- **NVIDIA Fabric Manager; version 580.126.20 (matches Nvidia Driver; 550.127.08 on AL2)** — <https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/>
+- **NVIDIA IMEX; version 580.126.20 (matches Nvidia Driver; 550.127.08 on AL2)** — <https://docs.nvidia.com/multi-node-nvlink-systems/imex-guide/>
 - **NVIDIA NVLSM; version 2025.03.9-1** — <https://docs.nvidia.com/networking/display/mlnxofedv461000/nvidia+subnet+manager>
 
 ```text

--- a/cookbooks/aws-parallelcluster-awsbatch/kitchen.awsbatch-install.yml
+++ b/cookbooks/aws-parallelcluster-awsbatch/kitchen.awsbatch-install.yml
@@ -21,4 +21,4 @@ suites:
         - /custom_awsbatchcli_package_installed/
     attributes:
       cluster:
-        custom_awsbatchcli_package: https://github.com/aws/aws-parallelcluster/archive/develop.tar.gz
+        custom_awsbatchcli_package: https://github.com/aws/aws-parallelcluster/archive/release-3.15.tar.gz

--- a/cookbooks/aws-parallelcluster-entrypoints/kitchen.entrypoints-install.yml
+++ b/cookbooks/aws-parallelcluster-entrypoints/kitchen.entrypoints-install.yml
@@ -14,8 +14,8 @@ provisioner:
     cluster:
       # The following parameters are required when running install recipes on system tests
       region: us-east-1
-      custom_node_package: https://github.com/aws/aws-parallelcluster-node/archive/develop.tar.gz
-      custom_awsbatchcli_package: https://github.com/aws/aws-parallelcluster/archive/develop.tar.gz
+      custom_node_package: https://github.com/aws/aws-parallelcluster-node/archive/release-3.15.tar.gz
+      custom_awsbatchcli_package: https://github.com/aws/aws-parallelcluster/archive/release-3.15.tar.gz
 
 suites:
   - name: entrypoints_install

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -16,7 +16,7 @@ default['cluster']['enroot']['persistent_dir'] = '/var/enroot'
 
 # NVidia
 default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '580.105.08'
+default['cluster']['nvidia']['driver_version'] = '580.126.20'
 default['cluster']['nvidia']['dcgm_version'] = '4.5.1-1'
 if platform?('amazon') && node['platform_version'] == "2"
   default['cluster']['nvidia']['driver_version'] = '550.127.08'


### PR DESCRIPTION
### Description of changes
* Upgrade NVIDIA to 580.126.18 (from 580.105.08) to handle [CVE-2025-33219](https://nvd.nist.gov/vuln/detail/CVE-2025-33219)


### Tests
Build AMI and below test
```
test-suites:
  basic:
    test_essential_features.py::test_essential_features:
      dimensions:
        - regions: [{{ US_EAST_1_INSTANCE_TYPE_0_xlarge_CAPACITY_RESERVATION_8_INSTANCES_2_HOURS_NOPG_OS_X86_1 }}]
          instances: [{{ US_EAST_1_INSTANCE_TYPE_0 }}.xlarge]
          oss: [{{ DCV_OS_X86_1 }}]
          schedulers: ["slurm"]
  health_checks:
    test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
      dimensions:
        - regions: [{{ US_WEST_2_GPU_INSTANCE_TYPE_0_CAPACITY_RESERVATION_3_INSTANCES_2_HOURS_NOPG_OS_X86_5 }}]
          instances: [{{ US_WEST_2_GPU_INSTANCE_TYPE_0 }}]
          oss: [{{ OS_X86_5 }}]
          schedulers: ["slurm"]

```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
