### PR TITLE
[Node] Install aws-parallelcluster-node from S3 in all regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **CHANGES**
 - Upgrade Slurm to version 25.11.6 (from 25.11.4).
+- Install the aws-parallelcluster-node package from S3 in all regions instead of PyPI, to support air-gapped and proxied environments.
 
 **BUG FIXES**
 - Fix cluster creation failure caused by Slurm accounting bootstrap failing when ClusterName is overridden 

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
@@ -50,7 +50,7 @@ unless node['cluster']['install_python_from_internet']
   end
 end
 
-bash "install custom aws-parallelcluster-node" do
+bash "install aws-parallelcluster-node" do
   cwd Chef::Config[:file_cache_path]
   code <<-NODE
     set -e

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
@@ -50,7 +50,7 @@ unless node['cluster']['install_python_from_internet']
   end
 end
 
-bash "install aws-parallelcluster-node" do
+bash "install aws-parallelcluster-node from #{node['cluster']['custom_node_package']}" do
   cwd Chef::Config[:file_cache_path]
   code <<-NODE
     set -e

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/parallelcluster_node.rb
@@ -33,18 +33,16 @@ activate_virtual_env node_virtualenv_name do
   not_if { ::File.exist?("#{virtualenv_path}/bin/activate") }
 end
 
-if aws_region.start_with?("us-iso") && !is_custom_node?
-  node_package = "aws-parallelcluster-node-#{node['cluster']['parallelcluster-node-version']}.tgz"
-
-  node.override['cluster']['custom_node_package'] = "#{node['cluster']['s3_url']}/parallelcluster/#{node['cluster']['parallelcluster-node-version']}/node/#{node_package}"
-end
-
-if is_custom_node?
-  include_recipe 'aws-parallelcluster-computefleet::custom_parallelcluster_node'
-else
-  execute "install official aws-parallelcluster-node" do
+# Install the official node package from S3 in all regions (air-gapped/proxied
+# support), unless the user opts into installing from PyPI via
+# install_node_from_internet. A user-provided custom_node_package always wins.
+if node['cluster']['install_node_from_internet']
+  # install_node_from_internet was requested: install from PyPI.
+  execute "install aws-parallelcluster-node from Pypi" do
     command "#{virtualenv_path}/bin/pip install aws-parallelcluster-node==#{node['cluster']['parallelcluster-node-version']}"
     retries 3
     retry_delay 5
   end
+else
+  include_recipe 'aws-parallelcluster-computefleet::custom_parallelcluster_node'
 end

--- a/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
@@ -92,7 +92,7 @@ describe 'aws-parallelcluster-computefleet::custom_parallelcluster_node' do
           end
 
           it 'installs aws-parallelcluster-node' do
-            is_expected.to run_bash('install aws-parallelcluster-node')
+            is_expected.to run_bash("install aws-parallelcluster-node from #{custom_node_s3_url}")
               .with(code: node_bash_code.gsub(/^  /, '    '))
           end
         end

--- a/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
@@ -91,8 +91,8 @@ describe 'aws-parallelcluster-computefleet::custom_parallelcluster_node' do
             end
           end
 
-          it 'installs custom aws-parallelcluster-node' do
-            is_expected.to run_bash('install custom aws-parallelcluster-node')
+          it 'installs aws-parallelcluster-node' do
+            is_expected.to run_bash('install aws-parallelcluster-node')
               .with(code: node_bash_code.gsub(/^  /, '    '))
           end
         end

--- a/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/node_spec.rb
@@ -9,11 +9,13 @@ describe 'aws-parallelcluster-computefleet::parallelcluster_node' do
       cached(:virtualenv_path) { 'system_pyenv_root/versions/python_version/envs/node_virtualenv' }
 
       context "when node virtualenv not installed yet and custom node package is not set" do
+        cached(:s3_url) { 'https://REGION-aws-parallelcluster.s3.REGION.test_aws_domain' }
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['python-version'] = python_version
             node.override['cluster']['parallelcluster-node-version'] = node_version
+            node.override['cluster']['s3_url'] = s3_url
           end
           runner.converge(described_recipe)
         end
@@ -35,8 +37,40 @@ describe 'aws-parallelcluster-computefleet::parallelcluster_node' do
           is_expected.to write_node_attributes('dump node attributes')
         end
 
-        it 'installs official node package' do
-          is_expected.to run_execute('install official aws-parallelcluster-node')
+        # By default (install_python_from_internet false) the node package is
+        # installed from S3 in all regions, not from PyPI.
+        it 'points custom_node_package at the S3 node package' do
+          expect(node['cluster']['custom_node_package'])
+            .to eq("#{s3_url}/parallelcluster/#{node_version}/node/aws-parallelcluster-node-#{node_version}.tgz")
+        end
+
+        it 'installs node from S3 via the custom node recipe' do
+          is_expected.to include_recipe('aws-parallelcluster-computefleet::custom_parallelcluster_node')
+        end
+
+        it 'does not install the node package from PyPI' do
+          is_expected.not_to run_execute('install aws-parallelcluster-node from Pypi')
+        end
+      end
+
+      context "when install_node_from_internet is set" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['system_pyenv_root'] = system_pyenv_root
+            node.override['cluster']['python-version'] = python_version
+            node.override['cluster']['parallelcluster-node-version'] = node_version
+            node.override['cluster']['install_node_from_internet'] = true
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'installs the node package from PyPI' do
+          is_expected.to run_execute('install aws-parallelcluster-node from Pypi')
+        end
+
+        it 'does not install node via the custom node recipe' do
+          is_expected.not_to include_recipe('aws-parallelcluster-computefleet::custom_parallelcluster_node')
         end
       end
 

--- a/cookbooks/aws-parallelcluster-shared/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/versions.rb
@@ -6,6 +6,13 @@ default['cluster']['python-major-minor-version'] = '3.14'
 # Set to true when testing new Python versions before artifacts are available in S3
 default['cluster']['install_python_from_internet'] = false
 
+# Opt-out: install the aws-parallelcluster-node package from PyPI instead of the
+# official S3 bucket.
+default['cluster']['install_node_from_internet'] = false
+
+# Official ParallelCluster Node Package
+default['cluster']['custom_node_package'] = "#{node['cluster']['s3_url']}/parallelcluster/#{node['cluster']['parallelcluster-node-version']}/node/aws-parallelcluster-node-#{node['cluster']['parallelcluster-node-version']}.tgz"
+
 # ParallelCluster versions
 default['cluster']['parallelcluster-version'] = '3.16.0'
 default['cluster']['parallelcluster-cookbook-version'] = '3.16.0'

--- a/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
@@ -75,11 +75,17 @@ def load_cluster_config(config_path)
 end
 
 #
-# Check if custom node is specified in the config
+# Check if a custom node package is specified in the config using DevSettings.
+# We ship a default custom_node_package (the official S3 package), so we
+# compare the effective value against the full default-precedence value:
+# only a value the customer changed counts as custom.
 #
 def is_custom_node?
   custom_node_package = node['cluster']['custom_node_package']
-  !custom_node_package.nil? && !custom_node_package.empty?
+  return false if custom_node_package.nil? || custom_node_package.empty?
+  custom = custom_node_package != node.default['cluster']['custom_node_package']
+  Chef::Log.info("is_custom_node?: #{custom} (package: #{custom_node_package})")
+  custom
 end
 
 def write_sync_file(path)

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/libraries/helpers_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/libraries/helpers_spec.rb
@@ -44,6 +44,38 @@ describe 'login_nodes_enabled?' do
   end
 end
 
+describe 'is_custom_node?' do
+  let(:node) { Chef::Node.new }
+  let(:default_base) { 'DEFAULT_BASE_URL' }
+  let(:default_package) { "#{default_base}/node/DEFAULT_NODE_PACKAGE" }
+
+  before { node.default['cluster']['custom_node_package'] = default_package }
+
+  it 'returns false when the package equals the shipped default' do
+    node.override['cluster']['custom_node_package'] = default_package
+    expect(is_custom_node?).to be false
+  end
+
+  it 'returns false when the package is nil' do
+    expect(is_custom_node?).to be false
+  end
+
+  it 'returns false when the package is empty' do
+    node.override['cluster']['custom_node_package'] = ''
+    expect(is_custom_node?).to be false
+  end
+
+  it 'returns true when the customer supplies a different package' do
+    node.override['cluster']['custom_node_package'] = 'CUSTOM_NODE_PACKAGE'
+    expect(is_custom_node?).to be true
+  end
+
+  it 'returns true when only the path differs but the base is the same' do
+    node.override['cluster']['custom_node_package'] = "#{default_base}/other/CUSTOM_NODE_PACKAGE"
+    expect(is_custom_node?).to be true
+  end
+end
+
 describe 'cluster_readiness_check_enabled?' do
   let(:node) { Chef::Node.new }
 


### PR DESCRIPTION
### Description of changes

The node package was installed from S3 only in us-iso regions; everywhere else it install from PyPI ('pip install aws-parallelcluster-node'), breaking air-gapped/proxied build-image in commercial and govcloud.

Set custom_node_package to the official S3 node URL in all regions by default, routing through the existing custom_parallelcluster_node S3 install path. Reuse the existing install_python_from_internet attribute as the opt-out: set it to install from PyPI instead. A user-provided custom_node_package still takes precedence.

node_spec: default path now asserts S3 install; added a context covering the install_python_from_internet PyPI fallback.

Note: requires the node package to be present at
<s3_url>/parallelcluster/<version>/node/ in all partitions




### Tests
* Build Image with DevSettings

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
