### PR TITLE
Move node bootstrap files from /tmp to /opt/parallelcluster/tmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
   - yum-8.0.0 (from yum-7.4.20)
   - yum-epel-5.0.9 (from yum-epel-5.0.8)
 - Upgrade aws-cfn-bootstrap to version 2.0-39 (from 2.0-38).
+- Move all ParallelCluster-managed bootstrap files off `/tmp` into a dedicated `/opt/parallelcluster/tmp`
+  directory. Therefore, Image builds, cluster creations and updates work on custom AMIs that mount `/tmp` with `noexec`.
+  
 
 **CHANGES**
 - Enforce NFSv4-only on the ParallelCluster-managed NFS server (head node). The NFSv3 client stack (rpcbind, rpc-statd, lockd) are unchanged, so cluster nodes can still mount external NFSv3 servers.

--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/install.rb
@@ -16,6 +16,13 @@ os_type 'Validate OS type specified by the user is the same as the OS identified
 
 return if node['conditions']['ami_bootstrapped']
 
+if node['cluster']['tmp_noexec'] == 'true'
+  execute 'TEST ONLY - remount /tmp as noexec' do
+    command 'mount --bind /tmp /tmp && mount -o remount,bind,noexec,nosuid,nodev /tmp'
+    not_if 'findmnt -no OPTIONS /tmp | grep -qw noexec'
+  end
+end
+
 include_recipe "aws-parallelcluster-shared::setup_envars"
 include_recipe "aws-parallelcluster-shared::setup_proxy" if node['cluster']['install_http_proxy_address']
 

--- a/cookbooks/aws-parallelcluster-environment/files/cfn_hup_configuration/manage_fleet_dna.py
+++ b/cookbooks/aws-parallelcluster-environment/files/cfn_hup_configuration/manage_fleet_dna.py
@@ -255,7 +255,7 @@ def write_dna_files(write_files_section, shared_storage_loc):
     try:
         file_path = shared_storage_loc + "-dna.json"
         for data in write_files_section:
-            if data["path"] in ["/tmp/dna.json"]:  # nosec B108
+            if data["path"] in ["/opt/parallelcluster/tmp/dna.json"]:
                 with open(file_path, "w", encoding="utf-8") as file:
                     logger.info("Writing %s", file_path)
                     file.write(json.dumps(json.loads(data["content"]), indent=4))
@@ -335,7 +335,7 @@ def wait_for_login_nodes_lt_update(expected_config_version, region):
 def _extract_cluster_config_version(write_directives):
     """Extract cluster.cluster_config_version from the dna.json entry in a write_files list."""
     for entry in write_directives or []:
-        if entry.get("path") in ["/tmp/dna.json"]:  # nosec B108
+        if entry.get("path") in ["/opt/parallelcluster/tmp/dna.json"]:
             try:
                 dna = json.loads(entry["content"])
                 return dna.get("cluster", {}).get("cluster_config_version")

--- a/cookbooks/aws-parallelcluster-environment/files/custom_action_executor/custom_action_executor.py
+++ b/cookbooks/aws-parallelcluster-environment/files/custom_action_executor/custom_action_executor.py
@@ -46,6 +46,8 @@ SCRIPT_LOG_NAME_FETCH_AND_RUN = "fetch_and_run"
 
 DOWNLOAD_SCRIPT_HTTP_TIMEOUT_SECONDS = 60
 
+PCLUSTER_EXEC_TMP_DIR = "/opt/parallelcluster/tmp"
+
 
 @dataclass
 class ScriptDefinition:
@@ -229,7 +231,7 @@ class ScriptRunner:
     async def _download_s3_script(self, exe_script: ExecutableScript):
         s3_client = boto3.resource("s3", region_name=self.region_name)
         bucket_name, key = self._parse_s3_url(exe_script.url)
-        with tempfile.NamedTemporaryFile(delete=False) as file:
+        with tempfile.NamedTemporaryFile(delete=False, dir=PCLUSTER_EXEC_TMP_DIR) as file:
             try:
                 s3_client.Bucket(bucket_name).download_file(key, file.name)
             except (NoCredentialsError, botocore.exceptions.ClientError) as err:
@@ -260,7 +262,7 @@ class ScriptRunner:
                     "status_reason": response.reason,
                 },
             )
-        with tempfile.NamedTemporaryFile(delete=False) as file:
+        with tempfile.NamedTemporaryFile(delete=False, dir=PCLUSTER_EXEC_TMP_DIR) as file:
             file.write(response.content)
         exe_script.path = file.name
         return exe_script

--- a/cookbooks/aws-parallelcluster-environment/recipes/config/network_interfaces.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/config/network_interfaces.rb
@@ -64,9 +64,11 @@ log "macs: #{macs}"
 
 if macs.length > 1
 
+  configure_nw_interface_script = "#{node['cluster']['exec_tmp_dir']}/configure_nw_interface.sh"
+
   cookbook_file 'configure_nw_interface.sh' do
     source 'network_interfaces/configure_nw_interface.sh'
-    path '/tmp/configure_nw_interface.sh'
+    path configure_nw_interface_script
     user 'root'
     group 'root'
     mode '0644'
@@ -87,7 +89,7 @@ if macs.length > 1
     execute 'configure_nw_interface' do
       user 'root'
       group 'root'
-      cwd "/tmp"
+      cwd node['cluster']['exec_tmp_dir']
       environment(
         # TODO: The variables are a superset of what's required by individual scripts. Consider simplification.
         'DEVICE_NAME' => device_name,
@@ -101,7 +103,7 @@ if macs.length > 1
         'MAC' => mac
       )
 
-      command 'sh /tmp/configure_nw_interface.sh'
+      command "sh #{configure_nw_interface_script}"
     end
   end
 

--- a/cookbooks/aws-parallelcluster-environment/recipes/init/backup_home_shared_data.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/init/backup_home_shared_data.rb
@@ -23,8 +23,8 @@ if node['cluster']['node_type'] == 'HeadNode'
     user 'root'
     group 'root'
     code <<-EOH
-      mkdir -p /tmp/home
-      rsync -a /home/ /tmp/home
+      mkdir -p #{node['cluster']['exec_tmp_dir']}/home
+      rsync -a /home/ #{node['cluster']['exec_tmp_dir']}/home
     EOH
   end
 end

--- a/cookbooks/aws-parallelcluster-environment/recipes/init/backup_internal_use_shared_data.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/init/backup_internal_use_shared_data.rb
@@ -25,8 +25,8 @@ if node['cluster']['node_type'] == 'HeadNode'
       user 'root'
       group 'root'
       code <<-EOH
-        mkdir -p /tmp#{dir}
-        rsync -a #{dir}/ /tmp#{dir}
+        mkdir -p #{node['cluster']['exec_tmp_dir']}#{dir}
+        rsync -a #{dir}/ #{node['cluster']['exec_tmp_dir']}#{dir}
       EOH
     end
   end

--- a/cookbooks/aws-parallelcluster-environment/recipes/init/config_default_user_home.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/init/config_default_user_home.rb
@@ -34,13 +34,13 @@ bash "Backup #{node['cluster']['cluster_user_home']}" do
   group 'root'
   code <<-EOH
     set -e
-    if [ -d /tmp#{node['cluster']['cluster_user_home']} ]; then
-      echo "/tmp#{node['cluster']['cluster_user_home']} exists!"
+    if [ -d #{node['cluster']['exec_tmp_dir']}#{node['cluster']['cluster_user_home']} ]; then
+      echo "#{node['cluster']['exec_tmp_dir']}#{node['cluster']['cluster_user_home']} exists!"
       exit 1
     else
-      mkdir -p /tmp#{node['cluster']['cluster_user_home']}
+      mkdir -p #{node['cluster']['exec_tmp_dir']}#{node['cluster']['cluster_user_home']}
     fi
-    rsync -a #{node['cluster']['cluster_user_home']}/ /tmp#{node['cluster']['cluster_user_home']}
+    rsync -a #{node['cluster']['cluster_user_home']}/ #{node['cluster']['exec_tmp_dir']}#{node['cluster']['cluster_user_home']}
   EOH
 end
 
@@ -56,7 +56,7 @@ bash "Move #{node['cluster']['cluster_user_home']}" do
   code <<-EOH
     set -e
     mkdir -p #{node['cluster']['cluster_user_local_home']}
-    rsync -a /tmp#{node['cluster']['cluster_user_home']}/ #{node['cluster']['cluster_user_local_home']}
+    rsync -a #{node['cluster']['exec_tmp_dir']}#{node['cluster']['cluster_user_home']}/ #{node['cluster']['cluster_user_local_home']}
     usermod -d #{node['cluster']['cluster_user_local_home']} #{node['cluster']['cluster_user']}
     chown -R #{node['cluster']['cluster_user']}: #{node['cluster']['cluster_user_local_home']}
   EOH
@@ -74,8 +74,8 @@ bash "Verify data integrity for #{node['cluster']['cluster_user_local_home']}" d
   code <<-EOH
     diff_output=$(diff -r #{node['cluster']['cluster_user_home']} #{node['cluster']['cluster_user_local_home']})
     if [[ $diff_output != *"Only in #{node['cluster']['cluster_user_home']}"* ]]; then
-      echo "Data integrity check succeeded, removing temporary directory /tmp#{node['cluster']['cluster_user_home']}"
-      rm -rf /tmp#{node['cluster']['cluster_user_home']}
+      echo "Data integrity check succeeded, removing temporary directory #{node['cluster']['exec_tmp_dir']}#{node['cluster']['cluster_user_home']}"
+      rm -rf #{node['cluster']['exec_tmp_dir']}#{node['cluster']['cluster_user_home']}
     else
       only_in_cluster_user_home=$(echo "$diff_output" | grep "Only in #{node['cluster']['cluster_user_home']}")
       echo "Data integrity check failed comparing #{node['cluster']['cluster_user_local_home']} and #{node['cluster']['cluster_user_home']}. Differences:"

--- a/cookbooks/aws-parallelcluster-environment/recipes/init/restore_home_shared_data.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/init/restore_home_shared_data.rb
@@ -27,14 +27,14 @@ if node['cluster']['node_type'] == 'HeadNode'
     user 'root'
     group 'root'
     code <<-EOH
-      rsync -a --ignore-existing /tmp/home/ /home
-      diff_output=$(diff -r /tmp/home/ /home)
-      if [[ $diff_output != *"Only in /tmp/home"* ]]; then
-        echo "Data integrity check succeeded, removing temporary directory /tmp/home"
-        rm -rf /tmp/home/
+      rsync -a --ignore-existing #{node['cluster']['exec_tmp_dir']}/home/ /home
+      diff_output=$(diff -r #{node['cluster']['exec_tmp_dir']}/home/ /home)
+      if [[ $diff_output != *"Only in #{node['cluster']['exec_tmp_dir']}/home"* ]]; then
+        echo "Data integrity check succeeded, removing temporary directory #{node['cluster']['exec_tmp_dir']}/home"
+        rm -rf #{node['cluster']['exec_tmp_dir']}/home/
       else
-        only_in_tmp=$(echo "$diff_output" | grep "Only in /tmp/home")
-        echo "Data integrity check failed comparing /home and /tmp/home. Differences:"
+        only_in_tmp=$(echo "$diff_output" | grep "Only in #{node['cluster']['exec_tmp_dir']}/home")
+        echo "Data integrity check failed comparing /home and #{node['cluster']['exec_tmp_dir']}/home. Differences:"
         echo "$only_in_tmp"
         exit 1
       fi

--- a/cookbooks/aws-parallelcluster-environment/recipes/init/restore_internal_use_shared_data.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/init/restore_internal_use_shared_data.rb
@@ -28,14 +28,14 @@ if node['cluster']['node_type'] == 'HeadNode'
       user 'root'
       group 'root'
       code <<-EOH
-        rsync -a --ignore-existing /tmp#{dir}/ #{dir}
-        diff_output=$(diff -r /tmp#{dir}/ #{dir})
-        if [[ $diff_output != *"Only in /tmp#{dir}"* ]]; then
-          echo "Data integrity check succeeded, removing temporary directory /tmp#{dir}"
-          rm -rf /tmp#{dir}
+        rsync -a --ignore-existing #{node['cluster']['exec_tmp_dir']}#{dir}/ #{dir}
+        diff_output=$(diff -r #{node['cluster']['exec_tmp_dir']}#{dir}/ #{dir})
+        if [[ $diff_output != *"Only in #{node['cluster']['exec_tmp_dir']}#{dir}"* ]]; then
+          echo "Data integrity check succeeded, removing temporary directory #{node['cluster']['exec_tmp_dir']}#{dir}"
+          rm -rf #{node['cluster']['exec_tmp_dir']}#{dir}
         else
-          only_in_tmp=$(echo "$diff_output" | grep "Only in /tmp#{dir}")
-          echo "Data integrity check failed comparing #{dir} and /tmp#{dir}. Differences:"
+          only_in_tmp=$(echo "$diff_output" | grep "Only in #{node['cluster']['exec_tmp_dir']}#{dir}")
+          echo "Data integrity check failed comparing #{dir} and #{node['cluster']['exec_tmp_dir']}#{dir}. Differences:"
           echo "$only_in_tmp"
           exit 1
         fi

--- a/cookbooks/aws-parallelcluster-environment/recipes/install/cfn_bootstrap.rb
+++ b/cookbooks/aws-parallelcluster-environment/recipes/install/cfn_bootstrap.rb
@@ -72,7 +72,7 @@ elsif region.start_with?("us-iso")
   bucket = "s3.#{aws_region}.#{aws_domain}"
 end
 
-remote_file "/tmp/#{cfnbootstrap_package}" do
+remote_file "#{node['cluster']['exec_tmp_dir']}/#{cfnbootstrap_package}" do
   source "https://#{bucket}/cloudformation-examples/#{cfnbootstrap_package}"
   retries 3
   retry_delay 5
@@ -85,7 +85,7 @@ command = "#{virtualenv_path}/bin/pip install #{cfnbootstrap_package} #{pip_inst
 bash "Install CloudFormation helpers from #{cfnbootstrap_package}" do
   user 'root'
   group 'root'
-  cwd '/tmp'
+  cwd node['cluster']['exec_tmp_dir']
   code command
   creates "#{virtualenv_path}/bin/cfn-hup"
 end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/cfn_bootstrap_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/cfn_bootstrap_spec.rb
@@ -63,7 +63,7 @@ describe 'aws-parallelcluster-environment::cfn_bootstrap' do
             end
 
             it 'downloads cfn_bootstrap package from s3' do
-              is_expected.to create_remote_file("/tmp/#{cfnbootstrap_package}").with(
+              is_expected.to create_remote_file("base_dir/tmp/#{cfnbootstrap_package}").with(
                 source: "https://s3.amazonaws.com/cloudformation-examples/#{cfnbootstrap_package}"
               )
             end
@@ -72,7 +72,7 @@ describe 'aws-parallelcluster-environment::cfn_bootstrap' do
               is_expected.to run_bash("Install CloudFormation helpers from #{cfnbootstrap_package}").with(
                 user: 'root',
                 group: 'root',
-                cwd: '/tmp',
+                cwd: 'base_dir/tmp',
                 code: cfn_install_command,
                 creates: "#{virtualenv_path}/bin/cfn-hup"
               )
@@ -155,12 +155,13 @@ describe 'aws-parallelcluster-environment::cfn_bootstrap' do
           runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['python-version'] = python_version
+            node.override['cluster']['base_dir'] = base_dir
             node.override['cluster']['region'] = 'cn-something'
           end
           runner.converge(described_recipe)
         end
         it 'downloads cfn_bootstrap package from a different s3 bucket' do
-          is_expected.to create_remote_file("/tmp/#{cfnbootstrap_package}").with(
+          is_expected.to create_remote_file("base_dir/tmp/#{cfnbootstrap_package}").with(
             source: "https://s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster/cloudformation-examples/#{cfnbootstrap_package}"
           )
         end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/config_default_user_home_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/config_default_user_home_spec.rb
@@ -4,11 +4,13 @@ describe 'aws-parallelcluster-environment::config_default_user_home' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       context 'when local' do
+        cached(:exec_tmp_dir) { 'FAKE_EXEC_TMP_DIR' }
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['default_user_home'] = "local"
             node.override['cluster']['cluster_user_home'] = "/home/user"
             node.override['cluster']['cluster_user_local_home'] = "/local/home/user"
+            node.override['cluster']['exec_tmp_dir'] = exec_tmp_dir
           end
           runner.converge(described_recipe)
         end
@@ -31,8 +33,8 @@ describe 'aws-parallelcluster-environment::config_default_user_home' do
             code: <<-CODE
     diff_output=$(diff -r #{original_user_home} #{destination_user_local_home})
     if [[ $diff_output != *"Only in #{original_user_home}"* ]]; then
-      echo "Data integrity check succeeded, removing temporary directory /tmp#{original_user_home}"
-      rm -rf /tmp#{original_user_home}
+      echo "Data integrity check succeeded, removing temporary directory #{exec_tmp_dir}#{original_user_home}"
+      rm -rf #{exec_tmp_dir}#{original_user_home}
     else
       only_in_cluster_user_home=$(echo "$diff_output" | grep "Only in #{original_user_home}")
       echo "Data integrity check failed comparing #{destination_user_local_home} and #{original_user_home}. Differences:"

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/mount_internal_use_efs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/recipes/mount_internal_use_efs_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'aws-parallelcluster-environment::mount_internal_use_efs' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
+      cached(:exec_tmp_dir) { 'FAKE_EXEC_TMP_DIR' }
       cached(:chef_run) do
         runner = runner(platform: platform, version: version) do |node|
           node.override['cluster']['head_node_private_ip'] = '0.0.0.0'
@@ -25,6 +26,7 @@ describe 'aws-parallelcluster-environment::mount_internal_use_efs' do
             node.override['cluster']['node_type'] = 'HeadNode'
             node.override['cluster']['internal_shared_dirs'] = %w(/opt/slurm /opt/intel)
             node.override['cluster']['efs_shared_dirs'] = "/opt/parallelcluster/init_shared"
+            node.override['cluster']['exec_tmp_dir'] = exec_tmp_dir
           end
           runner.converge(described_recipe)
         end
@@ -35,14 +37,14 @@ describe 'aws-parallelcluster-environment::mount_internal_use_efs' do
             chef_run.node['cluster']['internal_shared_dirs'].each do |dir|
               expect(chef_run).to run_bash("Restore #{dir}").with(
                 code: <<-CODE
-        rsync -a --ignore-existing /tmp#{dir}/ #{dir}
-        diff_output=$(diff -r /tmp#{dir}/ #{dir})
-        if [[ $diff_output != *"Only in /tmp#{dir}"* ]]; then
-          echo "Data integrity check succeeded, removing temporary directory /tmp#{dir}"
-          rm -rf /tmp#{dir}
+        rsync -a --ignore-existing #{exec_tmp_dir}#{dir}/ #{dir}
+        diff_output=$(diff -r #{exec_tmp_dir}#{dir}/ #{dir})
+        if [[ $diff_output != *"Only in #{exec_tmp_dir}#{dir}"* ]]; then
+          echo "Data integrity check succeeded, removing temporary directory #{exec_tmp_dir}#{dir}"
+          rm -rf #{exec_tmp_dir}#{dir}
         else
-          only_in_tmp=$(echo "$diff_output" | grep "Only in /tmp#{dir}")
-          echo "Data integrity check failed comparing #{dir} and /tmp#{dir}. Differences:"
+          only_in_tmp=$(echo "$diff_output" | grep "Only in #{exec_tmp_dir}#{dir}")
+          echo "Data integrity check failed comparing #{dir} and #{exec_tmp_dir}#{dir}. Differences:"
           echo "$only_in_tmp"
           exit 1
         fi

--- a/cookbooks/aws-parallelcluster-environment/test/controls/network_interfaces_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/network_interfaces_spec.rb
@@ -12,7 +12,7 @@
 control 'network_interfaces_configuration_script_created' do
   title 'Check script to configure network interface is created'
 
-  describe file('/tmp/configure_nw_interface.sh') do
+  describe file("#{node['cluster']['exec_tmp_dir']}/configure_nw_interface.sh") do
     it { should exist }
     its('mode') { should cmp '0644' }
     its('owner') { should eq 'root' }

--- a/cookbooks/aws-parallelcluster-platform/files/ami_cleanup.sh
+++ b/cookbooks/aws-parallelcluster-platform/files/ami_cleanup.sh
@@ -6,6 +6,7 @@ IS_OFFICIAL_AMI_BUILD=${1:-"false"}
 cloud-init clean -s
 
 rm -rf /var/tmp/* /tmp/*
+rm -rf /opt/parallelcluster/tmp/*
 rm -rf /etc/ssh/ssh_host_*
 rm -f /etc/udev/rules.d/70-persistent-net.rules
 grep -l "Created by cloud-init on instance boot automatically" /etc/sysconfig/network-scripts/ifcfg-* | xargs rm -f

--- a/cookbooks/aws-parallelcluster-platform/recipes/config/config_check_update_systemd_service.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/config/config_check_update_systemd_service.rb
@@ -69,6 +69,7 @@ template "#{node['cluster']['scripts_dir']}/cluster-update-action.sh" do
   mode '0700'
   variables(
     monitor_shared_dir: node['cluster']['update']['dna_dir'],
-    launch_template_resource_id: node['cluster']['launch_template_id']
+    launch_template_resource_id: node['cluster']['launch_template_id'],
+    exec_tmp_dir: node['cluster']['exec_tmp_dir']
   )
 end

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/directories.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/directories.rb
@@ -17,6 +17,12 @@
 directory node['cluster']['etc_dir']
 directory node['cluster']['base_dir']
 directory node['cluster']['sources_dir']
+directory node['cluster']['exec_tmp_dir'] do
+  owner 'root'
+  group 'root'
+  mode '0755'
+  recursive true
+end
 directory node['cluster']['scripts_dir']
 directory node['cluster']['license_dir']
 directory node['cluster']['configs_dir']

--- a/cookbooks/aws-parallelcluster-platform/resources/manage_dna_files.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/manage_dna_files.rb
@@ -16,7 +16,7 @@ resource_name :manage_dna_files
 provides :manage_dna_files
 unified_mode true
 
-property :extra_chef_attribute_location, String, default: '/tmp/extra.json'
+property :extra_chef_attribute_location, String, default: lazy { "#{node['cluster']['exec_tmp_dir']}/extra.json" }
 
 default_action :share
 

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/config_check_update_systemd_service_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/config_check_update_systemd_service_spec.rb
@@ -56,6 +56,7 @@ describe 'aws-parallelcluster-platform::config_check_update_systemd_service' do
               .with(variables: {
                                monitor_shared_dir: node['cluster']['update']['dna_dir'],
                                launch_template_resource_id: node['cluster']['launch_template_id'],
+                               exec_tmp_dir: node['cluster']['exec_tmp_dir'],
                              })
           end
 

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/directories_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/directories_spec.rb
@@ -20,6 +20,15 @@ describe 'aws-parallelcluster-platform::directories' do
         is_expected.to create_directory(node['cluster']['sources_dir'])
       end
 
+      it 'creates the executable temp directory with root-owned 0755 permissions' do
+        is_expected.to create_directory(node['cluster']['exec_tmp_dir']).with(
+          owner: 'root',
+          group: 'root',
+          mode: '0755',
+          recursive: true
+        )
+      end
+
       it 'creates scripts directory' do
         is_expected.to create_directory(node['cluster']['scripts_dir'])
       end

--- a/cookbooks/aws-parallelcluster-platform/templates/check_update/cluster-update-action.sh.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/check_update/cluster-update-action.sh.erb
@@ -17,15 +17,15 @@ function run_cookbook_recipes() {
     while $GET_DNA_FILE; do
         if [[ -f $LATEST_DNA_FILE ]]; then
           GET_DNA_FILE=false
-          cp $LATEST_DNA_FILE /tmp/dna.json
-          chown root:root /tmp/dna.json
-          chmod 000644 /tmp/dna.json
-          cp $LATEST_EXTRA_FILE /tmp/extra.json
-          chown root:root /tmp/extra.json
-          chmod 000644 /tmp/extra.json
+          cp $LATEST_DNA_FILE <%= @exec_tmp_dir %>/dna.json
+          chown root:root <%= @exec_tmp_dir %>/dna.json
+          chmod 000644 <%= @exec_tmp_dir %>/dna.json
+          cp $LATEST_EXTRA_FILE <%= @exec_tmp_dir %>/extra.json
+          chown root:root <%= @exec_tmp_dir %>/extra.json
+          chmod 000644 <%= @exec_tmp_dir %>/extra.json
           mkdir -p /etc/chef/ohai/hints
           touch /etc/chef/ohai/hints/ec2.json
-          jq -s ".[0] * .[1]" /tmp/dna.json /tmp/extra.json > /etc/chef/dna.json || ( echo "jq not installed"; cp /tmp/dna.json /etc/chef/dna.json )
+          jq -s ".[0] * .[1]" <%= @exec_tmp_dir %>/dna.json <%= @exec_tmp_dir %>/extra.json > /etc/chef/dna.json || ( echo "jq not installed"; cp <%= @exec_tmp_dir %>/dna.json /etc/chef/dna.json )
           cd /etc/chef
           cinc-client --local-mode --config /etc/chef/client.rb --log_level info --logfile /var/log/chef-client.log --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster-entrypoints::update && /opt/parallelcluster/scripts/fetch_and_run -postupdate
 

--- a/cookbooks/aws-parallelcluster-platform/test/controls/directories_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/directories_spec.rb
@@ -2,11 +2,18 @@ control 'tag:install_pcluster_directories_exist' do
   title 'Setup of ParallelCluster directories'
 
   base_dir = "/opt/parallelcluster"
-  dirs = [ base_dir, "#{base_dir}/sources", "#{base_dir}/scripts", "#{base_dir}/licenses", "#{base_dir}/configs", "#{base_dir}/shared" ]
+  dirs = [ base_dir, "#{base_dir}/sources", "#{base_dir}/scripts", "#{base_dir}/licenses", "#{base_dir}/configs", "#{base_dir}/shared", "#{base_dir}/tmp" ]
   dirs.each do |path|
     describe directory(path) do
       it { should exist }
     end
+  end
+
+  # The dedicated executable temp directory must be root-owned and not world-writable.
+  describe directory("#{base_dir}/tmp") do
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+    its('mode') { should cmp '0755' }
   end
 end
 

--- a/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
@@ -9,6 +9,9 @@ default['cluster']['shared_dir_login_nodes'] = "#{node['cluster']['base_dir']}/s
 default['cluster']['log_base_dir'] = '/var/log/parallelcluster'
 default['cluster']['etc_dir'] = '/etc/parallelcluster'
 
+default['cluster']['exec_tmp_dir'] = "#{node['cluster']['base_dir']}/tmp"
+default['cluster']['tmp_noexec'] = 'false'
+
 # Cluster Updates
 # The trigger file lives in shared storage. The head node writes the current cluster config
 # version on every cluster update; compute and login nodes poll the file via the

--- a/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pyxis.rb
+++ b/cookbooks/aws-parallelcluster-slurm/recipes/install/install_pyxis.rb
@@ -37,8 +37,8 @@ bash "Install pyxis" do
   user 'root'
   code <<-PYXIS_INSTALL
     set -e
-    tar xf #{pyxis_tarball} -C /tmp
-    cd /tmp/pyxis-#{pyxis_version}
+    tar xf #{pyxis_tarball} -C #{node['cluster']['exec_tmp_dir']}
+    cd #{node['cluster']['exec_tmp_dir']}/pyxis-#{pyxis_version}
     CPPFLAGS='-I #{node['cluster']['slurm']['install_dir']}/include/' make
     CPPFLAGS='-I #{node['cluster']['slurm']['install_dir']}/include/' make install
   PYXIS_INSTALL

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_pyxis_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/install_pyxis_spec.rb
@@ -20,6 +20,7 @@ describe 'aws-parallelcluster-slurm::install_pyxis' do
       cached(:cluster_sources_dir) { '/path/to/cluster/sources/dir' }
       cached(:cluster_examples_dir) { '/path/to/cluster/examples/dir' }
       cached(:slurm_install_dir) { '/path/to/slurm/install/dir' }
+      cached(:cluster_exec_tmp_dir) { '/path/to/exec/tmp/dir' }
       cached(:pyxis_version) { '1.2.3' }
       cached(:pyxis_runtime_dir) { '/path/to/pyxis/runtime/dir' }
       cached(:default_base_url) { "#{cluster_artifacts_s3_url}/dependencies/pyxis" }
@@ -38,6 +39,7 @@ describe 'aws-parallelcluster-slurm::install_pyxis' do
               node.override['cluster']['sources_dir'] = cluster_sources_dir
               node.override['cluster']['examples_dir'] = cluster_examples_dir
               node.override['cluster']['slurm']['install_dir'] = slurm_install_dir
+              node.override['cluster']['exec_tmp_dir'] = cluster_exec_tmp_dir
               node.override['cluster']['pyxis']['version'] = pyxis_version
               node.override['cluster']['pyxis']['runtime_path'] = pyxis_runtime_dir
               node.override['cluster']['pyxis']['base_url'] = override_url if override_url
@@ -64,8 +66,8 @@ describe 'aws-parallelcluster-slurm::install_pyxis' do
               retry_delay: 5,
               code: <<-CODE
     set -e
-    tar xf #{cluster_sources_dir}/pyxis-#{pyxis_version}.tar.gz -C /tmp
-    cd /tmp/pyxis-#{pyxis_version}
+    tar xf #{cluster_sources_dir}/pyxis-#{pyxis_version}.tar.gz -C #{cluster_exec_tmp_dir}
+    cd #{cluster_exec_tmp_dir}/pyxis-#{pyxis_version}
     CPPFLAGS='-I #{slurm_install_dir}/include/' make
     CPPFLAGS='-I #{slurm_install_dir}/include/' make install
               CODE

--- a/test/unit/cfn_hup_configuration/test_manage_fleet_dna.py
+++ b/test/unit/cfn_hup_configuration/test_manage_fleet_dna.py
@@ -92,7 +92,7 @@ def test_get_compute_launch_template_ids(mocker, launch_template_config_content,
             "user_data_1.txt",
             [
                 {
-                    "path": "/tmp/dna.json",  # nosec B108
+                    "path": "/opt/parallelcluster/tmp/dna.json",
                     "permissions": "0644",
                     "owner": "root:root",
                     "content": '{"cluster":{"base_os":"alinux2023","cluster_name":"clustername",'
@@ -101,13 +101,13 @@ def test_get_compute_launch_template_ids(mocker, launch_template_config_content,
                     '"launch_template_id":"LoginNodeLaunchTemplate2736fab291f04e69"}}\n',
                 },
                 {
-                    "path": "/tmp/extra.json",  # nosec B108
+                    "path": "/opt/parallelcluster/tmp/extra.json",
                     "permissions": "0644",
                     "owner": "root:root",
                     "content": "{}\n",
                 },
                 {
-                    "path": "/tmp/bootstrap.sh",  # nosec B108
+                    "path": "/opt/parallelcluster/tmp/bootstrap.sh",
                     "permissions": "0744",
                     "owner": "root:root",
                     "content": '#!/bin/bash -x\n\nfunction error_exit\n{\n  echo "Bootstrap failed"\n}\n',
@@ -120,19 +120,19 @@ def test_get_compute_launch_template_ids(mocker, launch_template_config_content,
                 {
                     "content": '{"cluster":{"base_os":"alinux2023"}}\n',
                     "owner": "root:root",
-                    "path": "/tmp/dna.json",  # nosec B108
+                    "path": "/opt/parallelcluster/tmp/dna.json",
                     "permissions": "0644",
                 },
                 {
                     "content": '{"cluster": {"nvidia": {"enabled": "yes" }, "is_official_ami_build": "true"}}\n',
                     "owner": "root:root",
-                    "path": "/tmp/extra.json",  # nosec B108
+                    "path": "/opt/parallelcluster/tmp/extra.json",
                     "permissions": "0644",
                 },
                 {
                     "content": '#!/bin/bash -x\n\necho "Bootstrap failed with error: $1"\n',
                     "owner": "root:root",
-                    "path": "/tmp/bootstrap.sh",  # nosec B108
+                    "path": "/opt/parallelcluster/tmp/bootstrap.sh",
                     "permissions": "0744",
                 },
             ],
@@ -335,7 +335,7 @@ Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0
 
 write_files:
-  - path: /tmp/dna.json
+  - path: /opt/parallelcluster/tmp/dna.json
     permissions: '0644'
     owner: root:root
     content: |
@@ -429,11 +429,11 @@ def test_get_latest_dna_data_for_login_nodes_uses_version_from_config():
         pytest.param(
             [
                 {
-                    "path": "/tmp/extra.json",  # nosec B108
+                    "path": "/opt/parallelcluster/tmp/extra.json",
                     "content": "{}",
                 },
                 {
-                    "path": "/tmp/dna.json",  # nosec B108
+                    "path": "/opt/parallelcluster/tmp/dna.json",
                     "content": '{"cluster": {"base_os": "alinux2023"}}',
                 },
             ],
@@ -443,7 +443,7 @@ def test_get_latest_dna_data_for_login_nodes_uses_version_from_config():
         pytest.param(
             [
                 {
-                    "path": "/tmp/extra.json",  # nosec B108
+                    "path": "/opt/parallelcluster/tmp/extra.json",
                     "content": "{}",
                 },
             ],

--- a/test/unit/cfn_hup_configuration/test_manage_fleet_dna/test_get_write_directives_section/user_data_1.txt
+++ b/test/unit/cfn_hup_configuration/test_manage_fleet_dna/test_get_write_directives_section/user_data_1.txt
@@ -19,17 +19,17 @@ bootcmd:
 output:
   all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/ttyS0"
 write_files:
-  - path: /tmp/dna.json
+  - path: /opt/parallelcluster/tmp/dna.json
     permissions: '0644'
     owner: root:root
     content: |
       {"cluster":{"base_os":"alinux2023","cluster_name":"clustername","directory_service":{"domain_read_only_user":"","enabled":"false","generate_ssh_keys_for_users":"false"},"launch_template_id":"LoginNodeLaunchTemplate2736fab291f04e69"}}
-  - path: /tmp/extra.json
+  - path: /opt/parallelcluster/tmp/extra.json
     permissions: '0644'
     owner: root:root
     content: |
       {}
-  - path: /tmp/bootstrap.sh
+  - path: /opt/parallelcluster/tmp/bootstrap.sh
     permissions: '0744'
     owner: root:root
     content: |

--- a/test/unit/cfn_hup_configuration/test_manage_fleet_dna/test_get_write_directives_section/user_data_2.txt
+++ b/test/unit/cfn_hup_configuration/test_manage_fleet_dna/test_get_write_directives_section/user_data_2.txt
@@ -15,17 +15,17 @@ Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0
 
 write_files:
-  - path: /tmp/dna.json
+  - path: /opt/parallelcluster/tmp/dna.json
     permissions: '0644'
     owner: root:root
     content: |
       {"cluster":{"base_os":"alinux2023"}}
-  - path: /tmp/extra.json
+  - path: /opt/parallelcluster/tmp/extra.json
     permissions: '0644'
     owner: root:root
     content: |
       {"cluster": {"nvidia": {"enabled": "yes" }, "is_official_ami_build": "true"}}
-  - path: /tmp/bootstrap.sh
+  - path: /opt/parallelcluster/tmp/bootstrap.sh
     permissions: '0744'
     owner: root:root
     content: |

--- a/test/unit/custom_action_executor/test_custom_action_executor.py
+++ b/test/unit/custom_action_executor/test_custom_action_executor.py
@@ -41,6 +41,16 @@ from mock.mock import AsyncMock
 # pylint: disable=protected-access
 
 
+@pytest.fixture(autouse=True)
+def exec_tmp_dir(tmp_path, mocker):
+    # In production this directory is created during build-image and baked into the AMI, so the
+    # executor assumes it already exists. Create a writable stand-in here and point the executor at it.
+    exec_dir = tmp_path / "pcluster-exec-tmp"
+    exec_dir.mkdir()
+    mocker.patch("custom_action_executor.PCLUSTER_EXEC_TMP_DIR", str(exec_dir))
+    return exec_dir
+
+
 @pytest.fixture
 def script_runner():
     return ScriptRunner("OnMockTestEvent", "OnMockTestRegionName")


### PR DESCRIPTION
### Description of changes
Some custom AMIs mount /tmp with noexec, and create-cluster wrote and consumed bootstrap files under /tmp. Move them under /opt/parallelcluster/tmp instead so create-cluster works on such AMIs.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* We will add a check in integration tests to use `noexec` on`/tmp` after Nvidia and efs-utils are moved to repo based installation
* The following tests have passed
```
test_hit_no_cluster_dns_mpi[af-south-1-c5.xlarge-rhel8-slurm-None-official] – dns.test_dns25m 44s
test_console_output_with_monitoring_disabled[ap-east-1-c5.xlarge-ubuntu2404-slurm-None-official] – cloudwatch_logging.test_compute_console_output_logging47m 8s
test_fast_capacity_failover[ap-east-1-c5.xlarge-ubuntu2204-slurm-None-official-best-effort] – schedulers.test_slurm43m 22s
test_cloudwatch_logging[ap-east-1-c5.xlarge-rocky9-slurm-None-official] – cloudwatch_logging.test_cloudwatch_logging30m 54s
test_fast_capacity_failover[ap-east-1-c5.xlarge-ubuntu2204-slurm-None-official-greedy-all-or-nothing] – schedulers.test_slurm43m 54s
test_slurm_protected_mode_on_cluster_create[ap-east-1-c5.xlarge-rocky8-slurm-None-official] – schedulers.test_slurm21m 32s
test_custom_action_error[ap-east-1-c5.xlarge-rhel8-slurm-None-official] – cloudwatch_logging.test_compute_console_output_logging28m 9s
test_expedited_requeue[ap-east-1-c5.xlarge-ubuntu2204-slurm-None-official] – schedulers.test_slurm30m 2s
test_slurm_config_update[ap-east-1-c5.xlarge-ubuntu2404-slurm-None-official] – schedulers.test_slurm36m 27s
test_fast_capacity_failover[ap-east-1-c5.xlarge-ubuntu2204-slurm-None-official-all-or-nothing] – schedulers.test_slurm43m 22s
test_slurm_memory_based_scheduling[ap-east-1-c5.xlarge-alinux2023-slurm-None-official] – schedulers.test_slurm44m 31s
test_monitoring[ap-northeast-2-c5.xlarge-rocky9-slurm-None-official-True-True-True] – monitoring.test_monitoring57m 8s
test_slurm_custom_partitions[ap-northeast-2-c5.xlarge-ubuntu2404-slurm-None-official] – schedulers.test_slurm29m 59s
test_create_disable_sudo_access_for_default_user[ap-northeast-2-c5.xlarge-rhel8-slurm-None-official] – create.test_create49m 10s
test_slurm_cli_commands[ap-northeast-2-c5.xlarge-ubuntu2404-slurm-None-official-False] – cli_commands.test_cli_commands55m 12s
test_cluster_creation_with_problematic_preinstall_script[ap-south-1-m6g.xlarge-rocky9-slurm-None-official] – create.test_create18m 26s
test_update_instance_list[ap-south-1-c5.xlarge-ubuntu2404-slurm-None-official] – update.test_update1h 18m 46s
test_slurm_accounting[ap-south-1-c5.xlarge-rhel8-slurm-None-official] – schedulers.test_slurm_accounting1h 8m 5s
test_slurm_accounting_external_dbd[ap-south-1-c5.xlarge-rocky8-slurm-None-official] – schedulers.test_slurm_accounting1h 15m 56s
test_ad_integration[ap-southeast-1-c5.xlarge-ubuntu2404-slurm-None-official-MicrosoftAD-ldaps-True] – ad_integration.test_ad_integration1h 44m 29s
test_ad_integration[ap-southeast-1-c5.xlarge-rhel9-slurm-None-official-MicrosoftAD-ldaps-True] – ad_integration.test_ad_integration1h 31m 56s
test_ad_integration[ap-southeast-1-c5.xlarge-alinux2023-slurm-None-official-MicrosoftAD-ldaps-True] – ad_integration.test_ad_integration1h 30m 19s
test_ad_integration[ap-southeast-1-c5.xlarge-rhel9-slurm-None-official-SimpleAD-ldap-False] – ad_integration.test_ad_integration1h 0m 3s
test_ad_integration[ap-southeast-1-c5.xlarge-rocky9-slurm-None-official-MicrosoftAD-ldaps-True] – ad_integration.test_ad_integration1h 31m 28s
test_ad_integration[ap-southeast-1-c5.xlarge-alinux2023-slurm-None-official-SimpleAD-ldap-False] – ad_integration.test_ad_integration59m 1s
test_ad_integration[ap-southeast-1-c5.xlarge-rocky9-slurm-None-official-SimpleAD-ldap-False] – ad_integration.test_ad_integration1h 2m 6s
test_slurm_custom_config_parameters[ap-southeast-3-c5.xlarge-ubuntu2204-slurm-None-official] – schedulers.test_slurm22m 55s
test_job_level_scaling[ap-southeast-3-m6g.xlarge-rocky8-slurm-None-official-best-effort-scaling_behaviour_by_capacity1] – scaling.test_scaling46m 32s
test_job_level_scaling[ap-southeast-3-m6g.xlarge-rocky8-slurm-None-official-all-or-nothing-scaling_behaviour_by_capacity0] – scaling.test_scaling44m 22s
test_job_level_scaling[ap-southeast-3-m6g.xlarge-rocky8-slurm-None-official-greedy-all-or-nothing-scaling_behaviour_by_capacity2] – scaling.test_scaling44m 52s
test_proxy[ap-southeast-5-m6i.xlarge-ubuntu2404-slurm-None-official] – proxy.test_proxy32m 43s
test_cloudwatch_logging[ap-southeast-7-m6g.xlarge-alinux2023-slurm-None-official] – cloudwatch_logging.test_cloudwatch_logging34m 14s
test_efs_compute_az[ca-central-1-c5.xlarge-ubuntu2404-slurm-None-official] – storage.test_efs58m 48s
test_slurm_protected_mode[ca-central-1-c5.xlarge-rhel8-slurm-None-official-greedy-all-or-nothing] – schedulers.test_slurm55m 2s
test_efs_same_az[ca-central-1-c5.xlarge-alinux2023-slurm-None-official] – storage.test_efs30m 59s
test_multiple_efs[ca-central-1-m6g.xlarge-rhel9-slurm-None-official] – storage.test_efs47m 46s
test_slurm_protected_mode[ca-central-1-c5.xlarge-rhel8-slurm-None-official-best-effort] – schedulers.test_slurm56m 33s
test_slurm_protected_mode[ca-central-1-c5.xlarge-rhel8-slurm-None-official-all-or-nothing] – schedulers.test_slurm56m 44s
test_update_slurm[eu-central-1-c5.xlarge-rocky8-None-official] – update.test_update59m 33s
test_slurm[eu-central-1-c5.xlarge-alinux2023-slurm-None-official-True] – schedulers.test_slurm1h 10m 25s
test_file_cache[eu-north-1-m6g.xlarge-rocky8-slurm-None-official] – storage.test_fsx_lustre33m 2s
test_fsx_lustre_dra[eu-north-1-m6g.xlarge-rocky9-slurm-None-official] – storage.test_fsx_lustre1h 9m 3s
test_fsx_lustre[eu-north-1-m6g.xlarge-rhel8-slurm-None-official] – storage.test_fsx_lustre39m 43s
test_slurm_rest_api[eu-north-1-c5.xlarge-alinux2023-slurm-None-official] – schedulers.test_slurm_rest_api51m 21s
test_create_imds_secured[eu-south-1-c5.xlarge-rocky9-slurm-None-official-False-users_allow_list1] – create.test_create30m 19s
test_create_imds_secured[eu-south-1-c5.xlarge-rocky9-slurm-None-official-True-users_allow_list0] – create.test_create20m 39s
test_existing_hosted_zone[eu-south-1-c5.xlarge-rocky8-slurm-None-official] – dns.test_dns27m 22s
test_pyxis[eu-west-1-c5.xlarge-alinux2023-slurm-None-official-False] – pyxis.test_pyxis1h 3m 47s
test_slurm_from_login_nodes_in_private_network[eu-west-1-c5.xlarge-rhel9-slurm-None-official] – schedulers.test_slurm54m 54s
test_custom_munge_key[eu-west-1-c5.xlarge-alinux2023-slurm-None-official] – schedulers.test_custom_munge_key45m 4s
test_multiple_fsx[eu-west-2-m6g.xlarge-rhel9-slurm-None-official] – storage.test_fsx_lustre1h 53m 53s
test_multi_az_fsx[eu-west-2-c5.xlarge-rhel8-slurm-None-official] – storage.test_fsx_lustre2h 27m 17s
test_fsx_lustre_dra[eu-west-2-c5.xlarge-rocky8-slurm-None-official] – storage.test_fsx_lustre1h 8m 38s
test_dynamic_file_systems_update[eu-west-2-c5.xlarge-rhel9-slurm-None-official] – update.test_update2h 12m 10s
test_fsx_lustre[eu-west-2-c5.xlarge-rhel9-slurm-None-official] – storage.test_fsx_lustre33m 5s
test_multiple_fsx[eu-west-2-c5.xlarge-alinux2023-slurm-None-official] – storage.test_fsx_lustre1h 47m 42s
test_dynamic_file_systems_update_data_loss[eu-west-2-c5.xlarge-rocky9-slurm-None-official] – update.test_update1h 8m 1s
test_multi_az_create_and_update[eu-west-2-c5.xlarge-rhel8-slurm-None-official] – update.test_update28m 38s
test_cluster_in_private_subnet[il-central-1-c5.xlarge-ubuntu2404-slurm-None-official] – networking.test_cluster_networking51m 11s
test_update_race_conditions[us-east-1-c5.xlarge-rhel9-slurm-None-official] – update.test_update_race_conditions1h 7m 40s
test_scontrol_reboot[us-east-1-c5.xlarge-rhel9-slurm-None-official] – schedulers.test_slurm38m 37s
test_dcv_configuration[us-east-1-g5g.2xlarge-ubuntu2404-slurm-use1-az6-official] – dcv.test_dcv54m 24s
test_update_rollback_failure[us-east-1-c5.xlarge-rhel9-slurm-None-official] – update.test_update_rollback_failure1h 12m 32s
test_head_node_stop[us-east-1-m5d.xlarge-ubuntu2204-slurm-use1-az4-official] – storage.test_ephemeral25m 18s
test_cluster_in_no_internet_subnet[us-east-1-m6g.xlarge-ubuntu2404-slurm-None-official] – networking.test_cluster_networking1h 7m 25s
test_slurm_scaling[us-east-2-c5.xlarge-rocky9-slurm-None-official] – schedulers.test_slurm1h 1m 15s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-PERSISTENT_1-40-None-HDD-None-1800-512-LZ4] – storage.test_fsx_lustre45m 50s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-SCRATCH_1-None-NEW-None-None-1200-1024-LZ4] – storage.test_fsx_lustre51m 22s
test_efs_access_point[us-east-2-c5.xlarge-ubuntu2404-slurm-None-official] – storage.test_efs41m 26s
test_ebs_multiple[us-east-2-c5.xlarge-alinux2023-slurm-None-official] – storage.test_ebs44m 50s
test_cluster_with_subnet_prioritization[us-east-2-t3.large-rhel8-slurm-None-official] – networking.test_cluster_networking27m 9s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-SCRATCH_2-None-NEW_CHANGED_DELETED-None-None-1200-1024-LZ4] – storage.test_fsx_lustre50m 43s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-PERSISTENT_1-50-NEW_CHANGED-None-None-1200-1024-None] – storage.test_fsx_lustre53m 56s
test_scontrol_reboot_ec2_health_checks[us-east-2-t3.medium-rocky9-slurm-None-official] – schedulers.test_slurm36m 0s
test_launch_template_overrides[us-east-2-c5n.18xlarge-alinux2023-slurm-use2-az1-official] – launch_template_overrides.test_launch_template_overrides22m 49s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-PERSISTENT_1-12-None-HDD-READ-6000-1024-LZ4] – storage.test_fsx_lustre39m 9s
test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-rocky8-slurm-None-official-PERSISTENT_2-250-None-SSD-None-1200-2048-LZ4] – storage.test_fsx_lustre31m 39s
test_login_nodes_update[us-east-2-c5.xlarge-rocky8-slurm-None-official] – update.test_update1h 28m 37s
test_shared_home[us-west-1-c5.xlarge-alinux2023-slurm-None-official-FsxOpenZfs-Efs] – storage.test_shared_home1h 50m 16s
test_clustermgtd_instance_id_matching[us-west-1-c5.xlarge-rocky9-slurm-None-official] – schedulers.test_slurm23m 40s
test_fsx_lustre_backup[us-west-1-m6g.xlarge-alinux2023-slurm-None-official] – storage.test_fsx_lustre1h 3m 23s
test_shared_home[us-west-1-c5.xlarge-alinux2023-slurm-None-official-Ebs-Efs] – storage.test_shared_home1h 15m 32s
test_slurm_overrides[us-west-1-c5.xlarge-ubuntu2404-slurm-None-official] – schedulers.test_slurm17m 49s
test_shared_home[us-west-1-c5.xlarge-alinux2023-slurm-None-official-FsxLustre-Efs] – storage.test_shared_home1h 25m 33s
test_shared_home[us-west-1-c5.xlarge-alinux2023-slurm-None-official-FsxOntap-Efs] – storage.test_shared_home1h 47m 53s
test_shared_home[us-west-1-c5.xlarge-alinux2023-slurm-None-official-Efs-Efs] – storage.test_shared_home1h 14m 3s
test_existing_eip[us-west-1-c5.xlarge-rhel8-slurm-None-official] – networking.test_cluster_networking15m 39s
test_internal_efs[us-west-2-m6g.xlarge-ubuntu2404-slurm-None-official] – storage.test_internal_efs57m 24s
test_default_user_local_home[us-west-2-c5.xlarge-ubuntu2204-slurm-None-official] – users.test_default_user_home36m 40s
test_internal_efs[us-west-2-c5.xlarge-ubuntu2404-slurm-None-official] – storage.test_internal_efs
```

### References
* Corresponding CLI changes in userdata https://github.com/aws/aws-parallelcluster/pull/7481

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
