### PR TITLE
Make /etc/profile.d/path.sh POSIX sh compatible to avoid breaking login dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade Slurm to version 25.11.6 (from 25.11.4).
 
 **BUG FIXES**
+- Fix `/etc/profile.d/path.sh` aborting login `sh` (dash) with a syntax error by making the script POSIX sh compatible instead of using bash-only array syntax.
 - Fix cluster creation failure caused by Slurm accounting bootstrap failing when ClusterName is overridden 
 via custom Slurm settings or the cluster name contains upper-case letters.
 - Remove deprecated parameter `AccountingStorageUser` from Slurm configuration that was causing harmless error messages.

--- a/cookbooks/aws-parallelcluster-shared/templates/profile/path.sh.erb
+++ b/cookbooks/aws-parallelcluster-shared/templates/profile/path.sh.erb
@@ -1,9 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
-PATH_REQUIRED_DIRECTORIES=(<%= @path_required_directories.join(' ') %>)
-
-for directory in "${PATH_REQUIRED_DIRECTORIES[@]}"; do
-    [[ ":$PATH:" == *":$directory:"* ]] || PATH="${PATH:+"$PATH:"}$directory"
+# This file is installed under /etc/profile.d and is *sourced*, not executed,
+# so it must be POSIX sh compatible: on Debian/Ubuntu /etc/profile is processed
+# by dash, which has no arrays. Using bash-only syntax here makes login `sh`
+# abort with a syntax error.
+for directory in <%= @path_required_directories.join(' ') %>; do
+    case ":$PATH:" in
+        *":$directory:"*) ;;
+        *) PATH="${PATH:+$PATH:}$directory" ;;
+    esac
 done
 
 export PATH

--- a/cookbooks/aws-parallelcluster-shared/test/controls/setup_envars_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/controls/setup_envars_spec.rb
@@ -22,6 +22,13 @@ control 'tag:config_setup_envars_system_path_contains_required_directories' do
     its('group') { should eq 'root' }
   end
 
+  # Regression test: files under /etc/profile.d are sourced (not executed) by
+  # the login shell, which on Debian/Ubuntu is dash. The script must therefore
+  # be POSIX sh compatible, otherwise login `sh` aborts with a syntax error.
+  describe command('sh -n /etc/profile.d/path.sh') do
+    its('exit_status') { should eq 0 }
+  end
+
   path = bash('. /etc/profile.d/path.sh; echo ${PATH}').stdout.strip().split(':')
   describe "System path #{path}" do
     subject { path }


### PR DESCRIPTION
### Description of changes
`aws-parallelcluster-shared::setup_envars` renders `/etc/profile.d/path.sh` from `profile/path.sh.erb`. The template uses bash-only syntax (a `PATH_REQUIRED_DIRECTORIES=(...)` array and `[[ ... ]]`).

Scripts in `/etc/profile.d` are *sourced* (not executed) by the login shell, so the `#!/bin/bash` shebang is ignored. On Debian/Ubuntu `/etc/profile` is processed by dash, which has no arrays, so any `sh -l` login aborts with:

```
/etc/profile.d/path.sh: 3: Syntax error: "(" unexpected
```

This breaks tooling that relies on a working login `sh` on cluster nodes (e.g. remote dev-container / IDE setup steps that read the remote env via `sh -lc`). Interactive users in bash/zsh don't notice it.

This rewrites the template in portable POSIX sh (a plain `for` loop + `case`), preserving the existing behavior: append each required directory to `PATH` only if not already present, in the same order.

### Tests
* `sh -n` / `dash -n` on the rendered file: exits 0 (previously exit 2).
* Sourced under dash and bash: `PATH` gets the required directories, and is idempotent when a directory is already present.
* Added an InSpec regression assertion (`sh -n /etc/profile.d/path.sh` exits 0) to `setup_envars_spec.rb`; existing assertions unchanged.

### References
* N/A

### Checklist
- [x] Pointing to the right branch (`develop`).
- [x] Behavior-preserving change with an added regression test.
- [x] Commit message describes what and why.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.