### PR TITLE
[EFS] Pre-import efs-utils GPG key to fix RHEL9 repolist hang

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_install_from_repo_redhat.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/efs/partial/_install_from_repo_redhat.rb
@@ -53,10 +53,28 @@ action :install_utils do
 end
 
 action :install_efs_utils_from_repo do
+  # Import the repo's GPG key into the rpm keyring up front, before the repo is
+  # read. With repo_gpgcheck=true the metadata signature is verified on every
+  # `yum repolist`/makecache, and if the key isn't already trusted, dnf on RHEL9
+  # prompts interactively ("Is this ok [y/N]") and hangs non-interactive runs.
+  # Mirrors the official efs-utils installer (rpm --import + local file:// gpgkey).
+  efs_utils_gpg_key = "#{node['cluster']['sources_dir']}/efs-utils-armored.gpg"
+
+  remote_file efs_utils_gpg_key do
+    source "#{efs_domain}/efs-utils-armored.gpg"
+    mode '0644'
+    retries 3
+    retry_delay 5
+  end
+
+  execute "import efs-utils gpg key" do
+    command "rpm --import #{efs_utils_gpg_key}"
+  end
+
   yum_repository "efs-utils" do
     description "efs-utils repository"
     baseurl efs_repo_base_url
-    gpgkey "#{efs_domain}/efs-utils-armored.gpg"
+    gpgkey "file://#{efs_utils_gpg_key}"
     gpgcheck true
     repo_gpgcheck true
     enabled true

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efs_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/efs_spec.rb
@@ -32,18 +32,28 @@ describe 'efs:install_utils' do
       cached(:repo_base_url) { "#{efs_domain}/repo/rpm/redhat/#{version.to_i}.*" }
 
       context "utils package not yet installed" do
+        cached(:sources_dir) { 'sources_dir' }
+        cached(:gpg_key_path) { "#{sources_dir}/efs-utils-armored.gpg" }
         cached(:chef_run) do
           mock_already_installed(false)
           runner = runner(platform: platform, version: version, step_into: ['efs']) do |node|
             node.override['cluster']['efs']['version'] = utils_version
+            node.override['cluster']['sources_dir'] = sources_dir
           end
           ConvergeEfs.install_utils(runner)
+        end
+
+        it 'imports the efs-utils gpg key before adding the repository' do
+          is_expected.to create_remote_file(gpg_key_path)
+            .with(source: "#{efs_domain}/efs-utils-armored.gpg")
+          is_expected.to run_execute('import efs-utils gpg key')
+            .with(command: "rpm --import #{gpg_key_path}")
         end
 
         it 'adds the efs-utils yum repository' do
           is_expected.to create_yum_repository('efs-utils')
             .with(baseurl: repo_base_url)
-            .with(gpgkey: "#{efs_domain}/efs-utils-armored.gpg")
+            .with(gpgkey: "file://#{gpg_key_path}")
         end
 
         it 'installs the newest amazon-efs-utils within the tracked major' do


### PR DESCRIPTION
### Description of changes

The efs-utils yum repo is created with repo_gpgcheck=true, so dnf verifies the repo metadata signature on every 'yum repolist'/makecache. The key was only referenced by remote URL and never imported into the rpm keyring up front, so on RHEL9 the first metadata refresh triggered an interactive GPG-import prompt ('Is this ok [y/N]'). During non-interactive AMI builds this hung until killed, and because the InSpec check runs 'yum -v repolist all' for all repos at once, it also failed the unrelated aws-fsx (Lustre) repo assertions with a nil baseurl.

Fix mirrors the official efs-utils installer: download the key locally, run rpm --import before the repo is read, and reference it via a local file:// gpgkey (kept in sources_dir, consistent with the CloudWatch agent key). repo_gpgcheck stays enabled. No change needed to lustre_spec.rb; it passes once the hang is gone.





### Tests
* Unit spec updated accordingly (196 examples, 0 failures).
* Build Image


### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
