### PR TITLE
Modify Kitchen tests and Skip installation if dependency already exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ via custom Slurm settings or the cluster name contains upper-case letters.
 - Fix compute node bootstrap hanging without a clear error when the compute subnet cannot reach DynamoDB.
 - Fix login nodes not mounting `/opt/parallelcluster/shared` when EFS is used as the internal shared storage type.
 - Fix SELinux not actually being disabled on RHEL-family OSes (kernels >= 6.4) due to a [deprecated mechanism](https://github.com/SELinuxProject/selinux-kernel/wiki/DEPRECATE-runtime-disable) being silently ignored by newer kernels.
+- Fix `build-image` failure by skipping installation of `gdrcopy` and `dcgm` if parent image has an existing installed version.
 
 **DEPRECATIONS**
 - Amazon Linux 2 is no longer supported.

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
@@ -16,6 +16,14 @@ def gdrcopy_version
   node['cluster']['nvidia']['gdrcopy']['version']
 end
 
+# True if gdrcopy is installed (regardless of version). Like nvidia-smi for the
+# driver, the gdrcopy_sanity binary is the one of the test commands that are
+# installed by GDRCopy and we use it as signal of a healthy install
+# and is installed to /usr/bin on all platforms.
+def gdrcopy_installed?
+  ::File.exist?('/usr/bin/gdrcopy_sanity')
+end
+
 def gdrcopy_checksum
   node['cluster']['nvidia']['gdrcopy']['sha256']
 end
@@ -26,6 +34,9 @@ default_action :setup
 action :setup do
   return unless gdrcopy_enabled?
   return if on_docker?
+
+  # Skip rebuild + install if already installed (e.g. DLAMI).
+  return if gdrcopy_installed?
 
   # Save gdrcopy version for InSpec tests
   node.default['cluster']['nvidia']['gdrcopy']['version'] = gdrcopy_version
@@ -90,7 +101,6 @@ action :configure do
   return if on_docker?
   # Save gdrcopy version for InSpec tests
   node.default['cluster']['nvidia']['gdrcopy']['version'] = gdrcopy_version
-  node.default['cluster']['nvidia']['gdrcopy']['service'] = gdrcopy_service
   node_attributes 'dump node attributes'
 
   if graphic_instance? && is_service_installed?(gdrcopy_service)

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_dcgm/partial/_nvidia_dcgm_common.rb
@@ -19,12 +19,23 @@ property :nvidia_enabled, [true, false, nil]
 
 action :setup do
   return unless _nvidia_dcgm_enabled
+  # Skip if DCGM is already installed (e.g. DLAMI). Reinstalling a different
+  # version breaks the preinstalled, version-pinned DCGM subpackages and leaves
+  # the package manager in a broken state, failing later package installs.
+  return if dcgmi_installed?
 
   action_install_package
 end
 
 def _nvidia_enabled
   nvidia_enabled.nil? ? ['yes', true, 'true'].include?(node['cluster']['nvidia']['enabled']) : nvidia_enabled
+end
+
+# True if DCGM is installed (regardless of version). Like nvidia-smi for the
+# driver, the dcgmi binary is the single signal of a healthy install and is
+# installed to /usr/bin on all platforms.
+def dcgmi_installed?
+  ::File.exist?('/usr/bin/dcgmi')
 end
 
 def package_version

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
@@ -184,8 +184,10 @@ describe 'gdrcopy:setup' do
         platforms = {
           'amazon2023' => 'amzn-2023',
           'centos7' => 'el7',
+          'redhat8' => 'el8',
           'rhel8' => 'el8',
           'rocky8' => 'el8',
+          'redhat9' => 'el9',
           'rhel9' => 'el9',
           'rocky9' => 'el9',
           'ubuntu22.04' => 'Ubuntu22_04',
@@ -197,6 +199,7 @@ describe 'gdrcopy:setup' do
         stubs_for_resource('gdrcopy') do |res|
           allow(res).to receive(:gdrcopy_enabled?).and_return(true)
           allow(res).to receive(:gdrcopy_arch).and_return(gdrcopy_arch)
+          allow(res).to receive(:gdrcopy_installed?).and_return(false)
         end
         runner = runner(platform: platform, version: version, step_into: ['gdrcopy']) do |node|
           node.override['cluster']['sources_dir'] = sources_dir
@@ -279,6 +282,22 @@ describe 'gdrcopy:setup' do
 
       it 'disables gdrcopy service' do
         is_expected.to disable_service(gdrcopy_service).with_action(%i(disable stop))
+      end
+    end
+
+    context "on #{platform}#{version} when the target gdrcopy version is already installed" do
+      cached(:chef_run) do
+        stubs_for_resource('gdrcopy') do |res|
+          allow(res).to receive(:gdrcopy_enabled?).and_return(true)
+          allow(res).to receive(:gdrcopy_arch).and_return('gdrcopy_arch')
+          allow(res).to receive(:gdrcopy_installed?).and_return(true)
+        end
+        ConvergeGdrcopy.setup(runner(platform: platform, version: version, step_into: ['gdrcopy']))
+      end
+
+      it 'skips the rebuild and install' do
+        is_expected.not_to run_bash('Install NVIDIA GDRCopy')
+        is_expected.not_to write_node_attributes('dump node attributes')
       end
     end
   end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_dcgm_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_dcgm_spec.rb
@@ -14,6 +14,9 @@ end
 describe 'nvidia_dcgm:_nvidia_enabled' do
   context 'when nvidia enabled property is set' do
     cached(:chef_run) do
+      stubs_for_resource('nvidia_dcgm') do |res|
+        allow(res).to receive(:dcgmi_installed?).and_return(false)
+      end
       ChefSpec::SoloRunner.new(step_into: ['nvidia_dcgm']) do |node|
         node.override['cluster']['nvidia']['enabled'] = false
       end
@@ -31,6 +34,9 @@ describe 'nvidia_dcgm:_nvidia_enabled' do
   context 'when nvidia enabled property is not set' do
     context "and node['cluster']['nvidia']['enabled'] is true" do
       cached(:chef_run) do
+        stubs_for_resource('nvidia_dcgm') do |res|
+          allow(res).to receive(:dcgmi_installed?).and_return(false)
+        end
         ChefSpec::SoloRunner.new(step_into: ['nvidia_dcgm']) do |node|
           node.override['cluster']['nvidia']['enabled'] = true
         end
@@ -46,6 +52,9 @@ describe 'nvidia_dcgm:_nvidia_enabled' do
 
     context "and node['cluster']['nvidia']['enabled'] is yes" do
       cached(:chef_run) do
+        stubs_for_resource('nvidia_dcgm') do |res|
+          allow(res).to receive(:dcgmi_installed?).and_return(false)
+        end
         ChefSpec::SoloRunner.new(step_into: ['nvidia_dcgm']) do |node|
           node.override['cluster']['nvidia']['enabled'] = 'yes'
         end
@@ -61,6 +70,9 @@ describe 'nvidia_dcgm:_nvidia_enabled' do
 
     context "and node['cluster']['nvidia']['enabled'] is not yes or true" do
       cached(:chef_run) do
+        stubs_for_resource('nvidia_dcgm') do |res|
+          allow(res).to receive(:dcgmi_installed?).and_return(false)
+        end
         ChefSpec::SoloRunner.new(step_into: ['nvidia_dcgm']) do |node|
           node.override['cluster']['nvidia']['enabled'] = 'any'
         end
@@ -93,11 +105,12 @@ describe 'nvidia_dcgm:_nvidia_dcgm_enabled' do
       end
 
       context 'when on arm and nvidia enabled' do
-        cached(:chef_run) do
-          allow_any_instance_of(Object).to receive(:arm_instance?).and_return(true)
-          runner(platform: platform, version: version, step_into: ['nvidia_dcgm'])
-        end
         cached(:resource) do
+          allow_any_instance_of(Object).to receive(:arm_instance?).and_return(true)
+          stubs_for_resource('nvidia_dcgm') do |res|
+            allow(res).to receive(:dcgmi_installed?).and_return(false)
+          end
+          chef_run = runner(platform: platform, version: version, step_into: ['nvidia_dcgm'])
           ConvergeNvidiaDcgm.setup(chef_run, nvidia_enabled: true)
           chef_run.find_resource('nvidia_dcgm', 'setup')
         end
@@ -110,36 +123,39 @@ describe 'nvidia_dcgm:_nvidia_dcgm_enabled' do
         end
       end
 
-      context 'when not on arm' do
-        cached(:chef_run) do
+      context 'when not on arm and nvidia enabled' do
+        cached(:resource) do
           allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
-          runner(platform: platform, version: version, step_into: ['nvidia_dcgm'])
+          stubs_for_resource('nvidia_dcgm') do |res|
+            allow(res).to receive(:dcgmi_installed?).and_return(false)
+          end
+          chef_run = runner(platform: platform, version: version, step_into: ['nvidia_dcgm'])
+          ConvergeNvidiaDcgm.setup(chef_run, nvidia_enabled: true)
+          chef_run.find_resource('nvidia_dcgm', 'setup')
         end
 
-        context 'when nvidia enabled' do
-          cached(:resource) do
-            ConvergeNvidiaDcgm.setup(chef_run, nvidia_enabled: true)
-            chef_run.find_resource('nvidia_dcgm', 'setup')
-          end
-
-          it "is enabled" do
-            expect(resource._nvidia_dcgm_enabled).to eq(true)
-          end
-
-          it "returns correct platform for download URL" do
-            expect(resource.platform).to eq(expected_platform)
-          end
+        it "is enabled" do
+          expect(resource._nvidia_dcgm_enabled).to eq(true)
         end
 
-        context 'when nvidia not enabled' do
-          cached(:resource) do
-            ConvergeNvidiaDcgm.setup(chef_run, nvidia_enabled: false)
-            chef_run.find_resource('nvidia_dcgm', 'setup')
-          end
+        it "returns correct platform for download URL" do
+          expect(resource.platform).to eq(expected_platform)
+        end
+      end
 
-          it "is not enabled" do
-            expect(resource._nvidia_dcgm_enabled).to eq(false)
+      context 'when not on arm and nvidia not enabled' do
+        cached(:resource) do
+          allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+          stubs_for_resource('nvidia_dcgm') do |res|
+            allow(res).to receive(:dcgmi_installed?).and_return(false)
           end
+          chef_run = runner(platform: platform, version: version, step_into: ['nvidia_dcgm'])
+          ConvergeNvidiaDcgm.setup(chef_run, nvidia_enabled: false)
+          chef_run.find_resource('nvidia_dcgm', 'setup')
+        end
+
+        it "is not enabled" do
+          expect(resource._nvidia_dcgm_enabled).to eq(false)
         end
       end
     end
@@ -168,6 +184,7 @@ describe 'nvidia_dcgm:setup' do
         cached(:chef_run) do
           stubs_for_resource('nvidia_dcgm') do |res|
             allow(res).to receive(:_nvidia_enabled).and_return(true)
+            allow(res).to receive(:dcgmi_installed?).and_return(false)
           end
           runner(platform: platform, version: version, step_into: ['nvidia_dcgm'])
         end
@@ -197,6 +214,23 @@ describe 'nvidia_dcgm:setup' do
           # it 'installs datacenter gpu manager' do
           #   is_expected.to install_package('datacenter-gpu-manager')
           # end
+        end
+      end
+
+      context 'when nvidia enabled and DCGM is already installed' do
+        cached(:chef_run) do
+          stubs_for_resource('nvidia_dcgm') do |res|
+            allow(res).to receive(:_nvidia_enabled).and_return(true)
+            allow(res).to receive(:dcgmi_installed?).and_return(true)
+          end
+          runner = runner(platform: platform, version: version, step_into: ['nvidia_dcgm'])
+          ConvergeNvidiaDcgm.setup(runner)
+        end
+
+        it 'does not install datacenter gpu manager' do
+          is_expected.not_to run_bash('Install datacenter-gpu-manager-4-core')
+          is_expected.not_to run_bash('Install datacenter-gpu-manager-4-cuda13')
+          is_expected.not_to run_bash('Install datacenter-gpu-manager')
         end
       end
     end
@@ -255,6 +289,7 @@ describe 'nvidia_dcgm download URL construction' do
           cached(:chef_run) do
             stubs_for_resource('nvidia_dcgm') do |res|
               allow(res).to receive(:_nvidia_dcgm_enabled).and_return(true)
+              allow(res).to receive(:dcgmi_installed?).and_return(false)
             end
             allow_any_instance_of(Object).to receive(:arm_instance?).and_return(arm)
             runner = runner(platform: platform, version: version, step_into: ['nvidia_dcgm']) do |node|

--- a/cookbooks/aws-parallelcluster-platform/test/controls/arm_pl_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/arm_pl_spec.rb
@@ -17,7 +17,10 @@ control 'tag:install_arm_pl_installed' do
   gcc_major_minor_version = node['cluster']['armpl']['gcc']['major_minor_version']
 
   armpl_module_general_name = "armpl/#{armpl_version}"
-  armpl_module_name = "armpl/#{armpl_version}.0_gcc"
+  # ArmPL's gcc module name uses a 3-segment version: a 2-part version (24.10) is
+  # padded to 24.10.0, while a 3-part version (26.01.1) is used as-is.
+  armpl_module_version = armpl_version.split('.').length < 3 ? "#{armpl_version}.0" : armpl_version
+  armpl_module_name = "armpl/#{armpl_module_version}_gcc"
   gcc_module_name = "armpl/gcc-#{gcc_major_minor_version}"
 
   armpl_script_dir = "/opt/arm/#{armpl_module_general_name}/arm-performance-libraries_#{armpl_version}_gcc"

--- a/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_dcgm_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_dcgm_spec.rb
@@ -9,7 +9,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-control 'tag:install_nvidia_dcgm_installed' do
+control 'tag:install_nvidia_dcgmi_installed' do
   only_if do
     ['yes', true, 'true'].include?(node['cluster']['nvidia']['enabled']) && !instance.custom_ami? && !os_properties.arm?
   end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_gdrcopy_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_gdrcopy_spec.rb
@@ -23,13 +23,17 @@ control 'tag:install_expected_versions_of_nvidia_gdrcopy_installed' do
   end
 end
 
+# Service is gdrdrv on Debian/Ubuntu, gdrcopy on RHEL. Derive from OS, not a
+# node attribute, which is unset when the install is skipped (e.g. DLAMI).
+gdrcopy_service = os_properties.debian_family? ? 'gdrdrv' : 'gdrcopy'
+
 control 'tag:config_gdrcopy_enabled_on_graphic_instances' do
   only_if do
     !instance.custom_ami? && instance.graphic?
   end
 
   describe 'gdrcopy service should be enabled' do
-    subject { command("systemctl is-enabled #{node['cluster']['nvidia']['gdrcopy']['service']} | grep enabled") }
+    subject { command("systemctl is-enabled #{gdrcopy_service} | grep enabled") }
     its('exit_status') { should eq 0 }
   end
 
@@ -50,7 +54,7 @@ control 'tag:config_gdrcopy_disabled_on_non_graphic_instances' do
   end
 
   describe 'gdrcopy service should be disabled' do
-    subject { command("systemctl is-enabled #{node['cluster']['nvidia']['gdrcopy']['service']}") }
+    subject { command("systemctl is-enabled #{gdrcopy_service}") }
     its('exit_status') { should eq 1 }
   end
 end

--- a/cookbooks/aws-parallelcluster-slurm/test/controls/mysql_client_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/test/controls/mysql_client_spec.rb
@@ -44,7 +44,7 @@ control 'tag:install_mysql_client_source_code_created' do
     its('content') do
       should eq %(You can get MySQL source code here:
 
-https://#{node['cluster']['region']}-aws-parallelcluster.s3.#{node['cluster']['region']}.amazonaws.com/archives/mysql/source/mysql-#{node['cluster']['mysql']['source_version']}.tar.gz
+#{node['cluster']['mysql']['base_url']}/source/mysql-#{node['cluster']['mysql']['source_version']}.tar.gz
 )
     end
   end


### PR DESCRIPTION
### Description of changes
* ARMPL uses 3-part  version name for its gcc module. Updating the test to be version aware instead of harcoding a `0`
* Modify the mysql kitchen test to use base_url attribute which will work for both scenario: default Pcluster S3 URL and any overrides done using ExtraChefAttributes
* Skip installation of gdrcopy and dcgm if dependency already exists
Below are the errors of the failure
```
  error: Failed dependencies: gdrcopy = 2.5.2-1 is needed by
  (installed) gdrcopy-devel-2.5.2-1.noarch
```

```
 STDERR: E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
```

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
