### PR TITLE
[Test] Fix kitchen test failure caused by `instance` resource usage

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/dcv_spec.rb
@@ -214,8 +214,10 @@ control 'tag:config_dcv_correctly_configured' do
     it { should be_grouped_into 'root' }
     it { should be_mode 0755 }
 
-    unless instance.graphic? && instance.nvidia_installed? && instance.dcv_gpu_accel_supported?
-      its('content') { should match /enable-gl-in-virtual-sessions\s*=\s*"always-off"/ }
+    it 'should disable GL in virtual sessions when GPU acceleration is not supported' do
+      unless instance.graphic? && instance.nvidia_installed? && instance.dcv_gpu_accel_supported?
+        expect(subject.content).to match(/enable-gl-in-virtual-sessions\s*=\s*"always-off"/)
+      end
     end
   end
 


### PR DESCRIPTION
### Description of changes
https://github.com/aws/aws-parallelcluster-cookbook/pull/3156 introduced an `unless instance.graphic? && ...` conditional inside a `describe` block in dcv_spec.rb. This calls the custom InSpec resource `instance` at the RSpec example group level, where RSpec's own built-in `instance` method takes precedence and raises:
```
  `instance` is not available on an example group (e.g. a `describe` or
  `context` block). It is only available from within individual examples
  (e.g. `it` blocks) or from constructs that run in the scope of an
  example (e.g. `before`, `let`, etc).
```
The fix moves the conditional into an `it` block where InSpec custom resources are properly resolved.

This only affected head node kitchen tests on EC2 because the DCV control's `only_if` evaluates to true only on head nodes on EC2.

### Tests
* Tests will run after the PR is merged

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
