### PR TITLE
[Test] Save resolved full CUDA versions to node attributes for InSpec/build-image tests

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/recipes/install/cuda.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/cuda.rb
@@ -31,7 +31,8 @@ cuda_samples_url = "#{node['cluster']['nvidia']['cuda']['samples_base_url']}/v#{
 tmp_cuda_run = '/tmp/cuda.run'
 tmp_cuda_sample_archive = '/tmp/cuda-sample.tar.gz'
 
-node.default['cluster']['nvidia']['cuda']['version'] = cuda_version
+# Save resolved CUDA versions to .default so InSpec/build-image tests which run during ParallelClusterTestComponent see them (mirrors Nvidia driver).
+node.default['cluster']['nvidia']['cuda']['version'] = cuda_full_version
 node.default['cluster']['nvidia']['cuda_samples_version'] = cuda_samples_version
 node_attributes 'Save cuda and cuda samples versions for InSpec tests'
 

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cuda_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cuda_spec.rb
@@ -33,7 +33,7 @@ describe 'aws-parallelcluster-platform::cuda' do
     cached(:node) { chef_run.node }
 
     it 'saves cuda and cuda samples version' do
-      expect(node['cluster']['nvidia']['cuda']['version']).to eq(cuda_version)
+      expect(node['cluster']['nvidia']['cuda']['version']).to eq(cuda_complete_version)
       expect(node['cluster']['nvidia']['cuda_samples_version']).to eq(cuda_samples_version)
       is_expected.to write_node_attributes('Save cuda and cuda samples versions for InSpec tests')
     end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_spec.rb
@@ -41,7 +41,9 @@ control 'tag:install_expected_versions_of_nvidia_cuda_installed' do
       (node['cluster']['nvidia']['enabled'] == 'yes' || node['cluster']['nvidia']['enabled'] == true)
   end
 
-  expected_cuda_version = node['cluster']['nvidia']['cuda']['version']
+  # nvcc and the install dir use major.minor (e.g. 13.3); cuda.version may be a 3-part
+  # value (e.g. 13.3.0) when set via ExtraChefAttributes, so normalize to major.minor.
+  expected_cuda_version = node['cluster']['nvidia']['cuda']['version'].split('.')[0, 2].join('.')
   cmd = %(
     export PATH=/usr/local/cuda-#{expected_cuda_version}/bin:${PATH};
     export LD_LIBRARY_PATH=/usr/local/cuda-#{expected_cuda_version}/lib64:${LD_LIBRARY_PATH}


### PR DESCRIPTION
### Description of changes
*  Save full resolved CUDA versions to node attributes for InSpec/build-image tests

* We do similar process for NVIDIA driver version https://github.com/aws/aws-parallelcluster-cookbook/blob/46d010525d892fca98857645e002e9b176b0990e/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb#L26-L28

why do we save these attributes even if they exists already (i.e same for NVIDIA Driver)?
* cuda.version is 3-part (e.g. 13.3.0) when set via ExtraChefAttributes,
which shadows the recipe's default-level reassignment.
* Without this PR CUDA recipe truncates 13.3.0 → 13.3 for the install dir and for Inpsec tests [where nvcc only ever prints major.minor (release 13.3)]. So we do a transformation (3-part → 2-part) for handling these tests. This 3-part to 2-part conversion of cuda version **never wins** the Chef precedence and causes Inspec tests to fail.
* The test fails because of version transformation + ExtraChefAttribute due to attribute precedence (low → high): default < normal < override. Where the ExtraChefAttribute 3-part value wins over the default override we set in recipe.
https://docs.chef.io/client/19/cookbooks/attributes/attribute_precedence/

* For NVIDIA driver recipes the precedence with ExtraChefAttributes wins (similar to CUDA); unlike cuda we do no transformation on the version value for nvidia-driver which is why there is no issue for tests. Hence we mimic the NVIDIA driver and just change the tests to get the 2 part version from full version.

The test which fails without this PR as we get `nvcc -V | grep -E -o "release [0-9]+.[0-9]+`

```
026-06-12 17:03:19.765000	Stdout: [38;5;9m  Ã—  tag:install_expected_versions_of_nvidia_cuda_installed: cuda version is expected to be 13.3.0[0m
2026-06-12 17:03:19.765000	Stdout: [38;5;9m     Ã—  cuda version is expected to be 13.3.0 is expected to eq "release 13.3.0"
2026-06-12 17:03:19.765000	Stdout:
2026-06-12 17:03:19.765000	Stdout:      expected: "release 13.3.0"
2026-06-12 17:03:19.765000	Stdout:           got: ""
2026-06-12 17:03:19.765000	Stdout:
2026-06-12 17:03:19.765000	Stdout:      (compared using ==)
2026-06-12 17:03:19.765000	Stdout: [0m

```


With this change I need to handle the code change in CLI `parallelcluster-test.yaml` https://github.com/aws/aws-parallelcluster/pull/7449



### Tests
* Unit test & Build Image tests with https://github.com/aws/aws-parallelcluster/pull/7449

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
