### PR TITLE
Move NFS lockd port from 32768 to 4045 to avoid ephemeral-range collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 
 **CHANGES**
 - Enforce NFSv4-only on the ParallelCluster-managed NFS server (head node). The NFSv3 client stack (rpcbind, rpc-statd, lockd) are unchanged, so cluster nodes can still mount external NFSv3 servers.
+- Change the default NFS lock manager port from 32768 to 4045. 32768 is in the Linux ephemeral port range (32768–60999), causing sporadic mount failures because of port collision. This only affects nodes that mount an external NFSv3 server; all ParallelCluster managed storage is mounted over NFSv4 and is unaffected. Customers who mount external NFSv3 servers and restrict NFS ports in a firewall must allow TCP/UDP 4045 instead of 32768.
 - In GPU Health Check, skip DCGM diagnostics when NVIDIA MIG is enabled because dcgmi diag does not support MIG.
 - Upgrade Slurm to version 25.11.6 (from 25.11.4).
 - Upgrade EFA installer to 1.49.0 (from 1.47.0).

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -9,6 +9,8 @@ default['cluster']['nfs']['threads'] = [[node['cpu']['cores'].to_i * 4, 8].max, 
 default['nfs']['v4'] = 'yes'
 default['nfs']['v3'] = 'no'
 default['nfs']['v2'] = 'no'
+# Use 4045 as the lockd port to change the default 32768 from nfs third party cookbook
+default['nfs']['port']['lockd'] = 4045
 
 # Kernel release version used to select Lustre version
 # This is a mechanism used to mock kernel release on docker system-tests, see kitchen.docker.yml:

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/nfs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/nfs_spec.rb
@@ -105,7 +105,7 @@ describe 'nfs:configure' do
         it 'pins the ancillary v3 client ports in the drop-in (unpinned by nfs::server4 on AL2023)' do
           expect(chef_run).to render_file(nfs_conf_dropin).with_content(/\[statd\]\nport=32765\noutgoing-port=32766/)
           expect(chef_run).to render_file(nfs_conf_dropin).with_content(/\[mountd\]\nport=32767/)
-          expect(chef_run).to render_file(nfs_conf_dropin).with_content(/\[lockd\]\nport=32768\nudp-port=32768/)
+          expect(chef_run).to render_file(nfs_conf_dropin).with_content(/\[lockd\]\nport=4045\nudp-port=4045/)
         end
 
         it 'restart of the server is notified when the drop-in changes' do


### PR DESCRIPTION
### Description of changes

The NFSv3 lock manager (lockd/NLM) was pinned to 32768, which is the exact bottom of the Linux ephemeral port range (net.ipv4.ip_local_port_range = 32768-60999). A background process could grab 32768 before lockd claimed it, causing sporadic NFSv3 mount failures with:

    lockd_up: makesock failed, error=-98
    mount.nfs: Address already in use

This only affects the NFS *client* path: every ParallelCluster-managed mount is NFSv4, so lockd is exercised only when a node mounts an external NFSv3 server.

Change the default node['nfs']['port']['lockd'] to 4045 (the conventional Solaris/NetApp NLM port), which sits below the ephemeral floor and so is never auto-assigned by the kernel. The value drives both the lockd kernel-module options (nlm_tcpport/nlm_udpport).

Note: 4045 is registered by IANA as npp (Network Paging Protocol), a defunct protocol not present on ParallelCluster AMIs, so there is no practical conflict; lockd has no IANA-assigned port.

### Tests
The following tests have passed:
```
test-suites:
  storage:
    test_ebs.py::test_ebs_single:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["m6g.xlarge"]
          oss: ["alinux2023", "ubuntu2204", "ubuntu2404", "rhel8", "rocky8", "rocky9", "rhel9"]
          schedulers: ["slurm"]
    test_fsx_lustre.py::test_multiple_fsx:
      dimensions:
        - regions: ["eu-west-2"]
          instances: ["m6g.xlarge"]
          oss: ["alinux2023", "ubuntu2204", "ubuntu2404", "rhel8", "rocky8", "rocky9", "rhel9"]
          schedulers: ["slurm"]
```

### References
* Integration tests PR https://github.com/aws/aws-parallelcluster/pull/7477
* Address https://github.com/aws/aws-parallelcluster/issues/6949

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
