### PR TITLE
Install fabric managed, nvlsm, and imex from Nvidia repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 **CHANGES**
 - Enforce NFSv4-only on the ParallelCluster-managed NFS server (head node). The NFSv3 client stack (rpcbind, rpc-statd, lockd) are unchanged, so cluster nodes can still mount external NFSv3 servers.
 - Change the default NFS lock manager port from 32768 to 4045. 32768 is in the Linux ephemeral port range (32768–60999), causing sporadic mount failures because of port collision. This only affects nodes that mount an external NFSv3 server; all ParallelCluster managed storage is mounted over NFSv4 and is unaffected. Customers who mount external NFSv3 servers and restrict NFS ports in a firewall must allow TCP/UDP 4045 instead of 32768.
-- Install the NVIDIA driver and CUDA toolkit from the distribution package manager using NVIDIA local repo packages instead of the run file installers.
+- Install the NVIDIA driver, CUDA toolkit, Fabric Manager, NVLSM, and IMEX from the distribution package manager using NVIDIA local repo packages instead of the run file installers.
 - In GPU Health Check, skip DCGM diagnostics when NVIDIA MIG is enabled because dcgmi diag does not support MIG.
 - Upgrade Slurm to version 25.11.6 (from 25.11.4).
 - Upgrade EFA installer to 1.49.0 (from 1.47.0).

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -54,7 +54,7 @@ default['cluster']['nvidia']['imex']['force_configuration'] = false
 
 # NVIDIA NVLSM
 default['cluster']['nvidia']['nvlsm']['enabled'] = true
-default['cluster']['nvidia']['nvlsm']['version'] = '2025.03.9-1'
+default['cluster']['nvidia']['nvlsm']['version'] = '2025.06.11-1'
 default['cluster']['nvidia']['nvlsm']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_nvlsm"
 
 # DCV

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -35,7 +35,6 @@ default['cluster']['nvidia']['driver_extra_packages'] = 'nvidia-xconfig'
 
 default['cluster']['nvidia']['driver_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_driver"
 default['cluster']['nvidia']['dcgm_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_dcgm"
-default['cluster']['nvidia']['fabricmanager']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_fabric"
 
 # CUDA
 default['cluster']['nvidia']['cuda']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda"
@@ -49,13 +48,10 @@ default['cluster']['nvidia']['gdrcopy']['sha256'] = 'c9eaf0593567ac5765d04c48cf7
 default['cluster']['nvidia']['gdrcopy']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/gdr_copy/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"
 
 # nvidia-imex
-default['cluster']['nvidia']['imex']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_imex"
 default['cluster']['nvidia']['imex']['force_configuration'] = false
 
 # NVIDIA NVLSM
 default['cluster']['nvidia']['nvlsm']['enabled'] = true
-default['cluster']['nvidia']['nvlsm']['version'] = '2025.06.11-1'
-default['cluster']['nvidia']['nvlsm']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_nvlsm"
 
 # DCV
 default['cluster']['dcv']['install_enabled'] = true

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
@@ -28,7 +28,6 @@ action :setup do
   node_attributes "dump node attributes"
 
   package fabric_manager_package do
-    version fabric_manager_version
     retries 3
     retry_delay 5
   end

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
@@ -27,7 +27,13 @@ action :setup do
   node.default['cluster']['nvidia']['fabricmanager']['version'] = fabric_manager_version
   node_attributes "dump node attributes"
 
-  action_install_package
+  package fabric_manager_package do
+    version fabric_manager_version
+    retries 3
+    retry_delay 5
+  end
+
+  action_lock_package_version
 end
 
 action :configure do

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_common.rb
@@ -16,15 +16,13 @@ unified_mode true
 default_action :setup
 
 property :nvidia_enabled, [true, false, nil]
-property :nvidia_driver_version, String
 
 action :setup do
   return unless _fabric_manager_enabled
   return if fabric_manager_installed?
 
-  # Share fabric manager package and version with InSpec tests
+  # Share fabric manager package with InSpec tests
   node.default['cluster']['nvidia']['fabricmanager']['package'] = fabric_manager_package
-  node.default['cluster']['nvidia']['fabricmanager']['version'] = fabric_manager_version
   node_attributes "dump node attributes"
 
   package fabric_manager_package do
@@ -60,10 +58,6 @@ def _nvidia_enabled
   nvidia_enabled.nil? ? ['yes', true, 'true'].include?(node['cluster']['nvidia']['enabled']) : nvidia_enabled
 end
 
-def _nvidia_driver_version
-  nvidia_driver_version || node['cluster']['nvidia']['driver_version']
-end
-
 def fabric_manager_package
   'nvidia-fabricmanager'
 end
@@ -74,8 +68,4 @@ end
 # 'fabric' and 'manager'), matching all other platforms.
 def fabric_manager_service
   'nvidia-fabricmanager'
-end
-
-def fabric_manager_version
-  _nvidia_driver_version
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_debian.rb
@@ -12,34 +12,9 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-action :install_package do
-  # For ubuntu, CINC17 apt-package resources need full versions for `version`
-  remote_file "#{node['cluster']['sources_dir']}/#{fabric_manager_package}-#{fabric_manager_version}.deb" do
-    source "#{fabric_manager_url}"
-    mode '0644'
-    retries 3
-    retry_delay 5
-    action :create_if_missing
-  end
-
-  bash "install_fabricmanager_for_ubuntu" do
-    user 'root'
-    cwd node['cluster']['sources_dir']
-    code <<-FABRIC_MANAGER
-    set -e
-    dpkg -i #{fabric_manager_package}-#{fabric_manager_version}.deb && apt-mark hold #{fabric_manager_package}
-    FABRIC_MANAGER
+action :lock_package_version do
+  execute "apt-mark hold #{fabric_manager_package}" do
     retries 3
     retry_delay 5
   end
-end
-
-def arch_suffix
-  arm_instance? ? 'arm64' : 'amd64'
-end
-
-def fabric_manager_url
-  base_url = node['cluster']['nvidia']['fabricmanager']['base_url']
-  nvidia_package_url(base_url, platform,
-    "#{fabric_manager_package}_#{fabric_manager_version}-1_#{arch_suffix}.deb")
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fabric_manager/partial/_fabric_manager_install_rhel.rb
@@ -12,35 +12,10 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-action :install_package do
-  remote_file "#{node['cluster']['sources_dir']}/#{fabric_manager_package}-#{fabric_manager_version}.rpm" do
-    source "#{fabric_manager_url}"
-    mode '0644'
-    retries 3
-    retry_delay 5
-    action :create_if_missing
-  end
-
+action :lock_package_version do
   package 'yum-plugin-versionlock'
-  bash "Install #{fabric_manager_package}" do
-    user 'root'
-    cwd node['cluster']['sources_dir']
-    code <<-FABRIC_MANAGER_INSTALL
-    set -e
-    yum install -y #{fabric_manager_package}-#{fabric_manager_version}.rpm
-    yum versionlock #{fabric_manager_package}
-    FABRIC_MANAGER_INSTALL
+  execute "yum versionlock #{fabric_manager_package}" do
     retries 3
     retry_delay 5
   end
-end
-
-def arch_suffix
-  arm_instance? ? 'aarch64' : 'x86_64'
-end
-
-def fabric_manager_url
-  base_url = node['cluster']['nvidia']['fabricmanager']['base_url']
-  nvidia_package_url(base_url, platform,
-    "#{fabric_manager_package}-#{fabric_manager_version}-1.#{arch_suffix}.rpm")
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
@@ -20,7 +20,6 @@ action :install do
   return if on_docker? || imex_installed?
 
   package nvidia_imex_package do
-    version nvidia_imex_full_version
     retries 3
     retry_delay 5
   end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
@@ -19,7 +19,13 @@ action :install do
   return unless nvidia_enabled_or_installed?
   return if on_docker? || imex_installed?
 
-  action_install_imex
+  package nvidia_imex_package do
+    version nvidia_imex_full_version
+    retries 3
+    retry_delay 5
+  end
+
+  action_lock_package_version
 
   # Create Imex configuration files
   action_create_configuration_files

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_common.rb
@@ -28,8 +28,7 @@ action :install do
 
   # Create Imex configuration files
   action_create_configuration_files
-  # Save Imex version in Node Attributes for InSpec Tests
-  node.default['cluster']['nvidia']['imex']['version'] = nvidia_imex_full_version
+  # Save Imex package in Node Attributes for InSpec Tests
   node.default['cluster']['nvidia']['imex']['package'] = nvidia_imex_package
   node_attributes 'dump node attributes'
 end
@@ -88,16 +87,8 @@ def nvidia_imex_package
   "#{nvidia_imex_service}"
 end
 
-def nvidia_driver_major_version
-  node['cluster']['nvidia']['driver_version'].split('.')[0]
-end
-
 def nvidia_imex_service
   'nvidia-imex'
-end
-
-def nvidia_imex_full_version
-  "#{node['cluster']['nvidia']['driver_version']}-1"
 end
 
 def imex_installed?

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_debian.rb
@@ -12,33 +12,9 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-action :install_imex do
-  remote_file "#{node['cluster']['sources_dir']}/#{nvidia_imex_package}-#{nvidia_imex_full_version}.deb" do
-    source "#{nvidia_imex_url}"
-    mode '0644'
-    retries 3
-    retry_delay 5
-    action :create_if_missing
-  end
-
-  bash "Install nvidia-imex" do
-    user 'root'
-    cwd node['cluster']['sources_dir']
-    code <<-NVIDIA_IMEX
-    set -e
-    dpkg -i #{nvidia_imex_package}-#{nvidia_imex_full_version}.deb && apt-mark hold #{nvidia_imex_package}
-    NVIDIA_IMEX
+action :lock_package_version do
+  execute "apt-mark hold #{nvidia_imex_package}" do
     retries 3
     retry_delay 5
   end
-end
-
-def nvidia_imex_url
-  base_url = node['cluster']['nvidia']['imex']['base_url']
-  nvidia_package_url(base_url, platform,
-    "#{nvidia_imex_package}_#{nvidia_imex_full_version}_#{arch_suffix}.deb")
-end
-
-def arch_suffix
-  arm_instance? ? 'arm64' : 'amd64'
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_imex/partial/_nvidia_imex_rhel.rb
@@ -12,35 +12,10 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-action :install_imex do
-  remote_file "#{node['cluster']['sources_dir']}/#{nvidia_imex_package}-#{nvidia_imex_full_version}.rpm" do
-    source "#{nvidia_imex_url}"
-    mode '0644'
-    retries 3
-    retry_delay 5
-    action :create_if_missing
-  end
-
+action :lock_package_version do
   package 'yum-plugin-versionlock'
-  bash "Install nvidia-imex" do
-    user 'root'
-    cwd node['cluster']['sources_dir']
-    code <<-NVIDIA_IMEX
-    set -e
-    yum install -y #{nvidia_imex_package}-#{nvidia_imex_full_version}.rpm
-    yum versionlock #{nvidia_imex_package}
-    NVIDIA_IMEX
+  execute "yum versionlock #{nvidia_imex_package}" do
     retries 3
     retry_delay 5
   end
-end
-
-def arch_suffix
-  arm_instance? ? 'aarch64' : 'x86_64'
-end
-
-def nvidia_imex_url
-  base_url = node['cluster']['nvidia']['imex']['base_url']
-  nvidia_package_url(base_url, platform,
-    "#{nvidia_imex_package}-#{nvidia_imex_full_version}.#{arch_suffix}.rpm")
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_common.rb
@@ -19,7 +19,14 @@ action :install do
   return unless nvlsm_installation_enabled?
 
   action_install_nvlsm_dependencies
-  action_install_nvlsm
+
+  package nvidia_nvlsm_package do
+    version nvidia_nvlsm_version
+    retries 3
+    retry_delay 5
+  end
+
+  action_lock_package_version
 end
 
 action :install_nvlsm_dependencies do
@@ -40,34 +47,6 @@ action :install_nvlsm_dependencies do
     owner 'root'
     group 'root'
     mode '0644'
-  end
-end
-
-action :install_nvlsm do
-  base_url = node['cluster']['nvidia']['nvlsm']['base_url']
-  remote_file "#{node['cluster']['sources_dir']}/#{nvidia_nvlsm_package_full_name}" do
-    source nvidia_nvlsm_url
-    # The NVLSM checksum is specific to each distribution and architecture combination,
-    # and a single overridden value cannot satisfy all OS/architecture variants when
-    # build-image runs in parallel across them. Skip the checksum when base_url is
-    # overridden; the cookbook still validates the checksum on the default S3 path
-    # where the per-OS/per-arch values are pinned.
-    checksum nvidia_nvlsm_checksum if default_artifacts_url?(base_url)
-    mode '0644'
-    retries 3
-    retry_delay 5
-    action :create_if_missing
-  end
-
-  bash "Install nvlsm" do
-    user 'root'
-    cwd node['cluster']['sources_dir']
-    code <<-CODE
-    set -ex
-    #{nvidia_nvlsm_install_commands}
-    CODE
-    retries 3
-    retry_delay 5
   end
 end
 

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_common.rb
@@ -21,7 +21,6 @@ action :install do
   action_install_nvlsm_dependencies
 
   package nvidia_nvlsm_package do
-    version nvidia_nvlsm_version
     retries 3
     retry_delay 5
   end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_common.rb
@@ -53,26 +53,6 @@ def nvidia_nvlsm_package
   "nvlsm"
 end
 
-def nvidia_nvlsm_version
-  node['cluster']['nvidia']['nvlsm']['version']
-end
-
-def nvidia_nvlsm_url
-  nvidia_package_url(node['cluster']['nvidia']['nvlsm']['base_url'], platform, nvidia_nvlsm_package_full_name)
-end
-
-def nvidia_nvlsm_package_full_name
-  # OS dependent
-end
-
-def nvidia_nvlsm_checksum
-  # OS dependent
-end
-
-def nvidia_nvlsm_install_commands
-  # OS dependent
-end
-
 def nvidia_nvlsm_install_dependencies_commands
   # OS dependent
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_debian.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_debian.rb
@@ -12,24 +12,11 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-def nvidia_nvlsm_package_full_name
-  "#{nvidia_nvlsm_package}_#{nvidia_nvlsm_version}_#{arch_suffix}.deb"
-end
-
-def arch_suffix
-  arm_instance? ? 'arm64' : 'amd64'
-end
-
-def nvidia_nvlsm_checksum
-  if arm_instance?
-    '6bb405a3494d9fcb6dad6e641d02afb71fd4e2f6a2b4ed3d5cf6cbff22964eb3'
-  else
-    '61f280e469624c43eecb0e08305452887e02f73e4763252a41f728d1843f1cc5'
+action :lock_package_version do
+  execute "apt-mark hold #{nvidia_nvlsm_package}" do
+    retries 3
+    retry_delay 5
   end
-end
-
-def nvidia_nvlsm_install_commands
-  "dpkg -i #{nvidia_nvlsm_package_full_name} && apt-mark hold #{nvidia_nvlsm_package}"
 end
 
 def nvidia_nvlsm_install_dependencies_commands

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_nvlsm/partial/_nvidia_nvlsm_rhel.rb
@@ -12,24 +12,12 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-def nvidia_nvlsm_package_full_name
-  "#{nvidia_nvlsm_package}-#{nvidia_nvlsm_version}.#{arch_suffix}.rpm"
-end
-
-def arch_suffix
-  arm_instance? ? 'aarch64' : 'x86_64'
-end
-
-def nvidia_nvlsm_checksum
-  if arm_instance?
-    'f21f14843c11ce64136fd1c3fa763b7511e18f160695f54b2a8d763776313539'
-  else
-    '88d5e52183bb5ee763eb864bbd119b591e7f45af32c52bd7ba0aa8f74fc19057'
+action :lock_package_version do
+  package 'yum-plugin-versionlock'
+  execute "yum versionlock #{nvidia_nvlsm_package}" do
+    retries 3
+    retry_delay 5
   end
-end
-
-def nvidia_nvlsm_install_commands
-  "yum install -y #{nvidia_nvlsm_package_full_name} && yum versionlock #{nvidia_nvlsm_package}"
 end
 
 def nvidia_nvlsm_install_dependencies_commands

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
@@ -192,25 +192,11 @@ describe 'fabric_manager:setup' do
           is_expected.to write_node_attributes('dump node attributes')
         end
 
-        if platform == 'ubuntu'
-          it 'installs fabric manager for ubuntu' do
-            is_expected.to run_bash('install_fabricmanager_for_ubuntu')
-              .with_retries(3)
-              .with_retry_delay(5)
-              .with_code(/dpkg -i #{fabric_manager_package}-#{fabric_manager_version}.deb && apt-mark hold #{fabric_manager_package}/)
-          end
-        else
-          it 'installs yum-plugin-versionlock' do
-            is_expected.to install_package('yum-plugin-versionlock')
-          end
-
-          it 'installs fabric manager' do
-            is_expected.to run_bash("Install #{fabric_manager_package}")
-              .with(user: 'root')
-              .with_retries(3)
-              .with_retry_delay(5)
-              .with_code(/yum install -y #{fabric_manager_package}-#{fabric_manager_version}.rpm/)
-          end
+        it 'installs fabric manager package from nvidia repo' do
+          is_expected.to install_package(fabric_manager_package)
+            .with(version: fabric_manager_version)
+            .with(retries: 3)
+            .with(retry_delay: 5)
         end
       end
 
@@ -226,8 +212,7 @@ describe 'fabric_manager:setup' do
         cached(:node) { chef_run.node }
 
         it 'skips the install when fabric manager is already present' do
-          is_expected.not_to run_bash('install_fabricmanager_for_ubuntu')
-          is_expected.not_to run_bash("Install #{fabric_manager_package}")
+          is_expected.not_to install_package(fabric_manager_package)
         end
       end
     end
@@ -286,73 +271,6 @@ describe 'fabric_manager:configure' do
 
           it "doesn't start nvidia-fabricmanager service" do
             is_expected.not_to start_service(fabric_manager_service)
-          end
-        end
-      end
-    end
-  end
-end
-
-# Tests for the NVIDIA library helper nvidia_package_url as exercised
-# through fabric_manager URL construction.
-#
-# Default S3 path:  {base_url}/{platform}/{filename}
-# Public repo path: {base_url}/{platform}/{arch}/{filename}
-describe 'fabric_manager_url construction' do
-  FM_S3_ARTIFACTS_URL = 'https://REGION-aws-parallelcluster.s3.REGION.AWS_DOMAIN'.freeze
-  FM_S3_BASE_URL = "#{FM_S3_ARTIFACTS_URL}/dependencies/nvidia_fabric".freeze
-  FM_PUBLIC_BASE_URL = 'https://fake-public.example.DOMAIN/compute/cuda/repos'.freeze
-  FM_DRIVER_VERSION = '999.99.99'.freeze
-
-  PLATFORM_DIRS_FM = {
-    'amazon2023' => 'rhel9', # FM AL2023 partial sets platform to 'rhel9'
-    'ubuntu22.04' => 'ubuntu2204',
-    'ubuntu24.04' => 'ubuntu2404',
-    'redhat8' => 'rhel8',
-    'redhat9' => 'rhel9',
-    'rocky8' => 'rhel8',
-    'rocky9' => 'rhel9',
-  }.freeze
-
-  for_all_oses do |platform, version|
-    debian = (platform == 'ubuntu')
-    ext = debian ? 'deb' : 'rpm'
-    package_join = debian ? '_' : '-' # filename joiner between package and version
-    arch_join = debian ? '_' : '.' # joiner between version-release and arch
-    expected_platform = PLATFORM_DIRS_FM["#{platform}#{version}"]
-
-    [false, true].each do |arm|
-      arch_suffix = if debian
-                      arm ? 'arm64' : 'amd64'
-                    else
-                      arm ? 'aarch64' : 'x86_64'
-                    end
-      package_filename = "nvidia-fabricmanager#{package_join}#{FM_DRIVER_VERSION}-1#{arch_join}#{arch_suffix}.#{ext}"
-
-      [
-        ['default S3 base_url',
-         FM_S3_BASE_URL,
-         "#{FM_S3_BASE_URL}/#{expected_platform}/#{package_filename}"],
-        ['overridden public base_url',
-         FM_PUBLIC_BASE_URL,
-         "#{FM_PUBLIC_BASE_URL}/#{expected_platform}/#{arm ? 'sbsa' : 'x86_64'}/#{package_filename}"],
-      ].each do |scenario, base_url, expected_source|
-        context "on #{platform}#{version} #{arm ? 'ARM' : 'x86_64'} with #{scenario}" do
-          cached(:chef_run) do
-            allow_any_instance_of(Object).to receive(:arm_instance?).and_return(arm)
-            runner(platform: platform, version: version, step_into: ['fabric_manager']) do |node|
-              node.override['cluster']['artifacts_s3_url'] = FM_S3_ARTIFACTS_URL
-              node.override['cluster']['nvidia']['fabricmanager']['base_url'] = base_url
-              node.override['cluster']['nvidia']['driver_version'] = FM_DRIVER_VERSION
-            end
-          end
-          cached(:resource) do
-            ConvergeFabricManager.setup(chef_run, nvidia_enabled: true)
-            chef_run.find_resource('fabric_manager', 'setup')
-          end
-
-          it 'builds the expected URL' do
-            expect(resource.fabric_manager_url).to eq(expected_source)
           end
         end
       end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 class ConvergeFabricManager
-  def self.setup(chef_run, nvidia_driver_version: nil, nvidia_enabled: nil)
+  def self.setup(chef_run, nvidia_enabled: nil)
     chef_run.converge_dsl('aws-parallelcluster-platform') do
       fabric_manager 'setup' do
         nvidia_enabled nvidia_enabled
-        nvidia_driver_version nvidia_driver_version
         action :setup
       end
     end
@@ -16,38 +15,6 @@ class ConvergeFabricManager
       fabric_manager 'configure' do
         action :configure
       end
-    end
-  end
-end
-
-describe 'fabric_manager:_nvidia_driver_version' do
-  cached(:nvidia_driver_attribute) { 'nvidia_driver_attribute' }
-  cached(:nvidia_driver_property) { 'nvidia_driver_property' }
-  cached(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['fabric_manager']) do |node|
-      node.override['cluster']['nvidia']['driver_version'] = nvidia_driver_attribute
-    end
-  end
-
-  context 'when nvidia driver property is set' do
-    cached(:resource) do
-      ConvergeFabricManager.setup(chef_run, nvidia_driver_version: nvidia_driver_property)
-      chef_run.find_resource('fabric_manager', 'setup')
-    end
-
-    it 'takes the value from nvidia driver property' do
-      expect(resource._nvidia_driver_version).to eq(nvidia_driver_property)
-    end
-  end
-
-  context 'when nvidia driver property is not set' do
-    cached(:resource) do
-      ConvergeFabricManager.setup(chef_run)
-      chef_run.find_resource('fabric_manager', 'setup')
-    end
-
-    it 'takes the value from nvidia driver attribute' do
-      expect(resource._nvidia_driver_version).to eq(nvidia_driver_attribute)
     end
   end
 end
@@ -163,12 +130,8 @@ describe 'fabric_manager:_fabric_manager_enabled' do
 end
 
 describe 'fabric_manager:setup' do
-  cached(:nvidia_driver_version) { 'nvidia_driver_version' }
-  cached(:aws_region) { 'test_region' }
-
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
-      cached(:fabric_manager_version) { nvidia_driver_version }
       cached(:fabric_manager_package) { 'nvidia-fabricmanager' }
 
       context 'when fabric manager is to install' do
@@ -178,7 +141,7 @@ describe 'fabric_manager:setup' do
             allow(res).to receive(:fabric_manager_installed?).and_return(false)
           end
           runner = runner(platform: platform, version: version, step_into: ['fabric_manager'])
-          ConvergeFabricManager.setup(runner, nvidia_driver_version: nvidia_driver_version)
+          ConvergeFabricManager.setup(runner)
         end
         cached(:node) { chef_run.node }
 
@@ -186,16 +149,23 @@ describe 'fabric_manager:setup' do
           is_expected.to setup_fabric_manager('setup')
         end
 
-        it 'dumps node attributes' do
-          expect(node['cluster']['nvidia']['fabricmanager']['package']).to eq(fabric_manager_package)
-          expect(node['cluster']['nvidia']['fabricmanager']['version']).to eq(fabric_manager_version)
-          is_expected.to write_node_attributes('dump node attributes')
-        end
-
         it 'installs fabric manager package from nvidia repo' do
           is_expected.to install_package(fabric_manager_package)
             .with(retries: 3)
             .with(retry_delay: 5)
+        end
+
+        it 'locks the package version' do
+          if %w(ubuntu).include?(platform)
+            is_expected.to run_execute("apt-mark hold #{fabric_manager_package}")
+              .with(retries: 3)
+              .with(retry_delay: 5)
+          else
+            is_expected.to install_package('yum-plugin-versionlock')
+            is_expected.to run_execute("yum versionlock #{fabric_manager_package}")
+              .with(retries: 3)
+              .with(retry_delay: 5)
+          end
         end
       end
 
@@ -206,7 +176,7 @@ describe 'fabric_manager:setup' do
             allow(res).to receive(:fabric_manager_installed?).and_return(true)
           end
           runner = runner(platform: platform, version: version, step_into: ['fabric_manager'])
-          ConvergeFabricManager.setup(runner, nvidia_driver_version: nvidia_driver_version)
+          ConvergeFabricManager.setup(runner)
         end
         cached(:node) { chef_run.node }
 
@@ -219,13 +189,11 @@ describe 'fabric_manager:setup' do
 end
 
 describe 'fabric_manager:configure' do
-  cached(:nvidia_driver_version) { 'nvidia_driver_version' }
   cached(:fabric_manager_service) { 'nvidia-fabricmanager' }
   [true, false].each do |is_gb200|
     for_all_oses do |platform, version|
       context "on #{platform}#{version} on #{is_gb200} gb200 node" do
         cached(:fabric_manager_package) { 'nvidia-fabricmanager' }
-        cached(:fabric_manager_version) { nvidia_driver_version }
 
         context('when fabric manager is required (multiple GPUs with bridges)') do
           cached(:chef_run) do

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/fabric_manager_spec.rb
@@ -194,7 +194,6 @@ describe 'fabric_manager:setup' do
 
         it 'installs fabric manager package from nvidia repo' do
           is_expected.to install_package(fabric_manager_package)
-            .with(version: fabric_manager_version)
             .with(retries: 3)
             .with(retry_delay: 5)
         end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
@@ -395,5 +395,3 @@ describe 'nvidia_imex:configure' do
     end
   end
 end
-
-

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
@@ -256,7 +256,6 @@ describe 'nvidia_imex:install' do
 
           it 'installs nvidia-imex from nvidia repo' do
             is_expected.to install_package(nvidia_imex_package)
-              .with(version: nvidia_imex_version)
               .with(retries: 3)
               .with(retry_delay: 5)
           end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
@@ -1,14 +1,11 @@
 require 'spec_helper'
 
-nvidia_version = "1.2.3"
-SOURCE_DIR = 'SOURCE_DIR'.freeze
 nvidia_imex_dir = "/etc/nvidia-imex"
 imex_main_conf_file = "#{nvidia_imex_dir}/config.cfg"
 imex_nodes_conf_file = "#{nvidia_imex_dir}/nodes_config.cfg"
 imex_service_file = "/etc/systemd/system/nvidia-imex.service"
 imex_binary = '/usr/bin/nvidia-imex'
 imex_ctl_binary = '/usr/bin/nvidia-imex-ctl'
-cluster_artifacts_s3_url = 'https://aws_region-aws-parallelcluster.s3.aws_region.AWS_DOMAIN'
 
 class ConvergeNvidiaImex
   def self.install(chef_run)
@@ -207,33 +204,7 @@ describe 'nvidia_imex:install' do
 
       %w(aarch64 x86_64).each do |arm_or_x86|
         context "when nvidia is enabled on #{arm_or_x86}" do
-          cached(:nvidia_imex_version) { "1.2.3-1" }
           cached(:nvidia_imex_package) { "nvidia-imex" }
-          cached(:nvidia_imex_name) do
-            if %(redhat rocky).include?(platform) || platform == 'amazon' && version == '2023'
-              "#{nvidia_imex_package}-#{nvidia_imex_version}"
-            else
-              "#{nvidia_imex_package}_#{nvidia_imex_version}"
-            end
-          end
-          cached(:url_arch) do
-            if %(redhat rocky amazon).include?(platform)
-              arm_or_x86
-            elsif platform == 'ubuntu'
-              arm_or_x86 == 'x86_64' ? 'amd64' : 'arm64'
-            else
-              arm_or_x86 == 'x86_64' ? 'x86_64' : 'aarch64'
-            end
-          end
-          cached(:url_suffix) do
-            if %(redhat rocky).include?(platform)
-              "rhel#{version}/#{nvidia_imex_name}.#{url_arch}"
-            elsif platform == 'amazon' && version == '2023'
-              "amzn2023/#{nvidia_imex_name}.#{url_arch}"
-            else
-              "#{platform}#{version.delete('.')}/#{nvidia_imex_name}_#{url_arch}"
-            end
-          end
 
           cached(:chef_run) do
             stubs_for_resource('nvidia_imex') do |res|
@@ -246,11 +217,8 @@ describe 'nvidia_imex:install' do
           cached(:node) { chef_run.node }
 
           before do
-            chef_run.node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
             chef_run.node.override['cluster']['region'] = 'aws_region'
-            chef_run.node.override['cluster']['sources_dir'] = SOURCE_DIR
             chef_run.node.automatic['kernel']['machine'] = arm_or_x86
-            chef_run.node.override['cluster']['nvidia']['driver_version'] = nvidia_version
             ConvergeNvidiaImex.install(chef_run)
           end
 
@@ -260,10 +228,17 @@ describe 'nvidia_imex:install' do
               .with(retry_delay: 5)
           end
 
-          it 'sets nvidia-imex version' do
-            expect(node.default['cluster']['nvidia']['imex']['version']).to eq(nvidia_imex_version)
-            expect(node.default['cluster']['nvidia']['imex']['package']).to eq(nvidia_imex_package)
-            is_expected.to write_node_attributes('dump node attributes')
+          it 'locks the package version' do
+            if %w(ubuntu).include?(platform)
+              is_expected.to run_execute("apt-mark hold #{nvidia_imex_package}")
+                .with(retries: 3)
+                .with(retry_delay: 5)
+            else
+              is_expected.to install_package('yum-plugin-versionlock')
+              is_expected.to run_execute("yum versionlock #{nvidia_imex_package}")
+                .with(retries: 3)
+                .with(retry_delay: 5)
+            end
           end
         end
       end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_imex_spec.rb
@@ -254,33 +254,11 @@ describe 'nvidia_imex:install' do
             ConvergeNvidiaImex.install(chef_run)
           end
 
-          it 'installs nvidia-imex' do
-            if platform == 'ubuntu'
-              is_expected.to create_if_missing_remote_file("#{SOURCE_DIR}/#{nvidia_imex_package}-#{nvidia_imex_version}.deb").with(
-                source: "#{cluster_artifacts_s3_url}/dependencies/nvidia_imex/#{url_suffix}.deb",
-                mode: '0644',
-                retries: 3,
-                retry_delay: 5
-              )
-              is_expected.to run_bash('Install nvidia-imex')
-                .with(user: 'root')
-                .with_retries(3)
-                .with_retry_delay(5)
-                .with_code(/    set -e\n    dpkg -i #{nvidia_imex_package}-#{nvidia_imex_version}.deb && apt-mark hold #{nvidia_imex_package}/)
-            else
-              is_expected.to create_if_missing_remote_file("#{SOURCE_DIR}/#{nvidia_imex_package}-#{nvidia_imex_version}.rpm").with(
-                source: "#{cluster_artifacts_s3_url}/dependencies/nvidia_imex/#{url_suffix}.rpm",
-                mode: '0644',
-                retries: 3,
-                retry_delay: 5
-              )
-              is_expected.to install_package('yum-plugin-versionlock')
-              is_expected.to run_bash("Install nvidia-imex")
-                .with(user: 'root')
-                .with_retries(3)
-                .with_retry_delay(5)
-                .with_code(/yum install -y #{nvidia_imex_name}.rpm/)
-            end
+          it 'installs nvidia-imex from nvidia repo' do
+            is_expected.to install_package(nvidia_imex_package)
+              .with(version: nvidia_imex_version)
+              .with(retries: 3)
+              .with(retry_delay: 5)
           end
 
           it 'sets nvidia-imex version' do
@@ -419,73 +397,4 @@ describe 'nvidia_imex:configure' do
   end
 end
 
-# Tests for the NVIDIA library helper nvidia_package_url as exercised
-# through nvidia_imex URL construction.
-#
-# Default S3 path:  {base_url}/{platform}/{filename}
-# Public repo path: {base_url}/{platform}/{arch}/{filename}
-describe 'nvidia_imex_url construction' do
-  s3_imex_base_url = "#{cluster_artifacts_s3_url}/dependencies/nvidia_imex"
-  public_imex_base_url = 'https://fake-public.example.DOMAIN/compute/cuda/repos'
 
-  platform_dirs = {
-    'amazon2023' => 'amzn2023',
-    'ubuntu22.04' => 'ubuntu2204',
-    'ubuntu24.04' => 'ubuntu2404',
-    'redhat8' => 'rhel8',
-    'redhat9' => 'rhel9',
-    'rocky8' => 'rhel8',
-    'rocky9' => 'rhel9',
-  }.freeze
-
-  for_all_oses do |platform, version|
-    debian = (platform == 'ubuntu')
-    ext = debian ? 'deb' : 'rpm'
-    package_join = debian ? '_' : '-' # joiner between package name and version
-    arch_join = debian ? '_' : '.' # joiner between version-release and arch
-    expected_platform = platform_dirs["#{platform}#{version}"]
-
-    [false, true].each do |arm|
-      arch_suffix = if debian
-                      arm ? 'arm64' : 'amd64'
-                    else
-                      arm ? 'aarch64' : 'x86_64'
-                    end
-      package_filename = "nvidia-imex#{package_join}#{nvidia_version}-1#{arch_join}#{arch_suffix}.#{ext}"
-
-      [
-        ['default S3 base_url',
-         s3_imex_base_url,
-         "#{s3_imex_base_url}/#{expected_platform}/#{package_filename}"],
-        ['overridden public base_url',
-         public_imex_base_url,
-         "#{public_imex_base_url}/#{expected_platform}/#{arm ? 'sbsa' : 'x86_64'}/#{package_filename}"],
-      ].each do |scenario, base_url, expected_source|
-        context "on #{platform}#{version} #{arm ? 'ARM' : 'x86_64'} with #{scenario}" do
-          cached(:chef_run) do
-            stubs_for_resource('nvidia_imex') do |res|
-              allow(res).to receive(:nvidia_enabled_or_installed?).and_return(true)
-              allow(res).to receive(:imex_installed?).and_return(false)
-            end
-            allow_any_instance_of(Object).to receive(:arm_instance?).and_return(arm)
-            runner = runner(platform: platform, version: version, step_into: ['nvidia_imex']) do |node|
-              node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
-              node.override['cluster']['nvidia']['imex']['base_url'] = base_url
-              node.override['cluster']['nvidia']['driver_version'] = nvidia_version
-            end
-            runner.converge_dsl('aws-parallelcluster-platform') do
-              nvidia_imex 'install' do
-                action :install
-              end
-            end
-          end
-
-          it 'builds the expected URL' do
-            remote_file = chef_run.find_resource('remote_file', /nvidia-imex.*\.#{ext}/)
-            expect(remote_file.source.first).to eq(expected_source)
-          end
-        end
-      end
-    end
-  end
-end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
@@ -91,7 +91,7 @@ describe 'nvidia_nvlsm:install' do
         cached(:node) { chef_run.node }
 
         it 'does not install nvlsm' do
-          is_expected.not_to run_bash("Install nvlsm")
+          is_expected.not_to install_package("nvlsm")
         end
       end
 
@@ -111,44 +111,6 @@ describe 'nvidia_nvlsm:install' do
           cached(:node) { chef_run.node }
 
           cached(:nvlsm_version) { "2025.03.9-1" }
-          cached(:nvlsm_package_full_name) do
-            if %(redhat rocky amazon).include?(platform)
-              "nvlsm-#{nvlsm_version}.#{arch_suffix_rhel[arch]}.rpm"
-            else
-              "nvlsm_#{nvlsm_version}_#{arch_suffix_debian[arch]}.deb"
-            end
-          end
-          cached(:nvlsm_checksum) do
-            if %(redhat rocky amazon).include?(platform)
-              if arch == 'aarch64'
-                'f21f14843c11ce64136fd1c3fa763b7511e18f160695f54b2a8d763776313539'
-              else
-                '88d5e52183bb5ee763eb864bbd119b591e7f45af32c52bd7ba0aa8f74fc19057'
-              end
-            elsif arch == 'aarch64'
-              '6bb405a3494d9fcb6dad6e641d02afb71fd4e2f6a2b4ed3d5cf6cbff22964eb3'
-            else
-              '61f280e469624c43eecb0e08305452887e02f73e4763252a41f728d1843f1cc5'
-            end
-          end
-          cached(:nvlsm_url) do
-            os_directory = if platform == 'amazon'
-                             "amzn#{version}"
-                           elsif %(redhat rocky).include?(platform)
-                             "rhel#{version}"
-                           else
-                             "#{platform}#{version.delete('.')}"
-                           end
-            "#{cluster_artifacts_s3_url}/dependencies/nvidia_nvlsm/#{os_directory}/#{nvlsm_package_full_name}"
-          end
-
-          cached(:nvlsm_installation_commands) do
-            if %(redhat rocky amazon).include?(platform)
-              "    set -ex\n    yum install -y #{nvlsm_package_full_name} && yum versionlock nvlsm\n"
-            else
-              "    set -ex\n    dpkg -i #{nvlsm_package_full_name} && apt-mark hold nvlsm\n"
-            end
-          end
           cached(:nvlsm_dependencies_installation_commands) do
             if %(redhat rocky amazon).include?(platform)
               "    set -ex\n    yum install -y infiniband-diags libibumad\n"
@@ -175,24 +137,11 @@ describe 'nvidia_nvlsm:install' do
             )
           end
 
-          it 'downloads nvlsm' do
-            is_expected.to create_if_missing_remote_file("#{source_dir}/#{nvlsm_package_full_name}").with(
-              source: nvlsm_url,
-              checksum: nvlsm_checksum,
-              mode: '0644',
-              retries: 3,
-              retry_delay: 5
-            )
-          end
-
-          it 'installs nvlsm' do
-            is_expected.to run_bash("Install nvlsm").with(
-              user: 'root',
-              cwd: source_dir,
-              retries: 3,
-              retry_delay: 5,
-              code: nvlsm_installation_commands
-            )
+          it 'installs nvlsm package from nvidia repo' do
+            is_expected.to install_package("nvlsm")
+              .with(version: nvlsm_version)
+              .with(retries: 3)
+              .with(retry_delay: 5)
           end
         end
       end
@@ -200,75 +149,4 @@ describe 'nvidia_nvlsm:install' do
   end
 end
 
-# Tests for the NVIDIA library helpers nvidia_package_url and default_artifacts_url?
-# as exercised through nvidia_nvlsm URL construction and checksum verification.
-#
-# Default S3 path:   {base_url}/{platform}/{filename} (with checksum verification)
-# Public repo path:  {base_url}/{platform}/{arch}/{filename} (checksum skipped because
-# the test harness pre-computes checksums only for the S3-hosted artifacts)
-describe 'nvidia_nvlsm install URL and checksum override behavior' do
-  s3_nvlsm_base_url = "#{cluster_artifacts_s3_url}/dependencies/nvidia_nvlsm"
-  public_nvlsm_base_url = 'https://fake-public.example.DOMAIN/compute/cuda/repos'
 
-  for_all_oses do |platform, version|
-    debian = (platform == 'ubuntu')
-    ext = debian ? 'deb' : 'rpm'
-    package_join = debian ? '_' : '-'
-    arch_join = debian ? '_' : '.'
-    expected_platform = if platform == 'amazon'
-                          "amzn#{version}"
-                        elsif %w(redhat rocky).include?(platform)
-                          "rhel#{version}"
-                        else
-                          "#{platform}#{version.delete('.')}"
-                        end
-
-    %w(x86_64 aarch64).each do |arch|
-      arch_suffix = debian ? arch_suffix_debian[arch] : arch_suffix_rhel[arch]
-      package_filename = "nvlsm#{package_join}2025.03.9-1#{arch_join}#{arch_suffix}.#{ext}"
-
-      [
-        ['default S3 base_url',
-         s3_nvlsm_base_url,
-         "#{s3_nvlsm_base_url}/#{expected_platform}/#{package_filename}",
-         true],
-        ['overridden public base_url',
-         public_nvlsm_base_url,
-         "#{public_nvlsm_base_url}/#{expected_platform}/#{arch == 'aarch64' ? 'sbsa' : 'x86_64'}/#{package_filename}",
-         false],
-      ].each do |scenario, base_url, expected_source, checksum_expected|
-        context "on #{platform}#{version} #{arch} with #{scenario}" do
-          cached(:chef_run) do
-            stubs_for_resource('nvidia_nvlsm') do |res|
-              allow(res).to receive(:nvlsm_installation_enabled?).and_return(true)
-            end
-            runner = runner(platform: platform, version: version, step_into: ['nvidia_nvlsm']) do |node|
-              node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
-              node.override['cluster']['nvidia']['nvlsm']['base_url'] = base_url
-              node.override['cluster']['sources_dir'] = source_dir
-              node.automatic['kernel']['machine'] = arch
-            end
-            ConvergeNvidiaNvlsm.install(runner)
-          end
-
-          it 'builds the expected URL' do
-            remote_file = chef_run.find_resource('remote_file', "#{source_dir}/#{package_filename}")
-            expect(remote_file.source.first).to eq(expected_source)
-          end
-
-          if checksum_expected
-            it 'verifies checksum on default S3 download' do
-              remote_file = chef_run.find_resource('remote_file', "#{source_dir}/#{package_filename}")
-              expect(remote_file.checksum).not_to be_nil
-            end
-          else
-            it 'skips checksum when base_url is overridden' do
-              remote_file = chef_run.find_resource('remote_file', "#{source_dir}/#{package_filename}")
-              expect(remote_file.checksum).to be_nil
-            end
-          end
-        end
-      end
-    end
-  end
-end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
@@ -102,7 +102,6 @@ describe 'nvidia_nvlsm:install' do
           end
           cached(:node) { chef_run.node }
 
-          cached(:nvlsm_version) { "2025.06.11-1" }
           cached(:nvlsm_dependencies_installation_commands) do
             if %(redhat rocky amazon).include?(platform)
               "    set -ex\n    yum install -y infiniband-diags libibumad\n"

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
@@ -1,8 +1,5 @@
 require 'spec_helper'
 
-cluster_artifacts_s3_url = 'https://aws_region-aws-parallelcluster.s3.AWS_REGION.AWS_DOMAIN'
-source_dir = 'SOURCE_DIR'
-
 class ConvergeNvidiaNvlsm
   def self.install(chef_run)
     chef_run.converge_dsl('aws-parallelcluster-platform') do
@@ -94,8 +91,6 @@ describe 'nvidia_nvlsm:install' do
               allow(res).to receive(:nvlsm_installation_enabled?).and_return(true)
             end
             runner = runner(platform: platform, version: version, step_into: ['nvidia_nvlsm']) do |node|
-              node.override['cluster']['artifacts_s3_url'] = cluster_artifacts_s3_url
-              node.override['cluster']['sources_dir'] = source_dir
               node.automatic['kernel']['machine'] = arch
             end
             ConvergeNvidiaNvlsm.install(runner)
@@ -132,6 +127,19 @@ describe 'nvidia_nvlsm:install' do
             is_expected.to install_package("nvlsm")
               .with(retries: 3)
               .with(retry_delay: 5)
+          end
+
+          it 'locks the package version' do
+            if %w(ubuntu).include?(platform)
+              is_expected.to run_execute("apt-mark hold nvlsm")
+                .with(retries: 3)
+                .with(retry_delay: 5)
+            else
+              is_expected.to install_package('yum-plugin-versionlock')
+              is_expected.to run_execute("yum versionlock nvlsm")
+                .with(retries: 3)
+                .with(retry_delay: 5)
+            end
           end
         end
       end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
@@ -2,14 +2,6 @@ require 'spec_helper'
 
 cluster_artifacts_s3_url = 'https://aws_region-aws-parallelcluster.s3.AWS_REGION.AWS_DOMAIN'
 source_dir = 'SOURCE_DIR'
-arch_suffix_rhel = {
-  'x86_64' => 'x86_64',
-  'aarch64' => 'aarch64',
-}.freeze
-arch_suffix_debian = {
-  'x86_64' => 'amd64',
-  'aarch64' => 'arm64',
-}.freeze
 
 class ConvergeNvidiaNvlsm
   def self.install(chef_run)
@@ -147,5 +139,3 @@ describe 'nvidia_nvlsm:install' do
     end
   end
 end
-
-

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_nvlsm_spec.rb
@@ -110,7 +110,7 @@ describe 'nvidia_nvlsm:install' do
           end
           cached(:node) { chef_run.node }
 
-          cached(:nvlsm_version) { "2025.03.9-1" }
+          cached(:nvlsm_version) { "2025.06.11-1" }
           cached(:nvlsm_dependencies_installation_commands) do
             if %(redhat rocky amazon).include?(platform)
               "    set -ex\n    yum install -y infiniband-diags libibumad\n"
@@ -139,7 +139,6 @@ describe 'nvidia_nvlsm:install' do
 
           it 'installs nvlsm package from nvidia repo' do
             is_expected.to install_package("nvlsm")
-              .with(version: nvlsm_version)
               .with(retries: 3)
               .with(retry_delay: 5)
           end

--- a/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_fabric_manager_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_fabric_manager_spec.rb
@@ -12,13 +12,8 @@
 control 'tag:install_expected_versions_of_nvidia_fabric_manager_installed' do
   only_if { !os_properties.arm? && ['yes', true, 'true'].include?(node['cluster']['nvidia']['enabled']) }
 
-  # On images that ship their own NVIDIA stack (e.g. DLAMI) pcluster skips the
-  # install and leaves Fabric Manager as-is, so the version attribute is unset and
-  # we only verify it is present. When pcluster installs it, the version attribute
-  # is set and we verify the package matches the configured version.
   describe package(node['cluster']['nvidia']['fabricmanager']['package']) do
     it { should be_installed }
-    its('version') { should match /#{node['cluster']['nvidia']['fabricmanager']['version']}/ }
   end
 end
 

--- a/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_imex_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_imex_spec.rb
@@ -24,7 +24,6 @@ control 'tag:install_expected_versions_of_nvidia_imex_installed' do
 
   describe package("#{node['cluster']['nvidia']['imex']['package']}") do
     it { should be_installed }
-    its('version') { should match /#{node['cluster']['nvidia']['imex']['version']}/ }
   end
 end
 


### PR DESCRIPTION
### Description of changes
* Install fabric manages, nvlsm, and imex from Nvidia repo
* Continue same package lock we did when we installed them from rpm files
* Remove versions for fabric manager, nvlsm, and imex because we install the version included in the repo
* Remove references to download url because we are retrieving from the repo
* Change unit tests to test they get installed from repo
* Keep the exisiting behavior of locking the packages

### Tests
1. Unit test (added/updated) included in this PR check
4. Build image on all supported OSs (with DevSettings pointing to NVIDIA local repos from Nvidia website because artifacts are not published to our bucket yet)
5. Successful integ tests:
```
test-suites:
  basic:
    test_essential_features.py::test_essential_features:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["g4dn.xlarge"]
          oss: ["rhel8"]
          schedulers: ["slurm"]
  health_checks:
    test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["g4dn.xlarge"]
          oss: ["rhel8"]
          schedulers: ["slurm"]

``` 


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
