### PR TITLE
[Cookbook] Add CreateFleet instance info retrieval timeout configurable via DevSettings

### DIFF
--- a/cookbooks/aws-parallelcluster-computefleet/attributes/computefleet.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/attributes/computefleet.rb
@@ -2,3 +2,7 @@ default['cluster']['computefleet_status_path'] = "#{node['cluster']['shared_dir'
 
 # Compute nodes bootstrap timeout
 default['cluster']['compute_node_bootstrap_timeout'] = 1800
+
+# Time budget (seconds) for retrieving EC2 instance info after a CreateFleet launch, to tolerate
+# EC2 API eventual consistency.
+default['cluster']['compute_instance_info_timeout'] = 90

--- a/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_resume.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/config/config_slurm_resume.rb
@@ -51,6 +51,10 @@ template "#{node['cluster']['slurm_plugin_dir']}/parallelcluster_slurm_resume.co
     head_node_hostname: on_docker? ? 'local_hostname' : node['ec2']['local_hostname'],
     clustermgtd_heartbeat_file_path: "#{node['cluster']['slurm']['install_dir']}/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat",
     instance_id: on_docker? ? 'instance_id' : node['ec2']['instance_id'],
-    scaling_strategy: lazy { node['cluster']['config'].dig(:Scheduling, :ScalingStrategy) }
+    scaling_strategy: lazy { node['cluster']['config'].dig(:Scheduling, :ScalingStrategy) },
+    instance_info_retrieval_timeout: lazy do
+      node['cluster']['config'].dig(:DevSettings, :Timeouts, :ComputeInstanceInfoTimeout) ||
+        node['cluster']['compute_instance_info_timeout']
+    end
   )
 end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurm_resume_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/config_slurm_resume_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Copyright:: 2026 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-slurm::config_slurm_resume' do
+  RESUME_CONF = '/etc/parallelcluster/slurm_plugin/parallelcluster_slurm_resume.conf'
+
+  # The template passes instance_info_retrieval_timeout as a lazy attribute, which ChefSpec does not
+  # evaluate during rendering. Evaluate the lazy value directly off the template resource instead.
+  def rendered_timeout(chef_run)
+    chef_run.find_resource(:template, RESUME_CONF).variables[:instance_info_retrieval_timeout].call
+  end
+
+  context 'when ComputeInstanceInfoTimeout is set in DevSettings/Timeouts' do
+    cached(:chef_run) do
+      runner = runner(platform: 'amazon', version: '2023') do |node|
+        allow_any_instance_of(Object).to receive(:on_docker?).and_return(true)
+        node.override['cluster']['config'] = { DevSettings: { Timeouts: { ComputeInstanceInfoTimeout: 150 } } }
+      end
+      runner.converge(described_recipe)
+    end
+
+    it 'uses the configured value' do
+      expect(rendered_timeout(chef_run)).to eq(150)
+    end
+  end
+
+  context 'when ComputeInstanceInfoTimeout is not set' do
+    cached(:chef_run) do
+      runner = runner(platform: 'amazon', version: '2023') do |node|
+        allow_any_instance_of(Object).to receive(:on_docker?).and_return(true)
+        node.override['cluster']['config'] = {}
+      end
+      runner.converge(described_recipe)
+    end
+
+    it 'falls back to the compute_instance_info_timeout default' do
+      expect(rendered_timeout(chef_run)).to eq(chef_run.node['cluster']['compute_instance_info_timeout'])
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_clustermgtd.conf.erb
@@ -11,6 +11,7 @@ head_node_private_ip = <%= node['ec2']['local_ipv4'] %>
 head_node_hostname = <%= node['ec2']['local_hostname'] %>
 node_replacement_timeout = <%= node['cluster']['compute_node_bootstrap_timeout'] %>
 insufficient_capacity_timeout = 600
+instance_info_retrieval_timeout = <%= node['cluster']['config'].dig(:DevSettings, :Timeouts, :ComputeInstanceInfoTimeout) || node['cluster']['compute_instance_info_timeout'] %>
 compute_console_logging_enabled = <%= node['cluster']['cw_logging_enabled'] || true %>
 compute_console_logging_max_sample_size = <%= node['cluster']['slurm_plugin_console_logging']['sample_size'] %>
 compute_console_wait_time = 300

--- a/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
+++ b/cookbooks/aws-parallelcluster-slurm/templates/default/slurm/parallelcluster_slurm_resume.conf.erb
@@ -11,3 +11,4 @@ head_node_hostname = <%= @head_node_hostname %>
 clustermgtd_heartbeat_file_path = <%= @clustermgtd_heartbeat_file_path %>
 instance_id = <%= @instance_id %>
 scaling_strategy = <%= @scaling_strategy %>
+instance_info_retrieval_timeout = <%= @instance_info_retrieval_timeout %>


### PR DESCRIPTION
### Description of changes
Exposes the CreateFleet post-launch `DescribeInstances` retry timeout as a devsetting under `DevSettings/Timeouts/ComputeInstanceInfoTimeout` (default 90s).

When a compute resource uses CreateFleet (flexible instance types), the node package retries `DescribeInstances` after launch to tolerate EC2 API eventual consistency. This change lets that timeout be tuned from the cluster config:

```yaml
DevSettings:
  Timeouts:
    ComputeInstanceInfoTimeout: 90  # seconds
```

### Tests
* Unit test passed

### References
* https://github.com/aws/aws-parallelcluster-node/pull/694
* https://github.com/aws/aws-parallelcluster/pull/7425

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
