### PR TITLE
[SELinux] Replace Sed commands with line cookbook's filter_lines ressource

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/recipes/install/disable_selinux.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/disable_selinux.rb
@@ -38,13 +38,13 @@ end
 # OSes long-term (kernel updates create new BLS entries from this template).
 
 # Replace selinux=1 with selinux=0 if present (AL2023, RHEL/Rocky 8).
-execute 'replace selinux=1 in /etc/default/grub' do
-  command 'sed -i -E \'/^GRUB_CMDLINE_LINUX(_DEFAULT)?=/ s/selinux=1/selinux=0/g\' /etc/default/grub'
-  only_if 'grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1" /etc/default/grub'
+filter_lines 'replace selinux=1 in /etc/default/grub' do
+  path '/etc/default/grub'
+  filters substitute: [/^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1/, /selinux=1/, 'selinux=0']
 end
 
 # Append selinux=0 if no selinux= is present on the line (Rocky9).
-execute 'append selinux=0 to /etc/default/grub' do
-  command 'sed -i -E \'/^GRUB_CMDLINE_LINUX(_DEFAULT)?=/ {/selinux=/!s/"$/ selinux=0"/}\' /etc/default/grub'
-  not_if 'grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=" /etc/default/grub'
+filter_lines 'append selinux=0 to /etc/default/grub' do
+  path '/etc/default/grub'
+  filters substitute: [/^GRUB_CMDLINE_LINUX(_DEFAULT)?=(?!.*selinux=)/, /"$/, ' selinux=0"']
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_selinux_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_selinux_spec.rb
@@ -7,8 +7,6 @@ describe 'aws-parallelcluster-platform::disable_selinux' do
         # Stub guards so ChefSpec doesn't shell out during converge.
         stub_command('which getenforce').and_return('/usr/sbin/getenforce')
         stub_command('grubby --info=ALL | grep -q "selinux=0"').and_return(false)
-        stub_command('grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1" /etc/default/grub').and_return(true)
-        stub_command('grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=" /etc/default/grub').and_return(false)
         # The recipe early-returns on Docker; force false to exercise the real branch.
         allow_any_instance_of(Chef::Recipe).to receive(:on_docker?).and_return(false)
 
@@ -19,8 +17,8 @@ describe 'aws-parallelcluster-platform::disable_selinux' do
         it 'is a no-op on Debian-family OSes' do
           is_expected.not_to disabled_selinux_state('SELinux Disabled')
           is_expected.not_to run_execute('disable selinux via grubby')
-          is_expected.not_to run_execute('replace selinux=1 in /etc/default/grub')
-          is_expected.not_to run_execute('append selinux=0 to /etc/default/grub')
+          is_expected.not_to edit_filter_lines('replace selinux=1 in /etc/default/grub')
+          is_expected.not_to edit_filter_lines('append selinux=0 to /etc/default/grub')
         end
       else
         it 'disables SELinux via the selinux_state resource' do
@@ -33,13 +31,17 @@ describe 'aws-parallelcluster-platform::disable_selinux' do
         end
 
         it 'replaces selinux=1 in /etc/default/grub' do
-          is_expected.to run_execute('replace selinux=1 in /etc/default/grub')
-            .with_command(%q(sed -i -E '/^GRUB_CMDLINE_LINUX(_DEFAULT)?=/ s/selinux=1/selinux=0/g' /etc/default/grub))
+          is_expected.to edit_filter_lines('replace selinux=1 in /etc/default/grub').with(
+            path: '/etc/default/grub',
+            filters: { substitute: [/^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1/, /selinux=1/, 'selinux=0'] }
+          )
         end
 
         it 'appends selinux=0 to /etc/default/grub' do
-          is_expected.to run_execute('append selinux=0 to /etc/default/grub')
-            .with_command(%q(sed -i -E '/^GRUB_CMDLINE_LINUX(_DEFAULT)?=/ {/selinux=/!s/"$/ selinux=0"/}' /etc/default/grub))
+          is_expected.to edit_filter_lines('append selinux=0 to /etc/default/grub').with(
+            path: '/etc/default/grub',
+            filters: { substitute: [/^GRUB_CMDLINE_LINUX(_DEFAULT)?=(?!.*selinux=)/, /"$/, ' selinux=0"'] }
+          )
         end
       end
     end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -401,8 +401,6 @@ describe 'dcv:setup' do
         lambda {
           stub_command('which getenforce').and_return(true)
           stub_command('grubby --info=ALL | grep -q "selinux=0"').and_return(false)
-          stub_command('grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=1" /etc/default/grub').and_return(false)
-          stub_command('grep -qE "^GRUB_CMDLINE_LINUX(_DEFAULT)?=.*selinux=" /etc/default/grub').and_return(true)
           allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
           allow(::File).to receive(:exist?).with('/etc/dcv/dcv.conf').and_return(false)
           allow(::File).to receive(:exist?).with(dcv_tarball).and_return(false)


### PR DESCRIPTION
### Description of changes
Replace Sed commands with line cookbook's filter_lines ressource

 The substitute filter edits the kernel args in place while preserving the rest of the
 GRUB_CMDLINE_LINUX(_DEFAULT) line, and the resource is idempotent on its own
 (it only rewrites the file when the content actually changes), so no grep guard is needed.


Addressing comment in https://github.com/aws/aws-parallelcluster-cookbook/pull/3195#discussion_r3388535071

### Tests
* Unit tests 

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
