### PR TITLE
[pcluster-diag] Introduce pcluster-diag as the official pcluster diagnostic tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
           - Python 3.10 Tests
           - Python 3.10 Tests Coverage
           - Code Checks
+          - pcluster-diag Tests
+          - pcluster-diag Tests Coverage
+          - pcluster-diag Code Checks
         include:
           - name: Python 3.8 Tests
             python: 3.8
@@ -68,6 +71,15 @@ jobs:
           - name: Code Checks
             python: '3.10'
             toxenv: code-linters
+          - name: pcluster-diag Tests
+            python: '3.14'
+            toxenv: pcluster-diag -- -e test
+          - name: pcluster-diag Tests Coverage
+            python: '3.14'
+            toxenv: pcluster-diag -- -e test-with-coverage
+          - name: pcluster-diag Code Checks
+            python: '3.14'
+            toxenv: pcluster-diag -- -e code-linters
 
     steps:
       - uses: actions/checkout@main
@@ -85,6 +97,13 @@ jobs:
         with:
           files: coverage.xml
           flags: unittests
+          verbose: true
+      - name: Upload pcluster-diag code coverage report to Codecov
+        if: ${{ matrix.toxenv == 'pcluster-diag -- -e test-with-coverage' }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/coverage.xml
+          flags: pcluster-diag
           verbose: true
   shellcheck:
     name: Shellcheck

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ report.html
 /.kitchen.env.sh
 
 .DS_Store
+
+.kiro/specs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 ------
 
 **ENHANCEMENTS**
+- Ship the diagnostics tool `pcluster-diag` into ParallelCluster AMIs to run on-demand diagnostics check on the cluster.
+  See the `pcluster-diag` README for usage instructions.
 - Improve resilience of EBS volume attachment during cluster creation by retrying on transient IMDS connectivity failures.
 - Further reduce transient build-image failures on RHEL and Rocky caused by out-of-sync repo mirrors by resetting metadata upon retry.
 - Improve cluster update resiliency on login nodes by reusing the head-node-driven orchestration already in place on compute nodes, 

--- a/chefignore
+++ b/chefignore
@@ -95,3 +95,7 @@ Vagrantfile
 
 # Kitchen #
 .kitchen/*
+
+# pcluster-diag developer-only tools (never shipped to nodes)
+*/pcluster-diag/tools/*
+*/pcluster-diag/DEVELOPMENT.md

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/.flake8
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/.flake8
@@ -1,0 +1,24 @@
+[flake8]
+# D100 Missing docstring in public module
+# D101 Missing docstring in public class
+# D102 Missing docstring in public method
+# D103 Missing docstring in public function
+# D104 Missing docstring in public package
+per-file-ignores =
+    */__init__.py: D104
+    tests/*: D100, D101, D102, D103
+exclude =
+    .tox,
+    .git,
+    .pytest_cache,
+    build,
+    dist,
+    *.pyc,
+    *.egg-info,
+    .cache,
+    .eggs
+max-complexity = 10
+max-line-length = 120
+import-order-style = google
+application-import-names = flake8
+format = %(cyan)s%(path)s%(reset)s:%(bold)s%(yellow)s%(row)d%(reset)s:%(bold)s%(green)s%(col)d%(reset)s: %(bold)s%(red)s%(code)s%(reset)s %(text)s

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/.gitignore
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/.gitignore
@@ -1,0 +1,19 @@
+# Local pyenv/pyenv-virtualenv auto-activation file (developer-specific)
+.python-version
+
+# tox / build / test artifacts
+.tox/
+build/
+dist/
+*.egg-info/
+__pycache__/
+*.pyc
+.pytest_cache/
+.cache/
+report.html
+coverage.xml
+.coverage
+.coverage.*
+
+# Diagnostics report output produced by running the tool
+pcluster-diag-output/

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/DEVELOPMENT.md
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/DEVELOPMENT.md
@@ -1,0 +1,44 @@
+# Developing pcluster-diag
+
+This document is for ParallelCluster engineers working on the `pcluster-diag` tool itself.
+
+## Development environment
+
+```bash
+# Create the virtual environment
+pyenv virtualenv 3.10 pcluster-diag
+
+# Activate the virtual environment
+pyenv activate pcluster-diag
+
+# Install the tool, including development dependencies
+pip install -e ".[dev]"
+```
+
+## Tests and linters
+
+```bash
+# Run the tests with coverage and all code linters
+tox
+
+# Run only the tests
+tox -e test
+
+# Run the tests and report coverage
+tox -e test-with-coverage
+
+# Run only the code linters
+tox -e code-linters
+
+# Auto-format the code
+tox -e autoformat
+```
+
+## Testing local changes
+
+To try out your local changes on a running cluster, use the [`sync-to-cluster.sh`](tools/sync-to-cluster.sh)
+helper. It overwrites the tool's source dir on the head node with this local copy.
+
+```bash
+./tools/sync-to-cluster.sh my-cluster us-east-1 ~/.ssh/my-key.pem
+```

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/README.md
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/README.md
@@ -1,0 +1,19 @@
+# pcluster-diag
+
+Diagnostics tool for AWS ParallelCluster nodes.
+
+It runs a context-aware set of checks against a running cluster and produces a structured
+report as JSON plus console output.
+
+The tool is invoked via the `pcluster-diag` command and runs as root from whatever cluster node.
+
+## Updating the tool
+
+You can update it without waiting for a ParallelCluster release by running the commands below as root.
+
+```bash
+# Overwrite the tool source with the version on GitHub (replace develop with another branch or tag).
+curl -fL https://github.com/aws/aws-parallelcluster-cookbook/archive/refs/heads/develop.tar.gz \
+  | tar -xz --strip-components=5 -C /opt/parallelcluster/sources/pcluster-diag \
+    --wildcards '*/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/*'
+```

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/__init__.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Top-level pcluster-diag package: the CLI entrypoint and subpackages."""
+
+__version__ = "1.0.0"

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/__init__.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Diagnostic Check implementations."""

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/cfn_hup.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/cfn_hup.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check asserting the cfn-hup daemon's expected state per node type."""
+
+from pcluster_diag.core.constants import CFN_HUP_PROGRAM
+from pcluster_diag.models.check import Check
+from pcluster_diag.models.context import Context, NodeType
+from pcluster_diag.models.result import Result
+from pcluster_diag.util.services import is_supervisord_program_running
+
+
+class CfnHupRunsOnlyOnHeadNode(Check):
+    """Verify that the cfn-hup daemon runs only on the head node."""
+
+    @property
+    def description(self) -> str:
+        """Return the human-readable description of this Check."""
+        return "Verify that the cfn-hup daemon runs only on the head node."
+
+    def run(self, context: Context) -> Result:
+        """Pass when cfn-hup is running on the head node and stopped elsewhere; fail otherwise."""
+        should_be_running = context.node_type is NodeType.HEAD
+        is_running = is_supervisord_program_running(CFN_HUP_PROGRAM)
+        node_type = context.node_type.value
+        if is_running == should_be_running:
+            return Result.passed(self)
+        if should_be_running:
+            message = "{} is not running on the {}.".format(CFN_HUP_PROGRAM, node_type)
+        else:
+            message = "{} is running on the {}.".format(CFN_HUP_PROGRAM, node_type)
+        return Result.failure(self, message=message)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/sample.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/sample.py
@@ -1,0 +1,34 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A placeholder Check that exercises the confirmation-gated execution path."""
+
+from pcluster_diag.models.check import Check
+from pcluster_diag.models.context import Context
+from pcluster_diag.models.result import Result
+
+
+class SampleCheck(Check):
+    """A no-op Check that requires confirmation and always passes (exercises the approval path)."""
+
+    @property
+    def description(self) -> str:
+        """Return the human-readable description of this Check."""
+        return "Placeholder check that requires confirmation and always passes."
+
+    def approval_required(self, context: Context) -> bool:
+        """Require confirmation before running."""
+        return True
+
+    def run(self, context: Context) -> Result:
+        """Pass without inspecting anything."""
+        return Result.passed(self)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/cli.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/cli.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Click-based command-line interface.
+
+Defines the `pcluster-diag` command group and registers its subcommands.
+"""
+
+import click
+
+from pcluster_diag import __version__
+from pcluster_diag.commands.run import run
+from pcluster_diag.core.constants import PACKAGE_NAME
+from pcluster_diag.core.exception_handler import ExceptionHandler
+from pcluster_diag.util.logging_utils import configure_logging
+
+
+class PclusterDiagGroup(click.Group):
+    """A Click group that configures logging and routes any command exception to the ExceptionHandler."""
+
+    def invoke(self, ctx: click.Context):
+        """Configure logging, then invoke the selected command, delegating exceptions to the handler."""
+        try:
+            configure_logging()
+            return super().invoke(ctx)
+        except Exception as error:  # noqa: BLE001  -- the handler decides how to treat every non-system exception
+            ExceptionHandler().handle(error)
+
+
+@click.group(cls=PclusterDiagGroup)
+@click.version_option(__version__, prog_name=PACKAGE_NAME)
+def main() -> None:
+    """Diagnostics for AWS ParallelCluster nodes."""
+
+
+main.add_command(run)
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/commands/__init__.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/commands/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The CLI subcommands."""

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/commands/run.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/commands/run.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The `run` subcommand.
+
+Runs the applicable diagnostic Checks for the current Context and emits the
+resulting Report.
+"""
+
+import json
+import logging
+import os
+
+import click
+
+from pcluster_diag.core.context_builder import ContextBuilder
+from pcluster_diag.core.registry import DEFAULT_REGISTRY
+from pcluster_diag.core.runner import Runner
+from pcluster_diag.models.exceptions import DiagnosticCheckNotPassedError, InsufficientPrivilegesError
+from pcluster_diag.models.report import Report
+from pcluster_diag.models.result import FAILED_STATUSES
+from pcluster_diag.util.serialization import to_dict
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name="run")
+@click.option(
+    "--output-file",
+    "output_file",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="File where the JSON report is written (default: a timestamped file under ./pcluster-diag-output).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Approve every check that requires confirmation, without prompting.",
+)
+def run(output_file, assume_yes) -> None:
+    """Run the applicable diagnostic checks and emit the report.
+
+    Prints the JSON report to stdout and writes it to a file (best-effort). Progress and errors are
+    logged to stderr. Exits 0 only when every check passes; otherwise non-zero.
+    """
+    _require_root()
+
+    context = ContextBuilder().build()
+    all_checks, checks_not_applicable, checks_not_approved = DEFAULT_REGISTRY.select_checks(
+        context, assume_yes=assume_yes
+    )
+    results = Runner().execute(
+        context,
+        all_checks,
+        check_not_applicable=checks_not_applicable,
+        check_not_approved=checks_not_approved,
+    )
+    report = Report(context=context, results=results)
+
+    _emit_report(report, output_file)
+
+    if any(result.status in FAILED_STATUSES for result in results):
+        raise DiagnosticCheckNotPassedError()
+
+
+def _require_root() -> None:
+    """Raise InsufficientPrivilegesError unless the process is running as root."""
+    if os.geteuid() != 0:
+        raise InsufficientPrivilegesError()
+
+
+def _emit_report(report: Report, output_file) -> None:
+    """Write the report file (best-effort) and print the serialized report as JSON to stdout."""
+    _write_report_file(report, output_file)
+    print(json.dumps(to_dict(report), indent=2))
+
+
+def _write_report_file(report: Report, output_file) -> None:
+    """Write the Report to ``output_file`` (or a default timestamped path) best-effort.
+
+    A write failure is logged but does not abort the run; the report is still printed to stdout.
+    """
+    path = output_file or report.default_path
+    try:
+        saved = report.save(path)
+        logger.info("Report written to %s", saved)
+    except Exception as exc:  # noqa: B902 - best-effort: a write failure must not fail the run
+        logger.error("Could not write the JSON report file: %s", exc)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/__init__.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Core controllers."""

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared constants."""
+
+# General
+PACKAGE_NAME = "pcluster-diag"
+TIMESTAMP_FORMAT = "%Y-%m-%dT%H-%M-%S"
+
+# Relevant paths
+DEFAULT_DNA_JSON_PATH = "/etc/chef/dna.json"
+DEFAULT_CLUSTER_CONFIG_PATH = "/opt/parallelcluster/shared/cluster-config.yaml"
+DEFAULT_BOOTSTRAPPED_PATH = "/opt/parallelcluster/.bootstrapped"
+
+# cfn-hup runs as a supervisord program (not a systemd service) managed via the cookbook virtualenv's
+# supervisorctl, reading the supervisord config installed by the cookbook.
+CFN_HUP_PROGRAM = "cfn-hup"
+SUPERVISORCTL_GLOB = "/opt/parallelcluster/pyenv/versions/*/envs/cookbook_virtualenv/bin/supervisorctl"

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/context_builder.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/context_builder.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Construction of the runtime diagnostic Context."""
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from pcluster_diag import __version__
+from pcluster_diag.core.constants import (
+    DEFAULT_BOOTSTRAPPED_PATH,
+    DEFAULT_CLUSTER_CONFIG_PATH,
+    DEFAULT_DNA_JSON_PATH,
+    TIMESTAMP_FORMAT,
+)
+from pcluster_diag.models.context import Context, NodeType
+from pcluster_diag.models.exceptions import ContextBuildError
+from pcluster_diag.util import imds
+from pcluster_diag.util.cfn import get_stack_output
+
+logger = logging.getLogger(__name__)
+
+
+class ContextBuilder:
+    """Builds a fully-resolved Context describing the runtime environment."""
+
+    def __init__(
+        self,
+        dna_json_path: str = DEFAULT_DNA_JSON_PATH,
+        cluster_config_path: str = DEFAULT_CLUSTER_CONFIG_PATH,
+        bootstrapped_path: str = DEFAULT_BOOTSTRAPPED_PATH,
+    ) -> None:
+        """Create a builder, optionally overriding the read-only source paths (used by tests)."""
+        self._dna_json_path = dna_json_path
+        self._cluster_config_path = cluster_config_path
+        self._bootstrapped_path = bootstrapped_path
+
+    def build(self) -> Context:
+        """Resolve every attribute via its helper and return a fully-resolved Context.
+
+        Construction is all-or-nothing: if any helper fails, no Context is produced and a
+        ContextBuildError is raised carrying a user-facing message and the underlying cause.
+        """
+        try:
+            dna_json = self._dna_json()
+            node_type = self._node_type(dna_json)
+            instance_id = self._instance_id()
+            return Context(
+                timestamp=datetime.now(timezone.utc).strftime(TIMESTAMP_FORMAT),
+                pcluster_diag_version=self._pcluster_diag_version(),
+                pcluster_version=self._pcluster_version(),
+                instance_id=instance_id,
+                node_type=node_type,
+                cluster_config=self._cluster_config(),
+                dna_json=dna_json,
+                head_node_instance_id=self._head_node_instance_id(node_type, dna_json),
+            )
+        except Exception as error:  # any failure means the Context cannot be built
+            raise ContextBuildError(
+                "Failed to build the diagnostic context. pcluster-diag is meant to run on an AWS ParallelCluster node. "
+                "This failure most likely means it is not running on a cluster node. "
+                "Underlying error: {}".format(error)
+            ) from error
+
+    def _pcluster_diag_version(self) -> str:
+        """Return the pcluster-diag version declared in the package."""
+        return __version__
+
+    def _pcluster_version(self) -> str:
+        """Read the ParallelCluster version from the node's bootstrapped marker file."""
+        content = Path(self._bootstrapped_path).read_text(encoding="utf-8").strip()
+        match = re.search(r"\d+\.\d+\.\d+", content)
+        if match:
+            return match.group(0)
+        if not content:
+            raise ValueError("bootstrapped marker is empty")
+        return content
+
+    def _instance_id(self) -> Optional[str]:
+        """Return the current instance id from IMDS, or None (logging an error) if it cannot be determined."""
+        try:
+            return imds.get_instance_id()
+        except Exception as error:  # best-effort: a failure must not abort the build
+            logger.error("Could not determine the current instance id from IMDS: %s", error)
+            return None
+
+    def _node_type(self, dna_json: dict) -> NodeType:
+        """Classify the node type from ``dna.json``; the token is the NodeType member value."""
+        raw = ((dna_json or {}).get("cluster") or {}).get("node_type")
+        return NodeType(raw)
+
+    def _cluster_config(self) -> dict:
+        """Read and parse the deployed cluster configuration (YAML)."""
+        return yaml.safe_load(Path(self._cluster_config_path).read_text(encoding="utf-8"))
+
+    def _dna_json(self) -> dict:
+        """Read and parse the node's ``dna.json`` into a dict."""
+        return json.loads(Path(self._dna_json_path).read_text(encoding="utf-8"))
+
+    def _head_node_instance_id(self, node_type: NodeType, dna_json: dict) -> Optional[str]:
+        """Return the head node instance id.
+
+        On the head node it is the current instance id; on any other node it is read from the cluster
+        stack's ``HeadNodeInstanceID`` output, returning None (logging an error) if that cannot be done.
+        """
+        if node_type is NodeType.HEAD:
+            return self._instance_id()
+        try:
+            cluster = (dna_json or {}).get("cluster") or {}
+            return get_stack_output(cluster["stack_name"], cluster["region"], "HeadNodeInstanceID")
+        except Exception as error:  # best-effort: a failure must not abort the build
+            logger.error("Could not determine the head node instance id from CloudFormation: %s", error)
+            return None

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/exception_handler.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/exception_handler.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Centralized translation of command exceptions into structured JSON errors and a clean exit."""
+
+import json
+import logging
+import traceback
+
+from pcluster_diag.models.exceptions import DiagnosticCheckNotPassedError, ExitCode
+
+logger = logging.getLogger(__name__)
+
+
+class ExceptionHandler:
+    """Turns an exception raised by a CLI command into a structured JSON error and a clean exit."""
+
+    def handle(self, error: Exception) -> None:
+        """Handle any exception raised by the CLI.
+
+        * Click exceptions: re-raised without logging, as they are expected control flow, such as
+          the exceptions raised by --help/--version.
+        * DiagnosticCheckNotPassedError: exits with its specific error code without logging, because
+          the diagnostic report already contains the details of the failed checks.
+        * Any other exception: logs the error, prints the error description as JSON, and exits with
+          the error's exit code (or the internal-error code when it has none).
+        """
+        if self._is_click_exception(error):
+            raise error
+        # The failed checks are already reported in the diagnostic report, so only exit with the code.
+        if isinstance(error, DiagnosticCheckNotPassedError):
+            raise SystemExit(error.exit_code) from error
+        logger.error("%s: %s", type(error).__name__, error, exc_info=error)
+        print(json.dumps(self._error_to_dict(error), indent=2))
+        raise SystemExit(getattr(error, "exit_code", ExitCode.INTERNAL_ERROR)) from error
+
+    @staticmethod
+    def _error_to_dict(error: Exception) -> dict:
+        """Render an exception as ``{"errorType", "errorMessage"}`` (message falls back to the stack trace)."""
+        stack_trace = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+        return {"errorType": type(error).__name__, "errorMessage": str(error) or stack_trace}
+
+    @staticmethod
+    def _is_click_exception(error: Exception) -> bool:
+        """Return whether ``error`` is any exception defined by the Click library."""
+        return any(klass.__module__.split(".")[0] == "click" for klass in type(error).__mro__)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/registry.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/registry.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry of diagnostic Checks.
+
+Only explicitly registered Checks will be executed, in registration order.
+"""
+
+import logging
+from typing import Dict, List, Optional, Set, Tuple
+
+import click
+
+from pcluster_diag.checks.cfn_hup import CfnHupRunsOnlyOnHeadNode
+from pcluster_diag.checks.sample import SampleCheck
+from pcluster_diag.models.check import Check
+from pcluster_diag.models.context import Context
+
+logger = logging.getLogger(__name__)
+
+
+class Registry:
+    """An explicit, order-preserving collection of registered Checks.
+
+    Checks are registered via ``register``, returned in registration order
+    by ``registered_checks``, and resolved by identifier via ``get``.
+    """
+
+    def __init__(self) -> None:
+        """Create an empty registry."""
+        # Maps the check identifier -> the first Check registered under that name.
+        # A dict preserves insertion order, so this also captures registration order.
+        self._checks_by_id: Dict[str, Check] = {}
+
+    def register(self, check: Check) -> "Registry":
+        """Register ``check`` explicitly, preserving registration order, and return this registry.
+
+        Returning ``self`` lets Checks be registered inline by chaining ``register`` calls (see
+        ``DEFAULT_REGISTRY`` below). If a Check with the same identifier is already registered, warn,
+        keep the first Check, and drop ``check`` without aborting registration.
+        """
+        identifier = check.identifier
+        if identifier in self._checks_by_id:
+            logger.warning(
+                "Duplicate check identifier '%s': keeping the first Check registered "
+                "under that name and ignoring the duplicate.",
+                identifier,
+            )
+            return self
+        self._checks_by_id[identifier] = check
+        return self
+
+    def registered_checks(self) -> List[Check]:
+        """Return the registered Checks in registration order, one per identifier."""
+        return list(self._checks_by_id.values())
+
+    def select_checks(self, context: Context, assume_yes: bool = False) -> Tuple[List[Check], List[Check], List[Check]]:
+        """Classify the registered Checks for ``context`` and prompt for any required confirmations.
+
+        Returns a ``(registered, not_applicable, not_approved)`` triple, each in registration order:
+
+        - ``registered``: every registered Check (the Runner runs those that are neither skipped nor
+          declined).
+        - ``not_applicable``: non-applicable Checks (``should_run(context)`` False); the Runner records
+          these as SKIPPED.
+        - ``not_approved``: applicable, confirmation-required Checks whose prompt the user declined; the
+          Runner records these as SKIPPED ("Skipped by the user").
+
+        Confirmation-required Checks (``approval_required(context)`` True) are listed and prompted yes/no
+        here, before the Runner is invoked, so execution begins only once every decision is collected.
+        When ``assume_yes`` is True, they are approved without prompting.
+        """
+        registered = self.registered_checks()
+        applicable = [check for check in registered if check.should_run(context)]
+        applicable_ids = {check.identifier for check in applicable}
+
+        require_confirmation = [check for check in applicable if check.approval_required(context)]
+        declined = self._prompt_for_confirmations(require_confirmation, assume_yes=assume_yes)
+
+        not_applicable: List[Check] = []
+        not_approved: List[Check] = []
+        for check in registered:
+            if check.identifier not in applicable_ids:
+                not_applicable.append(check)
+            elif check.identifier in declined:
+                not_approved.append(check)
+
+        return registered, not_applicable, not_approved
+
+    @staticmethod
+    def _prompt_for_confirmations(checks_to_confirm: List[Check], assume_yes: bool = False) -> Set[str]:
+        """List the confirmation-required Checks, prompt yes/no for each, and return the declined identifiers.
+
+        All prompts are answered before any Check runs, so the listing happens up front (Req 6.10, 11.3).
+        When ``assume_yes`` is True, every Check is approved without prompting (nothing is declined).
+        """
+        if not checks_to_confirm or assume_yes:
+            return set()
+
+        logger.info("The following checks require your confirmation before they run:")
+        for check in checks_to_confirm:
+            logger.info("  - %s: %s", check.identifier, check.description)
+
+        return {
+            check.identifier
+            for check in checks_to_confirm
+            if not click.confirm("Run check '{}'?".format(check.identifier), err=True)
+        }
+
+    def get(self, identifier: str) -> Optional[Check]:
+        """Return the registered Check with ``identifier``, or ``None`` if none."""
+        return self._checks_by_id.get(identifier)
+
+
+# The default Registry, in execution order. Concrete Checks are registered inline here by chaining
+# ``register`` (which returns the registry).
+DEFAULT_REGISTRY = Registry().register(CfnHupRunsOnlyOnHeadNode()).register(SampleCheck())

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/runner.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/runner.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Execution engine for the diagnostic Checks.
+
+Runs the Checks in registration order, isolating failures, and aggregates
+their Results in that same order.
+"""
+
+import logging
+import traceback
+from typing import List
+
+from pcluster_diag.models.check import Check
+from pcluster_diag.models.context import Context
+from pcluster_diag.models.result import FAILED_STATUSES, Result
+
+logger = logging.getLogger(__name__)
+
+
+class Runner:
+    """Executes the Checks and aggregates their Results, one Result per Check, in registration order.
+
+    Checks that run execute in isolation (an unhandled exception becomes an ERROR Result), and a
+    FAILURE or ERROR never stops the run. Non-applicable Checks are recorded as SKIPPED and declined
+    confirmation-required Checks as SKIPPED ("Skipped by the user"). Each outcome is logged to stderr
+    and never alters the JSON Report.
+    """
+
+    def execute(
+        self,
+        context: Context,
+        checks: List[Check],
+        check_not_applicable: List[Check] = (),
+        check_not_approved: List[Check] = (),
+    ) -> List[Result]:
+        """Run ``checks`` in order, one Result per Check, preserving the order of ``checks``.
+
+        Each Check in ``checks`` is handled in order and, based on its disposition:
+
+        - recorded SKIPPED ("not applicable") when it is in ``check_not_applicable``;
+        - recorded SKIPPED ("Skipped by the user") when it is in ``check_not_approved``;
+        - otherwise executed in isolation (an unhandled exception becomes an ERROR Result).
+
+        Args:
+            context: The runtime Context for this diagnosis.
+            checks: Every Check to account for, in registration order.
+            check_not_applicable: Non-applicable Checks to record as SKIPPED.
+            check_not_approved: Confirmation-required Checks the user declined,
+                recorded as SKIPPED ("Skipped by the user").
+
+        Returns:
+            One Result per Check in ``checks``, in the same (registration) order.
+        """
+        not_applicable_ids = {check.identifier for check in check_not_applicable}
+        not_approved_ids = {check.identifier for check in check_not_approved}
+        results: List[Result] = []
+        for check in checks:
+            if check.identifier in not_applicable_ids:
+                result = Result.skipped(check, message="Check is not applicable to the current context.")
+            elif check.identifier in not_approved_ids:
+                result = Result.skipped(check, message="Skipped by the user")
+            else:
+                result = self._execute_check(context, check)
+            self._collect_result(results, result)
+        return results
+
+    def _collect_result(self, results: List[Result], result: Result) -> None:
+        """Record and log the outcome for one Check."""
+        results.append(result)
+        self._print_outcome(result)
+
+    @staticmethod
+    def _print_outcome(result: Result) -> None:
+        """Log a per-Check outcome line to stderr; never alters the JSON Report.
+
+        FAILURE and ERROR outcomes are logged at error level; PASSED and SKIPPED at info level.
+        """
+        line = "%s: %s" % (result.check_id, result.status.value)
+        if result.status in FAILED_STATUSES:
+            logger.error(line)
+        else:
+            logger.info(line)
+
+    def _execute_check(self, context: Context, check: Check) -> Result:
+        """Run the Check in isolation, converting any unexpected error into an ERROR Result."""
+        logger.info("Check %s: started", check.identifier)
+        try:
+            return check.run(context)
+        except Exception:  # noqa: B902 - isolation: any failure becomes an ERROR Result
+            return Result.error(check, message=traceback.format_exc())
+        finally:
+            logger.info("Check %s: finished", check.identifier)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/__init__.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Domain models."""

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/check.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/check.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The uniform Check interface implemented by every diagnostic Check."""
+
+from abc import ABC, abstractmethod
+
+from pcluster_diag.models.context import Context
+from pcluster_diag.models.result import Result
+
+
+class Check(ABC):
+    """A unit of diagnostic check."""
+
+    @property
+    def identifier(self) -> str:
+        """Return the check identifier: this Check's class simple name."""
+        return type(self).__name__
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Return the human-readable description of this Check."""
+        raise NotImplementedError
+
+    def should_run(self, context: Context) -> bool:
+        """Return whether this Check applies to the given Context.
+
+        Defaults to ``True`` (the Check applies to every Context).
+        """
+        return True
+
+    def approval_required(self, context: Context) -> bool:
+        """Return whether this Check requires user confirmation before running.
+
+        Defaults to ``False``. When ``True``, the user is prompted to confirm the execution.
+        """
+        return False
+
+    @abstractmethod
+    def run(self, context: Context) -> Result:
+        """Execute the Check and return its Result."""
+        raise NotImplementedError

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/context.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/context.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Context model describing the runtime environment a diagnosis runs in."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class NodeType(Enum):
+    """The type of cluster node the tool is running on."""
+
+    HEAD = "HeadNode"
+    COMPUTE = "ComputeFleet"
+    LOGIN = "LoginNode"
+
+
+@dataclass
+class Context:
+    """The runtime environment captured at CLI startup.
+
+    The builder resolves each value at CLI startup. The instance ids are best-effort: if they cannot
+    be determined (e.g. IMDS or AWS raises), they are set to None instead of failing the build.
+
+    Attributes:
+        timestamp: When the diagnosis ran, as a UTC string without timezone suffix
+            (``YYYY-MM-DDThh-mm-ss``); the same value names the report file.
+        pcluster_diag_version: The pcluster-diag package version (``1.0.0`` initially).
+        pcluster_version: The installed ParallelCluster version.
+        instance_id: The id of the instance the tool is running on, or None if it cannot be determined.
+        node_type: The node type the tool runs on (HEAD, COMPUTE, or LOGIN).
+        cluster_config: The deployed cluster configuration.
+        dna_json: The node's ``dna.json`` contents.
+        head_node_instance_id: The id of the cluster head node instance, or None if it cannot be determined.
+    """
+
+    timestamp: str
+    pcluster_diag_version: str
+    pcluster_version: str
+    instance_id: Optional[str]
+    node_type: NodeType
+    cluster_config: dict
+    dna_json: dict
+    head_node_instance_id: Optional[str]

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/exceptions.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/exceptions.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Domain exceptions for pcluster-diag.
+
+Every expected error derives from :class:`PclusterDiagError`; the CLI's top-level handler prints it as
+JSON and exits with its ``exit_code``.
+"""
+
+import enum
+
+
+class ExitCode(enum.IntEnum):
+    """Process exit codes returned by the pcluster-diag CLI."""
+
+    INTERNAL_ERROR = 1
+    CONTEXT_BUILD_ERROR = 2
+    DIAGNOSTIC_CHECK_FAILURE = 3
+    INSUFFICIENT_PRIVILEGES = 4
+
+
+class PclusterDiagError(Exception):
+    """Base class for expected pcluster-diag errors."""
+
+    #: Process exit code associated with this error type.
+    exit_code: ExitCode = ExitCode.INTERNAL_ERROR
+    #: User-facing message used when the error is raised without an explicit one.
+    default_message: str = "An unexpected pcluster-diag error occurred."
+
+    def __str__(self) -> str:
+        """Return the explicit message when provided, otherwise the type's default message."""
+        return super().__str__() or self.default_message
+
+
+class ContextBuildError(PclusterDiagError):
+    """Raised when the diagnostic Context cannot be built (e.g., not running on a cluster node)."""
+
+    exit_code = ExitCode.CONTEXT_BUILD_ERROR
+    default_message = "Failed to build the diagnostic context."
+
+
+class DiagnosticCheckNotPassedError(PclusterDiagError):
+    """Raised when at least one check did not pass (a FAILURE or ERROR result)."""
+
+    exit_code = ExitCode.DIAGNOSTIC_CHECK_FAILURE
+    default_message = "The diagnosis detected at least one failed check."
+
+
+class InsufficientPrivilegesError(PclusterDiagError):
+    """Raised when the CLI is not run as root, which its checks require."""
+
+    exit_code = ExitCode.INSUFFICIENT_PRIVILEGES
+    default_message = "pcluster-diag must be run as root."

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/report.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/report.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report model aggregating the captured Context and per-Check Results."""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+from pcluster_diag.core.constants import PACKAGE_NAME
+from pcluster_diag.models.context import Context
+from pcluster_diag.models.result import Result
+from pcluster_diag.util.io_utils import write_text_file
+from pcluster_diag.util.serialization import to_json
+
+# Directory (under a base directory) that holds report files by default.
+OUTPUT_DIR_NAME = f"{PACKAGE_NAME}-output"
+
+# Report filename template; the timestamp comes from the Context so file and content always match.
+_REPORT_FILENAME_TEMPLATE = f"{PACKAGE_NAME}-report-{{timestamp}}.json"
+
+
+@dataclass
+class Report:
+    """The aggregated output of a diagnostics execution: the captured Context plus per-Check Results.
+
+    Attributes:
+        context: The Context captured at startup.
+        results: The list of per-Check Results produced during the run.
+    """
+
+    context: Context
+    results: List[Result] = field(default_factory=list)
+
+    @property
+    def default_path(self) -> Path:
+        """Default report file path: ``<cwd>/<OUTPUT_DIR_NAME>/pcluster-diag-report-<timestamp>.json``.
+
+        The filename embeds this report's context run timestamp, so the file name matches the
+        ``timestamp`` recorded inside the report.
+        """
+        filename = _REPORT_FILENAME_TEMPLATE.format(timestamp=self.context.timestamp)
+        return Path(os.getcwd()) / OUTPUT_DIR_NAME / filename
+
+    def save(self, path) -> Path:
+        """Write this Report as JSON to ``path``, creating parent directories as needed; return ``path``.
+
+        Write errors propagate to the caller.
+        """
+        path = Path(path)
+        write_text_file(path, to_json(self))
+        return path

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/result.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/result.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Result model carrying the structured outcome of a Check execution."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class Status(Enum):
+    """The status of a Check execution."""
+
+    PASSED = "PASSED"  # condition satisfied
+    ERROR = "ERROR"  # check raised / could not complete
+    FAILURE = "FAILURE"  # check completed; condition not satisfied
+    SKIPPED = "SKIPPED"  # not applicable or user-skipped
+
+
+# Statuses that make the run unsuccessful: any of these in the results yields a non-zero exit code.
+FAILED_STATUSES = (Status.FAILURE, Status.ERROR)
+
+
+@dataclass
+class Result:
+    """The outcome of executing a Check.
+
+    Attributes:
+        check_id: The check identifier (the Check class simple name).
+        check_description: The Check's human-readable description.
+        status: The Status of the execution (PASSED, ERROR, FAILURE, or SKIPPED).
+        message: An optional human-readable message carrying the failure reason,
+            a recovery suggestion, or an exception stack trace.
+        metadata: An optional dictionary carrying any underlying data referenced by the Result.
+    """
+
+    check_id: str
+    check_description: str
+    status: Status
+    message: Optional[str] = None
+    metadata: Optional[dict] = None
+
+    @staticmethod
+    def passed(check, message: Optional[str] = None, metadata: Optional[dict] = None) -> "Result":
+        """Build a PASSED Result for ``check`` (its condition was satisfied)."""
+        return Result(
+            check_id=check.identifier,
+            check_description=check.description,
+            status=Status.PASSED,
+            message=message,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def error(check, message: Optional[str] = None, metadata: Optional[dict] = None) -> "Result":
+        """Build an ERROR Result for ``check`` (it raised or could not complete)."""
+        return Result(
+            check_id=check.identifier,
+            check_description=check.description,
+            status=Status.ERROR,
+            message=message,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def failure(check, message: Optional[str] = None, metadata: Optional[dict] = None) -> "Result":
+        """Build a FAILURE Result for ``check`` (it completed with its condition not satisfied)."""
+        return Result(
+            check_id=check.identifier,
+            check_description=check.description,
+            status=Status.FAILURE,
+            message=message,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def skipped(check, message: Optional[str] = None, metadata: Optional[dict] = None) -> "Result":
+        """Build a SKIPPED Result for ``check`` (not applicable or user-skipped)."""
+        return Result(
+            check_id=check.identifier,
+            check_description=check.description,
+            status=Status.SKIPPED,
+            message=message,
+            metadata=metadata,
+        )

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/__init__.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared utility helpers."""

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/cfn.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/cfn.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for reading CloudFormation stack outputs."""
+
+import boto3
+
+
+def get_stack_output(stack_name: str, region: str, output_key: str) -> str:
+    """Return the value of the ``output_key`` output of the CloudFormation stack ``stack_name``.
+
+    Raises:
+        KeyError: If the stack has no output named ``output_key``.
+    """
+    client = boto3.client("cloudformation", region_name=region)
+    stacks = client.describe_stacks(StackName=stack_name).get("Stacks", [])
+    outputs = stacks[0].get("Outputs", []) if stacks else []
+    for output in outputs:
+        if output.get("OutputKey") == output_key:
+            return output["OutputValue"]
+    raise KeyError("Stack '{}' has no output '{}'.".format(stack_name, output_key))

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/imds.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/imds.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for querying the EC2 Instance Metadata Service (IMDSv2)."""
+
+import urllib.request
+
+_BASE_URL = "http://169.254.169.254/latest"  # nosec B104  link-local IMDS endpoint
+_TOKEN_URL = _BASE_URL + "/api/token"
+_INSTANCE_ID_URL = _BASE_URL + "/meta-data/instance-id"
+_TOKEN_TTL_SECONDS = "21600"  # nosec B105  session-token TTL (seconds), not a secret
+_TIMEOUT_SECONDS = 5
+
+
+def get_instance_id() -> str:
+    """Return the id of the current instance, fetched from IMDSv2."""
+    token = _fetch_token()
+    return _get(_INSTANCE_ID_URL, token)
+
+
+def _fetch_token() -> str:
+    """Fetch a short-lived IMDSv2 session token."""
+    request = urllib.request.Request(
+        _TOKEN_URL, method="PUT", headers={"X-aws-ec2-metadata-token-ttl-seconds": _TOKEN_TTL_SECONDS}
+    )
+    with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as response:  # nosec B310  # nosemgrep
+        return response.read().decode("utf-8")
+
+
+def _get(url: str, token: str) -> str:
+    """GET ``url`` from IMDS with the given session token and return the stripped body."""
+    request = urllib.request.Request(url, headers={"X-aws-ec2-metadata-token": token})
+    with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as response:  # nosec B310  # nosemgrep
+        return response.read().decode("utf-8").strip()

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/io_utils.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/io_utils.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic I/O helpers."""
+
+from pathlib import Path
+
+
+def write_text_file(path: Path, text: str) -> None:
+    """Write ``text`` to ``path``, creating parent directories as needed.
+
+    Args:
+        path: The destination file path.
+        text: The text to write.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/logging_utils.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/logging_utils.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Logging configuration for the CLI."""
+
+import logging
+import sys
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Send log records to stderr as ``<timestamp> [<LEVEL>] <logger>: <message>``.
+
+    Configures the root logger, so records from every module logger propagate here. Binds a fresh
+    stderr handler each call (resolving ``sys.stderr`` at call time so test runners that replace it are
+    still captured) and clears existing root handlers so repeated invocations do not duplicate lines.
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s"))
+    root_logger.addHandler(handler)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/serialization.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/serialization.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic serialization helpers."""
+
+import dataclasses
+import json
+from enum import Enum
+
+
+def to_dict(obj):
+    """Convert a dataclass instance to a JSON-serializable dict (enum fields become their value)."""
+    return dataclasses.asdict(
+        obj,
+        dict_factory=lambda items: {key: (value.value if isinstance(value, Enum) else value) for key, value in items},
+    )
+
+
+def to_json(obj, indent: int = 2) -> str:
+    """Serialize ``obj`` to a JSON string, preserving dataclass field declaration order."""
+    return json.dumps(to_dict(obj), indent=indent, sort_keys=False)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/services.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/services.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for querying the state of supervisord-managed programs."""
+
+import glob
+from typing import Optional
+
+from pcluster_diag.core.constants import SUPERVISORCTL_GLOB
+from pcluster_diag.util.shell import run_command
+
+
+def is_supervisord_program_running(program: str) -> bool:
+    """Return whether the given supervisord program is currently RUNNING.
+
+    Raises:
+        RuntimeError: If supervisorctl cannot report the program status.
+    """
+    command = [_resolve_supervisorctl(), "status", program]
+    result = run_command(command)
+    state = _program_state(program, result.stdout)
+    if state is None:
+        raise RuntimeError(
+            "Could not parse the status of supervisord program '{}'. supervisorctl output: {!r}".format(
+                program, result.stdout
+            )
+        )
+    return state == "RUNNING"
+
+
+def _resolve_supervisorctl() -> str:
+    """Return the path to the cookbook virtualenv's ``supervisorctl`` binary.
+
+    Raises:
+        FileNotFoundError: If the ``supervisorctl`` binary cannot be located.
+    """
+    matches = sorted(glob.glob(SUPERVISORCTL_GLOB))
+    if not matches:
+        raise FileNotFoundError(
+            "Could not locate the supervisorctl binary (looked in '{}').".format(SUPERVISORCTL_GLOB)
+        )
+    return matches[0]
+
+
+def _program_state(program: str, status_output: str) -> Optional[str]:
+    """Return the status token reported for ``program`` in ``status_output``, or None if unparseable.
+
+    ``supervisorctl status`` prints ``<name> <STATUS> <description>`` per program.
+    If the status cannot be parsed, None is returned.
+    """
+    for line in status_output.splitlines():
+        tokens = line.split()
+        if not tokens:
+            continue
+        name = tokens[0].rstrip(":")
+        if name == program:
+            return tokens[1] if len(tokens) >= 2 else None
+    return None

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/shell.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/shell.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for running external commands."""
+
+import logging
+import subprocess  # nosec B404  # callers pass a fixed argument list, no shell
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Default command timeout in seconds.
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 60
+
+
+def run_command(
+    command: List[str], timeout: Optional[int] = DEFAULT_COMMAND_TIMEOUT_SECONDS
+) -> subprocess.CompletedProcess:
+    """Run ``command`` without a shell, log its outcome to stderr, and return the CompletedProcess.
+
+    The command is never run through a shell and its return code is not checked, so callers decide how
+    to interpret the result. ``timeout`` (seconds, default 60) may be overridden or set to ``None`` to
+    disable it.
+    """
+    result = subprocess.run(  # nosec B603  # no shell; the argument list is fixed by the caller
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+    logger.info(
+        "Executed command %s: exit code %d, stdout=%r, stderr=%r",
+        command,
+        result.returncode,
+        result.stdout,
+        result.stderr,
+    )
+    return result

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pyproject.toml
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pyproject.toml
@@ -1,0 +1,65 @@
+# The tool supports two independent workflows:
+#   * pip-installable
+#     In this case, the build-system is used.
+#   * run directly from source with `python -m pcluster_diag.cli`.
+#     In this case, the build-system is not used.
+[build-system]
+requires = ["setuptools>=80.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pcluster-diag"
+description = "Diagnostics tool for AWS ParallelCluster nodes."
+readme = "README.md"
+requires-python = ">=3.14"
+license = { text = "Apache-2.0" }
+authors = [
+    { name = "Amazon Web Services" },
+]
+dynamic = ["version"]
+dependencies = [
+    "boto3~=1.42",
+    "click~=8.0",
+    "pyyaml~=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest~=9.0",
+    "pytest-cov~=7.0",
+    "tox~=4.0",
+]
+
+[project.scripts]
+pcluster-diag = "pcluster_diag.cli:main"
+
+[tool.setuptools.dynamic]
+version = { attr = "pcluster_diag.__version__" }
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["pcluster_diag*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+cache_dir = "tests/.pytest_cache"
+
+[tool.black]
+line-length = 120
+
+[tool.isort]
+profile = "black"
+line_length = 120
+known_first_party = ["pcluster_diag"]
+
+[tool.coverage.run]
+source = ["pcluster_diag"]
+branch = true
+data_file = "tests/.coverage"
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 90
+
+[tool.coverage.xml]
+output = "tests/coverage.xml"

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_cfn_hup.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_cfn_hup.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the cfn-hup check covering description, should_run, approval_required, and run."""
+
+import pytest
+
+from pcluster_diag.checks import cfn_hup
+from pcluster_diag.checks.cfn_hup import CfnHupRunsOnlyOnHeadNode
+from pcluster_diag.models.context import NodeType
+from pcluster_diag.models.result import Status
+from tests.sample_data import sample_context
+
+
+def test_description():
+    description = CfnHupRunsOnlyOnHeadNode().description
+
+    assert description == "Verify that the cfn-hup daemon runs only on the head node."
+
+
+@pytest.mark.parametrize("node_type", list(NodeType), ids=lambda nt: nt.name)
+def test_should_run(node_type):
+    # The check compares actual vs expected state, so it applies on every node type.
+    assert CfnHupRunsOnlyOnHeadNode().should_run(sample_context(node_type)) is True
+
+
+@pytest.mark.parametrize("node_type", list(NodeType), ids=lambda nt: nt.name)
+def test_approval_required(node_type):
+    assert CfnHupRunsOnlyOnHeadNode().approval_required(sample_context(node_type)) is False
+
+
+@pytest.mark.parametrize(
+    "node_type, is_running, expected_status, expected_message",
+    [
+        (NodeType.HEAD, True, Status.PASSED, None),  # head: running as expected
+        (
+            NodeType.HEAD,
+            False,
+            Status.FAILURE,
+            "cfn-hup is not running on the HeadNode.",
+        ),  # head: should run but isn't
+        (NodeType.COMPUTE, False, Status.PASSED, None),  # compute: not running as expected
+        (
+            NodeType.COMPUTE,
+            True,
+            Status.FAILURE,
+            "cfn-hup is running on the ComputeFleet.",
+        ),  # compute: running but shouldn't be
+        (NodeType.LOGIN, False, Status.PASSED, None),  # login: not running as expected
+        (
+            NodeType.LOGIN,
+            True,
+            Status.FAILURE,
+            "cfn-hup is running on the LoginNode.",
+        ),  # login: running but shouldn't be
+    ],
+)
+def test_run(monkeypatch, node_type, is_running, expected_status, expected_message):
+    monkeypatch.setattr(cfn_hup, "is_supervisord_program_running", lambda _program: is_running)
+
+    result = CfnHupRunsOnlyOnHeadNode().run(sample_context(node_type))
+
+    assert result.status is expected_status
+    assert result.message == expected_message
+
+
+def test_run_propagates_when_status_cannot_be_determined(monkeypatch):
+    # An undeterminable status makes the check raise (the Runner maps it to an ERROR).
+    def _raise(_program):
+        raise RuntimeError("cannot determine status")
+
+    monkeypatch.setattr(cfn_hup, "is_supervisord_program_running", _raise)
+
+    with pytest.raises(RuntimeError):
+        CfnHupRunsOnlyOnHeadNode().run(sample_context(NodeType.HEAD))

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_sample.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_sample.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the sample check covering description, should_run, approval_required, and run."""
+
+from pcluster_diag.checks.sample import SampleCheck
+from pcluster_diag.models.result import Status
+from tests.sample_data import sample_context
+
+
+def test_description():
+    description = SampleCheck().description
+
+    assert description == "Placeholder check that requires confirmation and always passes."
+
+
+def test_should_run():
+    # SampleCheck does not restrict applicability, so it runs in every context.
+    assert SampleCheck().should_run(sample_context()) is True
+
+
+def test_approval_required():
+    assert SampleCheck().approval_required(sample_context()) is True
+
+
+def test_run():
+    check = SampleCheck()
+
+    result = check.run(sample_context())
+
+    assert result.status is Status.PASSED
+    assert result.check_id == check.identifier
+    assert result.message is None

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/commands/test_run.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/commands/test_run.py
@@ -1,0 +1,237 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the ``run`` subcommand: selection, confirmation gating, report emission, and errors."""
+
+import json
+import os
+
+import pytest
+from click.testing import CliRunner
+
+from pcluster_diag.cli import main
+from pcluster_diag.commands import run as run_module
+from pcluster_diag.commands.run import run
+from pcluster_diag.core.registry import Registry
+from pcluster_diag.models.exceptions import ContextBuildError
+from pcluster_diag.models.report import OUTPUT_DIR_NAME, Report
+from pcluster_diag.models.result import Status
+from tests.sample_data import FakeCheck, sample_context
+
+# Seam for the independently-built Context: the `run` command does ``ContextBuilder().build()``.
+_CONTEXT_BUILD = "pcluster_diag.core.context_builder.ContextBuilder.build"
+
+
+@pytest.fixture
+def runner():
+    # stdout carries only the JSON document; logs go to stderr (kept separate by CliRunner).
+    return CliRunner()
+
+
+@pytest.fixture
+def stub_context(monkeypatch):
+    """Stub the independently-built Context and use an empty registry so a default `run` selects no Checks."""
+    monkeypatch.setattr(_CONTEXT_BUILD, lambda self: sample_context())
+    monkeypatch.setattr("pcluster_diag.commands.run.DEFAULT_REGISTRY", Registry())
+
+
+def _stub_registry_with(monkeypatch, checks):
+    """Make `run` build a canned Context and evaluate a registry populated with the given checks."""
+    registry = Registry()
+    for check in checks:
+        registry.register(check)
+    monkeypatch.setattr(_CONTEXT_BUILD, lambda self: sample_context())
+    monkeypatch.setattr(run_module, "DEFAULT_REGISTRY", registry)
+
+
+def test_run_help(runner):
+    result = runner.invoke(main, ["run", "--help"])
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+
+
+@pytest.mark.parametrize(
+    "target, args",
+    [(main, ["run"]), (run, [])],
+    ids=["via-group", "direct-command"],
+)
+def test_run_emits_report_on_success(runner, stub_context, target, args):
+    result = runner.invoke(target, args)
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    # On success stdout is the serialized report itself (context + results), not an error.
+    assert "context" in payload
+    assert "results" in payload
+    assert "errorType" not in payload
+
+
+_CONTEXT_BUILD_ERROR_MESSAGE = (
+    "Failed to build the diagnostic context. pcluster-diag is meant to run on an AWS ParallelCluster node. "
+    "This failure most likely means it is not running on a cluster node. "
+    "Underlying error: [Errno 2] No such file or directory: '/etc/chef/dna.json'"
+)
+
+
+@pytest.mark.parametrize(
+    "exception, expected_exit_code, expected_error_type, expect_traceback",
+    [
+        (ContextBuildError(_CONTEXT_BUILD_ERROR_MESSAGE), 2, "ContextBuildError", False),
+        (RuntimeError("something unexpected broke"), 1, "RuntimeError", False),
+        (RuntimeError(), 1, "RuntimeError", True),
+    ],
+    ids=["context-build-error", "unexpected-runtime-error", "message-less-falls-back-to-stack-trace"],
+)
+def test_run_emits_structured_error(
+    runner, monkeypatch, exception, expected_exit_code, expected_error_type, expect_traceback
+):
+    def _boom(self):
+        raise exception
+
+    monkeypatch.setattr(_CONTEXT_BUILD, _boom)
+
+    result = runner.invoke(main, ["run"])
+
+    # No report could be produced; stdout carries the structured error and the run exits with the
+    # exception-specific code.
+    assert result.exit_code == expected_exit_code
+    payload = json.loads(result.stdout)
+    assert payload["errorType"] == expected_error_type
+    if expect_traceback:
+        # A message-less exception falls back to reporting its stack trace.
+        assert "Traceback (most recent call last)" in payload["errorMessage"]
+    else:
+        # When the exception carries a message it is reported verbatim, never as a raw traceback.
+        assert payload["errorMessage"] == str(exception)
+        assert "Traceback (most recent call last)" not in result.stdout
+
+
+def test_non_root_run_emits_insufficient_privileges_error(runner, monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000, raising=False)
+
+    result = runner.invoke(main, ["run"])
+
+    assert result.exit_code == 4
+    payload = json.loads(result.stdout)
+    assert payload["errorType"] == "InsufficientPrivilegesError"
+
+
+def test_run_evaluates_registry_against_independently_built_context(runner, monkeypatch):
+    context = sample_context()
+    seen = {}
+
+    class _RecordingRegistry(Registry):
+        def select_checks(self, ctx, assume_yes=False):
+            seen["context"] = ctx
+            return [], [], []
+
+    monkeypatch.setattr(_CONTEXT_BUILD, lambda self: context)
+    monkeypatch.setattr(run_module, "DEFAULT_REGISTRY", _RecordingRegistry())
+
+    result = runner.invoke(main, ["run"])
+
+    assert result.exit_code == 0
+    assert seen["context"] is context
+
+
+@pytest.mark.parametrize(
+    "invoke_args, cli_input, expected_ran, expect_prompt",
+    [
+        (["run"], "y\n", True, True),  # prompted and accepted -> runs
+        (["run"], "n\n", False, True),  # prompted and declined -> skipped by the user
+        (["run", "--yes"], None, True, False),  # --yes runs without prompting
+    ],
+    ids=["prompted-accepted", "prompted-declined", "yes-flag-bypasses-prompt"],
+)
+def test_confirmation_required_check_flow(runner, monkeypatch, invoke_args, cli_input, expected_ran, expect_prompt):
+    events = []
+    check = FakeCheck("ApprovalCheck", approval=True, events=events)
+    _stub_registry_with(monkeypatch, [check])
+
+    result = runner.invoke(main, invoke_args, input=cli_input)
+
+    assert result.exit_code == 0
+    # The check runs only when the confirmation is granted (via prompt or --yes).
+    assert ("run:ApprovalCheck" in events) is expected_ran
+    # The confirmation listing/prompt is emitted to stderr unless --yes bypasses it.
+    assert ("require your confirmation" in result.stderr) is expect_prompt
+    if not expected_ran:
+        # A declined check is recorded SKIPPED and carries the user-facing message in the report.
+        # (Interactive input is echoed onto stdout before the JSON, so parse from the first brace.)
+        assert "ApprovalCheck: SKIPPED" in result.stderr
+        brace_at = result.stdout.index("{")
+        payload = json.loads(result.stdout[brace_at:])
+        assert payload["results"][0]["message"] == "Skipped by the user"
+
+
+@pytest.mark.parametrize(
+    "checks_spec, expected_exit_code",
+    [
+        ([("PassedCheck", Status.PASSED, True), ("SkippedCheck", Status.PASSED, False)], 0),
+        ([("HealthyCheck", Status.PASSED, True), ("FailingCheck", Status.FAILURE, True)], 3),
+        ([("ErroringCheck", Status.ERROR, True)], 3),
+    ],
+    ids=["all-successful-exit-zero", "any-failure-exits-non-zero", "any-error-exits-non-zero"],
+)
+def test_run_exit_code_reflects_worst_result_status(runner, monkeypatch, checks_spec, expected_exit_code):
+    # A single FAILURE or ERROR makes the whole run unsuccessful; the report is still printed and the
+    # handler exits with the diagnostic-failure code without emitting a separate JSON error.
+    checks = [
+        FakeCheck(name, status=status, applicable=applicable, message="detail")
+        for name, status, applicable in checks_spec
+    ]
+    _stub_registry_with(monkeypatch, checks)
+
+    result = runner.invoke(main, ["run"])
+
+    assert result.exit_code == expected_exit_code
+    report, _ = json.JSONDecoder().raw_decode(result.stdout)
+    assert "results" in report
+    assert "errorType" not in report
+
+
+def test_report_write_failure_is_logged_but_report_is_still_emitted(runner, monkeypatch):
+    check = FakeCheck("HealthyCheck", status=Status.PASSED)
+    _stub_registry_with(monkeypatch, [check])
+
+    def boom(self, path):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Report, "save", boom)
+
+    result = runner.invoke(main, ["run"])
+
+    # A write failure does not crash the run: the report is still emitted on stdout (report takes
+    # precedence over the error), and the failure is only logged to stderr.
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["results"][0]["check_id"] == check.identifier
+    assert "errorType" not in payload
+    assert "Could not write the JSON report file" in result.stderr
+
+
+@pytest.mark.parametrize("use_output_file_option", [False, True], ids=["default-cwd", "custom-output-file"])
+def test_run_writes_json_report_to_expected_location(runner, monkeypatch, tmp_path, use_output_file_option):
+    check = FakeCheck("HealthyCheck", status=Status.PASSED)
+    _stub_registry_with(monkeypatch, [check])
+
+    if use_output_file_option:
+        target = tmp_path / "reports" / "my-report.json"
+        result = runner.invoke(main, ["run", "--output-file", str(target)])
+        assert result.exit_code == 0
+        # The report is written to the exact file requested.
+        assert target.exists()
+    else:
+        result = runner.invoke(main, ["run"])
+        assert result.exit_code == 0
+        # The default is a timestamped file under ./pcluster-diag-output.
+        written = os.listdir(os.path.join(os.getcwd(), OUTPUT_DIR_NAME))
+        assert any(name.startswith("pcluster-diag-report-") and name.endswith(".json") for name in written)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/conftest.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/conftest.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared pytest fixtures and test-output isolation for the suite."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_working_directory(tmp_path, monkeypatch):
+    """Run every test in a temporary working directory.
+
+    Some code paths (notably the ``run`` command) write output relative to the current working
+    directory. Changing into a per-test temp dir guarantees no test writes into the pcluster-diag
+    project root; pytest cleans these temp dirs up automatically.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _run_as_root(monkeypatch):
+    """Make the process look like root by default so the ``run`` privilege check passes.
+
+    Tests exercising the non-root path override ``os.geteuid`` themselves.
+    """
+    monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_context_builder.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_context_builder.py
@@ -1,0 +1,299 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ContextBuilder field population and node-type classification."""
+
+import json
+import logging
+import re
+
+import pytest
+
+from pcluster_diag import __version__
+from pcluster_diag.core.context_builder import ContextBuilder
+from pcluster_diag.models.context import Context, NodeType
+from pcluster_diag.models.exceptions import ContextBuildError
+from tests.sample_data import SAMPLE_HEAD_NODE_INSTANCE_ID, SAMPLE_INSTANCE_ID
+from tests.stubs import stub_raising, stub_returning
+
+# Shared node_type token -> NodeType mapping exercised by the classification and build tests.
+_NODE_TYPE_CASES = [
+    ("HeadNode", NodeType.HEAD),
+    ("ComputeFleet", NodeType.COMPUTE),
+    ("LoginNode", NodeType.LOGIN),
+]
+
+
+def _write(path, content):
+    """Write ``content`` to ``path`` and return the path as a string."""
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+def _builder_from_fixtures(tmp_path, node_type_token="HeadNode", cluster_config=None, pcluster_version="3.11.0"):
+    """Build a ContextBuilder pointed at on-disk fixtures under ``tmp_path``."""
+    dna = {"cluster": {"node_type": node_type_token, "region": "us-east-1", "stack_name": "test-stack"}}
+    config = cluster_config if cluster_config is not None else {"Region": "us-east-1"}
+    dna_path = _write(tmp_path / "dna.json", json.dumps(dna))
+    # JSON is valid YAML, so this fixture parses whether or not PyYAML is installed.
+    config_path = _write(tmp_path / "cluster-config.yaml", json.dumps(config))
+    bootstrapped_path = _write(tmp_path / ".bootstrapped", "aws-parallelcluster-cookbook-{}".format(pcluster_version))
+    builder = ContextBuilder(
+        dna_json_path=dna_path,
+        cluster_config_path=config_path,
+        bootstrapped_path=bootstrapped_path,
+    )
+    # Stub the network-backed resolvers (IMDS / CloudFormation) so build() stays offline here.
+    builder._instance_id = stub_returning(SAMPLE_INSTANCE_ID)
+    builder._head_node_instance_id = stub_returning(SAMPLE_HEAD_NODE_INSTANCE_ID)
+    return builder
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+    _NODE_TYPE_CASES + [("Mystery", ValueError)],
+    ids=["HeadNode", "ComputeFleet", "LoginNode", "unrecognized-raises"],
+)
+def test_node_type_classification_maps_each_token(token, expected):
+    builder = ContextBuilder()
+
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        # An unrecognized node_type token is rejected.
+        with pytest.raises(expected):
+            builder._node_type({"cluster": {"node_type": token}})
+    else:
+        assert builder._node_type({"cluster": {"node_type": token}}) is expected
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+    _NODE_TYPE_CASES,
+)
+def test_build_classifies_node_type_from_dna_json(tmp_path, token, expected):
+    builder = _builder_from_fixtures(tmp_path, node_type_token=token)
+
+    context = builder.build()
+
+    assert context.node_type is expected
+
+
+def _builder_with_unrecognized_node_type(tmp_path):
+    return _builder_from_fixtures(tmp_path, node_type_token="Mystery")
+
+
+def _builder_with_missing_dna_json(tmp_path):
+    builder = _builder_from_fixtures(tmp_path)
+    builder._dna_json_path = str(tmp_path / "does-not-exist.json")
+    return builder
+
+
+@pytest.mark.parametrize(
+    "make_builder",
+    [_builder_with_unrecognized_node_type, _builder_with_missing_dna_json],
+    ids=["unrecognized-node-type", "missing-dna-json"],
+)
+def test_build_fails_with_context_build_error(tmp_path, make_builder):
+    # Both an unrecognized node_type token and a missing dna.json cause build() to raise the
+    # dedicated ContextBuildError.
+    builder = make_builder(tmp_path)
+
+    with pytest.raises(ContextBuildError):
+        builder.build()
+
+
+def test_build_populates_all_context_fields_from_fixtures(tmp_path):
+    config = {"Region": "us-east-1"}
+    node_type_token = "HeadNode"
+    pcluster_version = "3.11.0"
+    builder = _builder_from_fixtures(
+        tmp_path, node_type_token=node_type_token, cluster_config=config, pcluster_version=pcluster_version
+    )
+
+    context = builder.build()
+
+    assert isinstance(context, Context)
+    assert context.node_type is NodeType.HEAD
+    assert context.pcluster_version == pcluster_version
+    assert context.cluster_config == config
+    assert context.dna_json["cluster"]["node_type"] == node_type_token
+    assert context.instance_id == SAMPLE_INSTANCE_ID
+    assert context.head_node_instance_id == SAMPLE_HEAD_NODE_INSTANCE_ID
+    # pcluster_diag_version is the installed package version.
+    assert context.pcluster_diag_version
+    # timestamp is generated at build time as a UTC string in the shared YYYY-MM-DDThh-mm-ss format.
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}", context.timestamp)
+
+
+_PCLUSTER_VERSION_RAISES = object()
+
+
+@pytest.mark.parametrize(
+    "marker_content, expected",
+    [
+        ("aws-parallelcluster-cookbook-3.11.0", "3.11.0"),  # version pattern is extracted
+        ("bootstrapped", "bootstrapped"),  # no version pattern: raw content is returned
+        ("   ", _PCLUSTER_VERSION_RAISES),  # blank marker is rejected
+    ],
+    ids=["version-pattern", "no-version-pattern", "blank-marker-raises"],
+)
+def test_pcluster_version_reads_bootstrapped_marker(tmp_path, marker_content, expected):
+    builder = _builder_from_fixtures(tmp_path)
+    builder._bootstrapped_path = _write(tmp_path / ".bootstrapped-case", marker_content)
+
+    if expected is _PCLUSTER_VERSION_RAISES:
+        with pytest.raises(ValueError):
+            builder._pcluster_version()
+    else:
+        assert builder._pcluster_version() == expected
+
+
+def test_pcluster_diag_version_resolves_to_package_version():
+    builder = ContextBuilder()
+    # The version comes from the package's __version__ constant (run-from-source, no dist metadata).
+    assert builder._pcluster_diag_version() == __version__
+
+
+def test_instance_id_reads_from_imds(monkeypatch):
+    monkeypatch.setattr("pcluster_diag.core.context_builder.imds.get_instance_id", lambda: "i-abc123")
+
+    assert ContextBuilder()._instance_id() == "i-abc123"
+
+
+def test_head_node_instance_id_reads_stack_output(monkeypatch):
+    captured = {}
+
+    def fake_get_stack_output(stack_name, region, output_key):
+        captured.update(stack_name=stack_name, region=region, output_key=output_key)
+        return "i-headnode"
+
+    monkeypatch.setattr("pcluster_diag.core.context_builder.get_stack_output", fake_get_stack_output)
+    dna_json = {"cluster": {"stack_name": "my-stack", "region": "eu-west-1"}}
+
+    # On a non-head node the head node id is read from the cluster stack's HeadNodeInstanceID output.
+    assert ContextBuilder()._head_node_instance_id(NodeType.COMPUTE, dna_json) == "i-headnode"
+    assert captured == {"stack_name": "my-stack", "region": "eu-west-1", "output_key": "HeadNodeInstanceID"}
+
+
+def test_head_node_instance_id_on_head_node_returns_current_instance_id(monkeypatch):
+    # On the head node the head node id is the current instance id (from IMDS); CloudFormation is never queried.
+    monkeypatch.setattr("pcluster_diag.core.context_builder.imds.get_instance_id", lambda: "i-current")
+
+    def _fail(*_args, **_kwargs):
+        raise AssertionError("get_stack_output should not be called on the head node")
+
+    monkeypatch.setattr("pcluster_diag.core.context_builder.get_stack_output", _fail)
+
+    result = ContextBuilder()._head_node_instance_id(NodeType.HEAD, {"cluster": {}})
+
+    assert result == "i-current"
+
+
+def test_instance_id_returns_none_and_logs_on_error(monkeypatch, caplog):
+    monkeypatch.setattr("pcluster_diag.core.context_builder.imds.get_instance_id", stub_raising("imds boom"))
+
+    with caplog.at_level(logging.ERROR, logger="pcluster_diag.core.context_builder"):
+        result = ContextBuilder()._instance_id()
+
+    # A failure to reach IMDS yields None instead of raising, and is logged at error level.
+    assert result is None
+    assert any("instance id" in record.getMessage().lower() for record in caplog.records)
+
+
+def test_head_node_instance_id_returns_none_and_logs_on_error(monkeypatch, caplog):
+    monkeypatch.setattr("pcluster_diag.core.context_builder.get_stack_output", stub_raising("aws boom"))
+    dna_json = {"cluster": {"stack_name": "my-stack", "region": "eu-west-1"}}
+
+    with caplog.at_level(logging.ERROR, logger="pcluster_diag.core.context_builder"):
+        result = ContextBuilder()._head_node_instance_id(NodeType.COMPUTE, dna_json)
+
+    # An AWS failure yields None instead of raising, and is logged at error level.
+    assert result is None
+    assert any("head node instance id" in record.getMessage().lower() for record in caplog.records)
+
+
+# --- build() resolution is all-or-nothing --------------------------------------------
+
+# The required Context attributes resolved from the environment, each backed by a resolver method that may fail.
+_RESOLVABLE_ATTRIBUTES = [
+    "dna_json",
+    "cluster_config",
+    "node_type",
+    "pcluster_version",
+    "pcluster_diag_version",
+]
+
+# The resolver method on ContextBuilder backing each attribute.
+_ATTRIBUTE_METHOD = {
+    "dna_json": "_dna_json",
+    "cluster_config": "_cluster_config",
+    "node_type": "_node_type",
+    "pcluster_version": "_pcluster_version",
+    "pcluster_diag_version": "_pcluster_diag_version",
+}
+
+# A valid value each resolver yields when it is NOT designated as undeterminable.
+_VALID_RETURNS = {
+    "dna_json": {"cluster": {"node_type": "HeadNode"}},
+    "cluster_config": {"Region": "us-east-1"},
+    "node_type": NodeType.HEAD,
+    "pcluster_version": "3.11.0",
+    "pcluster_diag_version": "1.0.0",
+}
+
+
+def _builder_with_failures(failing):
+    """Build a ContextBuilder whose resolvers all succeed except those named in ``failing``.
+
+    The best-effort instance-id resolvers are stubbed to fixed values so build() stays offline and
+    they never affect the all-or-nothing behavior.
+    """
+    builder = ContextBuilder()
+    for attribute in _RESOLVABLE_ATTRIBUTES:
+        if attribute in failing:
+            stub = stub_raising("cannot determine {}".format(attribute))
+        else:
+            stub = stub_returning(_VALID_RETURNS[attribute])
+        setattr(builder, _ATTRIBUTE_METHOD[attribute], stub)
+    builder._instance_id = stub_returning(SAMPLE_INSTANCE_ID)
+    builder._head_node_instance_id = stub_returning(SAMPLE_HEAD_NODE_INSTANCE_ID)
+    return builder
+
+
+@pytest.mark.parametrize(
+    "failing",
+    [
+        set(),
+        {"dna_json"},
+        {"node_type", "pcluster_version"},
+        set(_RESOLVABLE_ATTRIBUTES),
+    ],
+    ids=["none-fail", "one-fails", "two-fail", "all-fail"],
+)
+def test_context_build_is_all_or_nothing(failing):
+    """build() raises when any required attribute is undeterminable; otherwise returns a fully-resolved Context."""
+    builder = _builder_with_failures(failing)
+
+    if failing:
+        with pytest.raises(ContextBuildError) as exc_info:
+            builder.build()
+        # The friendly message carries the underlying cause, naming one of the undeterminable attributes.
+        assert any(attribute in str(exc_info.value) for attribute in failing)
+    else:
+        context = builder.build()
+        assert isinstance(context, Context)
+        assert context.node_type is _VALID_RETURNS["node_type"]
+        assert context.pcluster_version == _VALID_RETURNS["pcluster_version"]
+        assert context.cluster_config == _VALID_RETURNS["cluster_config"]
+        assert context.dna_json == _VALID_RETURNS["dna_json"]
+        assert context.pcluster_diag_version == _VALID_RETURNS["pcluster_diag_version"]
+        assert context.instance_id == SAMPLE_INSTANCE_ID
+        assert context.head_node_instance_id == SAMPLE_HEAD_NODE_INSTANCE_ID

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_exception_handler.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_exception_handler.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the ExceptionHandler that translates command exceptions into JSON errors and an exit."""
+
+import json
+import logging
+
+import click
+import pytest
+
+from pcluster_diag.core.exception_handler import ExceptionHandler
+from pcluster_diag.models.exceptions import ContextBuildError, DiagnosticCheckNotPassedError
+
+
+def _with_traceback(error: Exception) -> Exception:
+    """Return ``error`` with a real traceback attached, as it would have when raised."""
+    try:
+        raise error
+    except type(error) as raised:
+        return raised
+
+
+@pytest.mark.parametrize(
+    "error, expected_exception, expected_exit_code, expected_error_type, expected_message_substring, expected_logged",
+    [
+        # Click exceptions are re-raised unchanged (Click renders them); no SystemExit, no JSON, no log.
+        (click.ClickException("bad usage"), click.ClickException, None, None, None, False),
+        # The Exit signal raised by --help/--version is a Click exception too: re-raised, not reported, not logged.
+        (click.exceptions.Exit(0), click.exceptions.Exit, None, None, None, False),
+        # Failed checks are already in the report, so only the exit code is emitted: no JSON error, no log.
+        (DiagnosticCheckNotPassedError(), SystemExit, 3, None, None, False),
+        # A domain error is logged, prints its type/message as JSON, and exits with its own code.
+        (ContextBuildError("boom"), SystemExit, 2, "ContextBuildError", "boom", True),
+        # A message-less, non-domain exception is logged, exits with the internal-error code, and reports its trace.
+        (_with_traceback(RuntimeError()), SystemExit, 1, "RuntimeError", "Traceback (most recent call last)", True),
+    ],
+    ids=["click-reraised", "help-exit-reraised", "diagnostic-check-not-passed", "domain-error", "message-less-error"],
+)
+def test_handle(
+    capsys,
+    caplog,
+    error,
+    expected_exception,
+    expected_exit_code,
+    expected_error_type,
+    expected_message_substring,
+    expected_logged,
+):
+    with caplog.at_level(logging.ERROR, logger="pcluster_diag.core.exception_handler"):
+        with pytest.raises(expected_exception) as exc_info:
+            ExceptionHandler().handle(error)
+
+    stdout = capsys.readouterr().out
+
+    # Only the general (JSON-error) branch logs; Click control flow and already-reported check
+    # failures are not logged as errors.
+    logged = [record for record in caplog.records if record.name == "pcluster_diag.core.exception_handler"]
+    assert bool(logged) is expected_logged
+
+    if expected_exit_code is None:
+        # Re-raised Click exception: nothing is written to stdout.
+        assert stdout == ""
+        return
+
+    assert exc_info.value.code == expected_exit_code
+    if expected_error_type is None:
+        # No JSON error is emitted (the failure is already reported elsewhere).
+        assert stdout == ""
+    else:
+        payload = json.loads(stdout)
+        assert payload["errorType"] == expected_error_type
+        assert expected_message_substring in payload["errorMessage"]

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_registry.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_registry.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Registry: registration order, identifier resolution, duplicates, and selection."""
+
+import logging
+
+import pytest
+
+import pcluster_diag.core.registry as registry_module
+from pcluster_diag.core.registry import Registry
+from tests.sample_data import FakeCheck, sample_context
+
+
+def test_registered_checks_empty_by_default():
+    assert Registry().registered_checks() == []
+
+
+def test_register_preserves_registration_order():
+    registry = Registry()
+    a, b, c = FakeCheck("A"), FakeCheck("B"), FakeCheck("C")
+
+    registry.register(a)
+    registry.register(b)
+    registry.register(c)
+
+    assert registry.registered_checks() == [a, b, c]
+
+
+@pytest.mark.parametrize(
+    "identifier, expected_index",
+    [("A", 0), ("B", 1), ("Missing", None)],
+    ids=["resolves-first", "resolves-second", "unregistered-returns-none"],
+)
+def test_get_returns_check_by_identifier_or_none(identifier, expected_index):
+    registry = Registry()
+    checks = [FakeCheck("A"), FakeCheck("B")]
+    for check in checks:
+        registry.register(check)
+
+    resolved = registry.get(identifier)
+
+    if expected_index is None:
+        # An unregistered identifier resolves to None and never appears among registered checks.
+        assert resolved is None
+        assert all(check.identifier != identifier for check in registry.registered_checks())
+    else:
+        assert resolved is checks[expected_index]
+
+
+@pytest.mark.parametrize(
+    "register_later",
+    [False, True],
+    ids=["keeps-first-and-warns", "does-not-abort-subsequent-registration"],
+)
+def test_duplicate_identifier_keeps_first_warns_and_does_not_abort(caplog, register_later):
+    registry = Registry()
+    first = FakeCheck("Dup", description="first")
+    second = FakeCheck("Dup", description="second")
+    later = FakeCheck("Later")
+
+    registry.register(first)
+    with caplog.at_level(logging.WARNING):
+        registry.register(second)
+    if register_later:
+        registry.register(later)
+
+    # The first Check registered under the duplicated name wins everywhere.
+    assert registry.get("Dup") is first
+    # A warning naming the duplicated identifier was emitted at WARNING level.
+    assert any("Dup" in record.message for record in caplog.records)
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+    if register_later:
+        # Registration continued past the duplicate, and later checks still resolve.
+        assert registry.registered_checks() == [first, later]
+        assert registry.get("Later") is later
+    else:
+        assert registry.registered_checks() == [first]
+
+
+@pytest.mark.parametrize(
+    "applicability, expected_not_applicable_idx",
+    [
+        ([True, True], []),
+        ([False], [0]),
+        ([True, False, True, False], [1, 3]),
+        ([], []),
+    ],
+    ids=[
+        "all-applicable",
+        "none-applicable",
+        "mixed-preserves-registration-order",
+        "empty-registry",
+    ],
+)
+def test_select_checks_partitions_by_applicability(applicability, expected_not_applicable_idx):
+    registry = Registry()
+    checks = [FakeCheck("Check{}".format(i), applicable=is_applicable) for i, is_applicable in enumerate(applicability)]
+    for check in checks:
+        registry.register(check)
+
+    registered, not_applicable, not_approved = registry.select_checks(sample_context())
+    assert registered == checks
+    assert not_applicable == [checks[i] for i in expected_not_applicable_idx]
+    assert not_approved == []
+
+
+@pytest.mark.parametrize(
+    "confirmed, expected_not_approved",
+    [(True, False), (False, True)],
+    ids=["accepted-runs", "declined-goes-to-not-approved"],
+)
+def test_select_checks_routes_confirmation_required_check(monkeypatch, confirmed, expected_not_approved):
+    registry = Registry()
+    needs_approval = FakeCheck("Confirmable", approval=True)
+    registry.register(needs_approval)
+
+    monkeypatch.setattr(registry_module.click, "confirm", lambda *_a, **_k: confirmed)
+    registered, not_applicable, not_approved = registry.select_checks(sample_context())
+
+    assert registered == [needs_approval]
+    assert not_applicable == []
+    assert not_approved == ([needs_approval] if expected_not_approved else [])

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_runner.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_runner.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Runner execution engine."""
+
+import logging
+
+from pcluster_diag.core.runner import Runner
+from pcluster_diag.models.result import Status
+from tests.sample_data import FAKE_CHECK_RAISE_MESSAGE, FakeCheck, sample_context
+
+
+def test_executes_in_given_order():
+    checks = [FakeCheck("A"), FakeCheck("B"), FakeCheck("C")]
+
+    results = Runner().execute(sample_context(), checks)
+
+    assert [r.check_id for r in results] == ["A", "B", "C"]
+
+
+def test_failure_does_not_stop_remaining_checks():
+    a = FakeCheck("A", status=Status.FAILURE)
+    b = FakeCheck("B", status=Status.PASSED)
+
+    results = Runner().execute(sample_context(), [a, b])
+
+    assert results[0].status == Status.FAILURE
+    assert results[1].status == Status.PASSED
+    assert b.ran is True
+
+
+def test_unhandled_exception_becomes_error_with_stack_trace():
+    a = FakeCheck("A", raises=True)
+    b = FakeCheck("B")
+
+    results = Runner().execute(sample_context(), [a, b])
+
+    assert results[0].status == Status.ERROR
+    assert "Traceback" in results[0].message
+    assert FAKE_CHECK_RAISE_MESSAGE in results[0].message
+    # Isolation: the next Check still ran.
+    assert results[1].status == Status.PASSED
+
+
+def test_not_approved_check_yields_skipped_by_user():
+    a = FakeCheck("A")
+
+    results = Runner().execute(sample_context(), [a], check_not_approved=[a])
+
+    assert results[0].status == Status.SKIPPED
+    assert results[0].message == "Skipped by the user"
+    # A not-approved Check is never executed.
+    assert a.ran is False
+
+
+def test_check_to_run_is_executed_regardless_of_should_run():
+    # Applicability is decided before execute(); the Runner runs every check_to_run unconditionally.
+    a = FakeCheck("A", applicable=False)
+
+    results = Runner().execute(sample_context(), [a])
+
+    assert results[0].status == Status.PASSED
+    # The check's run body is invoked even though should_run would return False.
+    assert a.ran is True
+
+
+def test_emits_outcome_log_line_per_check(caplog):
+    a = FakeCheck("A", status=Status.PASSED)
+    b = FakeCheck("B", status=Status.FAILURE)
+
+    with caplog.at_level(logging.INFO, logger="pcluster_diag.core.runner"):
+        Runner().execute(sample_context(), [a, b])
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "A: PASSED" in messages
+    assert "B: FAILURE" in messages
+    # FAILURE outcomes are logged at error level; PASSED at info level.
+    levels = {record.getMessage(): record.levelno for record in caplog.records}
+    assert levels["A: PASSED"] == logging.INFO
+    assert levels["B: FAILURE"] == logging.ERROR
+
+
+def test_results_follow_registration_order_across_dispositions():
+    # Checks are emitted in the order given (registration order), regardless of disposition: an
+    # executed Check, a non-applicable one, another executed Check, and a user-declined one.
+    run1 = FakeCheck("Run1")
+    skip = FakeCheck("Skip", applicable=False)
+    run2 = FakeCheck("Run2")
+    declined = FakeCheck("Declined")
+
+    results = Runner().execute(
+        sample_context(),
+        [run1, skip, run2, declined],
+        check_not_applicable=[skip],
+        check_not_approved=[declined],
+    )
+
+    assert [(r.check_id, r.status) for r in results] == [
+        ("Run1", Status.PASSED),
+        ("Skip", Status.SKIPPED),
+        ("Run2", Status.PASSED),
+        ("Declined", Status.SKIPPED),
+    ]
+    # Skipped / declined Checks carry their user-facing messages and never execute.
+    skip_result = next(r for r in results if r.check_id == "Skip")
+    declined_result = next(r for r in results if r.check_id == "Declined")
+    assert skip_result.message == "Check is not applicable to the current context."
+    assert declined_result.message == "Skipped by the user"
+    assert skip.ran is False
+    assert declined.ran is False

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_check.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_check.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from pcluster_diag.models.check import Check
+from pcluster_diag.models.context import Context, NodeType
+from pcluster_diag.models.result import Result, Status
+from tests.sample_data import sample_context
+
+
+class _MinimalCheck(Check):
+    """A concrete Check that implements only the required abstract methods."""
+
+    @property
+    def description(self) -> str:
+        return "a minimal check"
+
+    def should_run(self, context: Context) -> bool:
+        return context.node_type is NodeType.HEAD
+
+    def run(self, context: Context) -> Result:
+        return Result(
+            check_id=self.identifier, check_description=self.description, status=Status.PASSED, metadata={"ran": True}
+        )
+
+
+class _ApprovalCheck(_MinimalCheck):
+    """A Check that overrides approval_required to require confirmation."""
+
+    def approval_required(self, context: Context) -> bool:
+        return True
+
+
+class _IncompleteCheck(Check):
+    """A subclass that leaves ``should_run`` and ``run`` unimplemented."""
+
+    @property
+    def description(self) -> str:
+        return "missing should_run and run"
+
+
+@pytest.mark.parametrize(
+    "check_cls",
+    [Check, _IncompleteCheck],
+    ids=["abstract-base", "incomplete-subclass"],
+)
+def test_abstract_or_incomplete_check_cannot_be_instantiated(check_cls):
+    with pytest.raises(TypeError):
+        check_cls()  # type: ignore[abstract]
+
+
+@pytest.mark.parametrize(
+    "check, expected_identifier",
+    [(_MinimalCheck(), "_MinimalCheck"), (_ApprovalCheck(), "_ApprovalCheck")],
+    ids=["minimal", "approval"],
+)
+def test_identifier_returns_class_simple_name(check, expected_identifier):
+    assert check.identifier == expected_identifier
+
+
+@pytest.mark.parametrize(
+    "check, expected_approval",
+    [(_MinimalCheck(), False), (_ApprovalCheck(), True)],
+    ids=["defaults-to-false", "overridden-to-true"],
+)
+def test_approval_required_reflects_subclass(check, expected_approval):
+    assert check.approval_required(sample_context()) is expected_approval
+
+
+@pytest.mark.parametrize(
+    "node_type, expected_should_run",
+    [(NodeType.HEAD, True), (NodeType.COMPUTE, False)],
+    ids=["head-runs", "compute-skips"],
+)
+def test_should_run_evaluates_context(node_type, expected_should_run):
+    assert _MinimalCheck().should_run(sample_context(node_type)) is expected_should_run
+
+
+def test_run_returns_result():
+    check = _MinimalCheck()
+
+    result = check.run(sample_context())
+
+    assert isinstance(result, Result)
+    assert result.check_id == check.identifier
+    assert result.status is Status.PASSED
+    assert result.metadata == {"ran": True}
+
+
+def test_abstract_method_bodies_raise_not_implemented():
+    check = _MinimalCheck()
+
+    with pytest.raises(NotImplementedError):
+        Check.description.fget(check)
+    with pytest.raises(NotImplementedError):
+        Check.run(check, sample_context())

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_context.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_context.py
@@ -1,0 +1,36 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Context model and NodeType enum."""
+
+import pytest
+
+from pcluster_diag.models.context import NodeType
+from tests.sample_data import SAMPLE_TIMESTAMP, sample_context
+
+
+@pytest.mark.parametrize(
+    "node_type, expected_value",
+    [
+        (NodeType.HEAD, "HeadNode"),
+        (NodeType.COMPUTE, "ComputeFleet"),
+        (NodeType.LOGIN, "LoginNode"),
+    ],
+    ids=["head", "compute", "login"],
+)
+def test_node_type_values(node_type, expected_value):
+    assert node_type.value == expected_value
+
+
+def test_context_carries_run_timestamp():
+    # The Context records the run timestamp (the same value that names the report file).
+    assert sample_context().timestamp == SAMPLE_TIMESTAMP

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_exceptions.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_exceptions.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the domain exceptions and their exit codes."""
+
+import pytest
+
+from pcluster_diag.models.exceptions import (
+    ContextBuildError,
+    DiagnosticCheckNotPassedError,
+    ExitCode,
+    InsufficientPrivilegesError,
+    PclusterDiagError,
+)
+
+
+def test_exit_code_values_are_stable():
+    # Hardcoded on purpose: these numbers are the CLI's contract, so a change here must break the test.
+    assert int(ExitCode.INTERNAL_ERROR) == 1
+    assert int(ExitCode.CONTEXT_BUILD_ERROR) == 2
+    assert int(ExitCode.DIAGNOSTIC_CHECK_FAILURE) == 3
+    assert int(ExitCode.INSUFFICIENT_PRIVILEGES) == 4
+
+
+def test_base_error_defaults_to_internal_error_code():
+    error = PclusterDiagError("boom")
+
+    assert error.exit_code == 1
+    assert str(error) == "boom"
+
+
+@pytest.mark.parametrize(
+    "factory, expected_code",
+    [
+        (ContextBuildError, 2),
+        (DiagnosticCheckNotPassedError, 3),
+        (InsufficientPrivilegesError, 4),
+    ],
+    ids=["context-build", "diagnostic-check-not-passed", "insufficient-privileges"],
+)
+def test_domain_errors_carry_expected_exit_code(factory, expected_code):
+    error = factory()
+
+    assert isinstance(error, PclusterDiagError)
+    assert error.exit_code == expected_code
+    # Each carries a non-empty default message.
+    assert str(error)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_report.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_report.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Report model: serialization content and file output."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pcluster_diag.models.report import OUTPUT_DIR_NAME
+from pcluster_diag.util.serialization import to_dict
+from tests.sample_data import sample_report
+
+
+@pytest.mark.parametrize(
+    "report",
+    [
+        sample_report(results=[]),
+        sample_report(),
+    ],
+    ids=["empty-results", "mixed-results"],
+)
+def test_report_serialization_content_per_check(report):
+    """The serialized Report carries the context and, per executed Check, its id, Status, message, and metadata."""
+    serialized = to_dict(report)
+
+    assert serialized["context"]["node_type"] == report.context.node_type.value
+    assert len(serialized["results"]) == len(report.results)
+
+    for entry, result in zip(serialized["results"], report.results):
+        assert set(entry.keys()) >= {"check_id", "status", "message", "metadata"}
+        assert entry["check_id"] == result.check_id
+        assert entry["status"] == result.status.value
+        assert entry["message"] == result.message
+        assert entry["metadata"] == result.metadata
+
+
+def test_report_save_writes_json_to_the_given_path(tmp_path):
+    report = sample_report()
+
+    # default_path lives under the CWD's output dir and embeds the context's run timestamp verbatim
+    # (the CWD is isolated to tmp_path by the autouse fixture).
+    target = report.default_path
+    assert target == tmp_path / OUTPUT_DIR_NAME / "pcluster-diag-report-{}.json".format(report.context.timestamp)
+
+    path = report.save(target)
+
+    # The file is written at the exact path (parent dirs created) and contains the serialized Report.
+    assert path == target
+    assert path.exists()
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    assert saved == to_dict(report)
+    # The report's context carries the same timestamp embedded in the filename.
+    assert saved["context"]["timestamp"] == report.context.timestamp
+
+
+def test_best_effort_write_is_enforced_by_caller():
+    """The generic writer does not suppress errors, so save() propagates a failing write."""
+    report = sample_report()
+
+    with tempfile.TemporaryDirectory() as base_dir:
+        with patch("pathlib.Path.write_text", side_effect=OSError("write boom")):
+            with pytest.raises(OSError):
+                report.save(Path(base_dir) / "report.json")

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_result.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_result.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Result model and its factory methods."""
+
+import pytest
+
+from pcluster_diag.models.result import Result, Status
+from tests.sample_data import FakeCheck, sample_result
+
+_SAMPLE_CHECK = FakeCheck(identifier="SampleCheck", description="a sample check")
+
+
+@pytest.mark.parametrize("status", list(Status), ids=lambda status: status.name)
+def test_result_status_is_a_valid_status_member(status):
+    """A Result's Status is one of PASSED, ERROR, FAILURE, or SKIPPED."""
+    result = sample_result(status=status, metadata={"key": "value"})
+
+    assert result.status in {Status.PASSED, Status.ERROR, Status.FAILURE, Status.SKIPPED}
+
+
+@pytest.mark.parametrize(
+    "factory, expected_status",
+    [
+        (Result.passed, Status.PASSED),
+        (Result.error, Status.ERROR),
+        (Result.failure, Status.FAILURE),
+        (Result.skipped, Status.SKIPPED),
+    ],
+    ids=["passed", "error", "failure", "skipped"],
+)
+def test_factory_builds_result_from_check(factory, expected_status):
+    message = "a message"
+    metadata = {"key": "value"}
+
+    result = factory(_SAMPLE_CHECK, message=message, metadata=metadata)
+
+    assert result.status is expected_status
+    assert result.check_id == _SAMPLE_CHECK.identifier
+    assert result.check_description == _SAMPLE_CHECK.description
+    assert result.message == message
+    assert result.metadata == metadata
+
+    # message and metadata default to None when omitted.
+    defaults = factory(_SAMPLE_CHECK)
+    assert defaults.status is expected_status
+    assert defaults.message is None
+    assert defaults.metadata is None

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/sample_data.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/sample_data.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared sample data for the test suite: Contexts, Check doubles, and Results."""
+
+from pcluster_diag.models.check import Check
+from pcluster_diag.models.context import Context, NodeType
+from pcluster_diag.models.report import Report
+from pcluster_diag.models.result import Result, Status
+
+# --- Contexts -------------------------------------------------------------------------
+
+# The canonical field values every sample Context carries (node type aside).
+SAMPLE_TIMESTAMP = "2026-07-01T16-03-48"
+SAMPLE_PCLUSTER_VERSION = "3.16.0"
+SAMPLE_PCLUSTER_DIAG_VERSION = "1.0.0"
+SAMPLE_INSTANCE_ID = "i-0123456789abcdef0"
+SAMPLE_HEAD_NODE_INSTANCE_ID = "i-000000000headnode"
+SAMPLE_CLUSTER_CONFIG = {"Region": "us-east-1"}
+
+
+def sample_context(node_type: NodeType = NodeType.HEAD) -> Context:
+    """Return a fully-resolved sample Context for ``node_type`` (defaults to the head node)."""
+    return Context(
+        timestamp=SAMPLE_TIMESTAMP,
+        node_type=node_type,
+        pcluster_version=SAMPLE_PCLUSTER_VERSION,
+        head_node_instance_id=SAMPLE_HEAD_NODE_INSTANCE_ID,
+        instance_id=SAMPLE_INSTANCE_ID,
+        cluster_config=dict(SAMPLE_CLUSTER_CONFIG),
+        dna_json={"cluster": {"node_type": node_type.value}},
+        pcluster_diag_version=SAMPLE_PCLUSTER_DIAG_VERSION,
+    )
+
+
+# --- Check doubles --------------------------------------------------------------------
+
+# The message a FakeCheck raises when configured with ``raises=True``.
+FAKE_CHECK_RAISE_MESSAGE = "boom raised inside the fake check"
+
+
+class FakeCheck(Check):
+    """A configurable Check double.
+
+    Args:
+        identifier: The check identifier (overrides the class-name default).
+        description: The description (defaults to one derived from the identifier).
+        applicable: What ``should_run`` returns.
+        approval: What ``approval_required`` returns.
+        status: The Status of the Result ``run`` returns.
+        message: The message of the Result ``run`` returns.
+        raises: When True, ``run`` raises instead of returning a Result.
+        events: When provided, ``should_run`` and ``run`` append ``"should_run:<id>"`` /
+            ``"run:<id>"`` so call ordering can be asserted.
+    """
+
+    def __init__(
+        self,
+        identifier="FakeCheck",
+        *,
+        description=None,
+        applicable=True,
+        approval=False,
+        status=Status.PASSED,
+        message=None,
+        raises=False,
+        events=None,
+    ):
+        """Initialize the FakeCheck with its configured behavior (see the class docstring)."""
+        self._identifier = identifier
+        self._description = description if description is not None else "description for {}".format(identifier)
+        self._applicable = applicable
+        self._approval = approval
+        self._status = status
+        self._message = message
+        self._raises = raises
+        self._events = events
+        self.ran = False
+
+    @property
+    def identifier(self) -> str:
+        return self._identifier
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    def should_run(self, context: Context) -> bool:
+        if self._events is not None:
+            self._events.append("should_run:{}".format(self._identifier))
+        return self._applicable
+
+    def approval_required(self, context: Context) -> bool:
+        return self._approval
+
+    def run(self, context: Context) -> Result:
+        self.ran = True
+        if self._events is not None:
+            self._events.append("run:{}".format(self._identifier))
+        if self._raises:
+            raise RuntimeError(FAKE_CHECK_RAISE_MESSAGE)
+        return Result(
+            check_id=self._identifier, check_description=self._description, status=self._status, message=self._message
+        )
+
+
+# --- Results --------------------------------------------------------------------------
+
+
+def sample_result(status: Status = Status.PASSED, *, check_id: str = "SampleCheck", message=None, metadata=None):
+    """Return a sample Result with the given status (and optional message/metadata)."""
+    return Result(
+        check_id=check_id,
+        check_description="description for {}".format(check_id),
+        status=status,
+        message=message,
+        metadata=metadata,
+    )
+
+
+def sample_results():
+    """Return one sample Result per Status, spanning absent, plain, and nested message/metadata shapes."""
+    return [
+        sample_result(Status.PASSED, check_id="PassedCheck"),
+        sample_result(Status.FAILURE, check_id="FailedCheck", message="nope", metadata={"path": "/x"}),
+        sample_result(Status.ERROR, check_id="ErroredCheck", message="trace"),
+        sample_result(
+            Status.SKIPPED,
+            check_id="SkippedCheck",
+            message="Skipped by the user",
+            metadata={"nested": {"values": [1, 2, 3], "flag": True, "empty": None}},
+        ),
+    ]
+
+
+# --- Reports --------------------------------------------------------------------------
+
+
+def sample_report(node_type: NodeType = NodeType.HEAD, results=None) -> Report:
+    """Return a sample Report for ``node_type``.
+
+    Defaults to a report carrying the full ``sample_results()`` spread; pass ``results`` (e.g. an
+    empty list) to override for edge cases such as a report with no executed checks.
+    """
+    return Report(
+        context=sample_context(node_type),
+        results=sample_results() if results is None else results,
+    )

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/stubs.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/stubs.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared stub factories for the test suite.
+
+These build argument-ignoring callables suitable for ``monkeypatch.setattr`` / ``setattr`` when a
+collaborator method must be replaced with one that returns a canned value or raises.
+"""
+
+
+def stub_returning(value):
+    """Return a stub that ignores its arguments and yields ``value``."""
+
+    def _stub(*_args, **_kwargs):
+        return value
+
+    return _stub
+
+
+def stub_raising(exception):
+    """Return a stub that raises when called.
+
+    ``exception`` may be an exception instance to raise as-is, or a message string, in which case a
+    ``RuntimeError`` carrying that message is raised.
+    """
+    error = exception if isinstance(exception, BaseException) else RuntimeError(exception)
+
+    def _stub(*_args, **_kwargs):
+        raise error
+
+    return _stub

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/test_cli.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/test_cli.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the top-level CLI group (help, version, and the console-script entry point)."""
+
+import pytest
+from click.testing import CliRunner
+
+from pcluster_diag import __version__
+from pcluster_diag.cli import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_group_help_lists_run_command(runner):
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "run" in result.output
+
+
+def test_group_version_matches_package_version(runner):
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.output

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_cfn.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_cfn.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the CloudFormation stack-output helper."""
+
+import pytest
+
+from pcluster_diag.util import cfn
+
+
+class _FakeCloudFormation:
+    def __init__(self, outputs):
+        self._outputs = outputs
+        self.captured = {}
+
+    def describe_stacks(self, StackName):  # noqa: N803  boto3 uses PascalCase kwargs
+        self.captured["StackName"] = StackName
+        return {"Stacks": [{"Outputs": self._outputs}]}
+
+
+def _patch_client(monkeypatch, fake):
+    captured = {}
+
+    def fake_client(service, region_name):
+        captured.update(service=service, region_name=region_name)
+        return fake
+
+    monkeypatch.setattr(cfn.boto3, "client", fake_client)
+    return captured
+
+
+def test_get_stack_output_returns_matching_output_value(monkeypatch):
+    fake = _FakeCloudFormation(
+        [{"OutputKey": "Other", "OutputValue": "x"}, {"OutputKey": "HeadNodeInstanceID", "OutputValue": "i-headnode"}]
+    )
+    captured = _patch_client(monkeypatch, fake)
+
+    value = cfn.get_stack_output("my-stack", "eu-west-1", "HeadNodeInstanceID")
+
+    assert value == "i-headnode"
+    assert captured == {"service": "cloudformation", "region_name": "eu-west-1"}
+    assert fake.captured["StackName"] == "my-stack"
+
+
+def test_get_stack_output_raises_when_output_absent(monkeypatch):
+    _patch_client(monkeypatch, _FakeCloudFormation([{"OutputKey": "Other", "OutputValue": "x"}]))
+
+    with pytest.raises(KeyError):
+        cfn.get_stack_output("my-stack", "eu-west-1", "HeadNodeInstanceID")

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_imds.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_imds.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the IMDSv2 helper."""
+
+import io
+
+from pcluster_diag.util import imds
+
+
+class _FakeResponse:
+    def __init__(self, body):
+        self._body = body
+
+    def __enter__(self):
+        return io.BytesIO(self._body)
+
+    def __exit__(self, *_args):
+        return False
+
+
+def test_get_instance_id_uses_token_then_reads_instance_id(monkeypatch):
+    calls = []
+
+    def fake_urlopen(request, timeout=None):
+        calls.append((request.get_method(), request.full_url, dict(request.header_items())))
+        if request.full_url.endswith("/api/token"):
+            return _FakeResponse(b"the-token")
+        return _FakeResponse(b"i-0123456789abcdef0\n")
+
+    monkeypatch.setattr(imds.urllib.request, "urlopen", fake_urlopen)
+
+    assert imds.get_instance_id() == "i-0123456789abcdef0"
+    # A PUT fetches the token first, then the instance-id GET carries that token.
+    assert calls[0][0] == "PUT" and calls[0][1].endswith("/api/token")
+    assert calls[1][1].endswith("/meta-data/instance-id")
+    assert calls[1][2]["X-aws-ec2-metadata-token"] == "the-token"

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_io_utils.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_io_utils.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the generic file I/O utility layer."""
+
+import pytest
+
+from pcluster_diag.util.io_utils import write_text_file
+
+_TEXT = '{"hello": "world"}'
+
+
+@pytest.mark.parametrize(
+    "rel_path, nested",
+    [("report.json", False), ("nested/dir/report.json", True)],
+    ids=["flat-target", "nested-target-creates-parents"],
+)
+def test_write_text_file_writes_content(tmp_path, rel_path, nested):
+    target = tmp_path / rel_path
+    if nested:
+        # Missing parent directories are created on demand before the file is written.
+        assert not target.parent.exists()
+
+    write_text_file(target, _TEXT)
+
+    if nested:
+        assert target.parent.is_dir()
+    assert target.read_text(encoding="utf-8") == _TEXT
+
+
+def _target_blocked_by_file_parent(tmp_path):
+    # A regular file sits where a parent directory would need to be created.
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("x", encoding="utf-8")
+    return blocker / "report.json"
+
+
+def _target_is_a_directory(tmp_path):
+    # A directory cannot be opened for text writing.
+    target = tmp_path / "a-directory"
+    target.mkdir()
+    return target
+
+
+@pytest.mark.parametrize(
+    "make_target",
+    [_target_blocked_by_file_parent, _target_is_a_directory],
+    ids=["parent-is-a-file", "target-is-a-directory"],
+)
+def test_write_text_file_propagates_os_errors(tmp_path, make_target):
+    # IsADirectoryError and PermissionError are subclasses of OSError, so this covers both.
+    target = make_target(tmp_path)
+
+    with pytest.raises(OSError):
+        write_text_file(target, _TEXT)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_logging_utils.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_logging_utils.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for CLI logging configuration."""
+
+import logging
+
+from pcluster_diag.util.logging_utils import configure_logging
+
+
+def test_configure_logging(capsys):
+    # Binds a single stderr handler at the given level.
+    configure_logging(level=logging.WARNING)
+    root_logger = logging.getLogger()
+
+    assert root_logger.level == logging.WARNING
+    assert len(root_logger.handlers) == 1
+    assert isinstance(root_logger.handlers[0], logging.StreamHandler)
+
+    # Repeated calls clear prior handlers, so lines are never duplicated (idempotent).
+    configure_logging()
+    configure_logging()
+
+    assert len(logging.getLogger().handlers) == 1
+
+    # Emits timestamp, level name, and message to stderr.
+    logging.getLogger("pcluster_diag.sample").info("hello world")
+
+    captured = capsys.readouterr()
+    # Format is "<timestamp> [<LEVEL>] <logger>: <message>", written to stderr.
+    assert "[INFO]" in captured.err
+    assert "pcluster_diag.sample" in captured.err
+    assert "hello world" in captured.err

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_serialization.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_serialization.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the generic dataclass serialization helpers."""
+
+import json
+
+from pcluster_diag.util.serialization import to_dict, to_json
+from tests.sample_data import sample_context, sample_result
+
+
+def test_to_dict_converts_enum_fields_to_their_value():
+    context = sample_context()
+
+    data = to_dict(context)
+
+    # Enum fields serialize to their value, not the enum member.
+    assert data["node_type"] == context.node_type.value
+    assert data["pcluster_version"] == context.pcluster_version
+    assert data["pcluster_diag_version"] == context.pcluster_diag_version
+
+
+def test_to_json_is_deterministic_and_valid_json():
+    result = sample_result(check_id="C")
+
+    text = to_json(result)
+
+    # Two serializations of the same object are identical, and the output is valid JSON.
+    assert to_json(result) == text
+    assert json.loads(text)["status"] == result.status.value

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_services.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_services.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the supervisord service-state helpers."""
+
+import subprocess
+
+import pytest
+
+from pcluster_diag.util import services
+from pcluster_diag.util.services import _program_state, _resolve_supervisorctl, is_supervisord_program_running
+
+_SUPERVISORCTL = "/opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/supervisorctl"
+
+
+@pytest.mark.parametrize(
+    "status_output, expected",
+    [
+        ("cfn-hup                          RUNNING   pid 3926, uptime 5:58:33", "RUNNING"),
+        ("cfn-hup                          STOPPED   Not started", "STOPPED"),
+        ("cfn-hup                          FATAL     Exited too quickly", "FATAL"),
+        ("cfn-hup                          STARTING", "STARTING"),
+        ("cfn-hup: ERROR (no such process)", "ERROR"),  # status token parsed as-is
+        ("cfn-hup", None),  # name only, no status token -> unparseable
+        ("clustermgtd                      RUNNING   pid 1, uptime 1:00:00", None),  # different program -> absent
+        ("\ncfn-hup                          RUNNING   pid 3926", "RUNNING"),  # leading blank line is skipped
+        ("", None),  # no output -> unparseable
+    ],
+)
+def test_program_state_parses_status_column(status_output, expected):
+    assert _program_state("cfn-hup", status_output) == expected
+
+
+@pytest.mark.parametrize(
+    "returncode, stdout, expected",
+    [
+        (0, "cfn-hup    RUNNING   pid 3926, uptime 5:58:33", True),
+        (3, "cfn-hup    STOPPED", False),
+    ],
+    ids=["running", "stopped"],
+)
+def test_is_supervisord_program_running_reflects_status(monkeypatch, returncode, stdout, expected):
+    monkeypatch.setattr(services, "_resolve_supervisorctl", lambda: _SUPERVISORCTL)
+    captured = {}
+
+    def fake_run_command(command):
+        captured["command"] = command
+        return subprocess.CompletedProcess(command, returncode, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(services, "run_command", fake_run_command)
+
+    assert is_supervisord_program_running("cfn-hup") is expected
+    # Always invokes supervisorctl with the resolved binary.
+    assert captured["command"] == [_SUPERVISORCTL, "status", "cfn-hup"]
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    ["", "cfn-hup", "unix:///var/run/supervisor.sock refused connection"],
+    ids=["empty", "name-without-status", "connection-error"],
+)
+def test_is_supervisord_program_running_raises_when_status_undeterminable(monkeypatch, stdout):
+    monkeypatch.setattr(services, "_resolve_supervisorctl", lambda: _SUPERVISORCTL)
+    monkeypatch.setattr(
+        services,
+        "run_command",
+        lambda command: subprocess.CompletedProcess(command, 1, stdout=stdout, stderr=""),
+    )
+
+    with pytest.raises(RuntimeError):
+        is_supervisord_program_running("cfn-hup")
+
+
+@pytest.mark.parametrize(
+    "glob_result, expected",
+    [
+        ([_SUPERVISORCTL], _SUPERVISORCTL),
+        ([], FileNotFoundError),
+    ],
+    ids=["match-found", "no-match-raises"],
+)
+def test_resolve_supervisorctl(monkeypatch, glob_result, expected):
+    monkeypatch.setattr(services.glob, "glob", lambda _pattern: glob_result)
+
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            _resolve_supervisorctl()
+    else:
+        assert _resolve_supervisorctl() == expected

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_shell.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_shell.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the shell command-runner utility."""
+
+import logging
+import subprocess
+
+from pcluster_diag.util import shell
+from pcluster_diag.util.shell import run_command
+
+
+def test_run_command_runs_without_shell_logs_and_returns_result(monkeypatch, caplog):
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(command, 0, stdout="out", stderr="err")
+
+    monkeypatch.setattr(shell.subprocess, "run", fake_run)
+
+    with caplog.at_level(logging.INFO, logger="pcluster_diag.util.shell"):
+        result = run_command(["echo", "hi"])
+
+    # The command is captured and never run through a shell nor raised on a non-zero exit.
+    assert captured["command"] == ["echo", "hi"]
+    assert "shell" not in captured["kwargs"]
+    # A default 60s timeout is applied.
+    assert captured["kwargs"] == {"capture_output": True, "text": True, "check": False, "timeout": 60}
+    # The CompletedProcess is returned unchanged.
+    assert result.returncode == 0
+    assert result.stdout == "out"
+    # The outcome is logged to stderr.
+    assert any("Executed command" in record.getMessage() for record in caplog.records)
+
+
+def test_run_command_uses_caller_supplied_timeout(monkeypatch):
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(shell.subprocess, "run", fake_run)
+
+    run_command(["echo", "hi"], timeout=5)
+
+    # The caller's timeout overrides the default.
+    assert captured["kwargs"]["timeout"] == 5

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tools/sync-to-cluster.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tools/sync-to-cluster.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+#
+# Developer-only helper: upload this local pcluster-diag source to a running cluster's head node,
+# overwriting the content of the node's tool source dir. NOT shipped to nodes (see chefignore).
+#
+# Usage (from the pcluster-diag directory):
+#   ./tools/sync-to-cluster.sh <cluster-name> <region> <ssh-key>
+
+set -euo pipefail
+
+info() { printf 'INFO: %s\n' "$*"; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; }
+
+# Report a clear failure if any step below errors out (set -e triggers this on the failing command).
+trap 'fail "sync-to-cluster failed."' ERR
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $(basename "$0") <cluster-name> <region> <ssh-key>" >&2
+  exit 2
+fi
+
+CLUSTER_NAME="$1"
+REGION="$2"
+SSH_KEY="$3"
+
+# The pcluster-diag source root (the parent of this tools/ directory).
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# The node source dir the cookbook stages the tool into.
+NODE_SOURCE_DIR="/opt/parallelcluster/sources/pcluster-diag"
+
+info "Syncing local pcluster-diag source to cluster '${CLUSTER_NAME}' (${REGION})"
+
+# Resolve the cluster's default OS user from the CloudFormation stack parameter "ClusterUser".
+# Capture stdout+stderr so the underlying AWS error is shown if the call fails.
+info "Resolving cluster user from CloudFormation stack '${CLUSTER_NAME}'..."
+if ! CLUSTER_USER="$(aws cloudformation describe-stacks --stack-name "${CLUSTER_NAME}" --region "${REGION}" \
+    --query "Stacks[0].Parameters[?ParameterKey=='ClusterUser'].ParameterValue | [0]" --output text 2>&1)"; then
+  fail "Failed to describe CloudFormation stack '${CLUSTER_NAME}':"
+  printf '%s\n' "${CLUSTER_USER}" >&2
+  exit 1
+fi
+if [ -z "${CLUSTER_USER}" ] || [ "${CLUSTER_USER}" = "None" ]; then
+  fail "Could not determine ClusterUser from CloudFormation stack '${CLUSTER_NAME}'."
+  exit 1
+fi
+info "Cluster user: ${CLUSTER_USER}"
+
+# Resolve the head node IP from the cluster. The pcluster CLI outputs JSON (no --output flag), so
+# capture the full document and extract the field with python3; capture stderr to surface failures.
+info "Resolving head node IP..."
+if ! DESCRIBE_JSON="$(pcluster describe-cluster --cluster-name "${CLUSTER_NAME}" --region "${REGION}" 2>&1)"; then
+  fail "Failed to describe cluster '${CLUSTER_NAME}':"
+  printf '%s\n' "${DESCRIBE_JSON}" >&2
+  exit 1
+fi
+HEAD_NODE_IP="$(printf '%s' "${DESCRIBE_JSON}" \
+  | python3 -c 'import json, sys; print((json.load(sys.stdin).get("headNode") or {}).get("publicIpAddress") or "")')"
+
+if [ -z "${HEAD_NODE_IP}" ] || [ "${HEAD_NODE_IP}" = "None" ]; then
+  fail "Could not determine the head node public IP for cluster '${CLUSTER_NAME}'."
+  exit 1
+fi
+info "Head node: ${CLUSTER_USER}@${HEAD_NODE_IP}"
+
+# Upload the local source straight into the node's (root-owned) tool source dir in one step: the
+# remote rsync runs under sudo. Honors .gitignore, skips git metadata, and --delete mirrors the tree.
+info "Syncing source from ${SOURCE_DIR} into ${NODE_SOURCE_DIR} on the head node..."
+rsync -av --filter=':- .gitignore' --exclude='.git' --delete \
+  -e "ssh -i ${SSH_KEY}" --rsync-path="sudo rsync" \
+  "${SOURCE_DIR}/" "${CLUSTER_USER}@${HEAD_NODE_IP}:${NODE_SOURCE_DIR}/"
+
+info "Success: pcluster-diag source synced on cluster '${CLUSTER_NAME}'. Verify with 'sudo pcluster-diag --version' on the node."

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tox.ini
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tox.ini
@@ -1,0 +1,126 @@
+[tox]
+# `tox` runs the tests (with coverage) plus the linters.
+envlist =
+    test-with-coverage
+    code-linters
+
+# Base settings shared by the test environments. Installs the package with its dev extra; deps come
+# from pyproject.toml so packaging and tests stay in sync.
+[testenv]
+basepython = python3
+extras = dev
+
+# Unit tests via pytest. Run with `tox -e test`.
+[testenv:test]
+description = Run unit tests
+commands =
+    pytest -l -v --basetemp={envtmpdir} {posargs:tests}
+
+# Dedicated coverage environment: runs the tests measuring coverage over the
+# pcluster_diag package. Run with `tox -e test-with-coverage`.
+[testenv:test-with-coverage]
+description = Run tests and report coverage over pcluster_diag
+commands =
+    pytest -l -v --basetemp={envtmpdir} \
+        --cov=pcluster_diag --cov-report=term-missing --cov-report=xml \
+        {posargs:tests}
+
+# Common variables shared by multiple environments.
+[vars]
+code_dirs =
+    pcluster_diag \
+    tests
+
+
+##############################
+###     AUTO-FORMATTER     ###
+##############################
+
+# black: code formatter (config in pyproject.toml [tool.black]).
+[testenv:black]
+basepython = python3
+skip_install = true
+deps =
+    black
+commands =
+    black {[vars]code_dirs} {posargs}
+
+# Checks that python files are correctly formatted.
+[testenv:black-check]
+basepython = python3
+skip_install = true
+deps =
+    {[testenv:black]deps}
+commands =
+    {[testenv:black]commands} --check --diff
+
+# isort: import sorter (config in pyproject.toml [tool.isort]).
+[testenv:isort]
+basepython = python3
+skip_install = true
+deps =
+    isort
+commands =
+    isort {[vars]code_dirs} {posargs}
+
+# Checks that python imports are correctly sorted.
+[testenv:isort-check]
+basepython = python3
+skip_install = true
+deps =
+    {[testenv:isort]deps}
+commands =
+    {[testenv:isort]commands} --check --diff
+
+# Reformats code with isort and black.
+[testenv:autoformat]
+basepython = python3
+skip_install = true
+deps =
+    {[testenv:isort]deps}
+    {[testenv:black]deps}
+commands =
+    {[testenv:isort]commands}
+    {[testenv:black]commands}
+
+
+#############################
+###        LINTERS        ###
+#############################
+
+# flake8: python linter (config in .flake8).
+[testenv:flake8]
+basepython = python3
+skip_install = true
+deps =
+    flake8
+    flake8-docstrings
+    flake8-bugbear
+    flake8-colors
+    pep8-naming
+commands =
+    flake8 {[vars]code_dirs} {posargs}
+
+# bandit: security linter for python.
+[testenv:bandit]
+basepython = python3
+skip_install = true
+deps =
+    bandit
+commands =
+    bandit -r pcluster_diag {posargs}
+
+# Groups all code linters together.
+[testenv:code-linters]
+basepython = python3
+skip_install = true
+deps =
+    {[testenv:black-check]deps}
+    {[testenv:isort-check]deps}
+    {[testenv:flake8]deps}
+    {[testenv:bandit]deps}
+commands =
+    {[testenv:black-check]commands}
+    {[testenv:isort-check]commands}
+    {[testenv:flake8]commands}
+    {[testenv:bandit]commands}

--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
@@ -288,6 +288,17 @@ suites:
     attributes:
       dependencies:
         - resource:package_repos:update
+  - name: pcluster_diag
+    run_list:
+      - recipe[aws-parallelcluster-tests::setup]
+      - recipe[aws-parallelcluster-platform::pcluster_diag]
+    verifier:
+      controls:
+        - /tag:install_pcluster_diag/
+    attributes:
+      dependencies:
+        - recipe:aws-parallelcluster-platform::directories
+        - recipe:aws-parallelcluster-platform::cookbook_virtualenv
   - name: sudo
     run_list:
       - recipe[aws-parallelcluster-platform::sudo_install]

--- a/cookbooks/aws-parallelcluster-platform/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install.rb
@@ -18,6 +18,7 @@ package_repos 'setup the repositories'
 include_recipe "aws-parallelcluster-platform::directories"
 install_packages 'Install OS and extra packages'
 include_recipe "aws-parallelcluster-platform::cookbook_virtualenv"
+include_recipe "aws-parallelcluster-platform::pcluster_diag"
 include_recipe "aws-parallelcluster-platform::awscli"
 unless alinux2023_on_docker? # Running this recipe on Alinux 2023 docker generates false failure.
   # Example failure https://github.com/aws/aws-parallelcluster-cookbook/actions/runs/9373643185/job/25807894209?pr=2692

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/pcluster_diag.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/pcluster_diag.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+#
+# Copyright:: 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stages the pcluster-diag source on the node and exposes `pcluster-diag` on PATH.
+
+source_dir = "#{node['cluster']['sources_dir']}/pcluster-diag"
+virtualenv_path = cookbook_virtualenv_path
+bin_path = '/usr/local/bin/pcluster-diag'
+
+# pcluster-diag runs with the cookbook_virtualenv interpreter, so skip whenever that venv is not created.
+return if redhat_on_docker?
+
+# Per-node copy of the tool source, baked into the AMI.
+remote_directory source_dir do
+  source 'pcluster-diag'
+  mode '0755'
+  action :create
+  recursive true
+end
+
+# Wrapper on PATH that runs the tool from source with the cookbook_virtualenv interpreter.
+template bin_path do
+  source 'pcluster-diag/pcluster-diag.erb'
+  variables(
+    source_dir: source_dir,
+    virtualenv_path: virtualenv_path
+  )
+  owner 'root'
+  group 'root'
+  mode '0744'
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/pcluster_diag_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/pcluster_diag_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'aws-parallelcluster-platform::pcluster_diag' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:python_version) { 'python_version' }
+      cached(:system_pyenv_root) { 'system_pyenv_root' }
+      cached(:virtualenv_path) { 'system_pyenv_root/versions/python_version/envs/cookbook_virtualenv' }
+      cached(:aws_region) { 'any-region' }
+      cached(:base_dir) { '/opt/parallelcluster' }
+      cached(:sources_dir) { '/opt/parallelcluster/sources' }
+      cached(:source_dir) { "#{sources_dir}/pcluster-diag" }
+      cached(:bin_path) { '/usr/local/bin/pcluster-diag' }
+      cached(:wrapper_content) do
+        <<~WRAPPER
+          #!/bin/sh
+          export PYTHONPATH="#{source_dir}"
+          exec #{virtualenv_path}/bin/python -m pcluster_diag.cli "$@"
+        WRAPPER
+      end
+
+      context "when installing the diagnostics tool" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            allow_any_instance_of(Object).to receive(:aws_region).and_return(aws_region)
+            node.override['cluster']['system_pyenv_root'] = system_pyenv_root
+            node.override['cluster']['python-version'] = python_version
+            node.override['cluster']['region'] = aws_region
+            node.override['cluster']['base_dir'] = base_dir
+            node.override['cluster']['sources_dir'] = sources_dir
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'stages the tool source from the cookbook' do
+          is_expected.to create_remote_directory(source_dir).with(
+            source: 'pcluster-diag',
+            recursive: true
+          )
+        end
+
+        it 'creates a wrapper on PATH that runs the tool from source with the cookbook_virtualenv interpreter' do
+          is_expected.to create_template(bin_path)
+            .with(owner: 'root', group: 'root', mode: '0744')
+          is_expected.to render_file(bin_path).with_content(wrapper_content)
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-platform/templates/pcluster-diag/pcluster-diag.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/pcluster-diag/pcluster-diag.erb
@@ -1,0 +1,3 @@
+#!/bin/sh
+export PYTHONPATH="<%= @source_dir %>"
+exec <%= @virtualenv_path %>/bin/python -m pcluster_diag.cli "$@"

--- a/cookbooks/aws-parallelcluster-platform/test/controls/pcluster_diag_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/pcluster_diag_spec.rb
@@ -1,0 +1,52 @@
+# Copyright:: 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+control 'tag:install_pcluster_diag_installed' do
+  title 'pcluster-diag source is staged in the expected location and its wrapper is installed on PATH'
+
+  only_if { !os_properties.redhat_on_docker? }
+
+  source_dir = "#{node['cluster']['sources_dir']}/pcluster-diag"
+
+  describe directory(source_dir) do
+    it { should exist }
+  end
+
+  # The tool is run directly from source, so its package must be present under the staged source dir.
+  describe file("#{source_dir}/pcluster_diag/cli.py") do
+    it { should exist }
+  end
+
+  describe file('/usr/local/bin/pcluster-diag') do
+    it { should exist }
+    it { should be_executable }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0744' }
+  end
+end
+
+control 'tag:install_pcluster_diag_runnable' do
+  title 'pcluster-diag is discoverable on PATH and runnable as root'
+
+  only_if { !os_properties.redhat_on_docker? }
+
+  describe 'pcluster-diag resolves on the root PATH to the wrapper' do
+    subject { bash("sudo su - -c 'which pcluster-diag'") }
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(%r{^/usr/local/bin/pcluster-diag$}) }
+  end
+
+  describe 'pcluster-diag runs as root' do
+    subject { bash("sudo su - -c 'pcluster-diag --version'") }
+    its('exit_status') { should eq 0 }
+  end
+end

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skipsdist=True
 envlist =
     py{37,38,39,310}-{cov,nocov}
     code-linters
+    pcluster-diag
 
 # Default testenv. Used to run tests on all python versions.
 [testenv]
@@ -213,3 +214,36 @@ commands =
     {[testenv:bandit]commands}
     {[testenv:semgrep]commands}
     {[testenv:pylint]commands}
+
+
+#############################
+###     PCLUSTER-DIAG     ###
+#############################
+
+# The pcluster-diag package ships its own self-contained tox configuration at
+# cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tox.ini.
+# This environment delegates to that tox project so the root tox includes it.
+#
+# Examples:
+#   tox -e pcluster-diag                          # run its default envlist (tests + coverage, linters)
+#   tox -e pcluster-diag -- -e test               # run only its unit tests (no coverage)
+#   tox -e pcluster-diag -- -e test-with-coverage # run only its tests-with-coverage target
+#   tox -e pcluster-diag -- -e code-linters       # run only its linters target
+[testenv:pcluster-diag]
+basepython = python3
+skip_install = true
+changedir = {toxinidir}/cookbooks/aws-parallelcluster-platform/files/pcluster-diag
+# Pass posargs through verbatim; without this tox rewrites path-like args (e.g. an env named like an
+# existing directory) relative to changedir.
+args_are_paths = false
+deps =
+    tox
+commands =
+    tox {posargs}
+
+# The pcluster-diag package is measured separately by its own tox suite (see [testenv:pcluster-diag])
+# and uploaded to Codecov under a distinct flag. Omit it here so it never appears in the main
+# coverage report, keeping the two reports from overlapping.
+[coverage:run]
+omit =
+    */files/pcluster-diag/*


### PR DESCRIPTION
### Description of changes
Ship a new on-demand diagnostics tool, `pcluster-diag`, into ParallelCluster AMIs.

`pcluster-diag` runs as root on any cluster node (head, compute, or login) and executes a context-aware set of diagnostic checks against the running node, emitting a structured JSON report to stdout and to a timestamped file. 
It is designed for end-user, support engineers and service team to quickly assess cluster health.

The tool is installed into the existing cookbook virtualenv and can be easily updated without waiting for a new pcluster release, by following the instructions in README.

This PR includes:
1. packaging of pcluster-diag
2. scaffolding of the pcluster-diag CLI
3. basic check related to cfn-hup
4. a dummy check to give an example of how to define checks that require user approval to be executed
5. installation of the cli into the existing cookbook virtual env
6. instructions for the user to update the tool
7. instructions for the developers to test local changes
8. developer tool to upload and install local changes to a running cluster
9. include plcuster-diag tox (unit tests, coverage, linters, autoformatting) into the usual PR checks.
10. enforce 90% code coverage on the pcluster-diag code.

#### Notes
* Skipping `resursive-deletion-check` is safe because it detected false positive. This Pr does not introduce any recursive deletion. We use `recursive: True` to create the directory used to store the pcluster-diag tool. We also use the term "recursive" in some pydoc to describe the behavior of some functions.
* Skipping `security-exclusion-check` is safe because we skipped the following security rules:
  * `B404` the rule highlight the general risk of using subprocess as it can be used to run shell commands. The import by itself is not risky as long as it is intentional. the import is intentional because we need subprocess to run shell commands.
  * `B603` we use the subprocess.run function which of corse opens the software to code injection. However, this is not an issue for use because the command is statically defined and nothing can be injected by an attacker.

### Tests
* Unit Tests introduced by this PR, which are not part of the PR checks)
* PR checks
* verified that pcluster-diag command is available on PATH for whatever user without the need to activate any virtualenv.
* Manual execution of pcluster-diag commands within cluster (see user experience for more details):
    * `pcluster-diag --version`
    * `pcluster-diag --help`
    * `pcluster-diag run --help` 
    * `pcluster-diag run`
    * `pcluster-diag run --yes`
    * `pcluster-diag run --output-file <filename>` 
* Tested sync of local changes to running cluster (actually used the script during the development)


### User Experience

#### Usage

```
[root@ip-27-6-39-34 ~]# pcluster-diag --help
Usage: pcluster-diag [OPTIONS] COMMAND [ARGS]...

  Diagnostics for AWS ParallelCluster nodes.

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  run  Run the applicable diagnostic checks and emit the report.
[root@ip-27-6-39-34 ~]# pcluster-diag run --help
Usage: pcluster-diag run [OPTIONS]

  Run the applicable diagnostic checks and emit the report.

  Prints the JSON report to stdout and writes it to a file (best-effort).
  Progress and errors are logged to stderr. Exits 0 only when every check
  passes; otherwise non-zero.

Options:
  --output-file FILE  File where the JSON report is written (default: a
                      timestamped file under ./pcluster-diag-output).
  -y, --yes           Approve every check that requires confirmation, without
                      prompting.
  --help              Show this message and exit.
```

#### Example of output (success checks)

```
[root@ip-27-6-39-34 ~]# pcluster-diag run
2026-07-01 16:03:38,939 [INFO] pcluster_diag.core.registry: The following checks require your confirmation before they run:
2026-07-01 16:03:38,939 [INFO] pcluster_diag.core.registry:   - SampleCheck: Placeholder check that requires confirmation and always passes.
Run check 'SampleCheck'? [y/N]: y
2026-07-01 16:03:47,934 [INFO] pcluster_diag.core.runner: Check CfnHupRunsOnlyOnHeadNode: started
2026-07-01 16:03:48,089 [INFO] pcluster_diag.util.shell: Executed command ['/opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/supervisorctl', 'status', 'cfn-hup']: exit code 0, stdout='cfn-hup                          RUNNING   pid 3926, uptime 21:11:04\n', stderr=''
2026-07-01 16:03:48,089 [INFO] pcluster_diag.core.runner: Check CfnHupRunsOnlyOnHeadNode: finished
2026-07-01 16:03:48,089 [INFO] pcluster_diag.core.runner: CfnHupRunsOnlyOnHeadNode: PASSED
2026-07-01 16:03:48,089 [INFO] pcluster_diag.core.runner: Check SampleCheck: started
2026-07-01 16:03:48,089 [INFO] pcluster_diag.core.runner: Check SampleCheck: finished
2026-07-01 16:03:48,089 [INFO] pcluster_diag.core.runner: SampleCheck: PASSED
2026-07-01 16:03:48,090 [INFO] pcluster_diag.commands.run: Report written to /root/pcluster-diag-output/pcluster-diag-report-2026-07-01T16-03-48.json
{
  "context": {
    "pcluster_diag_version": "1.0.0",
    "pcluster_version": "3.16.0",
    "node_type": "HeadNode",
    "cluster_config": { ...omitted cluster config for sake of brevity... },
    "dna_json": { ...omitted dna for sake of brevity... },
  "results": [
    {
      "check_id": "CfnHupRunsOnlyOnHeadNode",
      "check_description": "Verify that the cfn-hup daemon runs only on the head node.",
      "status": "PASSED",
      "message": null,
      "metadata": null
    },
    {
      "check_id": "SampleCheck",
      "check_description": "Placeholder check that requires confirmation and always passes.",
      "status": "PASSED",
      "message": null,
      "metadata": null
    }
  ]
}
[root@ip-27-6-39-34 ~]# echo $?
0
[root@ip-27-6-39-34 ~]# ls pcluster-diag-output/
pcluster-diag-report-2026-07-01T16-03-48.json
```

#### Example of output (failed checks)

```
[root@ip-27-6-39-34 ~]# /opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/supervisorctl stop cfn-hup
cfn-hup: stopped

[root@ip-27-6-39-34 ~]# pcluster-diag run
2026-07-01 16:07:18,221 [INFO] pcluster_diag.core.registry: The following checks require your confirmation before they run:
2026-07-01 16:07:18,221 [INFO] pcluster_diag.core.registry:   - SampleCheck: Placeholder check that requires confirmation and always passes.
Run check 'SampleCheck'? [y/N]: ^CAborted!
[root@ip-27-6-39-34 ~]# pcluster-diag run
2026-07-01 16:07:27,483 [INFO] pcluster_diag.core.registry: The following checks require your confirmation before they run:
2026-07-01 16:07:27,483 [INFO] pcluster_diag.core.registry:   - SampleCheck: Placeholder check that requires confirmation and always passes.
Run check 'SampleCheck'? [y/N]: y
2026-07-01 16:07:35,208 [INFO] pcluster_diag.core.runner: Check CfnHupRunsOnlyOnHeadNode: started
2026-07-01 16:07:35,356 [INFO] pcluster_diag.util.shell: Executed command ['/opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/supervisorctl', 'status', 'cfn-hup']: exit code 3, stdout='cfn-hup                          STOPPED   Jul 01 04:07 PM\n', stderr=''
2026-07-01 16:07:35,357 [INFO] pcluster_diag.core.runner: Check CfnHupRunsOnlyOnHeadNode: finished
2026-07-01 16:07:35,357 [ERROR] pcluster_diag.core.runner: CfnHupRunsOnlyOnHeadNode: FAILURE
2026-07-01 16:07:35,357 [INFO] pcluster_diag.core.runner: Check SampleCheck: started
2026-07-01 16:07:35,357 [INFO] pcluster_diag.core.runner: Check SampleCheck: finished
2026-07-01 16:07:35,357 [INFO] pcluster_diag.core.runner: SampleCheck: PASSED
2026-07-01 16:07:35,358 [INFO] pcluster_diag.commands.run: Report written to /root/pcluster-diag-output/pcluster-diag-report-2026-07-01T16-07-35.json
{
  "context": {
    "pcluster_diag_version": "1.0.0",
    "pcluster_version": "3.16.0",
    "node_type": "HeadNode",
    "cluster_config": { ...omitted cluster config for sake of brevity... },
    "dna_json": { ...omitted dna for sake of brevity... },
  "results": [
    {
      "check_id": "CfnHupRunsOnlyOnHeadNode",
      "check_description": "Verify that the cfn-hup daemon runs only on the head node.",
      "status": "FAILURE",
      "message": "cfn-hup is not running on the HeadNode. Restart it.",
      "metadata": null
    },
    {
      "check_id": "SampleCheck",
      "check_description": "Placeholder check that requires confirmation and always passes.",
      "status": "PASSED",
      "message": null,
      "metadata": null
    }
  ]
}
[root@ip-27-6-39-34 ~]# echo $?
3
[root@ip-27-6-39-34 ~]# ls pcluster-diag-output/
pcluster-diag-report-2026-07-01T16-03-48.json  pcluster-diag-report-2026-07-01T16-07-35.json
```


### Developer Experience

#### Syncing local changes to running cluster
```
(pcluster-dev) ➜  ./tools/sync-to-cluster.sh pcluster-diag-1 us-east-1 <path to my ssh key>
INFO: Syncing local pcluster-diag source to cluster 'pcluster-diag-1' (us-east-1)
INFO: Resolving cluster user from CloudFormation stack 'pcluster-diag-1'...
INFO: Cluster user: ec2-user
INFO: Resolving head node IP...
INFO: Head node: ec2-user@44.200.250.163
INFO: Uploading source from /Volumes/workplace/aws-parallelcluster-dev/aws-parallelcluster-cookbook/cookbooks/aws-parallelcluster-platform/files/pcluster-diag to the head node...
... omitted output from rsync command ...
INFO: Installing pcluster-diag into the cluster virtualenv (as root)...
... omitted output from pip command ...
INFO: Installed version: pcluster-diag, version 1.0.0
INFO: Success: pcluster-diag synced and installed on cluster 'pcluster-diag-1'.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
