### PR TITLE
[Deps] Skip DCV tarball checksum when base_url is overridden from default S3 mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - openssh-2.11.17 (from openssh-2.11.14)
   - yum-8.0.0 (from yum-7.4.20)
   - yum-epel-5.0.9 (from yum-epel-5.0.8)
+- Upgrade aws-cfn-bootstrap to version 2.0-39 (from 2.0-38).
 
 **CHANGES**
 - Enforce NFSv4-only on the ParallelCluster-managed NFS server (head node). The NFSv3 client stack (rpcbind, rpc-statd, lockd) are unchanged, so cluster nodes can still mount external NFSv3 servers.

--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -84,7 +84,7 @@ default['cluster']['efs']['version'] = '2.4.0'
 default['cluster']['efs']['sha256'] = '9b60c039c162388091d6fab6e9c6cfc5832f34b26b6d05b0a68b333147d78a25'
 default['cluster']['efs']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/efs"
 
-default['cluster']['cfn_bootstrap']['version'] = '2.0-38'
+default['cluster']['cfn_bootstrap']['version'] = '2.0-39'
 
 # TODO: Move to platform cookbook
 default['cluster']['spack_shared_dir'] = "#{node['cluster']['shared_dir']}/spack"

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
@@ -153,7 +153,9 @@ action :setup do
     unless ::File.exist?(dcv_tarball)
       remote_file dcv_tarball do
         source dcv_url
-        checksum dcv_sha256sum
+        # The hardcoded per-arch/os sha only matches the default S3 mirror; skip
+        # verification when base_url is overridden using ExtraChefAttributes.
+        checksum dcv_sha256sum if default_artifacts_url?(node['cluster']['dcv']['base_url'])
         mode '0644'
         retries 3
         retry_delay 5

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -1071,3 +1071,74 @@ describe 'dcv:configure' do
     end
   end
 end
+
+# Tests the DCV tarball checksum override: the hardcoded per-arch/os sha is verified
+# only on the default S3 mirror. When base_url is overridden the checksum is skipped,
+# because default_artifacts_url? returns false.
+describe 'dcv:setup checksum override behavior' do
+  cluster_artifacts_s3_url = 'https://aws_region-aws-parallelcluster.s3.AWS_REGION.AWS_DOMAIN'
+  s3_dcv_base_url = "#{cluster_artifacts_s3_url}/dependencies/dcv"
+  public_dcv_base_url = 'https://fake-public.example.DOMAIN/dcv'
+
+  for_all_oses do |platform, version|
+    cached(:sources_dir) { 'sources_dir' }
+    cached(:dcv_tarball) { 'dcv_tarball' }
+    cached(:checksum) { 'checksum' }
+    cached(:dcv_package) { 'dcv_package' }
+    cached(:dcv_server) { 'dcv_server' }
+    cached(:xdcv) { 'xdcv' }
+    cached(:dcv_web_viewer) { 'dcv_web_viewer' }
+    cached(:dcvauth_virtualenv) { 'dcvauth_virtualenv' }
+    cached(:dcvauth_virtualenv_path) { 'dcvauth_virtualenv_path' }
+    cached(:alinux_prereq_packages) { 'alinux_prereq_packages' }
+
+    [
+      ['default S3 base_url', s3_dcv_base_url, true],
+      ['overridden public base_url', public_dcv_base_url, false],
+    ].each do |scenario, base_url, checksum_expected|
+      context "on #{platform}#{version} with #{scenario}" do
+        cached(:chef_run) do
+          stub_command('which getenforce').and_return(true)
+          stub_command('grubby --info=ALL | grep -q "selinux=0"').and_return(false)
+          allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+          allow(::File).to receive(:exist?).with('/etc/dcv/dcv.conf').and_return(false)
+          allow(::File).to receive(:exist?).with(dcv_tarball).and_return(false)
+          stubs_for_resource('dcv') do |res|
+            allow(res).to receive(:dcv_sha256sum).and_return(checksum)
+            allow(res).to receive(:dcv_supported?).and_return(true)
+            allow(res).to receive(:prereq_packages).and_return(alinux_prereq_packages) if platform == 'amazon'
+            allow(res).to receive(:dcv_package).and_return(dcv_package)
+            allow(res).to receive(:dcv_server).and_return(dcv_server)
+            allow(res).to receive(:xdcv).and_return(xdcv)
+            allow(res).to receive(:dcv_web_viewer).and_return(dcv_web_viewer)
+            allow(res).to receive(:dcv_tarball).and_return(dcv_tarball)
+            allow(res).to receive(:dcvauth_virtualenv).and_return(dcvauth_virtualenv)
+            allow(res).to receive(:dcvauth_virtualenv_path).and_return(dcvauth_virtualenv_path)
+          end
+          runner = runner(platform: platform, version: version, step_into: ['dcv']) do |node|
+            node.override['cluster']['sources_dir'] = sources_dir
+            node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
+            node.override['cluster']['dcv']['base_url'] = base_url
+          end
+          ConvergeDcv.setup(runner)
+        end
+
+        it 'downloads the DCV tarball' do
+          is_expected.to create_remote_file(dcv_tarball).with(source: "#{base_url}/#{dcv_package}.tgz")
+        end
+
+        if checksum_expected
+          it 'verifies checksum on default S3 download' do
+            remote_file = chef_run.find_resource('remote_file', dcv_tarball)
+            expect(remote_file.checksum).to eq(checksum)
+          end
+        else
+          it 'skips checksum when base_url is overridden' do
+            remote_file = chef_run.find_resource('remote_file', dcv_tarball)
+            expect(remote_file.checksum).to be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes

* Skip DCV tarball checksum when base_url is overridden from default S3 mirror

Same as done here for NVLSM https://github.com/aws/aws-parallelcluster-cookbook/commit/ae29c45b5e86aee8a6848396b842a3dec294477d#diff-b5e3f07ce3025ee0313befb79bb7b5aae116987d29eb601bfd62c602ad373559

* Upgrade CFN bootstrap Scripts to 2.0-39

### Tests
* Unit tests
* Build Image

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
