### PR TITLE
[Deps] Install MySQL client from individual RPMs instead of a bundled tarball

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Upgrade aws-cfn-bootstrap to version 2.0-39 (from 2.0-38).
 - Move all ParallelCluster-managed bootstrap files off `/tmp` into a dedicated `/opt/parallelcluster/tmp`
   directory. Therefore, Image builds, cluster creations and updates work on custom AMIs that mount `/tmp` with `noexec`.
-  
+- Upgrade mysql-community-client to version 8.4.10 (from 8.4.8).
 
 **CHANGES**
 - Enforce NFSv4-only on the ParallelCluster-managed NFS server (head node). The NFSv3 client stack (rpcbind, rpc-statd, lockd) are unchanged, so cluster nodes can still mount external NFSv3 servers.

--- a/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb
@@ -13,6 +13,6 @@ default['cluster']['jwt']['version'] = '1.18.4'
 default['cluster']['jwt']['sha256'] = '8496257cb39ee7dddfdfc919e7b80a997399b0319f9fdcbefd374b0e4f147159'
 default['cluster']['jwt']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/jwt"
 ## MySql
-default['cluster']['mysql']['source_version'] = '8.4.8'
+default['cluster']['mysql']['source_version'] = '8.4.10'
 default['cluster']['mysql']['version'] = "#{node['cluster']['mysql']['source_version']}-1"
 default['cluster']['mysql']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/mysql"

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/partial/_common.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/partial/_common.rb
@@ -42,14 +42,6 @@ action_class do
     node['cluster']['mysql']['source_version']
   end
 
-  def package_filename
-    "mysql-community-client-#{package_version}.tar.gz"
-  end
-
-  def package_archive
-    "#{node['cluster']['mysql']['base_url']}/#{package_platform}/#{package_filename}"
-  end
-
   def package_source
     "#{node['cluster']['mysql']['base_url']}/source/mysql-#{package_source_version}.tar.gz"
   end

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/partial/_setup_rhel_based.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/partial/_setup_rhel_based.rb
@@ -14,20 +14,24 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 action :setup do
-  mysql_archive_url = package_archive
-  mysql_tar_file = "/tmp/#{package_filename}"
-
-  log "Downloading MySQL packages archive from #{mysql_archive_url}"
-
   # Add MySQL source file
   action_create_source_link
 
-  remote_file mysql_tar_file do
-    source mysql_archive_url
-    mode '0644'
-    retries 3
-    retry_delay 5
-    action :create_if_missing
+  # Download the individual MySQL community client RPMs from base_url and
+  # install them in a single yum transaction so interdependencies resolve.
+  # (Previously a single .tar.gz bundle was downloaded and extracted; the RPMs
+  # are now stored unbundled, so base_url can point at either the PCluster S3
+  # mirror or MySQL's public yum repo using ExtraChefAttributes.
+  rpm_files = mysql_rpm_filenames
+
+  rpm_files.each do |rpm|
+    remote_file "/tmp/#{rpm}" do
+      source "#{package_base_url}/#{rpm}"
+      mode '0644'
+      retries 3
+      retry_delay 5
+      action :create_if_missing
+    end
   end
 
   bash 'Install MySQL packages' do
@@ -36,26 +40,42 @@ action :setup do
     cwd '/tmp'
     code <<-MYSQL
         set -e
-
-        EXTRACT_DIR=$(mktemp -d --tmpdir mysql.XXXXXXX)
-        tar xf "#{mysql_tar_file}" --directory "${EXTRACT_DIR}"
-        yum install -y ${EXTRACT_DIR}/*
+        yum install -y #{rpm_files.join(' ')}
     MYSQL
   end
 end
 
 action_class do
-  def package_platform
+  def el_version
     platform_version = node['platform_version'].to_i
-    if platform_version == 2
-      platform_version = 7
-    elsif platform_version == 2023
-      platform_version = 9
+    if platform_version == 2023
+      9
+    else
+      platform_version
     end
-    arm_instance? ? "el/#{platform_version}/aarch64" : "el/#{platform_version}/x86_64"
   end
 
-  def repository_packages
-    %w(mysql-community-devel mysql-community-libs mysql-community-common mysql-community-client-plugins mysql-community-libs-compat)
+  def rpm_arch
+    arm_instance? ? 'aarch64' : 'x86_64'
+  end
+
+  def package_platform
+    "el/#{el_version}/#{rpm_arch}"
+  end
+
+  # base_url + platform path holding the individual RPMs.
+  def package_base_url
+    "#{node['cluster']['mysql']['base_url']}/#{package_platform}"
+  end
+
+  # MySQL community client RPM filenames for this platform/arch.
+  def mysql_rpm_components
+    %w(common client-plugins libs devel)
+  end
+
+  def mysql_rpm_filenames
+    mysql_rpm_components.map do |component|
+      "mysql-community-#{component}-#{node['cluster']['mysql']['version']}.el#{el_version}.#{rpm_arch}.rpm"
+    end
   end
 end

--- a/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/partial/_setup_ubuntu.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/mysql_client/partial/_setup_ubuntu.rb
@@ -15,12 +15,4 @@ action_class do
   def repository_packages
     %w(libmysqlclient-dev libmysqlclient21)
   end
-
-  def package_platform
-    if arm_instance?
-      'el/7/aarch64'
-    else
-      "ubuntu/#{node['platform_version']}/x86_64"
-    end
-  end
 end

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/resources/mysql_client_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/resources/mysql_client_spec.rb
@@ -25,40 +25,28 @@ describe 'mysql_client:setup' do
         cached(:source_dir) { 'SOURCE_DIR' }
         cached(:package_source_version) { 'VERSION' }
         cached(:package_version) { 'VERSION-1' }
-        cached(:package_filename) { "mysql-community-client-#{package_version}.tar.gz" }
         cached(:s3_url) { 's3://url' }
         cached(:mysql_base_url) { "#{s3_url}/mysql" }
-        cached(:package_platform) do
-          platform_version = if version.to_i == 2
-                               7
-                             elsif platform == 'amazon' && version == '2023'
-                               9
-                             else
-                               version.to_i
-                             end
-          if architecture == 'aarch64'
-            "el/#{platform_version}/aarch64"
-          elsif architecture == 'x86_64'
-            if platform == 'ubuntu'
-              "ubuntu/${version}/x86_64"
-            else
-              "el/#{platform_version}/x86_64"
-            end
+        cached(:el_version) do
+          if platform == 'amazon' && version == '2023'
+            9
           else
-            pending "unsupported architecture #{architecture}"
+            version.to_i
           end
         end
-        cached(:package_archive) { "#{mysql_base_url}/#{package_platform}/#{package_filename}" }
-        cached(:tarfile) { "/tmp/mysql-community-client-#{package_version}.tar.gz" }
+        cached(:package_platform) { "el/#{el_version}/#{architecture}" }
+        cached(:package_base_url) { "#{mysql_base_url}/#{package_platform}" }
+        cached(:mysql_rpm_filenames) do
+          components = %w(common client-plugins libs devel)
+          components.map { |c| "mysql-community-#{c}-#{package_version}.el#{el_version}.#{architecture}.rpm" }
+        end
+        # Ubuntu installs from the apt repository by package name; RHEL-based
+        # platforms install the downloaded RPMs directly (see mysql_rpm_filenames).
         cached(:repository_packages) do
-          if platform == 'ubuntu'
-            if version.to_i == 18
-              %w(libmysqlclient-dev libmysqlclient20)
-            elsif version.to_i >= 20
-              %w(libmysqlclient-dev libmysqlclient21)
-            end
-          else
-            %w(mysql-community-devel mysql-community-libs mysql-community-common mysql-community-client-plugins mysql-community-libs-compat)
+          if version.to_i == 18
+            %w(libmysqlclient-dev libmysqlclient20)
+          elsif version.to_i >= 20
+            %w(libmysqlclient-dev libmysqlclient21)
           end
         end
         cached(:chef_run) do
@@ -78,28 +66,23 @@ describe 'mysql_client:setup' do
           is_expected.to setup_mysql_client('setup')
         end
 
-        if %w(amazon centos redhat).include?(platform)
-          it 'logs MySQL archive URL' do
-            is_expected.to write_log("Downloading MySQL packages archive from #{package_archive}")
-          end
-
-          it 'downloads and installs packages' do
-            is_expected.to create_if_missing_remote_file(tarfile)
-              .with(source: package_archive)
-              .with(mode: '0644')
-              .with(retries: 3)
-              .with(retry_delay: 5)
+        if %w(amazon centos redhat rocky).include?(platform)
+          it 'downloads each MySQL RPM and installs them in one transaction' do
+            mysql_rpm_filenames.each do |rpm|
+              is_expected.to create_if_missing_remote_file("/tmp/#{rpm}")
+                .with(source: "#{package_base_url}/#{rpm}")
+                .with(mode: '0644')
+                .with(retries: 3)
+                .with(retry_delay: 5)
+            end
 
             is_expected.to run_bash('Install MySQL packages')
               .with(user: 'root')
               .with(group: 'root')
               .with(cwd: '/tmp')
-              .with(code: %{        set -e
-
-        EXTRACT_DIR=$(mktemp -d --tmpdir mysql.XXXXXXX)
-        tar xf "#{tarfile}" --directory "${EXTRACT_DIR}"
-        yum install -y ${EXTRACT_DIR}/*
-})
+              .with(code: %(        set -e
+        yum install -y #{mysql_rpm_filenames.join(' ')}
+))
           end
 
         elsif platform == 'ubuntu'


### PR DESCRIPTION


### Description of changes
Install MySQL client from individual RPMs instead of a bundled tarball.

RHEL-based mysql_client previously downloaded a single PCluster-built mysql-community-client-<version>.tar.gz from S3, extracted it, and ran yum install on the contents. That bundle only ever exists in the PCluster S3 mirror, so base_url could not be redirected to a public source.

Download the individual community client RPMs (common, client-plugins, libs, devel; plus libs-compat on el7) from base_url/el/N/arch and install them in a single yum transaction. base_url can now point at either the S3 mirror or MySQL's public yum repo via ExtraChefAttributes of [mysql's base_url](https://github.com/aws/aws-parallelcluster-cookbook/blob/develop/cookbooks/aws-parallelcluster-slurm/attributes/versions.rb#L18 ). Drop the now-unused package_filename/package_archive helpers and the dead repository_packages method from the RHEL partial; add rocky to the spec's RPM-install assertions.






### Tests
* Build Image on all Osses using ExtrChefAttributes successful
* Slurm accounting integ tests

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
