### PR TITLE
[Kitchen] Merge AMI ExtraChefAttributes into EC2 kitchen converge

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,31 @@ export KITCHEN_INSTANCE_TYPE=t2.large
 export KITCHEN_IAM_PROFILE=test-kitchen  # required for tests with lifecycle hooks
 ```
 
+
+#### Testing against a locally-built AMI with dependency overrides
+
+When validating a dependency upgrade, point the `config` phase at the AMI you built and inject the
+same `ExtraChefAttributes` the build used, so the converge resolves the AMI-baked versions instead
+of the cookbook defaults:
+
+- Override the AMI per OS with `KITCHEN_<OS>_AMI` (e.g. `KITCHEN_ALINUX2023_AMI`, `KITCHEN_RHEL8_AMI`,
+  `KITCHEN_UBUNTU2404_AMI`). If unset, `kitchen.ec2.yml` `image_search` picks the latest matching
+  `aws-parallelcluster-<version>-<os>-*` AMI (version from `KITCHEN_PCLUSTER_VERSION`, default `3.16.0`).
+- Set `EXTRA_CHEF_ATTRIBUTES` (the same JSON used to build the AMI). `kitchen.ec2.yml` parses it and
+  deep-merges its `cluster` hash into the provisioner attributes for the converge (EC2 only — Docker
+  runs are unaffected). Per-platform `attributes.cluster` (e.g. `base_os`) merges on top.
+
+```
+export KITCHEN_ALINUX2023_AMI=ami-0123456789abcdef0
+export EXTRA_CHEF_ATTRIBUTES='{"cluster": {"python-version": "3.14.6", "efs": {"version": "3.1.3"}}}'
+./kitchen.ec2.sh environment-config test efs-alinux2023
+```
+
+If the converge can't find an upgraded component on the AMI (e.g. a `python` venv path under
+`/opt/parallelcluster/pyenv/versions/<python-version>/...` or a version-pinned binary), the AMI and
+the injected attributes disagree — rebuild the AMI with the same overrides, or align
+`EXTRA_CHEF_ATTRIBUTES` to what the AMI actually carries.
+
 ### Kitchen tests definition
 
 The different `kitchen.${context}.yml` files in the functional cookbooks contain a list of Inspec tests

--- a/kitchen.ec2.yml
+++ b/kitchen.ec2.yml
@@ -1,6 +1,13 @@
 <%
+  require 'json'
   pcluster_version = ENV['KITCHEN_PCLUSTER_VERSION'] || '3.16.0'
   pcluster_prefix = "aws-parallelcluster-#{pcluster_version}"
+
+  # The ExtraChefAttributes used to build the AMI is also used for testing
+  # ('{"cluster": {...}}'); merge its cluster hash so the converge resolves the
+  # AMI-baked versions (e.g. cluster.python-version) instead of the cookbook defaults.
+  extra = ENV['EXTRA_CHEF_ATTRIBUTES'].to_s
+  extra_cluster = extra.empty? ? {} : (JSON.parse(extra)['cluster'] || {}) rescue {}
 %>
 ---
 driver:
@@ -79,6 +86,9 @@ provisioner:
     exit_status: :enabled # Opt-in to the standardized exit codes
     client_fork: false  # Forked instances don't return the real exit code
   log_level: info
+  # Per-platform attributes.cluster (e.g. base_os) deep-merge on top of this.
+  attributes:
+    cluster: <%= extra_cluster.to_json %>
 
 platforms:
   - name: alinux2023


### PR DESCRIPTION
### Description of changes

The kitchen converge resolves dependency versions (e.g. cluster.python-version) from cookbook defaults, which do not match the upgraded versions baked into the AMI via ExtraChefAttributes. This caused the
converge to reference a venv path (.../versions/<python-version>/...) that does not exist on the AMI, failing with Errno::ENOENT.

Parse EXTRA_CHEF_ATTRIBUTES (exported by the kitchen job) and merge its cluster hash into the shared provisioner attributes so the converge resolves the AMI-baked versions. 
Per-platform attributes.cluster (base_os) deep-merges on top.



### Tests
Kitchen tests

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
