### PR TITLE
[tests] Fix a bug in kitchen tests introduced by AL2 deprecation

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/arm_pl_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/arm_pl_spec.rb
@@ -43,7 +43,7 @@ control 'tag:install_arm_pl_installed' do
 
   describe bash("#{setup} && module load #{armpl_module_general_name} && "\
                 "cd #{armpl_install_dir}/examples_lp64 && "\
-                "make clean") do
+                "make clean && make") do
     its('exit_status') { should eq(0) }
     its('stdout') { should match /testing: no example difference files were generated/i }
     its('stdout') { should match /test passed ok/i }


### PR DESCRIPTION
### Description of changes
* This fixes a mistaken deletion at https://github.com/aws/aws-parallelcluster-cookbook/pull/3180/changes#diff-d0890a448eb10fafd04a030d219dc2695676f6892284a0a01e631c12f0d90746L48

### Tests
* Build image on all Oses have passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
