### PR TITLE
[Test] Package fftw* now installed on Rocky9 because GNOME (installed…

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
@@ -20,9 +20,11 @@ control 'tag:install_install_packages' do
   end unless instance.custom_ami? || os_properties.alinux2023? || os_properties.ubuntu2404?
   # Need to change the jq --argfile commands as its deprecated in 1.7( latest)
 
-  # NOTE: Skipped on AL2023 because the Desktop group (installed for DCV) now pulls in
-  # ImageMagick-libs which depends on fftw-libs-double
-  unless os_properties.alinux2023?
+  # NOTE: Skipped where the desktop group (@gnome, installed for DCV) transitively
+  # pulls in FFTW:
+  #   - AL2023: via ImageMagick-libs (fftw-libs-double)
+  #   - Rocky9: via pipewire-libs (fftw-libs-single)
+  unless os_properties.alinux2023? || os_properties.rocky?
     # Verify fftw package is not installed
     describe bash('ls 2>/dev/null /usr/lib64/libfftw*') do
       its('stdout') { should be_empty }


### PR DESCRIPTION
### Description of changes
Package fftw* now installed on Rocky9 because GNOME (installed for DCV) now pulls it in through pipewire-libs.
We did the same when it happened for AL2023 https://github.com/aws/aws-parallelcluster-cookbook/commit/844b8276.

The chain:

```
[root@ip-27-6-29-128 ~]# sudo docker run --rm rockylinux:9 bash -c "dnf -y install @gnome >/dev/null 2>&1; echo '=== whatrequires (resolves sonames) ==='; dnf repoquery --installed --whatrequires fftw-libs-single --qf '%{name}'"
=== whatrequires (resolves sonames) ===
Failed loading plugin "notify_packagekit": No module named 'dnfpluginscore'
pipewire-libs
[root@ip-27-6-29-128 ~]# sudo docker run --rm rockylinux:9 bash -c "dnf -y install @gnome >/dev/null 2>&1; echo '=== requires pipewire-libs ==='; dnf repoquery --installed --whatrequires pipewire-libs --qf '%{name}'"
=== requires pipewire-libs ===
Failed loading plugin "notify_packagekit": No module named 'dnfpluginscore'
gnome-remote-desktop
mutter
pipewire
pipewire-alsa
pipewire-gstreamer
pipewire-jack-audio-connection-kit-libs
pipewire-pulseaudio
wireplumber
wireplumber-libs
xdg-desktop-portal
```

### Tests
Pr check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
