### PR TITLE
[Deps] Support 3rd party dependency upgrade using ExtraChefAttributes

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -75,6 +75,7 @@ default['cluster']['efa']['sha256'] = '2df4201e046833c7dc8160907bee7f52b76ff80ed
 
 default['cluster']['efs']['version'] = '2.4.0'
 default['cluster']['efs']['sha256'] = '9b60c039c162388091d6fab6e9c6cfc5832f34b26b6d05b0a68b333147d78a25'
+default['cluster']['efs']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/efs"
 
 default['cluster']['cfn_bootstrap']['version'] = '2.0-38'
 

--- a/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_install_from_tar.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_install_from_tar.rb
@@ -17,7 +17,7 @@ package_name = "amazon-efs-utils"
 action :install_utils do
   package_version = _efs_utils_version
   efs_utils_tarball = "#{node['cluster']['sources_dir']}/efs-utils-#{package_version}.tar.gz"
-  efs_utils_url = "#{node['cluster']['artifacts_s3_url']}/dependencies/efs/v#{package_version}.tar.gz"
+  efs_utils_url = "#{node['cluster']['efs']['base_url']}/v#{package_version}.tar.gz"
 
   package_repos 'update package repositories' do
     action :update

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efs_spec.rb
@@ -81,6 +81,28 @@ describe 'efs:install_utils' do
         end
       end
 
+      context "when base_url is overridden via ExtraChefAttributes" do
+        cached(:public_base_url) { 'https://fake-public.example.DOMAIN/aws/efs-utils/archive' }
+
+        cached(:chef_run) do
+          mock_already_installed('amazon-efs-utils', utils_version, false)
+          runner = runner(platform: platform, version: version, step_into: ['efs']) do |node|
+            node.override['cluster']['efs_utils']['tarball_path'] = tarball_path
+            node.override['cluster']['sources_dir'] = source_dir
+            node.override['cluster']['region'] = aws_region
+            node.override['cluster']['efs']['version'] = utils_version
+            node.override['cluster']['efs']['sha256'] = tarball_checksum
+            node.override['cluster']['efs']['base_url'] = public_base_url
+          end
+          ConvergeEfs.install_utils(runner)
+        end
+
+        it 'downloads tarball from overridden base_url' do
+          is_expected.to create_if_missing_remote_file(tarball_path)
+            .with(source: "#{public_base_url}/v#{utils_version}.tar.gz")
+        end
+      end
+
       context "utils package already installed" do
         cached(:chef_run) do
           mock_already_installed('amazon-efs-utils', utils_version, true)

--- a/cookbooks/aws-parallelcluster-environment/test/controls/efs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/efs_spec.rb
@@ -4,9 +4,9 @@ control 'tag:install_efs_utils_installed' do
 
   only_if { !os_properties.redhat_on_docker? }
 
-  describe file("#{node['cluster']['sources_dir']}/efs-utils-2.4.0.tar.gz") do
+  describe file("#{node['cluster']['sources_dir']}/efs-utils-#{node['cluster']['efs']['version']}.tar.gz") do
     it { should exist }
-    its('sha256sum') { should eq '9b60c039c162388091d6fab6e9c6cfc5832f34b26b6d05b0a68b333147d78a25' }
+    its('sha256sum') { should eq node['cluster']['efs']['sha256'] }
     its('owner') { should eq 'root' }
     its('group') { should eq 'root' }
     its('mode') { should cmp '0644' }

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -36,6 +36,7 @@ default['cluster']['nvidia']['gdrcopy']['sha256'] = '32bc7b2c198dd97ec251de0ff48
 default['cluster']['nvidia']['gdrcopy']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/gdr_copy/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"
 
 # nvidia-imex
+default['cluster']['nvidia']['imex']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_imex"
 default['cluster']['nvidia']['imex']['force_configuration'] = false
 
 # NVIDIA NVLSM

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -22,6 +22,7 @@ default['cluster']['nvidia']['dcgm_version'] = '4.5.1-1'
 
 default['cluster']['nvidia']['driver_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_driver"
 default['cluster']['nvidia']['dcgm_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_dcgm"
+default['cluster']['nvidia']['fabricmanager']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_fabric"
 
 # CUDA
 default['cluster']['nvidia']['cuda']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda"

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -20,6 +20,12 @@ default['cluster']['nvidia']['driver_version'] = '580.105.08'
 default['cluster']['nvidia']['dcgm_version'] = '4.5.1-1'
 default['cluster']['nvidia']['dcgm_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_dcgm"
 
+# CUDA
+default['cluster']['nvidia']['cuda']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda"
+default['cluster']['nvidia']['cuda']['samples_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda/samples"
+default['cluster']['nvidia']['cuda']['version'] = '13.0.2'
+default['cluster']['nvidia']['cuda']['driver_version_suffix'] = '580.95.05'
+
 # GDRCopy
 default['cluster']['nvidia']['gdrcopy']['version'] = '2.5.2'
 default['cluster']['nvidia']['gdrcopy']['sha256'] = '32bc7b2c198dd97ec251de0ff4823252c95e31a4c79a5f843c82514c9af2052b'

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -11,6 +11,7 @@ default['conditions']['arm_pl_supported'] = arm_instance?
 
 # Enroot
 default['cluster']['enroot']['version'] = '3.4.1'
+default['cluster']['enroot']['caps_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/enroot"
 default['cluster']['enroot']['temporary_dir'] = '/run/enroot'
 default['cluster']['enroot']['persistent_dir'] = '/var/enroot'
 

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -18,6 +18,8 @@ default['cluster']['enroot']['persistent_dir'] = '/var/enroot'
 default['cluster']['nvidia']['enabled'] = 'no'
 default['cluster']['nvidia']['driver_version'] = '580.105.08'
 default['cluster']['nvidia']['dcgm_version'] = '4.5.1-1'
+
+default['cluster']['nvidia']['driver_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_driver"
 default['cluster']['nvidia']['dcgm_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_dcgm"
 
 # CUDA

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -41,6 +41,8 @@ default['cluster']['nvidia']['imex']['force_configuration'] = false
 
 # NVIDIA NVLSM
 default['cluster']['nvidia']['nvlsm']['enabled'] = true
+default['cluster']['nvidia']['nvlsm']['version'] = '2025.03.9-1'
+default['cluster']['nvidia']['nvlsm']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_nvlsm"
 
 # DCV
 default['cluster']['dcv']['install_enabled'] = true

--- a/cookbooks/aws-parallelcluster-platform/libraries/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-platform/libraries/nvidia.rb
@@ -14,6 +14,32 @@ def nvidia_enabled?
   ['yes', true, 'true'].include?(node['cluster']['nvidia']['enabled'])
 end
 
+# Whether a base_url attribute still points to the default ParallelCluster artifacts location.
+# Used by: fabric manager, dcgm, nvlsm, enroot (caps).
+# Limitation: this check assumes attribute precedence resolves at attribute-load time
+# (the ExtraChefAttributes path). If artifacts_s3_url is overridden after cookbook
+# attributes load — for example via node.override from inside a recipe — base_url
+# will still embed the original value and this check may return false incorrectly.
+def default_artifacts_url?(base_url)
+  base_url.include?(node['cluster']['artifacts_s3_url'])
+end
+
+# NVIDIA public repo uses 'x86_64' or 'sbsa' as the arch directory
+def nvidia_repo_arch
+  arm_instance? ? 'sbsa' : 'x86_64'
+end
+
+# Build download URL for NVIDIA-hosted packages (dcgm, fabric manager, nvlsm).
+# Default: downloads from ParallelCluster S3 mirror — URL pattern is {base_url}/{platform}/{filename}
+# Overridden: downloads from NVIDIA public repo — URL pattern is {base_url}/{platform}/{arch}/{filename}
+def nvidia_package_url(base_url, platform, filename)
+  if default_artifacts_url?(base_url)
+    "#{base_url}/#{platform}/#{filename}"
+  else
+    "#{base_url}/#{platform}/#{nvidia_repo_arch}/#{filename}"
+  end
+end
+
 #
 # Check if the instance has a GPU
 #

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/cuda.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/cuda.rb
@@ -19,14 +19,15 @@ return unless nvidia_enabled?
 
 # Cuda installer from https://developer.nvidia.com/cuda-toolkit-archive
 # Cuda installer naming: cuda_11.8.0_520.61.05_linux
-cuda_version = '13.0'
-cuda_patch = '2'
-cuda_complete_version = "#{cuda_version}.#{cuda_patch}"
-cuda_version_suffix = '580.95.05'
-cuda_samples_version = '13.0'
+
+cuda_full_version = node['cluster']['nvidia']['cuda']['version']
+cuda_parts = cuda_full_version.split('.')
+cuda_version = "#{cuda_parts[0]}.#{cuda_parts[1]}"
+cuda_version_suffix = node['cluster']['nvidia']['cuda']['driver_version_suffix']
+cuda_samples_version = cuda_version
 cuda_arch = arm_instance? ? 'linux_sbsa' : 'linux'
-cuda_url = "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda/cuda_#{cuda_complete_version}_#{cuda_version_suffix}_#{cuda_arch}.run"
-cuda_samples_url = "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda/samples/v#{cuda_samples_version}.tar.gz"
+cuda_url = "#{node['cluster']['nvidia']['cuda']['base_url']}/cuda_#{cuda_full_version}_#{cuda_version_suffix}_#{cuda_arch}.run"
+cuda_samples_url = "#{node['cluster']['nvidia']['cuda']['samples_base_url']}/v#{cuda_samples_version}.tar.gz"
 tmp_cuda_run = '/tmp/cuda.run'
 tmp_cuda_sample_archive = '/tmp/cuda-sample.tar.gz'
 

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_debian.rb
@@ -41,7 +41,9 @@ def enroot_url
 end
 
 def enroot_caps_url
-  "#{node['cluster']['artifacts_s3_url']}/dependencies/enroot/enroot-caps_#{package_version}-1_#{arch_suffix}.deb"
+  base_url = node['cluster']['enroot']['caps_base_url']
+  caps_name = default_artifacts_url?(base_url) ? 'enroot-caps' : 'enroot+caps'
+  "#{base_url}/#{caps_name}_#{package_version}-1_#{arch_suffix}.deb"
 end
 
 def arch_suffix

--- a/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/enroot/partial/_enroot_rhel.rb
@@ -37,7 +37,9 @@ def enroot_url
 end
 
 def enroot_caps_url
-  "#{node['cluster']['artifacts_s3_url']}/dependencies/enroot/enroot-caps-#{package_version}-1.el8.#{arch_suffix}.rpm"
+  base_url = node['cluster']['enroot']['caps_base_url']
+  caps_name = default_artifacts_url?(base_url) ? 'enroot-caps' : 'enroot+caps'
+  "#{base_url}/#{caps_name}-#{package_version}-1.el8.#{arch_suffix}.rpm"
 end
 
 def arch_suffix

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_debian.rb
@@ -39,5 +39,7 @@ def arch_suffix
 end
 
 def fabric_manager_url
-  "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_fabric/#{platform}/#{fabric_manager_package}_#{fabric_manager_version}-1_#{arch_suffix}.deb"
+  base_url = node['cluster']['nvidia']['fabricmanager']['base_url']
+  nvidia_package_url(base_url, platform,
+    "#{fabric_manager_package}_#{fabric_manager_version}-1_#{arch_suffix}.deb")
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_rhel.rb
@@ -40,5 +40,7 @@ def arch_suffix
 end
 
 def fabric_manager_url
-  "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_fabric/#{platform}/#{fabric_manager_package}-#{fabric_manager_version}-1.#{arch_suffix}.rpm"
+  base_url = node['cluster']['nvidia']['fabricmanager']['base_url']
+  nvidia_package_url(base_url, platform,
+    "#{fabric_manager_package}-#{fabric_manager_version}-1.#{arch_suffix}.rpm")
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_debian.rb
@@ -20,7 +20,7 @@ action :install_package do
                        end
   packages_urls_list.each do |package|
     remote_file "#{node['cluster']['sources_dir']}/#{package}-#{package_version}.deb" do
-      source "#{node['cluster']['nvidia']['dcgm_base_url']}/#{platform}/#{package}_#{package_version}_#{arch_suffix}.deb"
+      source dcgm_url(package)
       mode '0644'
       retries 3
       retry_delay 5
@@ -54,6 +54,11 @@ end
 
 def arch_suffix
   arm_instance? ? 'arm64' : 'amd64'
+end
+
+def dcgm_url(package)
+  nvidia_package_url(node['cluster']['nvidia']['dcgm_base_url'], platform,
+    "#{package}_#{package_version}_#{arch_suffix}.deb")
 end
 
 def package_version

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_rhel.rb
@@ -22,7 +22,7 @@ action :install_package do
   end
   packages_urls_list.each do |package|
     remote_file "#{node['cluster']['sources_dir']}/#{package}-#{package_version}.rpm" do
-      source "#{node['cluster']['nvidia']['dcgm_base_url']}/#{platform}/#{package}-#{package_version}#{package_url_separator}#{arch_suffix}.rpm"
+      source dcgm_url(package, package_url_separator)
       mode '0644'
       retries 3
       retry_delay 5
@@ -56,6 +56,11 @@ end
 
 def arch_suffix
   arm_instance? ? 'aarch64' : 'x86_64'
+end
+
+def dcgm_url(package, separator)
+  nvidia_package_url(node['cluster']['nvidia']['dcgm_base_url'], platform,
+    "#{package}-#{package_version}#{separator}#{arch_suffix}.rpm")
 end
 
 def package_version

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
@@ -103,7 +103,7 @@ def _nvidia_driver_version
 end
 
 def nvidia_driver_url
-  "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_driver/NVIDIA-Linux-#{nvidia_arch}-#{_nvidia_driver_version}.run"
+  "#{node['cluster']['nvidia']['driver_base_url']}/NVIDIA-Linux-#{nvidia_arch}-#{_nvidia_driver_version}.run"
 end
 
 def nvidia_driver_enabled?

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_debian.rb
@@ -34,7 +34,9 @@ action :install_imex do
 end
 
 def nvidia_imex_url
-  "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_imex/#{platform}/#{nvidia_imex_package}_#{nvidia_imex_full_version}_#{arch_suffix}.deb"
+  base_url = node['cluster']['nvidia']['imex']['base_url']
+  nvidia_package_url(base_url, platform,
+    "#{nvidia_imex_package}_#{nvidia_imex_full_version}_#{arch_suffix}.deb")
 end
 
 def arch_suffix

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_rhel.rb
@@ -40,5 +40,7 @@ def arch_suffix
 end
 
 def nvidia_imex_url
-  "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_imex/#{platform}/#{nvidia_imex_package}-#{nvidia_imex_full_version}.#{arch_suffix}.rpm"
+  base_url = node['cluster']['nvidia']['imex']['base_url']
+  nvidia_package_url(base_url, platform,
+    "#{nvidia_imex_package}-#{nvidia_imex_full_version}.#{arch_suffix}.rpm")
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_common.rb
@@ -44,9 +44,15 @@ action :install_nvlsm_dependencies do
 end
 
 action :install_nvlsm do
+  base_url = node['cluster']['nvidia']['nvlsm']['base_url']
   remote_file "#{node['cluster']['sources_dir']}/#{nvidia_nvlsm_package_full_name}" do
     source nvidia_nvlsm_url
-    checksum nvidia_nvlsm_checksum
+    # The NVLSM checksum is specific to each distribution and architecture combination,
+    # and a single overridden value cannot satisfy all OS/architecture variants when
+    # build-image runs in parallel across them. Skip the checksum when base_url is
+    # overridden; the cookbook still validates the checksum on the default S3 path
+    # where the per-OS/per-arch values are pinned.
+    checksum nvidia_nvlsm_checksum if default_artifacts_url?(base_url)
     mode '0644'
     retries 3
     retry_delay 5
@@ -70,11 +76,11 @@ def nvidia_nvlsm_package
 end
 
 def nvidia_nvlsm_version
-  "2025.03.9-1"
+  node['cluster']['nvidia']['nvlsm']['version']
 end
 
 def nvidia_nvlsm_url
-  "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_nvlsm/#{platform}/#{nvidia_nvlsm_package_full_name}"
+  nvidia_package_url(node['cluster']['nvidia']['nvlsm']['base_url'], platform, nvidia_nvlsm_package_full_name)
 end
 
 def nvidia_nvlsm_package_full_name

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/libraries/nvidia_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/libraries/nvidia_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# -------------------------------------------------------------------
+# nvidia_enabled? — tested via the nvidia_install recipe guard.
+# The recipe returns early if nvidia_enabled? is false.
+# -------------------------------------------------------------------
+describe 'nvidia_enabled? via nvidia_driver resource' do
+  [
+    ['yes', true],
+    [true, true],
+    ['true', true],
+    ['no', false],
+    [false, false],
+    ['false', false],
+    ['any_other_value', false],
+  ].each do |input, should_install|
+    context "when node['cluster']['nvidia']['enabled'] is #{input.inspect}" do
+      cached(:chef_run) do
+        allow(::File).to receive(:exist?).and_call_original
+        allow(::File).to receive(:exist?).with('/usr/bin/nvidia-smi').and_return(false)
+        stub_command("lsinitramfs /boot/initrd.img-$(uname -r) | grep nouveau").and_return(false)
+        ChefSpec::SoloRunner.new(step_into: ['nvidia_driver']) do |node|
+          node.override['cluster']['nvidia']['enabled'] = input
+        end.converge('aws-parallelcluster-platform::nvidia_install')
+      end
+
+      if should_install
+        it 'runs nvidia driver install bash' do
+          is_expected.to run_bash('nvidia.run advanced')
+        end
+      else
+        it 'does not run nvidia driver install bash' do
+          is_expected.not_to run_bash('nvidia.run advanced')
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cuda_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cuda_spec.rb
@@ -83,19 +83,42 @@ describe 'aws-parallelcluster-platform::cuda' do
 
   context 'when not on arm' do
     cached(:cuda_arch) { 'linux' }
-    cached(:cuda_url) { "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda/cuda_#{cuda_complete_version}_#{cuda_version_suffix}_#{cuda_arch}.run" }
+    cached(:default_base_url) { "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda" }
+    cached(:default_samples_base_url) { "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda/samples" }
 
-    cached(:chef_run) do
-      allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
-      allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
-      allow(::File).to receive(:exist?).with("/usr/local/cuda-#{cuda_version}").and_return(false)
-      allow(::File).to receive(:exist?).with("/usr/local/cuda-#{cuda_version}/samples").and_return(false)
-      ChefSpec::Runner.new.converge(described_recipe)
-    end
-    cached(:node) { chef_run.node }
+    {
+      'default S3 base_url' => { base_url: nil, samples_base_url: nil },
+      'base_url overridden via ExtraChefAttributes' => {
+        base_url: 'https://fake-public.example.DOMAIN/cuda',
+        samples_base_url: 'https://fake-public.example.DOMAIN/cuda-samples',
+      },
+    }.each do |scenario, urls|
+      context "when #{scenario}" do
+        cached(:expected_base_url) { urls[:base_url] || default_base_url }
+        cached(:expected_samples_base_url) { urls[:samples_base_url] || default_samples_base_url }
+        cached(:cuda_url) { "#{expected_base_url}/cuda_#{cuda_complete_version}_#{cuda_version_suffix}_#{cuda_arch}.run" }
+        cached(:cuda_samples_url) { "#{expected_samples_base_url}/v#{cuda_version}.tar.gz" }
 
-    it 'downloads CUDA run file' do
-      is_expected.to create_remote_file('/tmp/cuda.run').with_source(cuda_url)
+        cached(:chef_run) do
+          allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
+          allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+          allow(::File).to receive(:exist?).with("/usr/local/cuda-#{cuda_version}").and_return(false)
+          allow(::File).to receive(:exist?).with("/usr/local/cuda-#{cuda_version}/samples").and_return(false)
+          ChefSpec::Runner.new do |node|
+            node.override['cluster']['nvidia']['cuda']['base_url'] = urls[:base_url] if urls[:base_url]
+            node.override['cluster']['nvidia']['cuda']['samples_base_url'] = urls[:samples_base_url] if urls[:samples_base_url]
+          end.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'downloads CUDA run file from the expected URL' do
+          is_expected.to create_remote_file('/tmp/cuda.run').with_source(cuda_url)
+        end
+
+        it 'downloads CUDA samples from the expected URL' do
+          is_expected.to create_remote_file('/tmp/cuda-sample.tar.gz').with_source(cuda_samples_url)
+        end
+      end
     end
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/enroot_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/enroot_spec.rb
@@ -198,3 +198,58 @@ describe 'aws-parallelcluster-platform::enroot:setup' do
     end
   end
 end
+
+# Tests for the NVIDIA library helper default_artifacts_url? as exercised
+# through the enroot caps filename construction.
+#
+# Default S3 mirror uses "enroot-caps" (hyphen). Public NVIDIA repo uses
+# "enroot+caps" (plus). The helper distinguishes between the two by checking
+# whether the configured caps_base_url still references the cluster's
+# artifacts_s3_url.
+describe 'enroot_caps_url filename selection' do
+  ENROOT_S3_ARTIFACTS_URL = 'https://REGION-aws-parallelcluster.s3.REGION.AWS_DOMAIN'.freeze
+  ENROOT_S3_CAPS_BASE_URL = "#{ENROOT_S3_ARTIFACTS_URL}/dependencies/enroot".freeze
+  ENROOT_PUBLIC_CAPS_BASE_URL = 'https://fake-public.example.DOMAIN/releases/download/v3.4.1'.freeze
+  ENROOT_VERSION = '9.9.9'.freeze
+
+  for_all_oses do |platform, version|
+    debian = (platform == 'ubuntu')
+    ext = debian ? 'deb' : 'rpm'
+    arch_suffix = debian ? 'amd64' : 'x86_64'
+    rhel_suffix = debian ? '' : '.el8' # rhel partial pins to el8
+
+    [
+      ['default S3 caps_base_url', ENROOT_S3_CAPS_BASE_URL, 'enroot-caps'],
+      ['overridden public caps_base_url', ENROOT_PUBLIC_CAPS_BASE_URL, 'enroot+caps'],
+    ].each do |scenario, base_url, expected_caps_name|
+      context "on #{platform}#{version} with #{scenario}" do
+        cached(:chef_run) do
+          stubs_for_resource('enroot') do |res|
+            allow(res).to receive(:enroot_installed).and_return(false)
+          end
+          allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
+          allow_any_instance_of(Object).to receive(:nvidia_installed?).and_return(false)
+          allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+          runner(platform: platform, version: version, step_into: ['enroot']) do |node|
+            node.override['cluster']['artifacts_s3_url'] = ENROOT_S3_ARTIFACTS_URL
+            node.override['cluster']['enroot']['version'] = ENROOT_VERSION
+            node.override['cluster']['enroot']['caps_base_url'] = base_url
+          end
+        end
+        cached(:resource) do
+          ConvergeEnroot.setup(chef_run)
+          chef_run.find_resource('enroot', 'setup')
+        end
+
+        it "uses '#{expected_caps_name}' in the caps filename" do
+          expected_filename = if debian
+                                "#{expected_caps_name}_#{ENROOT_VERSION}-1_#{arch_suffix}.#{ext}"
+                              else
+                                "#{expected_caps_name}-#{ENROOT_VERSION}-1#{rhel_suffix}.#{arch_suffix}.#{ext}"
+                              end
+          expect(resource.enroot_caps_url).to eq("#{base_url}/#{expected_filename}")
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
@@ -275,6 +275,73 @@ describe 'fabric_manager:configure' do
   end
 end
 
+# Tests for the NVIDIA library helper nvidia_package_url as exercised
+# through fabric_manager URL construction.
+#
+# Default S3 path:  {base_url}/{platform}/{filename}
+# Public repo path: {base_url}/{platform}/{arch}/{filename}
+describe 'fabric_manager_url construction' do
+  FM_S3_ARTIFACTS_URL = 'https://REGION-aws-parallelcluster.s3.REGION.AWS_DOMAIN'.freeze
+  FM_S3_BASE_URL = "#{FM_S3_ARTIFACTS_URL}/dependencies/nvidia_fabric".freeze
+  FM_PUBLIC_BASE_URL = 'https://fake-public.example.DOMAIN/compute/cuda/repos'.freeze
+  FM_DRIVER_VERSION = '999.99.99'.freeze
+
+  PLATFORM_DIRS_FM = {
+    'amazon2023' => 'rhel9', # FM AL2023 partial sets platform to 'rhel9'
+    'ubuntu22.04' => 'ubuntu2204',
+    'ubuntu24.04' => 'ubuntu2404',
+    'redhat8' => 'rhel8',
+    'redhat9' => 'rhel9',
+    'rocky8' => 'rhel8',
+    'rocky9' => 'rhel9',
+  }.freeze
+
+  for_all_oses do |platform, version|
+    debian = (platform == 'ubuntu')
+    ext = debian ? 'deb' : 'rpm'
+    package_join = debian ? '_' : '-' # filename joiner between package and version
+    arch_join = debian ? '_' : '.' # joiner between version-release and arch
+    expected_platform = PLATFORM_DIRS_FM["#{platform}#{version}"]
+
+    [false, true].each do |arm|
+      arch_suffix = if debian
+                      arm ? 'arm64' : 'amd64'
+                    else
+                      arm ? 'aarch64' : 'x86_64'
+                    end
+      package_filename = "nvidia-fabricmanager#{package_join}#{FM_DRIVER_VERSION}-1#{arch_join}#{arch_suffix}.#{ext}"
+
+      [
+        ['default S3 base_url',
+         FM_S3_BASE_URL,
+         "#{FM_S3_BASE_URL}/#{expected_platform}/#{package_filename}"],
+        ['overridden public base_url',
+         FM_PUBLIC_BASE_URL,
+         "#{FM_PUBLIC_BASE_URL}/#{expected_platform}/#{arm ? 'sbsa' : 'x86_64'}/#{package_filename}"],
+      ].each do |scenario, base_url, expected_source|
+        context "on #{platform}#{version} #{arm ? 'ARM' : 'x86_64'} with #{scenario}" do
+          cached(:chef_run) do
+            allow_any_instance_of(Object).to receive(:arm_instance?).and_return(arm)
+            runner(platform: platform, version: version, step_into: ['fabric_manager']) do |node|
+              node.override['cluster']['artifacts_s3_url'] = FM_S3_ARTIFACTS_URL
+              node.override['cluster']['nvidia']['fabricmanager']['base_url'] = base_url
+              node.override['cluster']['nvidia']['driver_version'] = FM_DRIVER_VERSION
+            end
+          end
+          cached(:resource) do
+            ConvergeFabricManager.setup(chef_run, nvidia_enabled: true)
+            chef_run.find_resource('fabric_manager', 'setup')
+          end
+
+          it 'builds the expected URL' do
+            expect(resource.fabric_manager_url).to eq(expected_source)
+          end
+        end
+      end
+    end
+  end
+end
+
 describe 'fabric_manager:enable_fabric_manager?' do
   cached(:fabric_manager_service) { 'nvidia-fabricmanager' }
   for_all_oses do |platform, version|

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_dcgm_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_dcgm_spec.rb
@@ -202,3 +202,76 @@ describe 'nvidia_dcgm:setup' do
     end
   end
 end
+
+# Tests for the NVIDIA library helpers nvidia_package_url and nvidia_repo_arch
+# as exercised through DCGM download URL construction.
+#
+# Helpers verified:
+#   - nvidia_package_url(base_url, platform, filename): builds {base_url}/{platform}/{filename}
+#     for the default S3 mirror and {base_url}/{platform}/{arch}/{filename} for the public
+#     NVIDIA repo.
+#   - nvidia_repo_arch: returns 'sbsa' for ARM and 'x86_64' for non-ARM.
+describe 'nvidia_dcgm download URL construction' do
+  S3_ARTIFACTS_URL = 'https://REGION-aws-parallelcluster.s3.REGION.AWS_DOMAIN'.freeze
+  S3_DCGM_BASE_URL = "#{S3_ARTIFACTS_URL}/dependencies/nvidia_dcgm".freeze
+  PUBLIC_NVIDIA_BASE_URL = 'https://fake-public.example.DOMAIN/compute/cuda/repos'.freeze
+  DCGM_VERSION = '9.9.9-1'.freeze # any non-3.x version exercises the 4-core / 4-cudaXX package path
+
+  PLATFORM_DIRS = {
+    'amazon2023' => 'amzn2023',
+    'ubuntu22.04' => 'ubuntu2204',
+    'ubuntu24.04' => 'ubuntu2404',
+    'redhat8' => 'rhel8',
+    'redhat9' => 'rhel9',
+    'rocky8' => 'rhel8',
+    'rocky9' => 'rhel9',
+  }.freeze
+
+  for_all_oses do |platform, version|
+    debian = (platform == 'ubuntu')
+    ext = debian ? 'deb' : 'rpm'
+    package_join = debian ? '_' : '-'
+    arch_join = debian ? '_' : '.'
+    expected_platform = PLATFORM_DIRS["#{platform}#{version}"]
+    expected_filename = "datacenter-gpu-manager-4-core-#{DCGM_VERSION}.#{ext}"
+
+    [false, true].each do |arm|
+      arch_suffix = if debian
+                      arm ? 'arm64' : 'amd64'
+                    else
+                      arm ? 'aarch64' : 'x86_64'
+                    end
+      package_filename = "datacenter-gpu-manager-4-core#{package_join}#{DCGM_VERSION}#{arch_join}#{arch_suffix}.#{ext}"
+
+      [
+        ['default S3 base_url',
+         S3_DCGM_BASE_URL,
+         "#{S3_DCGM_BASE_URL}/#{expected_platform}/#{package_filename}"],
+        ['overridden public base_url',
+         PUBLIC_NVIDIA_BASE_URL,
+         "#{PUBLIC_NVIDIA_BASE_URL}/#{expected_platform}/#{arm ? 'sbsa' : 'x86_64'}/#{package_filename}"],
+      ].each do |scenario, base_url, expected_source|
+        context "on #{platform}#{version} #{arm ? 'ARM' : 'x86_64'} with #{scenario}" do
+          cached(:chef_run) do
+            stubs_for_resource('nvidia_dcgm') do |res|
+              allow(res).to receive(:_nvidia_dcgm_enabled).and_return(true)
+            end
+            allow_any_instance_of(Object).to receive(:arm_instance?).and_return(arm)
+            runner = runner(platform: platform, version: version, step_into: ['nvidia_dcgm']) do |node|
+              node.override['cluster']['artifacts_s3_url'] = S3_ARTIFACTS_URL
+              node.override['cluster']['nvidia']['dcgm_base_url'] = base_url
+              node.override['cluster']['nvidia']['dcgm_version'] = DCGM_VERSION
+            end
+            ConvergeNvidiaDcgm.setup(runner, nvidia_enabled: true)
+          end
+
+          it 'downloads from the expected URL' do
+            expect(chef_run).to create_if_missing_remote_file(
+              "#{chef_run.node['cluster']['sources_dir']}/#{expected_filename}"
+            ).with(source: expected_source)
+          end
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
@@ -43,6 +43,41 @@ describe 'nvidia_driver:_nvidia_driver_version' do
   end
 end
 
+describe 'nvidia_driver:nvidia_driver_url' do
+  cached(:driver_version) { 'fake_driver_version' }
+  cached(:s3_base_url) { 'fake_s3_base_url/dependencies/nvidia_driver' }
+  cached(:public_base_url) { 'fake_public_nvidia_url/tesla' }
+
+  {
+    'default S3 base_url' => 'fake_s3_base_url/dependencies/nvidia_driver',
+    'base_url overridden to public NVIDIA Tesla URL' => 'fake_public_nvidia_url/tesla',
+  }.each do |scenario, base_url|
+    context "when driver_base_url is #{scenario}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(step_into: ['nvidia_driver']) do |node|
+          node.override['cluster']['nvidia']['driver_version'] = driver_version
+          node.override['cluster']['nvidia']['driver_base_url'] = base_url
+        end
+      end
+
+      cached(:resource) do
+        ConvergeNvidiaDriver.setup(chef_run)
+        chef_run.find_resource('nvidia_driver', 'setup')
+      end
+
+      it 'constructs URL using x86_64 for non-ARM' do
+        allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+        expect(resource.nvidia_driver_url).to eq("#{base_url}/NVIDIA-Linux-x86_64-#{driver_version}.run")
+      end
+
+      it 'constructs URL using aarch64 for ARM' do
+        allow_any_instance_of(Object).to receive(:arm_instance?).and_return(true)
+        expect(resource.nvidia_driver_url).to eq("#{base_url}/NVIDIA-Linux-aarch64-#{driver_version}.run")
+      end
+    end
+  end
+end
+
 describe 'nvidia_driver:nvidia_driver_enabled?' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
@@ -406,3 +406,74 @@ describe 'nvidia_imex:configure' do
     end
   end
 end
+
+# Tests for the NVIDIA library helper nvidia_package_url as exercised
+# through nvidia_imex URL construction.
+#
+# Default S3 path:  {base_url}/{platform}/{filename}
+# Public repo path: {base_url}/{platform}/{arch}/{filename}
+describe 'nvidia_imex_url construction' do
+  s3_imex_base_url = "#{cluster_artifacts_s3_url}/dependencies/nvidia_imex"
+  public_imex_base_url = 'https://fake-public.example.DOMAIN/compute/cuda/repos'
+
+  platform_dirs = {
+    'amazon2023' => 'amzn2023',
+    'ubuntu22.04' => 'ubuntu2204',
+    'ubuntu24.04' => 'ubuntu2404',
+    'redhat8' => 'rhel8',
+    'redhat9' => 'rhel9',
+    'rocky8' => 'rhel8',
+    'rocky9' => 'rhel9',
+  }.freeze
+
+  for_all_oses do |platform, version|
+    debian = (platform == 'ubuntu')
+    ext = debian ? 'deb' : 'rpm'
+    package_join = debian ? '_' : '-' # joiner between package name and version
+    arch_join = debian ? '_' : '.' # joiner between version-release and arch
+    expected_platform = platform_dirs["#{platform}#{version}"]
+
+    [false, true].each do |arm|
+      arch_suffix = if debian
+                      arm ? 'arm64' : 'amd64'
+                    else
+                      arm ? 'aarch64' : 'x86_64'
+                    end
+      package_filename = "nvidia-imex#{package_join}#{nvidia_version}-1#{arch_join}#{arch_suffix}.#{ext}"
+
+      [
+        ['default S3 base_url',
+         s3_imex_base_url,
+         "#{s3_imex_base_url}/#{expected_platform}/#{package_filename}"],
+        ['overridden public base_url',
+         public_imex_base_url,
+         "#{public_imex_base_url}/#{expected_platform}/#{arm ? 'sbsa' : 'x86_64'}/#{package_filename}"],
+      ].each do |scenario, base_url, expected_source|
+        context "on #{platform}#{version} #{arm ? 'ARM' : 'x86_64'} with #{scenario}" do
+          cached(:chef_run) do
+            stubs_for_resource('nvidia_imex') do |res|
+              allow(res).to receive(:nvidia_enabled_or_installed?).and_return(true)
+              allow(res).to receive(:imex_installed?).and_return(false)
+            end
+            allow_any_instance_of(Object).to receive(:arm_instance?).and_return(arm)
+            runner = runner(platform: platform, version: version, step_into: ['nvidia_imex']) do |node|
+              node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
+              node.override['cluster']['nvidia']['imex']['base_url'] = base_url
+              node.override['cluster']['nvidia']['driver_version'] = nvidia_version
+            end
+            runner.converge_dsl('aws-parallelcluster-platform') do
+              nvidia_imex 'install' do
+                action :install
+              end
+            end
+          end
+
+          it 'builds the expected URL' do
+            remote_file = chef_run.find_resource('remote_file', /nvidia-imex.*\.#{ext}/)
+            expect(remote_file.source.first).to eq(expected_source)
+          end
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
@@ -199,3 +199,76 @@ describe 'nvidia_nvlsm:install' do
     end
   end
 end
+
+# Tests for the NVIDIA library helpers nvidia_package_url and default_artifacts_url?
+# as exercised through nvidia_nvlsm URL construction and checksum verification.
+#
+# Default S3 path:   {base_url}/{platform}/{filename} (with checksum verification)
+# Public repo path:  {base_url}/{platform}/{arch}/{filename} (checksum skipped because
+# the test harness pre-computes checksums only for the S3-hosted artifacts)
+describe 'nvidia_nvlsm install URL and checksum override behavior' do
+  s3_nvlsm_base_url = "#{cluster_artifacts_s3_url}/dependencies/nvidia_nvlsm"
+  public_nvlsm_base_url = 'https://fake-public.example.DOMAIN/compute/cuda/repos'
+
+  for_all_oses do |platform, version|
+    debian = (platform == 'ubuntu')
+    ext = debian ? 'deb' : 'rpm'
+    package_join = debian ? '_' : '-'
+    arch_join = debian ? '_' : '.'
+    expected_platform = if platform == 'amazon'
+                          "amzn#{version}"
+                        elsif %w(redhat rocky).include?(platform)
+                          "rhel#{version}"
+                        else
+                          "#{platform}#{version.delete('.')}"
+                        end
+
+    %w(x86_64 aarch64).each do |arch|
+      arch_suffix = debian ? arch_suffix_debian[arch] : arch_suffix_rhel[arch]
+      package_filename = "nvlsm#{package_join}2025.03.9-1#{arch_join}#{arch_suffix}.#{ext}"
+
+      [
+        ['default S3 base_url',
+         s3_nvlsm_base_url,
+         "#{s3_nvlsm_base_url}/#{expected_platform}/#{package_filename}",
+         true],
+        ['overridden public base_url',
+         public_nvlsm_base_url,
+         "#{public_nvlsm_base_url}/#{expected_platform}/#{arch == 'aarch64' ? 'sbsa' : 'x86_64'}/#{package_filename}",
+         false],
+      ].each do |scenario, base_url, expected_source, checksum_expected|
+        context "on #{platform}#{version} #{arch} with #{scenario}" do
+          cached(:chef_run) do
+            stubs_for_resource('nvidia_nvlsm') do |res|
+              allow(res).to receive(:nvlsm_installation_enabled?).and_return(true)
+            end
+            runner = runner(platform: platform, version: version, step_into: ['nvidia_nvlsm']) do |node|
+              node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
+              node.override['cluster']['nvidia']['nvlsm']['base_url'] = base_url
+              node.override['cluster']['sources_dir'] = source_dir
+              node.automatic['kernel']['machine'] = arch
+            end
+            ConvergeNvidiaNvlsm.install(runner)
+          end
+
+          it 'builds the expected URL' do
+            remote_file = chef_run.find_resource('remote_file', "#{source_dir}/#{package_filename}")
+            expect(remote_file.source.first).to eq(expected_source)
+          end
+
+          if checksum_expected
+            it 'verifies checksum on default S3 download' do
+              remote_file = chef_run.find_resource('remote_file', "#{source_dir}/#{package_filename}")
+              expect(remote_file.checksum).not_to be_nil
+            end
+          else
+            it 'skips checksum when base_url is overridden' do
+              remote_file = chef_run.find_resource('remote_file', "#{source_dir}/#{package_filename}")
+              expect(remote_file.checksum).to be_nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/resources/install_pyenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/resources/install_pyenv_spec.rb
@@ -57,6 +57,43 @@ describe 'install_pyenv:run' do
         end
       end
 
+      context "when install_python_from_internet is enabled" do
+        cached(:python_version) { 'overridden_python_version' }
+        cached(:system_pyenv_root) { 'overridden_pyenv_root' }
+
+        def converge_with_region(platform, version, region, system_pyenv_root, python_version)
+          allow_any_instance_of(Object).to receive(:aws_region).and_return(region)
+          test_runner = runner(platform: platform, version: version, step_into: ['install_pyenv']) do |node|
+            node.override['cluster']['system_pyenv_root'] = system_pyenv_root
+            node.override['cluster']['python-version'] = python_version
+            node.override['cluster']['install_python_from_internet'] = true
+            node.override['cluster']['artifacts_s3_url'] = "https://bucket.s3.#{aws_domain}/archives"
+          end
+          ConvergeInstallPyenv.run(test_runner)
+          test_runner
+        end
+
+        context "in a non-isolated region" do
+          cached(:chef_run) { converge_with_region(platform, version, "us-east-1", system_pyenv_root, python_version) }
+
+          it 'downloads python tarball from python.org instead of S3' do
+            is_expected.to create_if_missing_remote_file("#{system_pyenv_root}/Python-#{python_version}.tgz").with(
+              source: "https://www.python.org/ftp/python/#{python_version}/Python-#{python_version}.tgz"
+            )
+          end
+        end
+
+        context "in an isolated region (us-iso)" do
+          cached(:chef_run) { converge_with_region(platform, version, "us-iso-east-1", system_pyenv_root, python_version) }
+
+          it 'still uses S3 (python.org is not reachable from isolated regions)' do
+            is_expected.to create_if_missing_remote_file("#{system_pyenv_root}/Python-#{python_version}.tgz").with(
+              source: "#{chef_run.node['cluster']['artifacts_s3_url']}/dependencies/python/Python-#{python_version}.tgz"
+            )
+          end
+        end
+      end
+
       context "when python version and pyenv root are set" do
         cached(:python_version) { 'python_version_parameter' }
         cached(:system_pyenv_root) { 'pyenv_root_parameter' }

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -28,6 +28,10 @@ default['cluster']['pyxis']['version'] = '0.20.0'
 default['cluster']['pyxis']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/pyxis"
 default['cluster']['pyxis']['runtime_path'] = '/run/pyxis'
 
+# HTTP Parser (only needed on AL2023)
+default['cluster']['http_parser']['version'] = '2.9.4'
+default['cluster']['http_parser']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/http_parser"
+
 # Block Topology Plugin
 default['cluster']['slurm']['block_topology']['force_configuration'] = false
 default['cluster']['p6egb200_block_sizes'] = nil

--- a/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/slurm_attributes.rb
@@ -25,6 +25,7 @@ default['cluster']['slurm']['spank_config_dir'] = "#{node['cluster']['slurm']['i
 
 # Pyxis
 default['cluster']['pyxis']['version'] = '0.20.0'
+default['cluster']['pyxis']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/pyxis"
 default['cluster']['pyxis']['runtime_path'] = '/run/pyxis'
 
 # Block Topology Plugin

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pyxis.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pyxis.rb
@@ -19,7 +19,7 @@ return unless nvidia_enabled? || nvidia_installed?
 return if pyxis_installed?
 
 pyxis_version = node['cluster']['pyxis']['version']
-pyxis_url = "#{node['cluster']['artifacts_s3_url']}/dependencies/pyxis/v#{pyxis_version}.tar.gz"
+pyxis_url = "#{node['cluster']['pyxis']['base_url']}/v#{pyxis_version}.tar.gz"
 pyxis_tarball = "#{node['cluster']['sources_dir']}/pyxis-#{pyxis_version}.tar.gz"
 
 spank_examples_dir = "#{node['cluster']['examples_dir']}/spank"

--- a/cookbooks/aws-parallelcluster-slurm/resources/slurm_dependencies/slurm_dependencies_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/slurm_dependencies/slurm_dependencies_alinux2023.rb
@@ -14,10 +14,6 @@ end
 
 use 'partial/_slurm_dependencies_common'
 
-http_parser_version = "2.9.4"
-http_parser_url = "#{node['cluster']['artifacts_s3_url']}/dependencies/http_parser/v#{http_parser_version}.tar.gz"
-http_parser_tarball = "#{node['cluster']['sources_dir']}/http-parser-#{http_parser_version}.tar.gz"
-
 def dependencies
   %w(json-c-devel perl perl-Switch lua-devel dbus-devel)
 end
@@ -29,8 +25,14 @@ action :install_extra_dependencies do
   # We install into /usr (LIBDIR=/usr/lib64) so the shared library lands in the dynamic linker's
   # default search path.
 
-  remote_file "#{http_parser_tarball}" do
-    source "#{http_parser_url}"
+  # Construct URLs inside the action so that node attribute overrides (e.g. via
+  # ExtraChefAttributes) take effect at runtime.
+  http_parser_version = node['cluster']['http_parser']['version']
+  http_parser_url = "#{node['cluster']['http_parser']['base_url']}/v#{http_parser_version}.tar.gz"
+  http_parser_tarball = "#{node['cluster']['sources_dir']}/http-parser-#{http_parser_version}.tar.gz"
+
+  remote_file http_parser_tarball do
+    source http_parser_url
     mode '0644'
     retries 3
     retry_delay 5
@@ -40,7 +42,7 @@ action :install_extra_dependencies do
   bash 'make install' do
     user 'root'
     group 'root'
-    cwd "#{node['cluster']['sources_dir']}"
+    cwd node['cluster']['sources_dir']
     code <<-HTTP
       set -e
       tar xf #{http_parser_tarball}

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_http_parser_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_http_parser_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Copyright:: 2026 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+# http_parser is only installed on AL2023 via slurm_dependencies_alinux2023
+describe 'aws-parallelcluster-slurm http_parser base_url' do
+  context "on amazon 2023" do
+    cached(:cluster_artifacts_s3_url) { 'https://fake-s3-url' }
+    cached(:cluster_sources_dir) { '/fake/sources/dir' }
+    cached(:http_parser_version) { 'fake_http_parser_version' }
+    cached(:default_base_url) { "#{cluster_artifacts_s3_url}/dependencies/http_parser" }
+
+    {
+      'default S3 base_url' => nil,
+      'base_url overridden via ExtraChefAttributes' => 'https://fake-public-http-parser-url',
+    }.each do |scenario, override_url|
+      context "when #{scenario}" do
+        cached(:expected_base_url) { override_url || default_base_url }
+        cached(:chef_run) do
+          test_runner = runner(platform: 'amazon', version: '2023', step_into: ['slurm_dependencies']) do |node|
+            node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
+            node.override['cluster']['sources_dir'] = cluster_sources_dir
+            node.override['cluster']['http_parser']['version'] = http_parser_version
+            node.override['cluster']['http_parser']['base_url'] = override_url if override_url
+          end
+          test_runner.converge_dsl('aws-parallelcluster-slurm') do
+            slurm_dependencies 'install' do
+              action :install_extra_dependencies
+            end
+          end
+        end
+
+        it 'downloads http_parser from the expected URL' do
+          is_expected.to create_if_missing_remote_file("#{cluster_sources_dir}/http-parser-#{http_parser_version}.tar.gz").with(
+            source: "#{expected_base_url}/v#{http_parser_version}.tar.gz"
+          )
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_jwt_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_jwt_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright:: 2024 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+# Copyright:: 2026 Amazon.com, Inc. and its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -20,35 +20,43 @@ describe 'aws-parallelcluster-slurm::install_jwt' do
       cached(:cluster_sources_dir) { '/path/to/cluster/sources/dir' }
       cached(:jwt_version) { '1.2.3' }
       cached(:jwt_checksum) { 'somechecksum' }
+      cached(:default_base_url) { "#{cluster_artifacts_s3_url}/dependencies/jwt" }
 
-      cached(:chef_run) do
-        runner = runner(platform: platform, version: version) do |node|
-          RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+      {
+        'default S3 base_url' => nil,
+        'base_url overridden via ExtraChefAttributes' => 'https://fake-public.example.DOMAIN/libjwt',
+      }.each do |scenario, override_url|
+        context "when #{scenario}" do
+          cached(:expected_base_url) { override_url || default_base_url }
+          cached(:chef_run) do
+            runner = runner(platform: platform, version: version) do |node|
+              RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-          node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
-          node.override['cluster']['sources_dir'] = cluster_sources_dir
-          node.override['cluster']['jwt']['version'] = jwt_version
-          node.override['cluster']['jwt']['sha256'] = jwt_checksum
-        end
-        allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
-        runner.converge(described_recipe)
-      end
+              node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
+              node.override['cluster']['sources_dir'] = cluster_sources_dir
+              node.override['cluster']['jwt']['version'] = jwt_version
+              node.override['cluster']['jwt']['sha256'] = jwt_checksum
+              node.override['cluster']['jwt']['base_url'] = override_url if override_url
+            end
+            allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
+            runner.converge(described_recipe)
+          end
 
-      it 'downloads libjwt' do
-        is_expected.to create_if_missing_remote_file("#{cluster_sources_dir}/libjwt-#{jwt_version}.tar.gz").with(
-          source: "#{cluster_artifacts_s3_url}/dependencies/jwt/v#{jwt_version}.tar.gz",
-          mode: '0644',
-          retries: 3,
-          retry_delay: 5,
-          checksum: jwt_checksum
-        )
-      end
+          it 'downloads libjwt from the expected URL' do
+            is_expected.to create_if_missing_remote_file("#{cluster_sources_dir}/libjwt-#{jwt_version}.tar.gz").with(
+              source: "#{expected_base_url}/v#{jwt_version}.tar.gz",
+              mode: '0644',
+              retries: 3,
+              retry_delay: 5,
+              checksum: jwt_checksum
+            )
+          end
 
-      it 'installs libjwt' do
-        is_expected.to run_bash('libjwt').with(
-          user: 'root',
-          group: 'root',
-          code: <<-CODE
+          it 'installs libjwt' do
+            is_expected.to run_bash('libjwt').with(
+              user: 'root',
+              group: 'root',
+              code: <<-CODE
     set -e
     tar xf #{"#{cluster_sources_dir}/libjwt-#{jwt_version}.tar.gz"} --no-same-owner
     cd libjwt-#{jwt_version}
@@ -57,8 +65,10 @@ describe 'aws-parallelcluster-slurm::install_jwt' do
     CORES=$(grep processor /proc/cpuinfo | wc -l)
     make -j $CORES
     sudo make install
-          CODE
-        )
+              CODE
+            )
+          end
+        end
       end
     end
   end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_pmix_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_pmix_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Copyright:: 2026 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::install_pmix' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:cluster_artifacts_s3_url) { 'https://fake-s3-url' }
+      cached(:cluster_sources_dir) { '/fake/sources/dir' }
+      cached(:pmix_version) { 'fake_pmix_version' }
+      cached(:pmix_sha256) { 'fake_pmix_sha256' }
+      cached(:default_base_url) { "#{cluster_artifacts_s3_url}/dependencies/pmix" }
+
+      {
+        'default S3 base_url' => nil,
+        'base_url overridden via ExtraChefAttributes' => 'https://fake-public-pmix-url',
+      }.each do |scenario, override_url|
+        context "when #{scenario}" do
+          cached(:expected_base_url) { override_url || default_base_url }
+          cached(:chef_run) do
+            runner(platform: platform, version: version) do |node|
+              node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
+              node.override['cluster']['sources_dir'] = cluster_sources_dir
+              node.override['cluster']['pmix']['version'] = pmix_version
+              node.override['cluster']['pmix']['sha256'] = pmix_sha256
+              node.override['cluster']['pmix']['base_url'] = override_url if override_url
+            end.converge(described_recipe)
+          end
+
+          it 'downloads PMIx tarball from the expected URL' do
+            is_expected.to create_if_missing_remote_file("#{cluster_sources_dir}/pmix-#{pmix_version}.tar.gz").with(
+              source: "#{expected_base_url}/pmix-#{pmix_version}.tar.gz"
+            )
+          end
+
+          it 'installs PMIx' do
+            is_expected.to run_bash('Install PMIx').with(user: 'root', group: 'root')
+          end
+
+          it 'creates the PMIx ld.so.conf file' do
+            is_expected.to create_cookbook_file('/etc/ld.so.conf.d/pmix.conf').with(
+              source: 'pmix/ld.so.conf.d/pmix.conf',
+              owner: 'root',
+              group: 'root',
+              mode: '0644'
+            )
+          end
+
+          it 'runs ldconfig to refresh the runtime loader cache' do
+            is_expected.to run_execute('ldconfig').with(user: 'root')
+          end
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_pyxis_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_pyxis_spec.rb
@@ -22,71 +22,82 @@ describe 'aws-parallelcluster-slurm::install_pyxis' do
       cached(:slurm_install_dir) { '/path/to/slurm/install/dir' }
       cached(:pyxis_version) { '1.2.3' }
       cached(:pyxis_runtime_dir) { '/path/to/pyxis/runtime/dir' }
-      cached(:chef_run) do
-        runner = runner(platform: platform, version: version) do |node|
-          RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+      cached(:default_base_url) { "#{cluster_artifacts_s3_url}/dependencies/pyxis" }
 
-          node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
-          node.override['cluster']['sources_dir'] = cluster_sources_dir
-          node.override['cluster']['examples_dir'] = cluster_examples_dir
-          node.override['cluster']['slurm']['install_dir'] = slurm_install_dir
-          node.override['cluster']['pyxis']['version'] = pyxis_version
-          node.override['cluster']['pyxis']['runtime_path'] = pyxis_runtime_dir
-        end
-        allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
-        allow_any_instance_of(Object).to receive(:nvidia_installed?).and_return(true)
-        allow_any_instance_of(Object).to receive(:pyxis_installed?).and_return(false)
-        runner.converge(described_recipe)
-      end
+      {
+        'default S3 base_url' => nil,
+        'base_url overridden via ExtraChefAttributes' => 'https://fake-public.example.DOMAIN/pyxis',
+      }.each do |scenario, override_url|
+        context "when #{scenario}" do
+          cached(:expected_base_url) { override_url || default_base_url }
+          cached(:chef_run) do
+            runner = runner(platform: platform, version: version) do |node|
+              RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
-      it 'downloads Pyxis tarball' do
-        is_expected.to create_if_missing_remote_file("#{cluster_sources_dir}/pyxis-#{pyxis_version}.tar.gz").with(
-          source: "#{cluster_artifacts_s3_url}/dependencies/pyxis/v#{pyxis_version}.tar.gz",
-          mode: '0644',
-          retries: 3,
-          retry_delay: 5
-        )
-      end
+              node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
+              node.override['cluster']['sources_dir'] = cluster_sources_dir
+              node.override['cluster']['examples_dir'] = cluster_examples_dir
+              node.override['cluster']['slurm']['install_dir'] = slurm_install_dir
+              node.override['cluster']['pyxis']['version'] = pyxis_version
+              node.override['cluster']['pyxis']['runtime_path'] = pyxis_runtime_dir
+              node.override['cluster']['pyxis']['base_url'] = override_url if override_url
+            end
+            allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
+            allow_any_instance_of(Object).to receive(:nvidia_installed?).and_return(true)
+            allow_any_instance_of(Object).to receive(:pyxis_installed?).and_return(false)
+            runner.converge(described_recipe)
+          end
 
-      it 'install Pyxis' do
-        is_expected.to run_bash('Install pyxis').with(
-          user: 'root',
-          retries: 3,
-          retry_delay: 5,
-          code: <<-CODE
+          it 'downloads Pyxis tarball from the expected URL' do
+            is_expected.to create_if_missing_remote_file("#{cluster_sources_dir}/pyxis-#{pyxis_version}.tar.gz").with(
+              source: "#{expected_base_url}/v#{pyxis_version}.tar.gz",
+              mode: '0644',
+              retries: 3,
+              retry_delay: 5
+            )
+          end
+
+          it 'install Pyxis' do
+            is_expected.to run_bash('Install pyxis').with(
+              user: 'root',
+              retries: 3,
+              retry_delay: 5,
+              code: <<-CODE
     set -e
     tar xf #{cluster_sources_dir}/pyxis-#{pyxis_version}.tar.gz -C /tmp
     cd /tmp/pyxis-#{pyxis_version}
     CPPFLAGS='-I #{slurm_install_dir}/include/' make
     CPPFLAGS='-I #{slurm_install_dir}/include/' make install
-          CODE
-        )
-      end
+              CODE
+            )
+          end
 
-      it 'creates the Spank examples directory' do
-        is_expected.to create_directory("#{cluster_examples_dir}/spank")
-      end
+          it 'creates the Spank examples directory' do
+            is_expected.to create_directory("#{cluster_examples_dir}/spank")
+          end
 
-      it 'creates the Spank example configuration' do
-        is_expected.to create_template("#{cluster_examples_dir}/spank/plugstack.conf").with(
-          source: 'pyxis/plugstack.conf.erb',
-          owner: 'root',
-          group: 'root',
-          mode: '0644'
-        )
-      end
+          it 'creates the Spank example configuration' do
+            is_expected.to create_template("#{cluster_examples_dir}/spank/plugstack.conf").with(
+              source: 'pyxis/plugstack.conf.erb',
+              owner: 'root',
+              group: 'root',
+              mode: '0644'
+            )
+          end
 
-      it 'creates the Pyxis examples directory' do
-        is_expected.to create_directory("#{cluster_examples_dir}/pyxis")
-      end
+          it 'creates the Pyxis examples directory' do
+            is_expected.to create_directory("#{cluster_examples_dir}/pyxis")
+          end
 
-      it 'creates the Pyxis example configuration' do
-        is_expected.to create_template("#{cluster_examples_dir}/pyxis/pyxis.conf").with(
-          source: 'pyxis/pyxis.conf.erb',
-          owner: 'root',
-          group: 'root',
-          mode: '0644'
-        )
+          it 'creates the Pyxis example configuration' do
+            is_expected.to create_template("#{cluster_examples_dir}/pyxis/pyxis.conf").with(
+              source: 'pyxis/pyxis.conf.erb',
+              owner: 'root',
+              group: 'root',
+              mode: '0644'
+            )
+          end
+        end
       end
 
       context "when Pyxis is already installed" do


### PR DESCRIPTION
### Description of changes


Make ParallelCluster's third-party dependency downloads override-aware (through ExtraChefAttributes) so that we can upgrade dependencies by redirecting to an alternative source (typically the upstream public repo or GitHub release) without affecting the other dependencies.



## Why

Today, dependency download URLs are hardcoded against `node['cluster']['artifacts_s3_url']`. We need to test new dependency versions before mirroring them to the ParallelCluster S3 bucket, but overriding `artifacts_s3_url` is too coarse — it would redirect every dependency, not just the one being tested.

This change introduces per-dependency `base_url` (and where applicable, `version` and `sha`) Chef attributes that can be overridden via ExtraChefAttributes. Each download URL is built from the dependency-specific attribute, so we can override exactly one dependency at a time.

## What's in this PR

### Phase 1 — standalone dependencies

These dependencies are downloaded from a single URL pattern and don't need any helper logic to switch between S3 and a public repo.

- **EFS-utils** — add `efs_utils.base_url` attribute
- **Pyxis** — add `pyxis.base_url` attribute
- **HTTP parser** — add `http_parser.base_url` and `http_parser.version` attributes
- **pyenv** — add unit test for ExtraChefAttributes override scenario since they already have Chef attributes
- **libjwt** — add unit test for ExtraChefAttributes override scenario since they already have Chef attributes
- **PMIx** — add unit test for ExtraChefAttributes override scenario since they already have Chef attributes
- **CUDA** — add `nvidia.cuda.base_url`, `nvidia.cuda.samples_base_url`, `nvidia.cuda.version`, and `nvidia.cuda.driver_version_suffix` attributes; remove the hardcoded version-suffix lookup table
- **NVIDIA driver** — add `nvidia.driver_base_url` attribute (URL pattern is identical between S3 and the public Tesla URL, so no helper needed)

### Phase 2 — NVIDIA library helpers + repo-aware dependencies

The NVIDIA public repo uses a different URL layout than the ParallelCluster S3 buckets — packages live under `{platform}/{arch}/{filename}` instead of `{platform}/{filename}`. To keep the overhead in one place, three helpers are added to `cookbooks/aws-parallelcluster-platform/libraries/nvidia.rb`:

- `default_artifacts_url?(base_url)` — detects whether a given `base_url` still points at the ParallelCluster S3 mirror.
- `nvidia_repo_arch` — returns `'sbsa'` for ARM and `'x86_64'` otherwise (NVIDIA repo arch convention).
- `nvidia_package_url(base_url, platform, filename)` — builds `{base_url}/{platform}/{filename}` for the S3 mirror and `{base_url}/{platform}/{arch}/{filename}` for the public NVIDIA repo.

Each NVIDIA dependency is updated to switch URL construction to `nvidia_package_url`, paired with a per-dependency `base_url` attribute:

- **DCGM** — `nvidia.dcgm_base_url`
- **Enroot caps** — `enroot.caps_base_url`. Also detects the package-name swap (`enroot-caps` on S3 vs `enroot+caps` on the public repo) via `default_artifacts_url?`.
- **Fabric Manager** — `nvidia.fabricmanager.base_url`
- **NVIDIA IMEX** — `nvidia.imex.base_url`
- **NVLSM** — `nvidia.nvlsm.base_url` and `nvidia.nvlsm.version` (previously hardcoded). Checksum verification is skipped when the `base_url` is overridden, since checksums are pre-computed only for the S3-hosted artifacts.



## Tests

Each updated resource has unit tests added that cover, for every supported OS:
- both x86_64 and aarch64 architectures
- both default S3 and overridden public `base_url` scenarios
- where applicable: filename swaps (enroot caps), checksum-skip behavior (NVLSM), and resource integration (IMEX, NVLSM)

NVIDIA library helpers themselves are exercised through the resource-driven tests; the `nvidia_enabled?` parameterized values are covered separately in `spec/unit/libraries/nvidia_spec.rb`.

* Build image to test default behavour successful

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
