### PR TITLE
[Nvidia] Upgrade NVIDIA driver to version 580.173.02 and CUDA Toolkit to version 13.3.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Enforce NFSv4-only on the ParallelCluster-managed NFS server (head node). The NFSv3 client stack (rpcbind, rpc-statd, lockd) are unchanged, so cluster nodes can still mount external NFSv3 servers.
 - Change the default NFS lock manager port from 32768 to 4045. 32768 is in the Linux ephemeral port range (32768–60999), causing sporadic mount failures because of port collision. This only affects nodes that mount an external NFSv3 server; all ParallelCluster managed storage is mounted over NFSv4 and is unaffected. Customers who mount external NFSv3 servers and restrict NFS ports in a firewall must allow TCP/UDP 4045 instead of 32768.
 - Install the NVIDIA driver, CUDA toolkit, Fabric Manager, NVLSM, and IMEX from the distribution package manager using NVIDIA local repo packages instead of the run file installers.
+- Upgrade NVIDIA driver, Fabric manager and IMEX to version 580.173.02 (from 580.126.20).
+- Upgrade CUDA Toolkit to version 13.3.1 (from 13.0.2).
 - In GPU Health Check, skip DCGM diagnostics when NVIDIA MIG is enabled because dcgmi diag does not support MIG.
 - Upgrade Slurm to version 25.11.6 (from 25.11.4).
 - Upgrade EFA installer to 1.49.0 (from 1.47.0).

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -25,7 +25,7 @@ default['cluster']['enroot']['persistent_dir'] = '/var/enroot'
 
 # NVidia
 default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '580.126.20'
+default['cluster']['nvidia']['driver_version'] = '580.173.02'
 default['cluster']['nvidia']['dcgm_version'] = '4.6.0-1'
 
 # Extra packages installed from the NVIDIA local repo alongside the driver
@@ -39,8 +39,8 @@ default['cluster']['nvidia']['dcgm_base_url'] = "#{node['cluster']['artifacts_s3
 # CUDA
 default['cluster']['nvidia']['cuda']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda"
 default['cluster']['nvidia']['cuda']['samples_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda/samples"
-default['cluster']['nvidia']['cuda']['version'] = '13.0.2'
-default['cluster']['nvidia']['cuda']['driver_version_suffix'] = '580.95.05'
+default['cluster']['nvidia']['cuda']['version'] = '13.3.1'
+default['cluster']['nvidia']['cuda']['driver_version_suffix'] = '610.43.02'
 
 # GDRCopy
 default['cluster']['nvidia']['gdrcopy']['version'] = '2.6'

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_cuda_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_cuda_spec.rb
@@ -12,7 +12,7 @@ class ConvergeNvidiaCuda
 end
 
 describe 'nvidia_cuda helpers' do
-  cached(:cuda_version) { '13.0.2' }
+  cached(:cuda_version) { '13.3.1' }
 
   cached(:chef_run) do
     allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(false)
@@ -24,35 +24,35 @@ describe 'nvidia_cuda helpers' do
   end
 
   it 'computes the cuda major.minor form' do
-    expect(resource.cuda_major_minor).to eq('13.0')
+    expect(resource.cuda_major_minor).to eq('13.3')
   end
 
   it 'computes the cuda toolkit package name' do
-    expect(resource.cuda_toolkit_package).to eq('cuda-toolkit-13-0')
+    expect(resource.cuda_toolkit_package).to eq('cuda-toolkit-13-3')
   end
 
   it 'computes the install dir, samples dir and path' do
     expect(resource.cuda_installation_base_dir).to eq('/usr/local')
-    expect(resource.cuda_install_dir).to eq('/usr/local/cuda-13.0')
-    expect(resource.cuda_samples_dir).to eq('/usr/local/cuda-13.0/samples')
+    expect(resource.cuda_install_dir).to eq('/usr/local/cuda-13.3')
+    expect(resource.cuda_samples_dir).to eq('/usr/local/cuda-13.3/samples')
     expect(resource.cuda_path).to eq('/usr/local/cuda')
   end
 
   it 'computes the samples archive and url' do
     expect(resource.cuda_samples_archive).to eq('/tmp/cuda-sample.tar.gz')
-    expect(resource.cuda_samples_url).to eq("#{resource.node['cluster']['nvidia']['cuda']['samples_base_url']}/v13.0.tar.gz")
+    expect(resource.cuda_samples_url).to eq("#{resource.node['cluster']['nvidia']['cuda']['samples_base_url']}/v13.3.tar.gz")
   end
 end
 
 describe 'nvidia_cuda: overriding samples_base_url to the official NVIDIA URL' do
-  cached(:cuda_version) { '13.0.2' }
+  cached(:cuda_version) { '13.3.1' }
   cached(:samples_base_url) { 'https://github.com/NVIDIA/cuda-samples/archive/refs/tags' }
 
   cached(:chef_run) do
     allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
     allow_any_instance_of(Object).to receive(:on_docker?).and_return(false)
     mock_file_exists('/usr/local/cuda', false)
-    mock_file_exists('/usr/local/cuda-13.0/samples', false)
+    mock_file_exists('/usr/local/cuda-13.3/samples', false)
     runner = runner(platform: 'amazon', version: '2023', step_into: ['nvidia_cuda']) do |node|
       node.override['cluster']['nvidia']['cuda']['samples_base_url'] = samples_base_url
     end
@@ -61,14 +61,14 @@ describe 'nvidia_cuda: overriding samples_base_url to the official NVIDIA URL' d
 
   it 'downloads the cuda samples from the official NVIDIA URL' do
     is_expected.to create_remote_file('/tmp/cuda-sample.tar.gz').with(
-      source: "#{samples_base_url}/v13.0.tar.gz"
+      source: "#{samples_base_url}/v13.3.tar.gz"
     )
   end
 end
 
 describe 'nvidia_cuda:setup' do
   for_all_oses do |platform, version|
-    cached(:cuda_version) { '13.0.2' }
+    cached(:cuda_version) { '13.3.1' }
 
     context "on #{platform}#{version} when nvidia not enabled" do
       cached(:chef_run) do
@@ -78,7 +78,7 @@ describe 'nvidia_cuda:setup' do
       end
 
       it 'does not install the cuda toolkit' do
-        is_expected.not_to install_package('cuda-toolkit-13-0')
+        is_expected.not_to install_package('cuda-toolkit-13-3')
       end
     end
 
@@ -92,7 +92,7 @@ describe 'nvidia_cuda:setup' do
       end
 
       it 'skips the entire cuda setup' do
-        is_expected.not_to install_package('cuda-toolkit-13-0')
+        is_expected.not_to install_package('cuda-toolkit-13-3')
         is_expected.not_to create_remote_file('/tmp/cuda-sample.tar.gz')
         is_expected.not_to create_template('/etc/profile.d/cuda.sh')
         is_expected.not_to write_node_attributes('Save cuda and cuda samples versions for InSpec tests')
@@ -104,7 +104,7 @@ describe 'nvidia_cuda:setup' do
         allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
         allow_any_instance_of(Object).to receive(:on_docker?).and_return(false)
         mock_file_exists('/usr/local/cuda', false)
-        mock_file_exists('/usr/local/cuda-13.0/samples', false)
+        mock_file_exists('/usr/local/cuda-13.3/samples', false)
         runner = runner(platform: platform, version: version, step_into: ['nvidia_cuda'])
         ConvergeNvidiaCuda.setup(runner, cuda_version: cuda_version)
       end
@@ -116,12 +116,12 @@ describe 'nvidia_cuda:setup' do
 
       it 'shares the cuda versions for InSpec' do
         is_expected.to write_node_attributes('Save cuda and cuda samples versions for InSpec tests')
-        expect(node['cluster']['nvidia']['cuda']['major_minor_version']).to eq('13.0')
-        expect(node['cluster']['nvidia']['cuda_samples_version']).to eq('13.0')
+        expect(node['cluster']['nvidia']['cuda']['major_minor_version']).to eq('13.3')
+        expect(node['cluster']['nvidia']['cuda_samples_version']).to eq('13.3')
       end
 
       it 'leaves the canonical cuda version attribute untouched (full version)' do
-        expect(node['cluster']['nvidia']['cuda']['version']).to eq('13.0.2')
+        expect(node['cluster']['nvidia']['cuda']['version']).to eq('13.3.1')
       end
 
       it 'renders the cuda.sh profile with the cuda path' do
@@ -135,12 +135,12 @@ describe 'nvidia_cuda:setup' do
       it 'downloads and unpacks the cuda samples' do
         is_expected.to create_remote_file('/tmp/cuda-sample.tar.gz')
         is_expected.to run_bash('cuda.sample install').with(
-          creates: '/usr/local/cuda-13.0/samples'
+          creates: '/usr/local/cuda-13.3/samples'
         )
       end
 
       it 'installs the cuda toolkit via the platform package manager' do
-        is_expected.to install_package('cuda-toolkit-13-0').with(
+        is_expected.to install_package('cuda-toolkit-13-3').with(
           retries: 3,
           retry_delay: 5
         )

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_repo_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_repo_spec.rb
@@ -33,8 +33,8 @@ describe 'nvidia_repo helpers' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       cached(:driver_version) { '999.88.77' }
-      cached(:cuda_version) { '13.0.2' }
-      cached(:cuda_suffix) { '580.95.05' }
+      cached(:cuda_version) { '13.3.1' }
+      cached(:cuda_suffix) { '610.43.02' }
       cached(:driver_base_url) { 'https://driver.example/nvidia_driver' }
       cached(:cuda_base_url) { 'https://cuda.example/cuda' }
       cached(:sources_dir) { '/fake/sources' }
@@ -43,7 +43,7 @@ describe 'nvidia_repo helpers' do
       cached(:local_repo_platform) { nvidia_local_repo_platform_for(platform, version) }
       cached(:arch) { debian? ? 'amd64' : 'x86_64' }
       cached(:driver_pkg_name) { "nvidia-driver-local-repo-#{local_repo_platform}-#{driver_version}" }
-      cached(:cuda_pkg_name) { "cuda-repo-#{local_repo_platform}-13-0-local" }
+      cached(:cuda_pkg_name) { "cuda-repo-#{local_repo_platform}-13-3-local" }
       cached(:driver_pkg_file) do
         debian? ? "#{driver_pkg_name}_1.0-1_#{arch}.deb" : "#{driver_pkg_name}-1.0-1.#{arch}.rpm"
       end
@@ -118,8 +118,8 @@ describe 'nvidia_repo:add' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       cached(:driver_version) { '999.88.77' }
-      cached(:cuda_version) { '13.0.2' }
-      cached(:cuda_suffix) { '580.95.05' }
+      cached(:cuda_version) { '13.3.1' }
+      cached(:cuda_suffix) { '610.43.02' }
       cached(:driver_base_url) { 'https://driver.example/nvidia_driver' }
       cached(:cuda_base_url) { 'https://cuda.example/cuda' }
       cached(:sources_dir) { '/fake/sources' }
@@ -128,7 +128,7 @@ describe 'nvidia_repo:add' do
       cached(:local_repo_platform) { nvidia_local_repo_platform_for(platform, version) }
       cached(:arch) { debian? ? 'amd64' : 'x86_64' }
       cached(:driver_pkg_name) { "nvidia-driver-local-repo-#{local_repo_platform}-#{driver_version}" }
-      cached(:cuda_pkg_name) { "cuda-repo-#{local_repo_platform}-13-0-local" }
+      cached(:cuda_pkg_name) { "cuda-repo-#{local_repo_platform}-13-3-local" }
       cached(:driver_pkg_file) do
         debian? ? "#{driver_pkg_name}_1.0-1_#{arch}.deb" : "#{driver_pkg_name}-1.0-1.#{arch}.rpm"
       end
@@ -229,7 +229,7 @@ describe 'nvidia_repo:add skip conditions' do
 
     it 'skips the driver repo but still adds the cuda repo' do
       expect(converged).not_to install_rpm_package(/nvidia-driver-local-repo/)
-      expect(converged).to install_rpm_package(/cuda-repo-amzn2023-13-0-local/)
+      expect(converged).to install_rpm_package(/cuda-repo-amzn2023-13-3-local/)
     end
   end
 
@@ -238,19 +238,19 @@ describe 'nvidia_repo:add skip conditions' do
 
     it 'skips the cuda repo but still adds the driver repo' do
       expect(converged).to install_rpm_package(/nvidia-driver-local-repo/)
-      expect(converged).not_to install_rpm_package(/cuda-repo-amzn2023-13-0-local/)
+      expect(converged).not_to install_rpm_package(/cuda-repo-amzn2023-13-3-local/)
     end
   end
 end
 
 describe 'nvidia_repo: overriding base_url to the official NVIDIA URLs' do
-  cached(:driver_version) { '580.105.08' }
-  cached(:cuda_version) { '13.0.2' }
-  cached(:cuda_suffix) { '580.95.05' }
+  cached(:driver_version) { '580.173.02' }
+  cached(:cuda_version) { '13.3.1' }
+  cached(:cuda_suffix) { '610.43.02' }
   cached(:driver_base_url) { "https://developer.download.nvidia.com/compute/nvidia-driver/#{driver_version}/local_installers" }
   cached(:cuda_base_url) { "https://developer.download.nvidia.com/compute/cuda/#{cuda_version}/local_installers" }
   cached(:driver_pkg_file) { "nvidia-driver-local-repo-amzn2023-#{driver_version}-1.0-1.x86_64.rpm" }
-  cached(:cuda_pkg_file) { "cuda-repo-amzn2023-13-0-local-#{cuda_version}_#{cuda_suffix}-1.x86_64.rpm" }
+  cached(:cuda_pkg_file) { "cuda-repo-amzn2023-13-3-local-#{cuda_version}_#{cuda_suffix}-1.x86_64.rpm" }
 
   cached(:chef_run) do
     allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
@@ -283,14 +283,14 @@ describe 'nvidia_repo:remove' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
       cached(:driver_version) { '999.88.77' }
-      cached(:cuda_version) { '13.0.2' }
-      cached(:cuda_suffix) { '580.95.05' }
+      cached(:cuda_version) { '13.3.1' }
+      cached(:cuda_suffix) { '610.43.02' }
       cached(:sources_dir) { '/fake/sources' }
       cached(:debian?) { platform == 'ubuntu' }
       cached(:local_repo_platform) { nvidia_local_repo_platform_for(platform, version) }
       cached(:arch) { debian? ? 'amd64' : 'x86_64' }
       cached(:driver_pkg_name) { "nvidia-driver-local-repo-#{local_repo_platform}-#{driver_version}" }
-      cached(:cuda_pkg_name) { "cuda-repo-#{local_repo_platform}-13-0-local" }
+      cached(:cuda_pkg_name) { "cuda-repo-#{local_repo_platform}-13-3-local" }
       cached(:driver_pkg_file) do
         debian? ? "#{driver_pkg_name}_1.0-1_#{arch}.deb" : "#{driver_pkg_name}-1.0-1.#{arch}.rpm"
       end
@@ -314,7 +314,7 @@ describe 'nvidia_repo:remove' do
           runner.converge_dsl('aws-parallelcluster-platform') do
             nvidia_repo 'remove' do
               driver_version '999.88.77'
-              cuda_version '13.0.2'
+              cuda_version '13.3.1'
               action :remove
             end
           end
@@ -374,7 +374,7 @@ describe 'nvidia_repo:remove' do
           runner.converge_dsl('aws-parallelcluster-platform') do
             nvidia_repo 'remove' do
               driver_version '999.88.77'
-              cuda_version '13.0.2'
+              cuda_version '13.3.1'
               action :remove
             end
           end


### PR DESCRIPTION
### Description of changes
Upgrade NVIDIA driver to version 580.173.02 and CUDA Toolkit to version 13.3.1.

### Tests
Build image succeess on all OSs, kitchen test succeeded (validated with deps upgrade pipeline)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
