### PR TITLE
[UpdateWorkflow] Fix kitchen test related to cfn-hup configuration to be aligned to the recent changes to the update workflow

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/test/controls/cfn_hup_configuration_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/cfn_hup_configuration_spec.rb
@@ -9,8 +9,9 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'tag:config_cfn_hup_conf_files_created' do
-  title "cfn_hup configuration files and directories should be created"
+control 'tag:config_cfn_hup_head_node_configuration' do
+  title "cfn_hup configuration files and directories for HeadNode should be created"
+  only_if { instance.head_node? }
 
   %w(/etc/cfn /etc/cfn/hooks.d).each do |dir|
     describe directory(dir) do
@@ -29,11 +30,6 @@ control 'tag:config_cfn_hup_conf_files_created' do
       its('group') { should eq 'root' }
     end
   end
-end
-
-control 'tag:config_cfn_hup_head_node_configuration' do
-  title "cfn_hup configuration files and directories for HeadNode should be created"
-  only_if { instance.head_node? }
 
   describe file("#{node['cluster']['scripts_dir']}/share_compute_fleet_dna.py") do
     it { should exist }


### PR DESCRIPTION
### Description of changes
Fix kitchen test related to cfn-hup configuration to be aligned to the recent changes to the update workflow

Kitchen test now reflects the changes made to the update workflow in https://github.com/aws/aws-parallelcluster-cookbook/pull/3188, where cfn-hup files and directories are created only on the head node.

### Tests
PR checks

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
