### PR TITLE
[kitchen] Skip FFTW absence check on RHEL

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
@@ -23,8 +23,8 @@ control 'tag:install_install_packages' do
   # NOTE: Skipped where the desktop group (@gnome, installed for DCV) transitively
   # pulls in FFTW:
   #   - AL2023: via ImageMagick-libs (fftw-libs-double)
-  #   - Rocky9: via pipewire-libs (fftw-libs-single)
-  unless os_properties.alinux2023? || os_properties.rocky?
+  #   - Rocky9/RHEL9: via pipewire-libs (fftw-libs-single)
+  unless os_properties.alinux2023? || os_properties.rocky? || os_properties.redhat?
     # Verify fftw package is not installed
     describe bash('ls 2>/dev/null /usr/lib64/libfftw*') do
       its('stdout') { should be_empty }


### PR DESCRIPTION
### Description of changes
* FFTW started to be pulled in as transitive dependencies of other packages. We have been skipping the check on AL2023 and Rocky. This commit starts to skip the check on RHEL

### Tests
* RHEL9 build-image is successful

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
