### PR TITLE
Move ExpectedPathPermissions to models and share owner/group name lookups in util/users

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/critical_paths.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/critical_paths.py
@@ -18,7 +18,6 @@ longer writable by ``pcluster-admin`` makes ``clusterstatusmgtd`` raise ``[Errno
 and the compute fleet gets stuck mid-transition (e.g. never leaving STOPPING).
 """
 
-from dataclasses import dataclass
 from typing import List, Optional
 
 from pcluster_diag.core.constants import (
@@ -33,35 +32,16 @@ from pcluster_diag.core.constants import (
 from pcluster_diag.models.check import Check
 from pcluster_diag.models.check_error import CheckError
 from pcluster_diag.models.context import Context, NodeType
+from pcluster_diag.models.expected_path_permissions import ExpectedPathPermissions
 from pcluster_diag.models.result import Result
 from pcluster_diag.util import filesystem
 
-
-@dataclass(frozen=True)
-class CriticalPath:
-    """A filesystem path ParallelCluster owns, with the ownership and mode it must have.
-
-    Attributes:
-        path: The absolute path to inspect.
-        owner: The expected owning user name.
-        group: The expected owning group name.
-        mode: The expected permission bits as a 4-digit octal string (e.g. ``0755``).
-        node_types: The node types the path is expected on; the Check inspects it only on those.
-    """
-
-    path: str
-    owner: str
-    group: str
-    mode: str
-    node_types: tuple
-
-
 # The critical paths ParallelCluster provisions, with the ownership/mode set by the cookbook. Add an
 # entry here whenever an investigation traces a failure to a mis-permissioned path.
-CRITICAL_PATHS: List[CriticalPath] = [
+CRITICAL_PATHS: List[ExpectedPathPermissions] = [
     # clusterstatusmgtd runs as pcluster-admin and writes the compute-fleet status here; if it loses
     # write access, fleet status transitions fail with EACCES.
-    CriticalPath(
+    ExpectedPathPermissions(
         path=COMPUTEFLEET_STATUS_PATH,
         owner=CLUSTER_ADMIN_USER,
         group=CLUSTER_ADMIN_GROUP,
@@ -70,7 +50,7 @@ CRITICAL_PATHS: List[CriticalPath] = [
     ),
     # Munge underpins Slurm authentication; munged refuses to start if its key is not private to the
     # munge user, breaking Slurm cluster-wide. Present wherever munge runs (head and compute).
-    CriticalPath(
+    ExpectedPathPermissions(
         path=MUNGE_KEY_PATH,
         owner=MUNGE_USER,
         group=MUNGE_USER,
@@ -78,7 +58,7 @@ CRITICAL_PATHS: List[CriticalPath] = [
         node_types=(NodeType.HEAD, NodeType.COMPUTE),
     ),
     # Slurm's StateSaveLocation; slurmctld cannot start if it is not owned by and private to the slurm user.
-    CriticalPath(
+    ExpectedPathPermissions(
         path=SLURM_STATE_SAVE_PATH,
         owner=SLURM_USER,
         group=SLURM_USER,
@@ -95,7 +75,7 @@ class CriticalPathsHaveExpectedPermissions(Check):
     WRONG_OWNERSHIP = "E2"
     WRONG_MODE = "E3"
 
-    def __init__(self, critical_paths: Optional[List[CriticalPath]] = None) -> None:
+    def __init__(self, critical_paths: Optional[List[ExpectedPathPermissions]] = None) -> None:
         """Create the Check, optionally overriding the inspected critical paths (used by tests)."""
         self._critical_paths = CRITICAL_PATHS if critical_paths is None else critical_paths
 
@@ -114,11 +94,11 @@ class CriticalPathsHaveExpectedPermissions(Check):
             return Result.failure(self, errors=errors)
         return Result.passed(self)
 
-    def _applicable(self, context: Context) -> List[CriticalPath]:
+    def _applicable(self, context: Context) -> List[ExpectedPathPermissions]:
         """Return the critical paths expected on the current node type."""
         return [critical for critical in self._critical_paths if context.node_type in critical.node_types]
 
-    def _inspect(self, critical: CriticalPath) -> List[CheckError]:
+    def _inspect(self, critical: ExpectedPathPermissions) -> List[CheckError]:
         """Return the CheckErrors for ``critical``: empty when it exists with the expected ownership and mode."""
         try:
             observed = filesystem.stat_path(critical.path)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/expected_path_permissions.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/expected_path_permissions.py
@@ -1,0 +1,34 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model describing the ownership and permissions a filesystem path is expected to have."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ExpectedPathPermissions:
+    """The ownership and mode a filesystem path is expected to have on given node types.
+
+    Attributes:
+        path: The absolute path to inspect.
+        owner: The expected owning user name.
+        group: The expected owning group name.
+        mode: The expected permission bits as a 4-digit octal string (e.g. ``0755``).
+        node_types: The node types the path is expected on; a Check inspects it only on those.
+    """
+
+    path: str
+    owner: str
+    group: str
+    mode: str
+    node_types: tuple

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/filesystem.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/filesystem.py
@@ -12,11 +12,11 @@
 
 """Helpers for inspecting filesystem ownership and permissions."""
 
-import grp
-import pwd
 import stat
 from dataclasses import dataclass
 from pathlib import Path
+
+from pcluster_diag.util import users
 
 
 @dataclass
@@ -42,26 +42,10 @@ def stat_path(path: str) -> PathStat:
     """
     info = Path(path).stat()
     return PathStat(
-        owner=_owner_name(info.st_uid),
-        group=_group_name(info.st_gid),
+        owner=users.get_username_for_uid(info.st_uid),
+        group=users.get_groupname_for_gid(info.st_gid),
         mode=_octal_mode(info.st_mode),
     )
-
-
-def _owner_name(uid: int) -> str:
-    """Return the user name for ``uid``, or the numeric uid as a string if it has no passwd entry."""
-    try:
-        return pwd.getpwuid(uid).pw_name
-    except KeyError:
-        return str(uid)
-
-
-def _group_name(gid: int) -> str:
-    """Return the group name for ``gid``, or the numeric gid as a string if it has no group entry."""
-    try:
-        return grp.getgrgid(gid).gr_name
-    except KeyError:
-        return str(gid)
 
 
 def _octal_mode(mode: int) -> str:

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/users.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/users.py
@@ -41,6 +41,22 @@ def get_group_gid(name: str) -> Optional[int]:
         return None
 
 
+def get_username_for_uid(uid: int) -> str:
+    """Return the user name for ``uid``, or the numeric uid as a string if it has no ``/etc/passwd`` entry."""
+    try:
+        return pwd.getpwuid(uid).pw_name
+    except KeyError:
+        return str(uid)
+
+
+def get_groupname_for_gid(gid: int) -> str:
+    """Return the group name for ``gid``, or the numeric gid as a string if it has no ``/etc/group`` entry."""
+    try:
+        return grp.getgrgid(gid).gr_name
+    except KeyError:
+        return str(gid)
+
+
 def get_usernames_for_uid(uid: int) -> List[str]:
     """Return every user name mapped to ``uid`` in ``/etc/passwd``, in database order.
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_critical_paths.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_critical_paths.py
@@ -15,15 +15,16 @@
 import pytest
 
 from pcluster_diag.checks import critical_paths
-from pcluster_diag.checks.critical_paths import CriticalPath, CriticalPathsHaveExpectedPermissions
+from pcluster_diag.checks.critical_paths import CriticalPathsHaveExpectedPermissions
 from pcluster_diag.core.constants import COMPUTEFLEET_STATUS_PATH, MUNGE_KEY_PATH, SLURM_STATE_SAVE_PATH
 from pcluster_diag.models.context import NodeType
+from pcluster_diag.models.expected_path_permissions import ExpectedPathPermissions
 from pcluster_diag.models.result import Status
 from pcluster_diag.util.filesystem import PathStat
 from tests.sample_data import sample_context
 
 # A single head-node critical path used by most tests (mirrors computefleet-status.json).
-_HEAD_PATH = CriticalPath(
+_HEAD_PATH = ExpectedPathPermissions(
     path="/opt/parallelcluster/shared/computefleet-status.json",
     owner="pcluster-admin",
     group="pcluster-admin",
@@ -160,7 +161,7 @@ def test_run_fails_when_path_missing(monkeypatch):
 
 
 def test_run_only_inspects_paths_for_current_node_type(monkeypatch):
-    compute_path = CriticalPath("/x", "root", "root", "0644", (NodeType.COMPUTE,))
+    compute_path = ExpectedPathPermissions("/x", "root", "root", "0644", (NodeType.COMPUTE,))
     inspected = []
 
     def stat_path(path):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_filesystem.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_filesystem.py
@@ -22,7 +22,7 @@ from pcluster_diag.util import filesystem
 def test_stat_path_reports_owner_group_and_octal_mode(tmp_path, monkeypatch):
     target = tmp_path / "computefleet-status.json"
     target.write_text("{}", encoding="utf-8")
-    os.chmod(target, 0o755)
+    os.chmod(target, 0o700)
 
     monkeypatch.setattr(filesystem.users, "get_username_for_uid", lambda uid: "pcluster-admin")
     monkeypatch.setattr(filesystem.users, "get_groupname_for_gid", lambda gid: "pcluster-admin")
@@ -31,7 +31,7 @@ def test_stat_path_reports_owner_group_and_octal_mode(tmp_path, monkeypatch):
 
     assert result.owner == "pcluster-admin"
     assert result.group == "pcluster-admin"
-    assert result.mode == "0755"
+    assert result.mode == "0700"
 
 
 def test_stat_path_passes_the_paths_uid_and_gid_to_the_name_lookups(tmp_path, monkeypatch):
@@ -59,11 +59,11 @@ def test_stat_path_passes_the_paths_uid_and_gid_to_the_name_lookups(tmp_path, mo
 def test_stat_path_reports_mode_as_four_digit_octal(tmp_path, monkeypatch):
     target = tmp_path / "file"
     target.write_text("x", encoding="utf-8")
-    os.chmod(target, 0o640)
+    os.chmod(target, 0o600)
     monkeypatch.setattr(filesystem.users, "get_username_for_uid", lambda uid: "u")
     monkeypatch.setattr(filesystem.users, "get_groupname_for_gid", lambda gid: "g")
 
-    assert filesystem.stat_path(str(target)).mode == "0640"
+    assert filesystem.stat_path(str(target)).mode == "0600"
 
 
 def test_stat_path_raises_for_missing_path(tmp_path):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_filesystem.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_filesystem.py
@@ -12,9 +12,7 @@
 
 """Unit tests for the filesystem ownership/permission helpers."""
 
-import grp
 import os
-import pwd
 
 import pytest
 
@@ -26,10 +24,8 @@ def test_stat_path_reports_owner_group_and_octal_mode(tmp_path, monkeypatch):
     target.write_text("{}", encoding="utf-8")
     os.chmod(target, 0o755)
 
-    monkeypatch.setattr(
-        filesystem.pwd, "getpwuid", lambda uid: pwd.struct_passwd(("pcluster-admin", "x", uid, uid, "", "", ""))
-    )
-    monkeypatch.setattr(filesystem.grp, "getgrgid", lambda gid: grp.struct_group(("pcluster-admin", "x", gid, [])))
+    monkeypatch.setattr(filesystem.users, "get_username_for_uid", lambda uid: "pcluster-admin")
+    monkeypatch.setattr(filesystem.users, "get_groupname_for_gid", lambda gid: "pcluster-admin")
 
     result = filesystem.stat_path(str(target))
 
@@ -38,26 +34,36 @@ def test_stat_path_reports_owner_group_and_octal_mode(tmp_path, monkeypatch):
     assert result.mode == "0755"
 
 
-def test_stat_path_falls_back_to_numeric_ids_when_names_are_unknown(tmp_path, monkeypatch):
-    target = tmp_path / "orphaned"
+def test_stat_path_passes_the_paths_uid_and_gid_to_the_name_lookups(tmp_path, monkeypatch):
+    target = tmp_path / "file"
+    target.write_text("x", encoding="utf-8")
+    seen = {}
+
+    def fake_username(uid):
+        seen["uid"] = uid
+        return "u"
+
+    def fake_groupname(gid):
+        seen["gid"] = gid
+        return "g"
+
+    monkeypatch.setattr(filesystem.users, "get_username_for_uid", fake_username)
+    monkeypatch.setattr(filesystem.users, "get_groupname_for_gid", fake_groupname)
+
+    filesystem.stat_path(str(target))
+
+    assert seen["uid"] == target.stat().st_uid
+    assert seen["gid"] == target.stat().st_gid
+
+
+def test_stat_path_reports_mode_as_four_digit_octal(tmp_path, monkeypatch):
+    target = tmp_path / "file"
     target.write_text("x", encoding="utf-8")
     os.chmod(target, 0o640)
+    monkeypatch.setattr(filesystem.users, "get_username_for_uid", lambda uid: "u")
+    monkeypatch.setattr(filesystem.users, "get_groupname_for_gid", lambda gid: "g")
 
-    def _no_user(_uid):
-        raise KeyError("unknown uid")
-
-    def _no_group(_gid):
-        raise KeyError("unknown gid")
-
-    monkeypatch.setattr(filesystem.pwd, "getpwuid", _no_user)
-    monkeypatch.setattr(filesystem.grp, "getgrgid", _no_group)
-
-    result = filesystem.stat_path(str(target))
-
-    # With no passwd/group entry, the numeric ids are reported as strings.
-    assert result.owner == str(target.stat().st_uid)
-    assert result.group == str(target.stat().st_gid)
-    assert result.mode == "0640"
+    assert filesystem.stat_path(str(target)).mode == "0640"
 
 
 def test_stat_path_raises_for_missing_path(tmp_path):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_users.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_users.py
@@ -56,6 +56,30 @@ def test_get_group_gid_returns_value_and_none(monkeypatch):
     assert users.get_group_gid("ghost") is None
 
 
+def test_get_username_for_uid_returns_name_or_numeric_fallback(monkeypatch):
+    monkeypatch.setattr(users.pwd, "getpwuid", lambda uid: _passwd("pcluster-admin", uid, uid))
+    assert users.get_username_for_uid(400) == "pcluster-admin"
+
+    def _raise(_uid):
+        raise KeyError("no such uid")
+
+    monkeypatch.setattr(users.pwd, "getpwuid", _raise)
+    # With no /etc/passwd entry, the numeric uid is returned as a string.
+    assert users.get_username_for_uid(1234) == "1234"
+
+
+def test_get_groupname_for_gid_returns_name_or_numeric_fallback(monkeypatch):
+    monkeypatch.setattr(users.grp, "getgrgid", lambda gid: _group("pcluster-admin", gid))
+    assert users.get_groupname_for_gid(400) == "pcluster-admin"
+
+    def _raise(_gid):
+        raise KeyError("no such gid")
+
+    monkeypatch.setattr(users.grp, "getgrgid", _raise)
+    # With no /etc/group entry, the numeric gid is returned as a string.
+    assert users.get_groupname_for_gid(1234) == "1234"
+
+
 def test_get_usernames_for_uid_returns_every_matching_name_in_order(monkeypatch):
     # svc-erd is listed before pcluster-admin, both sharing uid 400.
     database = [_passwd("root", 0), _passwd("svc-erd", 400), _passwd("pcluster-admin", 400), _passwd("slurm", 401)]


### PR DESCRIPTION
### Description of changes
Address the minor non-blocking comments in PR: https://github.com/aws/aws-parallelcluster-cookbook/pull/3223

* Move ExpectedPathPermissions to models
* Share owner/group name lookups in util/users

### Tests
* Unit tests all passed
* E2E test on a real cluster as expected

### References
* This is a followup PR of https://github.com/aws/aws-parallelcluster-cookbook/pull/3223

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
