### PR TITLE
[Selinux] Disable SELinux via grubby on kernels >= 6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ via custom Slurm settings or the cluster name contains upper-case letters.
 - Fix slurmrestd failing to start on AL2023 because the http-parser library was not discoverable by the dynamic linker.
 - Fix compute node bootstrap hanging without a clear error when the compute subnet cannot reach DynamoDB.
 - Fix login nodes not mounting `/opt/parallelcluster/shared` when EFS is used as the internal shared storage type.
+- Fix SELinux not actually being disabled on RHEL-family OSes (kernels >= 6.4) due to a [deprecated mechanism](https://github.com/SELinuxProject/selinux-kernel/wiki/DEPRECATE-runtime-disable) being silently ignored by newer kernels.
 
 **DEPRECATIONS**
 - Amazon Linux 2 is no longer supported.

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/disable_selinux.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/disable_selinux.rb
@@ -33,10 +33,18 @@ execute 'disable selinux via grubby' do
 end
 
 # Persist selinux=0 in /etc/default/grub so the setting survives any later
-# grub2-mkconfig regeneration. Required on AL2023 / RHEL8 x86_64 where the
-# c_states resource regenerates BLS entries after this recipe runs and would
-# otherwise restore selinux=1 from /etc/default/grub.
-execute 'persist selinux=0 in /etc/default/grub' do
+# grub2-mkconfig regeneration and kernel updates that create new BLS entries.
+# Required on AL2023 / RHEL8 x86_64 (c_states regenerates BLS) and on all
+# OSes long-term (kernel updates create new BLS entries from this template).
+
+# Replace selinux=1 with selinux=0 if present (AL2023, RHEL/Rocky 8).
+execute 'replace selinux=1 in /etc/default/grub' do
   command 'sed -i -E \'/^GRUB_CMDLINE_LINUX(_DEFAULT)?=/ s/selinux=1/selinux=0/g\' /etc/default/grub'
   only_if 'grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1" /etc/default/grub'
+end
+
+# Append selinux=0 if no selinux= is present on the line (Rocky9).
+execute 'append selinux=0 to /etc/default/grub' do
+  command 'sed -i -E \'/^GRUB_CMDLINE_LINUX(_DEFAULT)?=/ {/selinux=/!s/"$/ selinux=0"/}\' /etc/default/grub'
+  not_if 'grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=" /etc/default/grub'
 end

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/disable_selinux.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/disable_selinux.rb
@@ -12,7 +12,31 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+# Skip Docker — Grubby is not installed; so no real kernel cmdline to modify.
+# Skip Debian/Ubuntu — they use AppArmor by default and do not ship SELinux.
+# packages/policies, so this recipe is a no-op there.
+return if on_docker? || platform_family?('debian')
+
+# Persist SELINUX=disabled to /etc/selinux/config. Honored on RHEL 8 / Rocky 8
+# (kernel 4.18); silently ignored on kernels >= 6.4 (AL2023 6.12, RHEL 9 / Rocky 9 - 5.14).
+# See: https://github.com/SELinuxProject/selinux-kernel/wiki/DEPRECATE-runtime-disable
 selinux_state "SELinux Disabled" do
   action :disabled
   only_if 'which getenforce'
+end
+
+# Disable SELinux on the kernel cmdline via grubby — the kernel-recommended
+# method that works on all RHEL-family kernels.
+execute 'disable selinux via grubby' do
+  command 'grubby --update-kernel=ALL --args="selinux=0"'
+  not_if 'grubby --info=ALL | grep -q "selinux=0"'
+end
+
+# Persist selinux=0 in /etc/default/grub so the setting survives any later
+# grub2-mkconfig regeneration. Required on AL2023 / RHEL8 x86_64 where the
+# c_states resource regenerates BLS entries after this recipe runs and would
+# otherwise restore selinux=1 from /etc/default/grub.
+execute 'persist selinux=0 in /etc/default/grub' do
+  command 'sed -i -E \'/^GRUB_CMDLINE_LINUX(_DEFAULT)?=/ s/selinux=1/selinux=0/g\' /etc/default/grub'
+  only_if 'grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1" /etc/default/grub'
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_selinux_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_selinux_spec.rb
@@ -8,6 +8,7 @@ describe 'aws-parallelcluster-platform::disable_selinux' do
         stub_command('which getenforce').and_return('/usr/sbin/getenforce')
         stub_command('grubby --info=ALL | grep -q "selinux=0"').and_return(false)
         stub_command('grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1" /etc/default/grub').and_return(true)
+        stub_command('grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=" /etc/default/grub').and_return(false)
         # The recipe early-returns on Docker; force false to exercise the real branch.
         allow_any_instance_of(Chef::Recipe).to receive(:on_docker?).and_return(false)
 
@@ -18,7 +19,8 @@ describe 'aws-parallelcluster-platform::disable_selinux' do
         it 'is a no-op on Debian-family OSes' do
           is_expected.not_to disabled_selinux_state('SELinux Disabled')
           is_expected.not_to run_execute('disable selinux via grubby')
-          is_expected.not_to run_execute('persist selinux=0 in /etc/default/grub')
+          is_expected.not_to run_execute('replace selinux=1 in /etc/default/grub')
+          is_expected.not_to run_execute('append selinux=0 to /etc/default/grub')
         end
       else
         it 'disables SELinux via the selinux_state resource' do
@@ -30,9 +32,14 @@ describe 'aws-parallelcluster-platform::disable_selinux' do
             .with_command('grubby --update-kernel=ALL --args="selinux=0"')
         end
 
-        it 'persists selinux=0 in /etc/default/grub' do
-          is_expected.to run_execute('persist selinux=0 in /etc/default/grub')
+        it 'replaces selinux=1 in /etc/default/grub' do
+          is_expected.to run_execute('replace selinux=1 in /etc/default/grub')
             .with_command(%q(sed -i -E '/^GRUB_CMDLINE_LINUX(_DEFAULT)?=/ s/selinux=1/selinux=0/g' /etc/default/grub))
+        end
+
+        it 'appends selinux=0 to /etc/default/grub' do
+          is_expected.to run_execute('append selinux=0 to /etc/default/grub')
+            .with_command(%q(sed -i -E '/^GRUB_CMDLINE_LINUX(_DEFAULT)?=/ {/selinux=/!s/"$/ selinux=0"/}' /etc/default/grub))
         end
       end
     end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_selinux_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_selinux_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-platform::disable_selinux' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        # Stub guards so ChefSpec doesn't shell out during converge.
+        stub_command('which getenforce').and_return('/usr/sbin/getenforce')
+        stub_command('grubby --info=ALL | grep -q "selinux=0"').and_return(false)
+        stub_command('grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1" /etc/default/grub').and_return(true)
+        # The recipe early-returns on Docker; force false to exercise the real branch.
+        allow_any_instance_of(Chef::Recipe).to receive(:on_docker?).and_return(false)
+
+        ChefSpec::Runner.new(platform: platform, version: version).converge(described_recipe)
+      end
+
+      if platform == 'ubuntu'
+        it 'is a no-op on Debian-family OSes' do
+          is_expected.not_to disabled_selinux_state('SELinux Disabled')
+          is_expected.not_to run_execute('disable selinux via grubby')
+          is_expected.not_to run_execute('persist selinux=0 in /etc/default/grub')
+        end
+      else
+        it 'disables SELinux via the selinux_state resource' do
+          is_expected.to disabled_selinux_state('SELinux Disabled')
+        end
+
+        it 'disables SELinux via grubby' do
+          is_expected.to run_execute('disable selinux via grubby')
+            .with_command('grubby --update-kernel=ALL --args="selinux=0"')
+        end
+
+        it 'persists selinux=0 in /etc/default/grub' do
+          is_expected.to run_execute('persist selinux=0 in /etc/default/grub')
+            .with_command(%q(sed -i -E '/^GRUB_CMDLINE_LINUX(_DEFAULT)?=/ s/selinux=1/selinux=0/g' /etc/default/grub))
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -402,6 +402,7 @@ describe 'dcv:setup' do
           stub_command('which getenforce').and_return(true)
           stub_command('grubby --info=ALL | grep -q "selinux=0"').and_return(false)
           stub_command('grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1" /etc/default/grub').and_return(false)
+          stub_command('grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=" /etc/default/grub').and_return(true)
           allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
           allow(::File).to receive(:exist?).with('/etc/dcv/dcv.conf').and_return(false)
           allow(::File).to receive(:exist?).with(dcv_tarball).and_return(false)

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -400,6 +400,8 @@ describe 'dcv:setup' do
       cached(:method_setup) do
         lambda {
           stub_command('which getenforce').and_return(true)
+          stub_command('grubby --info=ALL | grep -q "selinux=0"').and_return(false)
+          stub_command('grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1" /etc/default/grub').and_return(false)
           allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
           allow(::File).to receive(:exist?).with('/etc/dcv/dcv.conf').and_return(false)
           allow(::File).to receive(:exist?).with(dcv_tarball).and_return(false)

--- a/cookbooks/aws-parallelcluster-platform/test/controls/disable_selinux_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/disable_selinux_spec.rb
@@ -9,18 +9,37 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+# SELinux exists only on RHEL-family OSes. Skip Docker because the test
+# container has no real kernel cmdline and grubby is not installed.
+selinux_applies = (os_properties.alinux2023? || os_properties.redhat? || os_properties.rocky?) && !os_properties.on_docker?
+
 control 'tag:install_selinux_disabled' do
   title 'Check if selinux is disabled'
   describe selinux do
     it { should be_disabled }
     it { should_not be_enforcing }
   end unless os_properties.alinux2023? || os_properties.redhat? || os_properties.rocky? # Because it requires reboot of the instance
+
+  # Verify selinux=0 is configured (and selinux=1 removed) in the bootloader
+  # before reboot — works on kernels >= 6.4 where /etc/selinux/config is ignored.
+  describe command('grubby --info=ALL') do
+    its('stdout') { should match(/selinux=0/) }
+    its('stdout') { should_not match(/selinux=1/) }
+  end if selinux_applies
 end
 
 control 'tag:testami_selinux_disabled' do
   title 'Check if selinux is disabled'
+
   describe selinux do
     it { should be_disabled }
     it { should_not be_enforcing }
-  end
+  end if selinux_applies
+
+  # After reboot, verify the active kernel cmdline. Catches the "half-disabled"
+  # state where /etc/selinux/config says disabled but the kernel ignored it.
+  describe file('/proc/cmdline') do
+    its('content') { should match(/selinux=0/) }
+    its('content') { should_not match(/selinux=1/) }
+  end if selinux_applies
 end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/disable_selinux_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/disable_selinux_spec.rb
@@ -26,6 +26,13 @@ control 'tag:install_selinux_disabled' do
     its('stdout') { should match(/selinux=0/) }
     its('stdout') { should_not match(/selinux=1/) }
   end if selinux_applies
+
+  # Verify the GRUB template has selinux=0 so kernel updates and any later
+  # grub2-mkconfig regeneration produce BLS entries with SELinux disabled.
+  describe file('/etc/default/grub') do
+    its('content') { should match(/^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=0/) }
+    its('content') { should_not match(/^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1/) }
+  end if selinux_applies
 end
 
 control 'tag:testami_selinux_disabled' do


### PR DESCRIPTION
### Description of changes

Disable SELinux via grubby on kernels >= 6.4

The selinux_state :disabled action only writes `SELINUX=disabled to
/etc/selinux/config`, which kernels >= 6.4 silently ignore. This affects
AL2023 (kernel 6.12) and RHEL 9 / Rocky 9 (5.14, with the deprecation
backported), leaving SELinux in a "half-disabled" state where the LSM
is initialized but no policy is loaded. getenforce misleadingly reports
"Disabled".

Add a grubby execute resource that appends selinux=0 to the kernel
cmdline — the kernel-supported method that works on all RHEL-family
kernels. 

Tests:

[ONGOING] Build Image
* Unit: assert both selinux_state and grubby execute resources run
  across all supported OSes
* InSpec install: verify grubby --info=ALL contains selinux=0
* InSpec testami: verify /proc/cmdline contains selinux=0 after reboot

References:
* https://github.com/SELinuxProject/selinux-kernel/wiki/DEPRECATE-runtime-disable
* https://docs.aws.amazon.com/linux/al2023/ug/disable-option-selinux.html


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
