### PR TITLE
[Test] Skip fftw-absent check on RHEL9 (DCV @gnome pulls fftw-libs-single

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/install_packages_spec.rb
@@ -24,7 +24,8 @@ control 'tag:install_install_packages' do
   # pulls in FFTW:
   #   - AL2023: via ImageMagick-libs (fftw-libs-double)
   #   - Rocky9: via pipewire-libs (fftw-libs-single)
-  unless os_properties.alinux2023? || os_properties.rocky?
+  #   - RHEL9: via pipewire-libs (fftw-libs-single)
+  unless os_properties.alinux2023? || os_properties.rocky? || os_properties.redhat9?
     # Verify fftw package is not installed
     describe bash('ls 2>/dev/null /usr/lib64/libfftw*') do
       its('stdout') { should be_empty }

--- a/cookbooks/aws-parallelcluster-shared/test/libraries/os_properties.rb
+++ b/cookbooks/aws-parallelcluster-shared/test/libraries/os_properties.rb
@@ -40,6 +40,10 @@ class OsProperties < Inspec.resource(1)
     redhat? && inspec.os.release.to_i == 8
   end
 
+  def redhat9?
+    redhat? && inspec.os.release.to_i == 9
+  end
+
   def rocky8?
     rocky? && inspec.os.release.to_i == 8
   end


### PR DESCRIPTION

### Description of changes
* Skip fftw-absent check on RHEL9 (DCV @gnome pulls pipewire-libs -> fftw-libs-single

### Tests
* Build image

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
