### PR TITLE
[pcluster-diag] Diagnostics checks to return error codes rather than free-form error messages + simplifications to the returned diagnostics report

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/cfn_hup.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/cfn_hup.py
@@ -14,6 +14,7 @@
 
 from pcluster_diag.core.constants import CFN_HUP_PROGRAM
 from pcluster_diag.models.check import Check
+from pcluster_diag.models.check_error import CheckError
 from pcluster_diag.models.context import Context, NodeType
 from pcluster_diag.models.result import Result
 from pcluster_diag.util.services import is_supervisord_program_running
@@ -21,6 +22,9 @@ from pcluster_diag.util.services import is_supervisord_program_running
 
 class CfnHupRunsOnlyOnHeadNode(Check):
     """Verify that the cfn-hup daemon runs only on the head node."""
+
+    NOT_RUNNING_ON_HEAD_NODE = CheckError("E1", "{} is not running on the head node.".format(CFN_HUP_PROGRAM))
+    RUNNING_ON_NON_HEAD_NODE = CheckError("E2", "{} is running on a non-head node.".format(CFN_HUP_PROGRAM))
 
     @property
     def description(self) -> str:
@@ -31,11 +35,7 @@ class CfnHupRunsOnlyOnHeadNode(Check):
         """Pass when cfn-hup is running on the head node and stopped elsewhere; fail otherwise."""
         should_be_running = context.node_type is NodeType.HEAD
         is_running = is_supervisord_program_running(CFN_HUP_PROGRAM)
-        node_type = context.node_type.value
         if is_running == should_be_running:
             return Result.passed(self)
-        if should_be_running:
-            message = "{} is not running on the {}.".format(CFN_HUP_PROGRAM, node_type)
-        else:
-            message = "{} is running on the {}.".format(CFN_HUP_PROGRAM, node_type)
-        return Result.failure(self, message=message)
+        error = self.NOT_RUNNING_ON_HEAD_NODE if should_be_running else self.RUNNING_ON_NON_HEAD_NODE
+        return Result.failure(self, errors=[error])

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/registry.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/registry.py
@@ -71,9 +71,9 @@ class Registry:
         - ``registered``: every registered Check (the Runner runs those that are neither skipped nor
           declined).
         - ``not_applicable``: non-applicable Checks (``should_run(context)`` False); the Runner records
-          these as SKIPPED.
+          these as SKIPPED_NOT_APPLICABLE.
         - ``not_approved``: applicable, confirmation-required Checks whose prompt the user declined; the
-          Runner records these as SKIPPED ("Skipped by the user").
+          Runner records these as SKIPPED_BY_USER.
 
         Confirmation-required Checks (``approval_required(context)`` True) are listed and prompted yes/no
         here, before the Runner is invoked, so execution begins only once every decision is collected.

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/runner.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/runner.py
@@ -17,7 +17,6 @@ their Results in that same order.
 """
 
 import logging
-import traceback
 from typing import List
 
 from pcluster_diag.models.check import Check
@@ -30,9 +29,9 @@ logger = logging.getLogger(__name__)
 class Runner:
     """Executes the Checks and aggregates their Results, one Result per Check, in registration order.
 
-    Checks that run execute in isolation (an unhandled exception becomes an ERROR Result), and a
-    FAILURE or ERROR never stops the run. Non-applicable Checks are recorded as SKIPPED and declined
-    confirmation-required Checks as SKIPPED ("Skipped by the user"). Each outcome is logged to stderr
+    Checks that run execute in isolation (an unhandled exception becomes a CHECK_ERROR Result), and a
+    FAILURE or CHECK_ERROR never stops the run. Non-applicable Checks are recorded as SKIPPED_NOT_APPLICABLE
+    and declined confirmation-required Checks as SKIPPED_BY_USER. Each outcome is logged to stderr
     and never alters the JSON Report.
     """
 
@@ -47,16 +46,16 @@ class Runner:
 
         Each Check in ``checks`` is handled in order and, based on its disposition:
 
-        - recorded SKIPPED ("not applicable") when it is in ``check_not_applicable``;
-        - recorded SKIPPED ("Skipped by the user") when it is in ``check_not_approved``;
-        - otherwise executed in isolation (an unhandled exception becomes an ERROR Result).
+        - recorded SKIPPED_NOT_APPLICABLE when it is in ``check_not_applicable``;
+        - recorded SKIPPED_BY_USER when it is in ``check_not_approved``;
+        - otherwise executed in isolation (an unhandled exception becomes a CHECK_ERROR Result).
 
         Args:
             context: The runtime Context for this diagnosis.
             checks: Every Check to account for, in registration order.
-            check_not_applicable: Non-applicable Checks to record as SKIPPED.
+            check_not_applicable: Non-applicable Checks to record as SKIPPED_NOT_APPLICABLE.
             check_not_approved: Confirmation-required Checks the user declined,
-                recorded as SKIPPED ("Skipped by the user").
+                recorded as SKIPPED_BY_USER.
 
         Returns:
             One Result per Check in ``checks``, in the same (registration) order.
@@ -66,9 +65,9 @@ class Runner:
         results: List[Result] = []
         for check in checks:
             if check.identifier in not_applicable_ids:
-                result = Result.skipped(check, message="Check is not applicable to the current context.")
+                result = Result.skipped_not_applicable(check)
             elif check.identifier in not_approved_ids:
-                result = Result.skipped(check, message="Skipped by the user")
+                result = Result.skipped_by_user(check)
             else:
                 result = self._execute_check(context, check)
             self._collect_result(results, result)
@@ -83,7 +82,7 @@ class Runner:
     def _print_outcome(result: Result) -> None:
         """Log a per-Check outcome line to stderr; never alters the JSON Report.
 
-        FAILURE and ERROR outcomes are logged at error level; PASSED and SKIPPED at info level.
+        FAILURE and CHECK_ERROR outcomes are logged at error level; PASSED and SKIPPED_* at info level.
         """
         line = "%s: %s" % (result.check_id, result.status.value)
         if result.status in FAILED_STATUSES:
@@ -92,11 +91,11 @@ class Runner:
             logger.info(line)
 
     def _execute_check(self, context: Context, check: Check) -> Result:
-        """Run the Check in isolation, converting any unexpected error into an ERROR Result."""
+        """Run the Check in isolation, converting any unexpected error into a CHECK_ERROR Result."""
         logger.info("Check %s: started", check.identifier)
         try:
             return check.run(context)
-        except Exception:  # noqa: B902 - isolation: any failure becomes an ERROR Result
-            return Result.error(check, message=traceback.format_exc())
+        except Exception as exception:  # noqa: B902 - isolation: any failure becomes a CHECK_ERROR Result
+            return Result.error(check, exception)
         finally:
             logger.info("Check %s: finished", check.identifier)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/check_error.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/check_error.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Error model: a single failure mode identified by a Check."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CheckError:
+    """A single failure mode of a Check, uniquely identified by an error code.
+
+    Attributes:
+        code: The error code owned by the Check, formatted as ``E<N>`` (e.g. ``E1``).
+        message: The human-readable description of this failure mode.
+    """
+
+    code: str
+    message: str

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/exceptions.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/exceptions.py
@@ -49,7 +49,7 @@ class ContextBuildError(PclusterDiagError):
 
 
 class DiagnosticCheckNotPassedError(PclusterDiagError):
-    """Raised when at least one check did not pass (a FAILURE or ERROR result)."""
+    """Raised when at least one check did not pass (a FAILURE or CHECK_ERROR result)."""
 
     exit_code = ExitCode.DIAGNOSTIC_CHECK_FAILURE
     default_message = "The diagnosis detected at least one failed check."

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/result.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/result.py
@@ -23,13 +23,17 @@ class Status(Enum):
     """The status of a Check execution."""
 
     PASSED = "PASSED"  # condition satisfied
-    ERROR = "ERROR"  # check raised / could not complete
+    CHECK_ERROR = "CHECK_ERROR"  # check raised / could not complete
     FAILURE = "FAILURE"  # check completed; condition not satisfied
-    SKIPPED = "SKIPPED"  # not applicable or user-skipped
+    SKIPPED_BY_USER = "SKIPPED_BY_USER"  # user did not approve its execution
+    SKIPPED_NOT_APPLICABLE = "SKIPPED_NOT_APPLICABLE"  # does not apply to the context
 
 
 # Statuses that make the run unsuccessful: any of these in the results yields a non-zero exit code.
-FAILED_STATUSES = (Status.FAILURE, Status.ERROR)
+FAILED_STATUSES = (Status.FAILURE, Status.CHECK_ERROR)
+
+# The error code carried by a CHECK_ERROR Result (an exception prevented the Check's completion).
+INTERNAL_ERROR_CODE = "E0"
 
 
 @dataclass
@@ -39,60 +43,65 @@ class Result:
     Attributes:
         check_id: The check identifier (the Check class simple name).
         check_description: The Check's human-readable description.
-        status: The Status of the execution (PASSED, ERROR, FAILURE, or SKIPPED).
-        message: An optional human-readable message (e.g. a SKIPPED reason or an exception stack trace).
-        errors: The set of failure modes for a FAILURE Result, each a CheckError (code + message);
-            None for any other status.
-        metadata: An optional dictionary carrying any underlying data referenced by the Result.
+        status: The Status of the execution (PASSED, CHECK_ERROR, FAILURE, SKIPPED_BY_USER, or
+            SKIPPED_NOT_APPLICABLE).
+        errors: The set of failure modes for a FAILURE or CHECK_ERROR Result, each a CheckError
+            (code + message); None for any other status.
     """
 
     check_id: str
     check_description: str
     status: Status
-    message: Optional[str] = None
     errors: Optional[List[CheckError]] = None
-    metadata: Optional[dict] = None
 
     @staticmethod
-    def passed(check, message: Optional[str] = None, metadata: Optional[dict] = None) -> "Result":
+    def passed(check) -> "Result":
         """Build a PASSED Result for ``check`` (its condition was satisfied)."""
         return Result(
             check_id=check.identifier,
             check_description=check.description,
             status=Status.PASSED,
-            message=message,
-            metadata=metadata,
         )
 
     @staticmethod
-    def error(check, message: Optional[str] = None, metadata: Optional[dict] = None) -> "Result":
-        """Build an ERROR Result for ``check`` (it raised or could not complete)."""
+    def error(check, exception: Exception) -> "Result":
+        """Build a CHECK_ERROR Result for ``check`` (an exception prevented its completion).
+
+        The Result carries a single CheckError coded ``E0`` whose message is
+        ``"{exceptionName}: {exceptionMessage}"``.
+        """
+        error = CheckError(INTERNAL_ERROR_CODE, "{}: {}".format(type(exception).__name__, exception))
         return Result(
             check_id=check.identifier,
             check_description=check.description,
-            status=Status.ERROR,
-            message=message,
-            metadata=metadata,
+            status=Status.CHECK_ERROR,
+            errors=[error],
         )
 
     @staticmethod
-    def failure(check, errors: Optional[List[CheckError]] = None, metadata: Optional[dict] = None) -> "Result":
+    def failure(check, errors: Optional[List[CheckError]] = None) -> "Result":
         """Build a FAILURE Result for ``check``; the failure modes are described by ``errors``."""
         return Result(
             check_id=check.identifier,
             check_description=check.description,
             status=Status.FAILURE,
             errors=errors,
-            metadata=metadata,
         )
 
     @staticmethod
-    def skipped(check, message: Optional[str] = None, metadata: Optional[dict] = None) -> "Result":
-        """Build a SKIPPED Result for ``check`` (not applicable or user-skipped)."""
+    def skipped_by_user(check) -> "Result":
+        """Build a SKIPPED_BY_USER Result for ``check`` (the user did not approve its execution)."""
         return Result(
             check_id=check.identifier,
             check_description=check.description,
-            status=Status.SKIPPED,
-            message=message,
-            metadata=metadata,
+            status=Status.SKIPPED_BY_USER,
+        )
+
+    @staticmethod
+    def skipped_not_applicable(check) -> "Result":
+        """Build a SKIPPED_NOT_APPLICABLE Result for ``check`` (it does not apply to the context)."""
+        return Result(
+            check_id=check.identifier,
+            check_description=check.description,
+            status=Status.SKIPPED_NOT_APPLICABLE,
         )

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/result.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/result.py
@@ -14,7 +14,9 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import List, Optional
+
+from pcluster_diag.models.check_error import CheckError
 
 
 class Status(Enum):
@@ -38,8 +40,9 @@ class Result:
         check_id: The check identifier (the Check class simple name).
         check_description: The Check's human-readable description.
         status: The Status of the execution (PASSED, ERROR, FAILURE, or SKIPPED).
-        message: An optional human-readable message carrying the failure reason,
-            a recovery suggestion, or an exception stack trace.
+        message: An optional human-readable message (e.g. a SKIPPED reason or an exception stack trace).
+        errors: The set of failure modes for a FAILURE Result, each a CheckError (code + message);
+            None for any other status.
         metadata: An optional dictionary carrying any underlying data referenced by the Result.
     """
 
@@ -47,6 +50,7 @@ class Result:
     check_description: str
     status: Status
     message: Optional[str] = None
+    errors: Optional[List[CheckError]] = None
     metadata: Optional[dict] = None
 
     @staticmethod
@@ -72,13 +76,13 @@ class Result:
         )
 
     @staticmethod
-    def failure(check, message: Optional[str] = None, metadata: Optional[dict] = None) -> "Result":
-        """Build a FAILURE Result for ``check`` (it completed with its condition not satisfied)."""
+    def failure(check, errors: Optional[List[CheckError]] = None, metadata: Optional[dict] = None) -> "Result":
+        """Build a FAILURE Result for ``check``; the failure modes are described by ``errors``."""
         return Result(
             check_id=check.identifier,
             check_description=check.description,
             status=Status.FAILURE,
-            message=message,
+            errors=errors,
             metadata=metadata,
         )
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/serialization.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/serialization.py
@@ -18,10 +18,12 @@ from enum import Enum
 
 
 def to_dict(obj):
-    """Convert a dataclass instance to a JSON-serializable dict (enum fields become their value)."""
+    """Convert a dataclass to a JSON-serializable dict, dropping None fields (enums become their value)."""
     return dataclasses.asdict(
         obj,
-        dict_factory=lambda items: {key: (value.value if isinstance(value, Enum) else value) for key, value in items},
+        dict_factory=lambda items: {
+            key: (value.value if isinstance(value, Enum) else value) for key, value in items if value is not None
+        },
     )
 
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_cfn_hup.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_cfn_hup.py
@@ -38,39 +38,29 @@ def test_approval_required(node_type):
     assert CfnHupRunsOnlyOnHeadNode().approval_required(sample_context(node_type)) is False
 
 
+_NOT_RUNNING = CfnHupRunsOnlyOnHeadNode.NOT_RUNNING_ON_HEAD_NODE
+_RUNNING_ON_NON_HEAD = CfnHupRunsOnlyOnHeadNode.RUNNING_ON_NON_HEAD_NODE
+
+
 @pytest.mark.parametrize(
-    "node_type, is_running, expected_status, expected_message",
+    "node_type, is_running, expected_status, expected_errors",
     [
         (NodeType.HEAD, True, Status.PASSED, None),  # head: running as expected
-        (
-            NodeType.HEAD,
-            False,
-            Status.FAILURE,
-            "cfn-hup is not running on the HeadNode.",
-        ),  # head: should run but isn't
+        (NodeType.HEAD, False, Status.FAILURE, [_NOT_RUNNING]),  # head: should run but isn't
         (NodeType.COMPUTE, False, Status.PASSED, None),  # compute: not running as expected
-        (
-            NodeType.COMPUTE,
-            True,
-            Status.FAILURE,
-            "cfn-hup is running on the ComputeFleet.",
-        ),  # compute: running but shouldn't be
+        (NodeType.COMPUTE, True, Status.FAILURE, [_RUNNING_ON_NON_HEAD]),  # compute: running but shouldn't be
         (NodeType.LOGIN, False, Status.PASSED, None),  # login: not running as expected
-        (
-            NodeType.LOGIN,
-            True,
-            Status.FAILURE,
-            "cfn-hup is running on the LoginNode.",
-        ),  # login: running but shouldn't be
+        (NodeType.LOGIN, True, Status.FAILURE, [_RUNNING_ON_NON_HEAD]),  # login: running but shouldn't be
     ],
 )
-def test_run(monkeypatch, node_type, is_running, expected_status, expected_message):
+def test_run(monkeypatch, node_type, is_running, expected_status, expected_errors):
     monkeypatch.setattr(cfn_hup, "is_supervisord_program_running", lambda _program: is_running)
 
     result = CfnHupRunsOnlyOnHeadNode().run(sample_context(node_type))
 
     assert result.status is expected_status
-    assert result.message == expected_message
+    # A failure returns the Check's own constant error(s); a pass carries none.
+    assert result.errors == expected_errors
 
 
 def test_run_propagates_when_status_cannot_be_determined(monkeypatch):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_sample.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_sample.py
@@ -39,4 +39,3 @@ def test_run():
 
     assert result.status is Status.PASSED
     assert result.check_id == check.identifier
-    assert result.message is None

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/commands/test_run.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/commands/test_run.py
@@ -164,12 +164,12 @@ def test_confirmation_required_check_flow(runner, monkeypatch, invoke_args, cli_
     # The confirmation listing/prompt is emitted to stderr unless --yes bypasses it.
     assert ("require your confirmation" in result.stderr) is expect_prompt
     if not expected_ran:
-        # A declined check is recorded SKIPPED and carries the user-facing message in the report.
+        # A declined check is recorded SKIPPED_BY_USER in the report.
         # (Interactive input is echoed onto stdout before the JSON, so parse from the first brace.)
-        assert "ApprovalCheck: SKIPPED" in result.stderr
+        assert "ApprovalCheck: SKIPPED_BY_USER" in result.stderr
         brace_at = result.stdout.index("{")
         payload = json.loads(result.stdout[brace_at:])
-        assert payload["results"][0]["message"] == "Skipped by the user"
+        assert payload["results"][0]["status"] == "SKIPPED_BY_USER"
 
 
 @pytest.mark.parametrize(
@@ -177,17 +177,14 @@ def test_confirmation_required_check_flow(runner, monkeypatch, invoke_args, cli_
     [
         ([("PassedCheck", Status.PASSED, True), ("SkippedCheck", Status.PASSED, False)], 0),
         ([("HealthyCheck", Status.PASSED, True), ("FailingCheck", Status.FAILURE, True)], 3),
-        ([("ErroringCheck", Status.ERROR, True)], 3),
+        ([("ErroringCheck", Status.CHECK_ERROR, True)], 3),
     ],
     ids=["all-successful-exit-zero", "any-failure-exits-non-zero", "any-error-exits-non-zero"],
 )
 def test_run_exit_code_reflects_worst_result_status(runner, monkeypatch, checks_spec, expected_exit_code):
     # A single FAILURE or ERROR makes the whole run unsuccessful; the report is still printed and the
     # handler exits with the diagnostic-failure code without emitting a separate JSON error.
-    checks = [
-        FakeCheck(name, status=status, applicable=applicable, message="detail")
-        for name, status, applicable in checks_spec
-    ]
+    checks = [FakeCheck(name, status=status, applicable=applicable) for name, status, applicable in checks_spec]
     _stub_registry_with(monkeypatch, checks)
 
     result = runner.invoke(main, ["run"])

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_runner.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_runner.py
@@ -15,6 +15,7 @@
 import logging
 
 from pcluster_diag.core.runner import Runner
+from pcluster_diag.models.check_error import CheckError
 from pcluster_diag.models.result import Status
 from tests.sample_data import FAKE_CHECK_RAISE_MESSAGE, FakeCheck, sample_context
 
@@ -38,15 +39,15 @@ def test_failure_does_not_stop_remaining_checks():
     assert b.ran is True
 
 
-def test_unhandled_exception_becomes_error_with_stack_trace():
+def test_unhandled_exception_becomes_check_error_with_e0_error():
     a = FakeCheck("A", raises=True)
     b = FakeCheck("B")
 
     results = Runner().execute(sample_context(), [a, b])
 
-    assert results[0].status == Status.ERROR
-    assert "Traceback" in results[0].message
-    assert FAKE_CHECK_RAISE_MESSAGE in results[0].message
+    assert results[0].status == Status.CHECK_ERROR
+    # A CHECK_ERROR carries a single E0 error coded "{exceptionName}: {exceptionMessage}".
+    assert results[0].errors == [CheckError("E0", "RuntimeError: {}".format(FAKE_CHECK_RAISE_MESSAGE))]
     # Isolation: the next Check still ran.
     assert results[1].status == Status.PASSED
 
@@ -56,8 +57,7 @@ def test_not_approved_check_yields_skipped_by_user():
 
     results = Runner().execute(sample_context(), [a], check_not_approved=[a])
 
-    assert results[0].status == Status.SKIPPED
-    assert results[0].message == "Skipped by the user"
+    assert results[0].status == Status.SKIPPED_BY_USER
     # A not-approved Check is never executed.
     assert a.ran is False
 
@@ -106,14 +106,10 @@ def test_results_follow_registration_order_across_dispositions():
 
     assert [(r.check_id, r.status) for r in results] == [
         ("Run1", Status.PASSED),
-        ("Skip", Status.SKIPPED),
+        ("Skip", Status.SKIPPED_NOT_APPLICABLE),
         ("Run2", Status.PASSED),
-        ("Declined", Status.SKIPPED),
+        ("Declined", Status.SKIPPED_BY_USER),
     ]
-    # Skipped / declined Checks carry their user-facing messages and never execute.
-    skip_result = next(r for r in results if r.check_id == "Skip")
-    declined_result = next(r for r in results if r.check_id == "Declined")
-    assert skip_result.message == "Check is not applicable to the current context."
-    assert declined_result.message == "Skipped by the user"
+    # Skipped / declined Checks never execute.
     assert skip.ran is False
     assert declined.ran is False

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_check.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_check.py
@@ -29,9 +29,7 @@ class _MinimalCheck(Check):
         return context.node_type is NodeType.HEAD
 
     def run(self, context: Context) -> Result:
-        return Result(
-            check_id=self.identifier, check_description=self.description, status=Status.PASSED, metadata={"ran": True}
-        )
+        return Result(check_id=self.identifier, check_description=self.description, status=Status.PASSED)
 
 
 class _ApprovalCheck(_MinimalCheck):
@@ -94,7 +92,6 @@ def test_run_returns_result():
     assert isinstance(result, Result)
     assert result.check_id == check.identifier
     assert result.status is Status.PASSED
-    assert result.metadata == {"ran": True}
 
 
 def test_abstract_method_bodies_raise_not_implemented():

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_report.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_report.py
@@ -33,18 +33,18 @@ from tests.sample_data import sample_report
     ids=["empty-results", "mixed-results"],
 )
 def test_report_serialization_content_per_check(report):
-    """The serialized Report carries the context and, per executed Check, its id, Status, message, and metadata."""
+    """The serialized Report carries the context and, per executed Check, its id and Status."""
     serialized = to_dict(report)
 
     assert serialized["context"]["node_type"] == report.context.node_type.value
     assert len(serialized["results"]) == len(report.results)
 
     for entry, result in zip(serialized["results"], report.results):
-        assert set(entry.keys()) >= {"check_id", "status", "message", "metadata"}
+        assert set(entry.keys()) >= {"check_id", "status"}
+        # The message field has been removed from Result and must not appear in the serialized output.
+        assert "message" not in entry
         assert entry["check_id"] == result.check_id
         assert entry["status"] == result.status.value
-        assert entry["message"] == result.message
-        assert entry["metadata"] == result.metadata
 
 
 def test_report_save_writes_json_to_the_given_path(tmp_path):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_result.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_result.py
@@ -14,6 +14,7 @@
 
 import pytest
 
+from pcluster_diag.models.check_error import CheckError
 from pcluster_diag.models.result import Result, Status
 from tests.sample_data import FakeCheck, sample_result
 
@@ -33,12 +34,11 @@ def test_result_status_is_a_valid_status_member(status):
     [
         (Result.passed, Status.PASSED),
         (Result.error, Status.ERROR),
-        (Result.failure, Status.FAILURE),
         (Result.skipped, Status.SKIPPED),
     ],
-    ids=["passed", "error", "failure", "skipped"],
+    ids=["passed", "error", "skipped"],
 )
-def test_factory_builds_result_from_check(factory, expected_status):
+def test_message_factory_builds_result_from_check(factory, expected_status):
     message = "a message"
     metadata = {"key": "value"}
 
@@ -49,9 +49,31 @@ def test_factory_builds_result_from_check(factory, expected_status):
     assert result.check_description == _SAMPLE_CHECK.description
     assert result.message == message
     assert result.metadata == metadata
+    assert result.errors is None
 
-    # message and metadata default to None when omitted.
+    # message, metadata, and errors default to None when omitted.
     defaults = factory(_SAMPLE_CHECK)
     assert defaults.status is expected_status
     assert defaults.message is None
     assert defaults.metadata is None
+    assert defaults.errors is None
+
+
+def test_failure_factory_builds_result_with_errors():
+    errors = [CheckError("E1", "boom"), CheckError("E2", "kaboom")]
+    metadata = {"key": "value"}
+
+    result = Result.failure(_SAMPLE_CHECK, errors=errors, metadata=metadata)
+
+    assert result.status is Status.FAILURE
+    assert result.check_id == _SAMPLE_CHECK.identifier
+    assert result.check_description == _SAMPLE_CHECK.description
+    assert result.errors == errors
+    assert result.metadata == metadata
+    # A failure is described by its errors, never a message.
+    assert result.message is None
+
+    # errors default to None when omitted, and a failure still carries no message.
+    defaults = Result.failure(_SAMPLE_CHECK)
+    assert defaults.errors is None
+    assert defaults.message is None

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_result.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_result.py
@@ -15,7 +15,7 @@
 import pytest
 
 from pcluster_diag.models.check_error import CheckError
-from pcluster_diag.models.result import Result, Status
+from pcluster_diag.models.result import INTERNAL_ERROR_CODE, Result, Status
 from tests.sample_data import FakeCheck, sample_result
 
 _SAMPLE_CHECK = FakeCheck(identifier="SampleCheck", description="a sample check")
@@ -23,57 +23,68 @@ _SAMPLE_CHECK = FakeCheck(identifier="SampleCheck", description="a sample check"
 
 @pytest.mark.parametrize("status", list(Status), ids=lambda status: status.name)
 def test_result_status_is_a_valid_status_member(status):
-    """A Result's Status is one of PASSED, ERROR, FAILURE, or SKIPPED."""
-    result = sample_result(status=status, metadata={"key": "value"})
+    """A Result's Status is one of PASSED, CHECK_ERROR, FAILURE, SKIPPED_BY_USER, or SKIPPED_NOT_APPLICABLE."""
+    result = sample_result(status=status)
 
-    assert result.status in {Status.PASSED, Status.ERROR, Status.FAILURE, Status.SKIPPED}
+    assert result.status in {
+        Status.PASSED,
+        Status.CHECK_ERROR,
+        Status.FAILURE,
+        Status.SKIPPED_BY_USER,
+        Status.SKIPPED_NOT_APPLICABLE,
+    }
+
+
+def test_passed_factory_builds_result_from_check():
+    result = Result.passed(_SAMPLE_CHECK)
+
+    assert result.status is Status.PASSED
+    assert result.check_id == _SAMPLE_CHECK.identifier
+    assert result.check_description == _SAMPLE_CHECK.description
+    # A PASSED Result carries no errors.
+    assert result.errors is None
+
+
+def test_error_factory_builds_check_error_result_from_exception():
+    exception = ValueError("something went wrong")
+
+    result = Result.error(_SAMPLE_CHECK, exception)
+
+    assert result.status is Status.CHECK_ERROR
+    assert result.check_id == _SAMPLE_CHECK.identifier
+    assert result.check_description == _SAMPLE_CHECK.description
+    # A CHECK_ERROR carries a single E0 error coded "{exceptionName}: {exceptionMessage}".
+    assert result.errors == [CheckError(INTERNAL_ERROR_CODE, "ValueError: something went wrong")]
 
 
 @pytest.mark.parametrize(
     "factory, expected_status",
     [
-        (Result.passed, Status.PASSED),
-        (Result.error, Status.ERROR),
-        (Result.skipped, Status.SKIPPED),
+        (Result.skipped_by_user, Status.SKIPPED_BY_USER),
+        (Result.skipped_not_applicable, Status.SKIPPED_NOT_APPLICABLE),
     ],
-    ids=["passed", "error", "skipped"],
+    ids=["skipped-by-user", "skipped-not-applicable"],
 )
-def test_message_factory_builds_result_from_check(factory, expected_status):
-    message = "a message"
-    metadata = {"key": "value"}
-
-    result = factory(_SAMPLE_CHECK, message=message, metadata=metadata)
+def test_skipped_factory_builds_result_with_no_errors(factory, expected_status):
+    result = factory(_SAMPLE_CHECK)
 
     assert result.status is expected_status
     assert result.check_id == _SAMPLE_CHECK.identifier
     assert result.check_description == _SAMPLE_CHECK.description
-    assert result.message == message
-    assert result.metadata == metadata
+    # A skipped Result never carries errors.
     assert result.errors is None
-
-    # message, metadata, and errors default to None when omitted.
-    defaults = factory(_SAMPLE_CHECK)
-    assert defaults.status is expected_status
-    assert defaults.message is None
-    assert defaults.metadata is None
-    assert defaults.errors is None
 
 
 def test_failure_factory_builds_result_with_errors():
     errors = [CheckError("E1", "boom"), CheckError("E2", "kaboom")]
-    metadata = {"key": "value"}
 
-    result = Result.failure(_SAMPLE_CHECK, errors=errors, metadata=metadata)
+    result = Result.failure(_SAMPLE_CHECK, errors=errors)
 
     assert result.status is Status.FAILURE
     assert result.check_id == _SAMPLE_CHECK.identifier
     assert result.check_description == _SAMPLE_CHECK.description
     assert result.errors == errors
-    assert result.metadata == metadata
-    # A failure is described by its errors, never a message.
-    assert result.message is None
 
-    # errors default to None when omitted, and a failure still carries no message.
+    # errors default to None when omitted.
     defaults = Result.failure(_SAMPLE_CHECK)
     assert defaults.errors is None
-    assert defaults.message is None

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/sample_data.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/sample_data.py
@@ -58,7 +58,6 @@ class FakeCheck(Check):
         applicable: What ``should_run`` returns.
         approval: What ``approval_required`` returns.
         status: The Status of the Result ``run`` returns.
-        message: The message of the Result ``run`` returns.
         raises: When True, ``run`` raises instead of returning a Result.
         events: When provided, ``should_run`` and ``run`` append ``"should_run:<id>"`` /
             ``"run:<id>"`` so call ordering can be asserted.
@@ -72,7 +71,6 @@ class FakeCheck(Check):
         applicable=True,
         approval=False,
         status=Status.PASSED,
-        message=None,
         raises=False,
         events=None,
     ):
@@ -82,7 +80,6 @@ class FakeCheck(Check):
         self._applicable = applicable
         self._approval = approval
         self._status = status
-        self._message = message
         self._raises = raises
         self._events = events
         self.ran = False
@@ -109,42 +106,30 @@ class FakeCheck(Check):
             self._events.append("run:{}".format(self._identifier))
         if self._raises:
             raise RuntimeError(FAKE_CHECK_RAISE_MESSAGE)
-        return Result(
-            check_id=self._identifier, check_description=self._description, status=self._status, message=self._message
-        )
+        return Result(check_id=self._identifier, check_description=self._description, status=self._status)
 
 
 # --- Results --------------------------------------------------------------------------
 
 
-def sample_result(
-    status: Status = Status.PASSED, *, check_id: str = "SampleCheck", message=None, metadata=None, errors=None
-):
-    """Return a sample Result with the given status (and optional message/metadata/errors)."""
+def sample_result(status: Status = Status.PASSED, *, check_id: str = "SampleCheck", errors=None):
+    """Return a sample Result with the given status (and optional errors)."""
     return Result(
         check_id=check_id,
         check_description="description for {}".format(check_id),
         status=status,
-        message=message,
-        metadata=metadata,
         errors=errors,
     )
 
 
 def sample_results():
-    """Return one sample Result per Status, spanning absent, plain, and nested message/metadata shapes."""
+    """Return one sample Result per Status, spanning absent, plain, and error-bearing shapes."""
     return [
         sample_result(Status.PASSED, check_id="PassedCheck"),
-        sample_result(
-            Status.FAILURE, check_id="FailedCheck", errors=[CheckError("E1", "nope")], metadata={"path": "/x"}
-        ),
-        sample_result(Status.ERROR, check_id="ErroredCheck", message="trace"),
-        sample_result(
-            Status.SKIPPED,
-            check_id="SkippedCheck",
-            message="Skipped by the user",
-            metadata={"nested": {"values": [1, 2, 3], "flag": True, "empty": None}},
-        ),
+        sample_result(Status.FAILURE, check_id="FailedCheck", errors=[CheckError("E1", "nope")]),
+        sample_result(Status.CHECK_ERROR, check_id="ErroredCheck", errors=[CheckError("E0", "RuntimeError: boom")]),
+        sample_result(Status.SKIPPED_BY_USER, check_id="SkippedByUserCheck"),
+        sample_result(Status.SKIPPED_NOT_APPLICABLE, check_id="SkippedNotApplicableCheck"),
     ]
 
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/sample_data.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/sample_data.py
@@ -13,6 +13,7 @@
 """Shared sample data for the test suite: Contexts, Check doubles, and Results."""
 
 from pcluster_diag.models.check import Check
+from pcluster_diag.models.check_error import CheckError
 from pcluster_diag.models.context import Context, NodeType
 from pcluster_diag.models.report import Report
 from pcluster_diag.models.result import Result, Status
@@ -116,14 +117,17 @@ class FakeCheck(Check):
 # --- Results --------------------------------------------------------------------------
 
 
-def sample_result(status: Status = Status.PASSED, *, check_id: str = "SampleCheck", message=None, metadata=None):
-    """Return a sample Result with the given status (and optional message/metadata)."""
+def sample_result(
+    status: Status = Status.PASSED, *, check_id: str = "SampleCheck", message=None, metadata=None, errors=None
+):
+    """Return a sample Result with the given status (and optional message/metadata/errors)."""
     return Result(
         check_id=check_id,
         check_description="description for {}".format(check_id),
         status=status,
         message=message,
         metadata=metadata,
+        errors=errors,
     )
 
 
@@ -131,7 +135,9 @@ def sample_results():
     """Return one sample Result per Status, spanning absent, plain, and nested message/metadata shapes."""
     return [
         sample_result(Status.PASSED, check_id="PassedCheck"),
-        sample_result(Status.FAILURE, check_id="FailedCheck", message="nope", metadata={"path": "/x"}),
+        sample_result(
+            Status.FAILURE, check_id="FailedCheck", errors=[CheckError("E1", "nope")], metadata={"path": "/x"}
+        ),
         sample_result(Status.ERROR, check_id="ErroredCheck", message="trace"),
         sample_result(
             Status.SKIPPED,


### PR DESCRIPTION
### Description of changes
Diagnostics checks to return error codes rather than free-form error messages.
Also applied major UX simplifications to the returned diagnostics report.

1. Remove `message` attribute from the check result.
2. Remove `metadata` attribute from the check result.
3. Add result status `SKIPPED_NOT_APPLICABLE` to represent checks that are skipped as not applicable to the current context.
4. Add result status `SKIPPED_BY_USER` to represent checks that are skipped per user request.
5. Rename result status `ERROR` to `CHECK_ERROR` to better represent the situation where the check failed its execution.
6. A result with status `CHECK_ERROR` now has errorCodes representing the internal exception.

### User Experience

Example of a failed check (failure injected by forcefully stopping cfn-hup):

#### Example 1: checks passed
```
"results": [
    {
      "check_id": "CfnHupRunsOnlyOnHeadNode",
      "check_description": "Verify that the cfn-hup daemon runs only on the head node.",
      "status": "PASSED"
    },
    ...
  ]
```

#### Example 2: skipped by user
```
"results": [
    ...
    {
      "check_id": "SampleCheck",
      "check_description": "Placeholder check that requires confirmation and always passes.",
      "status": "SKIPPED_BY_USER"
    }
  ]
```

#### Example 3: check failed
```
  "results": [
    {
      "check_id": "CfnHupRunsOnlyOnHeadNode",
      "check_description": "Verify that the cfn-hup daemon runs only on the head node.",
      "status": "FAILURE",
      "errors": [
        {
          "code": "E1",
          "message": "cfn-hup is not running on the head node."
        }
      ]
    },
    ...
  ]
```

#### Example 4: check error
```
  "results": [
    {
      "check_id": "CfnHupRunsOnlyOnHeadNode",
      "check_description": "Verify that the cfn-hup daemon runs only on the head node.",
      "status": "CHECK_ERROR",
      "errors": [
        {
          "code": "E0",
          "message": "PermissionError: [Errno 13] Permission denied: '/opt/parallelcluster/pyenv/versions/3.14.2/envs/cookbook_virtualenv/bin/supervisorctl'"
        }
      ]
    },
    ...
  ]
```

### Tests
* unit tests
* Manual test (see UX above)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
