### PR TITLE
Improve Github CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,6 @@ jobs:
         with:
           omnitruckUrl: omnitruck.cinc.sh
           project: cinc-workstation
-          version: 23
       - name: Run ChefSpec on ${{ matrix.cookbook }}
         run: |
           cd ${{ matrix.cookbook }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,5 +119,3 @@ jobs:
         run: |
           cd ${{ matrix.cookbook }}
           chef exec rspec
-        env:
-          CHEF_LICENSE: accept-no-persist

--- a/.github/workflows/dokken-system-tests.yml
+++ b/.github/workflows/dokken-system-tests.yml
@@ -110,7 +110,6 @@ jobs:
         with:
           os: ${{ matrix.os }}
         env:
-          CHEF_LICENSE: accept-no-persist
           KITCHEN_YAML: kitchen.docker.yml
           KITCHEN_LOCAL_YAML: cookbooks/aws-parallelcluster-entrypoints/kitchen.entrypoints-install.yml
           KITCHEN_GLOBAL_YAML: kitchen.global.yml
@@ -131,7 +130,6 @@ jobs:
           os: ${{ matrix.os }}
           suite: slurm-config-head-node-x86-64-docker
         env:
-          CHEF_LICENSE: accept-no-persist
           KITCHEN_YAML: kitchen.docker.yml
           KITCHEN_LOCAL_YAML: kitchen.validate-config.yml
           KITCHEN_GLOBAL_YAML: kitchen.global.yml

--- a/.github/workflows/dokken-system-tests.yml
+++ b/.github/workflows/dokken-system-tests.yml
@@ -78,32 +78,22 @@ jobs:
         with:
           omnitruckUrl: omnitruck.cinc.sh
           project: cinc-workstation
-      - name: Downgrade Docker for kitchen-dokken 2.20.8 compatibility
-        if: steps.changed-files-excluding-tests.outputs.any_changed == 'true' && needs.check-labels.outputs.skip_system_tests != 'true' && !startsWith(matrix.os, 'alinux')
+      # kitchen-dokken 2.23.0 (bundled with cinc-workstation 26.0.2) has a bug:
+      # its check_license method calls license_acceptance_id and product_version
+      # which aren't available in cinc-workstation's class hierarchy.
+      # Since we use Cinc (no license needed), replace the whole method with a no-op.
+      - name: Patch kitchen-dokken check_license for cinc compatibility
+        if: steps.changed-files-excluding-tests.outputs.any_changed == 'true' && needs.check-labels.outputs.skip_system_tests != 'true'
         run: |
-          # kitchen-dokken 2.20.8 sends Cmd as string and platform as "os/arch" string
-          # Docker 29.x (rolled out Feb 9 2026) rejects these — downgrade to 28.x
-          # https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260201.15
-          DOCKER_VERSION=$(docker version --format '{{.Server.Version}}')
-          echo "Current Docker: $DOCKER_VERSION"
-          DOCKER_MAJOR=$(echo "$DOCKER_VERSION" | cut -d. -f1)
-          if [[ "$DOCKER_MAJOR" -ge 29 ]]; then
-            echo "Docker ${DOCKER_VERSION} (major >= 29) detected — downgrading to 28.x"
-            # Ensure Docker official repo is configured
-            sudo install -m 0755 -d /etc/apt/keyrings
-            sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-            echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-            sudo apt-get update
-            # List available versions for debugging
-            apt-cache madison docker-ce | head -20
-            # Find latest 28.x version (format is 5:28.x.y-1~ubuntu...)
-            VERSION_STRING=$(apt-cache madison docker-ce | awk -F'|' '{print $2}' | tr -d ' ' | grep '^5:28\.' | head -1)
-            echo "Installing Docker version: $VERSION_STRING"
-            sudo apt-get install -y --allow-downgrades docker-ce=$VERSION_STRING docker-ce-cli=$VERSION_STRING
-            echo "New Docker: $(docker --version)"
-          else
-            echo "Docker version is not 29.x — skipping downgrade"
-          fi
+          DOKKEN_PROVISIONER=$(find /opt/cinc-workstation/embedded -path '*/kitchen/provisioner/dokken.rb' -type f)
+          echo "Patching: $DOKKEN_PROVISIONER"
+          sudo ruby -i -e '
+            content = File.read(ARGV[0])
+            content.sub!(/def check_license.*?^      end/m, "def check_license\n        # no-op: cinc does not require license acceptance\n      end")
+            File.write(ARGV[0], content)
+          ' "$DOKKEN_PROVISIONER"
+          echo "Verifying patch:"
+          grep -A2 "def check_license" "$DOKKEN_PROVISIONER"
       - name: Kitchen Test Install
         if: steps.changed-files-excluding-tests.outputs.any_changed == 'true' && needs.check-labels.outputs.skip_system_tests != 'true'
         uses: actionshub/test-kitchen@main

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/libraries/storage_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/libraries/storage_spec.rb
@@ -11,7 +11,7 @@ describe "aws-parallelcluster-slurm:libraries:storage_change_supports_live_updat
 
   shared_examples "the correct method" do |changeset, info_outcome, expected_result|
     it "returns #{expected_result}" do
-      allow(File).to receive(:read).with("/SHARED_DIR/change-set.json").and_return(JSON.dump(changeset))
+      allow(File).to receive(:read).with("/SHARED_DIR/change-set.json", any_args).and_return(JSON.dump(changeset))
       allow(SharedStorageChangeInfo).to receive(:new).and_return(mock_shared_storage_change_info)
       allow(mock_shared_storage_change_info).to receive(:support_live_updates?).and_return(info_outcome)
       result = storage_change_supports_live_update?

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/libraries/update_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/libraries/update_spec.rb
@@ -13,10 +13,10 @@ describe "aws-parallelcluster-slurm:libraries:are_mount_or_unmount_required" do
     it "returns #{expected_result}" do
       if changeset.nil?
         allow(File).to receive(:exist?).with(CHANGE_SET_PATH).and_return(false)
-        allow(File).to receive(:read).with(CHANGE_SET_PATH).and_call_original
+        allow(File).to receive(:read).with(CHANGE_SET_PATH, any_args).and_call_original
       else
         allow(File).to receive(:exist?).with(CHANGE_SET_PATH).and_return(true)
-        allow(File).to receive(:read).with(CHANGE_SET_PATH).and_return(JSON.dump(changeset))
+        allow(File).to receive(:read).with(CHANGE_SET_PATH, any_args).and_return(JSON.dump(changeset))
       end
       result = are_mount_or_unmount_required?
       expect(result).to eq(expected_result)

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -4,10 +4,6 @@ driver:
   pull_platform_image: false # Use the local images, prevent pull of docker images from Docker Hub,
   chef_version: 18.8.54
   chef_image: cincproject/cinc
-  env:
-    # Since the kernel version of the docker images is not in the expected pattern,
-    # KERNEL_RELEASE is set in the environment to override the system value.
-    - KERNEL_RELEASE=3.10.0-1160.42.2.el7.x86_64
 
 provisioner:
   name: dokken

--- a/kitchen.docker.yml
+++ b/kitchen.docker.yml
@@ -2,7 +2,7 @@
 driver:
   name: dokken
   pull_platform_image: false # Use the local images, prevent pull of docker images from Docker Hub,
-  chef_version: 18.7.10
+  chef_version: 18.8.54
   chef_image: cincproject/cinc
   env:
     # Since the kernel version of the docker images is not in the expected pattern,


### PR DESCRIPTION
### Description of changes
* Upgrade cinc-workstation in Github CI to the latest version
* Align Chef version in docker with the version in our cookbook
* Remove accepting license with CINC
* Patch kitchen-dokken by removing the function body of check_license
* Remove setting KERNEL_RELEASE env var

See commits descriptions for details

### Tests
* All Github checks are passing

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
