### PR TITLE
Refactor directory checks into a single DirectoryService check

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/directory_lookup.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/directory_lookup.py
@@ -10,30 +10,32 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Checks about the directory service (NSS -> SSSD -> LDAP/AD) integration.
+"""A Check diagnosing the directory service (NSS -> SSSD -> LDAP/AD) integration.
 
 slurmctld resolves users and groups through NSS on its main control thread (e.g. AllowGroups refresh,
 job credential creation). When those lookups are slow, the controller's periodic loop is delayed, node
 pings are missed, and healthy compute nodes can be marked DOWN/NOT_RESPONDING and recycled. This module
 provides:
 
-- ``DirectoryLookupLatency``: times the exact NSS calls slurmctld depends on (``getent group``,
-  ``getent passwd``, ``id``) and flags lookups slow enough to put the controller at risk.
-- ``DirectoryBackendIsReachable``: consults a read-only ``sssctl domain-status`` and fails when SSSD
-  reports the directory backend offline.
-- ``DirectoryServiceManagedByClusterConfig``: warns when an AD/LDAP integration exists on the node but
-  is not declared in the cluster configuration (so ParallelCluster cannot manage or validate it).
-- ``DirectoryLookupResiliencySettings``: warns when the settings that reduce directory-lookup load
-  (the Slurm NSS plugin and SSSD credential caching) are not enabled.
-- ``DirectoryEndpointCertificateIsValid``: runs a read-only openssl TLS handshake and reports when the
-  directory endpoint's certificate does not validate against the configured CA.
-- ``DirectoryBindCredentialsAreValid``: reproduces SSSD's bind with a read-only ``ldapsearch`` to verify
-  the configured bind DN and password.
-- ``DirectoryUsersResolveUnderSearchBase``: searches the configured LDAP base (read-only ``ldapsearch``)
-  to confirm the allow-listed users actually resolve under it.
+- lookup latency: times the exact NSS calls slurmctld depends on (``getent group``, ``getent passwd``,
+  ``id``) and flags lookups slow enough to put the controller at risk;
+- managed-by-cluster-config: warns when an AD/LDAP integration exists on the node but is not declared in
+  the cluster configuration (so ParallelCluster cannot manage or validate it);
+- resiliency settings: warns when the settings that reduce directory-lookup load (the Slurm NSS plugin
+  and SSSD credential caching) are not enabled;
+- backend reachability: consults a read-only ``sssctl domain-status`` and fails when SSSD reports the
+  directory backend offline;
+- endpoint certificate: runs a read-only openssl TLS handshake and fails when the directory endpoint's
+  certificate does not validate against the configured CA;
+- bind credentials: reproduces SSSD's bind with a read-only ``ldapsearch`` to verify the configured bind
+  DN and password;
+- search-base membership: searches the configured LDAP base (read-only ``ldapsearch``) to confirm the
+  allow-listed users resolve under it.
 
-All checks are read-only and safe to run on a production node. The ldapsearch/openssl-based checks are
-best-effort: they record SKIPPED_NOT_APPLICABLE when the tool or the required input is unavailable.
+All probes are read-only and safe to run on a production node. A probe whose sub-feature is simply not
+enabled (e.g. no ``ldaps://`` endpoint to validate, no allow-listed users) contributes nothing. A probe
+that is relevant but cannot reach a verdict because a required tool is unavailable (openssl / ldapsearch /
+sssctl not installed) contributes a WARNING so the coverage gap is visible.
 """
 
 import configparser
@@ -52,9 +54,10 @@ from pcluster_diag.core.constants import (
     SLURM_CONF_RELATIVE_PATH,
     SSSD_CONF_PATH,
 )
+from pcluster_diag.core.probe import run_probe
 from pcluster_diag.models.check import Check
 from pcluster_diag.models.context import Context
-from pcluster_diag.models.finding import CheckError, CheckInfo, CheckWarning
+from pcluster_diag.models.finding import CheckError, CheckWarning
 from pcluster_diag.models.result import Result
 from pcluster_diag.models.sssd_backend_status import SssdBackendStatus
 from pcluster_diag.util import ldap
@@ -67,64 +70,244 @@ _STATUS_WARN = "warn"
 _STATUS_FAIL = "fail"
 
 
-class DirectoryLookupLatency(Check):
-    """Measure NSS/SSSD/AD lookup latency for the users and groups Slurm resolves."""
+class DirectoryService(Check):
+    """Diagnose the directory service (NSS/SSSD/AD) integration."""
 
-    SLOW_OR_FAILING_LOOKUPS = CheckError(
+    LOOKUP_SLOW_OR_FAILING = CheckError(
         1,
         "Directory lookups are slow or failing: {}. They are expected to resolve quickly and reliably.",
     )
-    ELEVATED_OR_UNRESOLVED_LOOKUPS = CheckWarning(
+    BACKEND_OFFLINE = CheckError(2, "SSSD reports the directory backend offline: {}.")
+    CERTIFICATE_INVALID = CheckError(
+        3,
+        "The directory endpoint TLS certificate did not validate: {}. With ldap_tls_reqcert={}, SSSD "
+        "refuses the connection, so identity lookups fail cluster-wide. Fix the certificate or the "
+        "configured CA (ldap_tls_cacert).",
+    )
+    BIND_CREDENTIALS_INVALID = CheckError(
+        4,
+        "The directory rejected SSSD's configured bind credentials (ldap_default_bind_dn / ldap_default_authtok).",
+    )
+    BIND_ERROR = CheckError(5, "Could not complete the directory bind to verify SSSD's credentials ({}).")
+
+    # --- Warnings (advisories and coverage gaps that do not by themselves break identity) ------
+    LOOKUP_ELEVATED = CheckWarning(
         1,
         "Directory lookups are elevated or unresolved: {}. They are expected to resolve quickly and reliably.",
     )
-    NO_LOOKUP_TARGETS = CheckInfo(
-        1,
-        "No lookup users/groups could be derived: sssd.conf has no simple_allow_groups/simple_allow_users "
-        "and no DomainReadOnlyUser (cluster config) or ldap_default_bind_dn (sssd.conf) fallback.",
+    AD_NOT_MANAGED_BY_CLUSTER_CONFIG = CheckWarning(
+        2,
+        "An Active Directory integration is configured in {} but the cluster configuration has no "
+        "DirectoryService section.",
+    )
+    NSS_SLURM_PLUGIN_DISABLED = CheckWarning(
+        3,
+        "The Slurm NSS plugin is not enabled ({} is absent from LaunchParameters in slurm.conf); it is "
+        "expected to be enabled to reduce directory-lookup load on compute nodes.",
+    )
+    SSSD_CACHE_CREDENTIALS_DISABLED = CheckWarning(
+        4,
+        "SSSD credential caching is not enabled (cache_credentials is not set to True in {}); it is "
+        "expected to be enabled so SSSD can serve cached identities when the backend is slow or briefly "
+        "unavailable.",
+    )
+    USER_NOT_UNDER_SEARCH_BASE = CheckWarning(
+        5,
+        "Allow-listed user(s) not found under the configured LDAP search base '{}': {}. They are "
+        "expected to resolve under the search base (ldap_search_base / ldap_user_search_base).",
+    )
+    BACKEND_STATUS_UNAVAILABLE = CheckWarning(
+        6, "Could not determine the directory backend status: sssctl is unavailable or reported no status."
+    )
+    CERTIFICATE_NOT_VALIDATED = CheckWarning(
+        7,
+        "Could not validate the directory endpoint TLS certificate: openssl is not available.",
+    )
+    BIND_LDAPSEARCH_UNAVAILABLE = CheckWarning(
+        8, "Could not verify the directory bind credentials: ldapsearch is not available."
+    )
+    SEARCH_BASE_LDAPSEARCH_UNAVAILABLE = CheckWarning(
+        9, "Could not check the LDAP search base: ldapsearch is not available."
     )
 
     @property
     def description(self) -> str:
         """Return the human-readable description of this Check."""
-        return "Measure directory service (NSS/SSSD/AD) lookup latency for cluster users and groups."
+        return "Verify that the directory service (NSS/SSSD/AD) integration is healthy."
 
     def should_run(self, context: Context) -> bool:
         """Run only when the node integrates a directory service (via cluster config or sssd.conf)."""
         return _ad_integration_configured(context)
 
     def run(self, context: Context) -> Result:
-        """Time getent/id lookups and fail when any exceeds the fail threshold or times out.
+        """Run every directory probe in isolation, accumulate findings, and derive the aggregate Result."""
+        errors: List[CheckError] = []
+        warnings: List[CheckWarning] = []
 
-        When no lookup targets can be derived, the check does not apply, so it is recorded as
-        SKIPPED_NOT_APPLICABLE. Lookups over the fail threshold (or that time out) produce a FAILURE.
-        Elevated-but-tolerable latency, or a name that does not resolve, produces a WARNING.
+        probes = (
+            ("directory-service management", lambda: self._probe_managed_by_cluster_config(context, warnings)),
+            ("resiliency settings", lambda: self._probe_resiliency_settings(context, warnings)),
+            ("lookup latency", lambda: self._probe_lookup_latency(context, errors, warnings)),
+            ("backend reachability", lambda: self._probe_backend_reachable(errors, warnings)),
+            ("endpoint certificate", lambda: self._probe_endpoint_certificate(errors, warnings)),
+            ("bind credentials", lambda: self._probe_bind_credentials(errors, warnings)),
+            ("search-base membership", lambda: self._probe_users_under_search_base(warnings)),
+        )
+        for label, probe in probes:
+            run_probe(label, probe, errors)
+
+        return Result.from_findings(self, errors=errors, warnings=warnings)
+
+    # --- Probes -------------------------------------------------------------------------------
+
+    def _probe_managed_by_cluster_config(self, context: Context, warnings: List[CheckWarning]) -> None:
+        """Warn when the AD/LDAP integration exists on the node but is not declared in the cluster config."""
+        if _directory_service_config(context):
+            return
+        warnings.append(self.AD_NOT_MANAGED_BY_CLUSTER_CONFIG.format(SSSD_CONF_PATH))
+
+    def _probe_resiliency_settings(self, context: Context, warnings: List[CheckWarning]) -> None:
+        """Warn when the Slurm NSS plugin or SSSD credential caching (which reduce lookup load) is disabled."""
+        if _nss_slurm_enabled(context) is False:
+            warnings.append(self.NSS_SLURM_PLUGIN_DISABLED.format(NSS_SLURM_LAUNCH_PARAMETER))
+        if not _cache_credentials_enabled():
+            warnings.append(self.SSSD_CACHE_CREDENTIALS_DISABLED.format(SSSD_CONF_PATH))
+
+    def _probe_lookup_latency(self, context: Context, errors: List[CheckError], warnings: List[CheckWarning]) -> None:
+        """Time getent/id lookups; fail on slow/timed-out lookups, warn on elevated latency or non-resolution.
+
+        When no lookup targets can be derived, the check does not apply.
         """
         groups, users = self._derive_targets(context)
         if not groups and not users:
-            return Result.skipped_not_applicable(self, infos=[self.NO_LOOKUP_TARGETS])
+            return
 
         probes = []
         for group in groups:
-            probes.append(self._probe(["getent", "group", group], "getent group {}".format(group)))
+            probes.append(self._classify_lookup(["getent", "group", group], "getent group {}".format(group)))
         for user in users:
-            probes.append(self._probe(["getent", "passwd", user], "getent passwd {}".format(user)))
-            probes.append(self._probe(["id", user], "id {}".format(user)))
+            probes.append(self._classify_lookup(["getent", "passwd", user], "getent passwd {}".format(user)))
+            probes.append(self._classify_lookup(["id", user], "id {}".format(user)))
 
         failures = [text for status, text in probes if status == _STATUS_FAIL]
         if failures:
-            return Result.failure(self, errors=[self.SLOW_OR_FAILING_LOOKUPS.format("; ".join(failures))])
+            errors.append(self.LOOKUP_SLOW_OR_FAILING.format("; ".join(failures)))
+            return
 
-        warnings = [text for status, text in probes if status == _STATUS_WARN]
-        if warnings:
-            return Result.warning(self, warnings=[self.ELEVATED_OR_UNRESOLVED_LOOKUPS.format("; ".join(warnings))])
-        return Result.passed(self)
+        elevated = [text for status, text in probes if status == _STATUS_WARN]
+        if elevated:
+            warnings.append(self.LOOKUP_ELEVATED.format("; ".join(elevated)))
 
-    def _probe(self, command: List[str], label: str) -> Tuple[str, str]:
+    def _probe_backend_reachable(self, errors: List[CheckError], warnings: List[CheckWarning]) -> None:
+        """Fail when SSSD reports the backend offline; warn when the status cannot be determined.
+
+        A ``getent``/``id`` lookup can be served from the SSSD cache, so passing latency does not prove the
+        backend is reachable. This consults SSSD directly (``sssctl domain-status``). When sssctl is
+        unavailable or reports no parseable status, the backend cannot be assessed, so it warns.
+        """
+        status = _sssd_backend_status()
+        if status is None:
+            warnings.append(self.BACKEND_STATUS_UNAVAILABLE)
+            return
+        if status.online is False:
+            errors.append(self.BACKEND_OFFLINE.format(status.summary))
+
+    def _probe_endpoint_certificate(self, errors: List[CheckError], warnings: List[CheckWarning]) -> None:
+        """Fail when a directory endpoint's TLS certificate does not validate and ``reqcert`` is strict.
+
+        Contributes nothing when no ``ldaps://`` endpoint is configured.
+        """
+        cacert, reqcert = _ldap_tls_settings()
+        ldaps_endpoints = [(host, port) for _uri, host, port, scheme in _ldap_endpoints() if scheme == "ldaps"]
+        if not ldaps_endpoints:
+            return
+
+        outcome = self._evaluate_endpoints(cacert, ldaps_endpoints)
+        if outcome is None:  # openssl not installed / not on PATH
+            warnings.append(self.CERTIFICATE_NOT_VALIDATED)
+            return
+
+        _validated, problems = outcome
+        if not problems:
+            return
+
+        # SSSD's reqcert default is "hard" when unset; hard/demand make an invalid cert fatal.
+        if reqcert in ("", "hard", "demand"):
+            detail = "; ".join(problems)
+            errors.append(self.CERTIFICATE_INVALID.format(detail, reqcert or "hard (default)"))
+
+    def _probe_bind_credentials(self, errors: List[CheckError], warnings: List[CheckWarning]) -> None:
+        """Fail when the configured bind DN/password is rejected; warn when ldapsearch is unavailable.
+
+        Contributes nothing when no verifiable plaintext bind is configured (missing or obfuscated
+        authtok) or no endpoint is configured. A rejected credential is authoritative regardless of
+        endpoint; only when every endpoint fails to bind for another reason is the last such error a
+        failure.
+        """
+        credentials = _ldap_bind_credentials()
+        endpoints = _ldap_endpoints()
+        if credentials is None or not endpoints:
+            return
+
+        bind_dn, password = credentials
+        cacert, reqcert = _ldap_tls_settings()
+        bind_error = None
+        for uri, _host, _port, _scheme in endpoints:
+            try:
+                probe = ldap.ldap_bind_search(
+                    uri, bind_dn, password, base="", attributes=["1.1"], cacert=cacert, reqcert=reqcert
+                )
+            except OSError as error:  # ldapsearch not installed / not on PATH
+                logger.warning("Could not run ldapsearch to verify bind credentials: %s", error)
+                warnings.append(self.BIND_LDAPSEARCH_UNAVAILABLE)
+                return
+
+            if probe.succeeded:
+                return
+            if probe.returncode == ldap.LDAP_INVALID_CREDENTIALS_CODE:
+                errors.append(self.BIND_CREDENTIALS_INVALID)
+                return
+            bind_error = (
+                "timed out" if probe.timed_out else "exit code {}: {}".format(probe.returncode, probe.stderr.strip())
+            )
+        errors.append(self.BIND_ERROR.format(bind_error))
+
+    def _probe_users_under_search_base(self, warnings: List[CheckWarning]) -> None:
+        """Warn when an allow-listed user is not found under the configured LDAP search base.
+
+        Contributes nothing when the search cannot be set up (no plaintext bind, search base, endpoint, or
+        allow-listed users) or when no endpoint yields a completable search (a bind/connectivity concern
+        reported by the bind/backend probes). Warns when ldapsearch is unavailable.
+        """
+        credentials = _ldap_bind_credentials()
+        base = _ldap_search_base()
+        endpoints = _ldap_endpoints()
+        users = [user for user in _split_csv(_read_sssd_value("simple_allow_users")) if user not in ("root", "nobody")]
+        if credentials is None or not base or not endpoints or not users:
+            return
+
+        bind_dn, password = credentials
+        cacert, reqcert = _ldap_tls_settings()
+        for uri, _host, _port, _scheme in endpoints:
+            try:
+                missing = self._missing_users(uri, users, base, bind_dn, password, cacert, reqcert)
+            except OSError as error:  # ldapsearch not installed / not on PATH
+                logger.warning("Could not run ldapsearch to check the search base: %s", error)
+                warnings.append(self.SEARCH_BASE_LDAPSEARCH_UNAVAILABLE)
+                return
+            if missing is None:
+                continue  # bind/connectivity error on this endpoint: try the next one
+            if missing:
+                warnings.append(self.USER_NOT_UNDER_SEARCH_BASE.format(base, ", ".join(missing)))
+            return
+
+    # --- Probe helpers ------------------------------------------------------------------------
+
+    def _classify_lookup(self, command: List[str], label: str) -> Tuple[str, str]:
         """Run one timed lookup and return ``(status, text)`` classified against the latency thresholds.
 
         ``status`` is one of the ``_STATUS_*`` tokens; ``text`` is a human-readable "``label (detail)``"
-        summary used verbatim in the Result message.
+        summary used verbatim in the finding message.
         """
         timed = time_command(command, timeout=DIRECTORY_LOOKUP_COMMAND_TIMEOUT_SECONDS)
         if timed.timed_out:
@@ -150,8 +333,7 @@ class DirectoryLookupLatency(Check):
         Returns a ``(groups, users)`` tuple. ``root`` and ``nobody`` are filtered out as local accounts.
         When neither simple_allow_* list yields a target (e.g. the cluster uses an LDAP access filter
         instead of the simple access provider), fall back to a single known directory account so the
-        latency probe can still run. Missing/unparseable sources yield empty lists (the Check then
-        reports SKIPPED_NOT_APPLICABLE).
+        latency probe can still run. Missing/unparseable sources yield empty lists.
         """
         groups = _split_csv(_read_sssd_value("simple_allow_groups"))
         users = [user for user in _split_csv(_read_sssd_value("simple_allow_users")) if user not in ("root", "nobody")]
@@ -176,168 +358,6 @@ class DirectoryLookupLatency(Check):
         else:
             raw = _read_sssd_value("ldap_default_bind_dn")
         return _principal_from_dn(raw)
-
-
-class DirectoryServiceManagedByClusterConfig(Check):
-    """Warn when an AD/LDAP integration exists on the node but is not declared in the cluster config."""
-
-    AD_NOT_MANAGED_BY_CLUSTER_CONFIG = CheckWarning(
-        1,
-        "An Active Directory integration is configured in {} but the cluster configuration has no "
-        "DirectoryService section. The integration was set up outside ParallelCluster, so ParallelCluster cannot manage"
-        " or validate it and the configuration may be "
-        "lost on a cluster update. Move the integration into the cluster configuration's DirectoryService section.",
-    )
-
-    @property
-    def description(self) -> str:
-        """Return the human-readable description of this Check."""
-        return "Verify that an Active Directory integration is managed through the cluster configuration."
-
-    def should_run(self, context: Context) -> bool:
-        """Run only when the node has an AD/LDAP integration (via cluster config or sssd.conf)."""
-        return _ad_integration_configured(context)
-
-    def run(self, context: Context) -> Result:
-        """Pass when the integration is declared in the cluster config; warn otherwise."""
-        if _directory_service_config(context):
-            return Result.passed(self)
-        return Result.warning(self, warnings=[self.AD_NOT_MANAGED_BY_CLUSTER_CONFIG.format(SSSD_CONF_PATH)])
-
-
-class DirectoryLookupResiliencySettings(Check):
-    """Warn when the settings that reduce directory-lookup load are not enabled."""
-
-    NSS_SLURM_PLUGIN_DISABLED = CheckWarning(
-        1,
-        "The Slurm NSS plugin is not enabled ({} is absent from LaunchParameters in slurm.conf); it is "
-        "expected to be enabled to reduce directory-lookup load on compute nodes.",
-    )
-    SSSD_CACHE_CREDENTIALS_DISABLED = CheckWarning(
-        2,
-        "SSSD credential caching is not enabled (cache_credentials is not set to True in {}); it is "
-        "expected to be enabled so SSSD can serve cached identities when the backend is slow or briefly "
-        "unavailable.",
-    )
-
-    @property
-    def description(self) -> str:
-        """Return the human-readable description of this Check."""
-        return "Verify the settings that reduce directory-lookup load (Slurm NSS plugin, SSSD credential caching)."
-
-    def should_run(self, context: Context) -> bool:
-        """Run only when the node has an AD/LDAP integration (via cluster config or sssd.conf)."""
-        return _ad_integration_configured(context)
-
-    def run(self, context: Context) -> Result:
-        """Warn when the Slurm NSS plugin or SSSD credential caching is not enabled; pass otherwise."""
-        advisories = []
-        if _nss_slurm_enabled(context) is False:
-            advisories.append(self.NSS_SLURM_PLUGIN_DISABLED.format(NSS_SLURM_LAUNCH_PARAMETER))
-        if not _cache_credentials_enabled():
-            advisories.append(self.SSSD_CACHE_CREDENTIALS_DISABLED.format(SSSD_CONF_PATH))
-        if advisories:
-            return Result.warning(self, warnings=advisories)
-        return Result.passed(self)
-
-
-class DirectoryBackendIsReachable(Check):
-    """Fail when SSSD reports the directory backend offline.
-
-    A ``getent``/``id`` lookup can be served from the SSSD cache, so DirectoryLookupLatency passing does
-    not prove the backend is reachable. This check consults SSSD directly (``sssctl domain-status``): an
-    offline backend means identities are being served from cache and will start failing once it expires,
-    which can stall slurmctld and block logins.
-    """
-
-    BACKEND_OFFLINE = CheckError(
-        1,
-        "SSSD reports the directory backend offline: {}.",
-    )
-    STATUS_UNAVAILABLE = CheckInfo(
-        1, "Could not determine the backend status: sssctl is unavailable or reported no status."
-    )
-
-    @property
-    def description(self) -> str:
-        """Return the human-readable description of this Check."""
-        return "Verify that SSSD reports the directory backend (AD/LDAP) online."
-
-    def should_run(self, context: Context) -> bool:
-        """Run only when the node has an AD/LDAP integration (via cluster config or sssd.conf)."""
-        return _ad_integration_configured(context)
-
-    def run(self, context: Context) -> Result:
-        """Fail when SSSD reports the backend offline; skip when the status cannot be determined.
-
-        The backend state comes from a read-only ``sssctl domain-status``. When sssctl is unavailable,
-        errors, or reports no parseable status (``_sssd_backend_status`` returns None), the check cannot
-        assess anything and records SKIPPED_NOT_APPLICABLE.
-        """
-        status = _sssd_backend_status()
-        if status is None:
-            return Result.skipped_not_applicable(self, infos=[self.STATUS_UNAVAILABLE])
-        if status.online is False:
-            return Result.failure(self, errors=[self.BACKEND_OFFLINE.format(status.summary)])
-        return Result.passed(self)
-
-
-class DirectoryEndpointCertificateIsValid(Check):
-    """Verify the TLS certificate the directory endpoint presents validates against the configured CA.
-
-    SSSD connects to AD/LDAP over TLS (``ldaps://``). If the server certificate does not validate, then
-    with ``ldap_tls_reqcert = demand`` (SSSD's default) SSSD refuses the connection and identity lookups
-    fail cluster-wide, so this check fails. With a relaxed ``reqcert`` (allow/never/try) SSSD proceeds
-    despite the invalid certificate, so the check passes. It runs a read-only openssl TLS handshake.
-    """
-
-    INVALID_CERTIFICATE = CheckError(
-        1,
-        "The directory endpoint TLS certificate did not validate: {}. With ldap_tls_reqcert={}, SSSD "
-        "refuses the connection, so identity lookups fail cluster-wide. Fix the certificate or the "
-        "configured CA (ldap_tls_cacert).",
-    )
-    NO_TLS_ENDPOINT = CheckInfo(1, "No TLS (ldaps://) directory endpoint is configured in ldap_uri.")
-    OPENSSL_UNAVAILABLE = CheckInfo(2, "openssl is not available to validate the endpoint certificate.")
-    NOT_VALIDATED = CheckInfo(3, "No configured directory endpoint could be reached to validate its certificate.")
-
-    @property
-    def description(self) -> str:
-        """Return the human-readable description of this Check."""
-        return "Verify that the directory endpoint's TLS certificate validates against the configured CA."
-
-    def should_run(self, context: Context) -> bool:
-        """Run only when at least one configured directory endpoint uses TLS (``ldaps://``)."""
-        return any(scheme == "ldaps" for _uri, _host, _port, scheme in _ldap_endpoints())
-
-    def run(self, context: Context) -> Result:
-        """Fail when a directory endpoint's TLS certificate does not validate and ``reqcert`` is strict.
-
-        With a relaxed ``reqcert`` an invalid certificate is not flagged (SSSD proceeds anyway).
-        Endpoints that cannot be reached (no handshake / no verify code) are left to
-        DirectoryBackendIsReachable and do not count here; if none could be validated, or openssl is
-        unavailable, the check records SKIPPED_NOT_APPLICABLE.
-        """
-        cacert, reqcert = _ldap_tls_settings()
-        ldaps_endpoints = [(host, port) for _uri, host, port, scheme in _ldap_endpoints() if scheme == "ldaps"]
-        if not ldaps_endpoints:
-            return Result.skipped_not_applicable(self, infos=[self.NO_TLS_ENDPOINT])
-
-        outcome = self._evaluate_endpoints(cacert, ldaps_endpoints)
-        if outcome is None:  # openssl not installed / not on PATH
-            return Result.skipped_not_applicable(self, infos=[self.OPENSSL_UNAVAILABLE])
-
-        validated, problems = outcome
-        if not problems:
-            if validated:
-                return Result.passed(self)
-            return Result.skipped_not_applicable(self, infos=[self.NOT_VALIDATED])
-
-        # SSSD's reqcert default is "hard" when unset; hard/demand make an invalid cert fatal.
-        detail = "; ".join(problems)
-        if reqcert in ("", "hard", "demand"):
-            return Result.failure(self, errors=[self.INVALID_CERTIFICATE.format(detail, reqcert or "hard (default)")])
-        return Result.passed(self)
 
     @staticmethod
     def _evaluate_endpoints(cacert, endpoints) -> Optional[Tuple[int, List[str]]]:
@@ -365,139 +385,6 @@ class DirectoryEndpointCertificateIsValid(Check):
             if validated_state is False:
                 problems.append("{}:{} ({})".format(host, port, ldap.tls_verify_error_reason(combined_output)))
         return validated, problems
-
-
-class DirectoryBindCredentialsAreValid(Check):
-    """Verify SSSD's configured bind DN and password authenticate against the directory.
-
-    SSSD binds to AD/LDAP with ``ldap_default_bind_dn`` / ``ldap_default_authtok`` to resolve identities.
-    If those credentials are wrong or expired, every lookup fails. This check reproduces the bind with a
-    read-only ``ldapsearch``. It can only run when the password is stored in plaintext
-    (``ldap_default_authtok_type = password``); an obfuscated token cannot be verified read-only.
-    """
-
-    INVALID_CREDENTIALS = CheckError(
-        1,
-        "The directory rejected SSSD's configured bind credentials (ldap_default_bind_dn / ldap_default_authtok).",
-    )
-    BIND_ERROR = CheckError(
-        2,
-        "Could not complete the directory bind to verify SSSD's credentials ({}).",
-    )
-    CANNOT_VERIFY = CheckInfo(
-        1,
-        "Cannot verify the bind: ldap_default_bind_dn/ldap_default_authtok is missing or obfuscated "
-        "(only a plaintext authtok can be verified), or no ldap_uri is configured.",
-    )
-    LDAPSEARCH_UNAVAILABLE = CheckInfo(2, "ldapsearch is not available to verify the bind credentials.")
-
-    @property
-    def description(self) -> str:
-        """Return the human-readable description of this Check."""
-        return "Verify that SSSD's configured bind DN and password authenticate against the directory."
-
-    def should_run(self, context: Context) -> bool:
-        """Run only when the node has an AD/LDAP integration (via cluster config or sssd.conf)."""
-        return _ad_integration_configured(context)
-
-    def run(self, context: Context) -> Result:
-        """Fail when the configured bind DN/password is rejected; skip when it cannot be verified.
-
-        Each configured endpoint is tried in turn: a successful bind against any of them passes, and a
-        rejected credential is authoritative regardless of endpoint. Only when every endpoint fails to
-        bind for another reason (unreachable / TLS) is the last such error reported.
-        """
-        credentials = _ldap_bind_credentials()
-        endpoints = _ldap_endpoints()
-        if credentials is None or not endpoints:
-            return Result.skipped_not_applicable(self, infos=[self.CANNOT_VERIFY])
-
-        bind_dn, password = credentials
-        cacert, reqcert = _ldap_tls_settings()
-        bind_error = None
-        for uri, _host, _port, _scheme in endpoints:
-            try:
-                # A base-scoped search of the rootDSE exercises only the bind, and needs no search base.
-                probe = ldap.ldap_bind_search(
-                    uri, bind_dn, password, base="", attributes=["1.1"], cacert=cacert, reqcert=reqcert
-                )
-            except OSError as error:  # ldapsearch not installed / not on PATH
-                logger.warning("Could not run ldapsearch to verify bind credentials: %s", error)
-                return Result.skipped_not_applicable(self, infos=[self.LDAPSEARCH_UNAVAILABLE])
-
-            if probe.succeeded:
-                return Result.passed(self)
-            if probe.returncode == ldap.LDAP_INVALID_CREDENTIALS_CODE:
-                return Result.failure(self, errors=[self.INVALID_CREDENTIALS])
-            bind_error = (
-                "timed out" if probe.timed_out else "exit code {}: {}".format(probe.returncode, probe.stderr.strip())
-            )
-        return Result.failure(self, errors=[self.BIND_ERROR.format(bind_error)])
-
-
-class DirectoryUsersResolveUnderSearchBase(Check):
-    """Verify the allow-listed users are found under the configured LDAP search base.
-
-    SSSD only resolves identities that fall under ``ldap_search_base`` (or ``ldap_user_search_base``). A
-    user configured in ``simple_allow_users`` that does not appear under that base cannot log in, even
-    though the endpoint and credentials are healthy, which points at a mis-scoped search base. This check
-    searches the base directly with a read-only ``ldapsearch``.
-    """
-
-    USER_NOT_UNDER_BASE = CheckWarning(
-        1,
-        "Allow-listed user(s) not found under the configured LDAP search base '{}': {}. They are "
-        "expected to resolve under the search base (ldap_search_base / ldap_user_search_base).",
-    )
-    CANNOT_VERIFY = CheckInfo(
-        1,
-        "Cannot verify search-base membership: a plaintext bind (ldap_default_bind_dn/authtok), a search "
-        "base (ldap_search_base/ldap_user_search_base), an ldap_uri, and simple_allow_users are all "
-        "required.",
-    )
-    LDAPSEARCH_UNAVAILABLE = CheckInfo(2, "ldapsearch is not available to search the configured base.")
-    SEARCH_INCOMPLETE = CheckInfo(3, "A directory search could not be completed (bind or connectivity error).")
-
-    @property
-    def description(self) -> str:
-        """Return the human-readable description of this Check."""
-        return "Verify that allow-listed users are found under the configured LDAP search base."
-
-    def should_run(self, context: Context) -> bool:
-        """Run only when the node has an AD/LDAP integration (via cluster config or sssd.conf)."""
-        return _ad_integration_configured(context)
-
-    def run(self, context: Context) -> Result:
-        """Warn when an allow-listed user is not found under the search base; skip when unverifiable.
-
-        Verification needs a plaintext bind, a search base, an endpoint, and allow-listed users; when any
-        is missing, or a search cannot be completed (bind/connectivity error), the check records
-        SKIPPED_NOT_APPLICABLE rather than reporting a false "not found".
-        """
-        credentials = _ldap_bind_credentials()
-        base = _ldap_search_base()
-        endpoints = _ldap_endpoints()
-        users = [user for user in _split_csv(_read_sssd_value("simple_allow_users")) if user not in ("root", "nobody")]
-        if credentials is None or not base or not endpoints or not users:
-            return Result.skipped_not_applicable(self, infos=[self.CANNOT_VERIFY])
-
-        bind_dn, password = credentials
-        cacert, reqcert = _ldap_tls_settings()
-        # Try each endpoint until one yields a completable search; the membership answer is the same for
-        # any healthy endpoint, so the first that completes is authoritative.
-        for uri, _host, _port, _scheme in endpoints:
-            try:
-                missing = self._missing_users(uri, users, base, bind_dn, password, cacert, reqcert)
-            except OSError as error:  # ldapsearch not installed / not on PATH
-                logger.warning("Could not run ldapsearch to check the search base: %s", error)
-                return Result.skipped_not_applicable(self, infos=[self.LDAPSEARCH_UNAVAILABLE])
-            if missing is None:
-                continue  # bind/connectivity error on this endpoint: try the next one
-            if missing:
-                return Result.warning(self, warnings=[self.USER_NOT_UNDER_BASE.format(base, ", ".join(missing))])
-            return Result.passed(self)
-        # No endpoint yielded a completable search; a bind/connectivity error is not a membership answer.
-        return Result.skipped_not_applicable(self, infos=[self.SEARCH_INCOMPLETE])
 
     @staticmethod
     def _missing_users(uri, users, base, bind_dn, password, cacert, reqcert) -> Optional[List[str]]:

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/probe.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/probe.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for running a diagnostic probe in isolation and recording an unexpected failure as a finding.
+
+A capability Check composed of several probes uses these so one probe's crash becomes an unexpected-error
+finding (which ``Result.from_findings`` reports as CHECK_ERROR) instead of aborting the whole check and
+discarding the findings the other probes already produced. This logic manipulates models, so it lives in
+``core`` rather than in the model package.
+"""
+
+import logging
+from typing import Callable, List
+
+from pcluster_diag.models.finding import CheckError
+from pcluster_diag.models.result import INTERNAL_ERROR_CODE
+
+logger = logging.getLogger(__name__)
+
+
+def unexpected_error_finding(detail: str) -> CheckError:
+    """Return the shared unexpected-error finding (code E0) for an uncaught failure inside a check/probe."""
+    return CheckError(
+        INTERNAL_ERROR_CODE, "A diagnostic probe did not complete due to an unexpected error: {}".format(detail)
+    )
+
+
+def run_probe(label: str, probe: Callable[[], None], errors: List[CheckError]) -> None:
+    """Run ``probe`` in isolation, converting an unexpected exception into a shared E0 error finding.
+
+    ``probe`` is a zero-argument callable that records its own findings as a side effect; ``errors`` is the
+    shared error list the crash finding is appended to. Expected conditions are handled inside each probe;
+    only an unexpected exception is caught here so one probe's crash does not sink its siblings' findings.
+    """
+    try:
+        probe()
+    except Exception as exc:  # noqa: B902 - isolation: one probe's crash must not sink the others
+        logger.exception("Diagnostic probe '%s' failed unexpectedly", label)
+        errors.append(unexpected_error_finding("{} ({}: {})".format(label, type(exc).__name__, exc)))

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/registry.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/registry.py
@@ -23,15 +23,7 @@ import click
 from pcluster_diag.checks.cfn_hup import CfnHupRunsOnlyOnHeadNode
 from pcluster_diag.checks.critical_paths import CriticalPathsHaveExpectedPermissions
 from pcluster_diag.checks.daemon_health import ClusterDaemonsAreRunning, ClustermgtdHeartbeatIsHealthy
-from pcluster_diag.checks.directory_lookup import (
-    DirectoryBackendIsReachable,
-    DirectoryBindCredentialsAreValid,
-    DirectoryEndpointCertificateIsValid,
-    DirectoryLookupLatency,
-    DirectoryLookupResiliencySettings,
-    DirectoryServiceManagedByClusterConfig,
-    DirectoryUsersResolveUnderSearchBase,
-)
+from pcluster_diag.checks.directory_lookup import DirectoryService
 from pcluster_diag.checks.imds import Imds
 from pcluster_diag.checks.instance_profile import ImdsRoleMatchesCfnHupConfig
 from pcluster_diag.checks.reserved_users import ReservedUsersAndGroups
@@ -145,11 +137,5 @@ DEFAULT_REGISTRY = (
     .register(ImdsRoleMatchesCfnHupConfig())
     .register(ClusterDaemonsAreRunning())
     .register(ClustermgtdHeartbeatIsHealthy())
-    .register(DirectoryServiceManagedByClusterConfig())
-    .register(DirectoryLookupResiliencySettings())
-    .register(DirectoryLookupLatency())
-    .register(DirectoryBackendIsReachable())
-    .register(DirectoryEndpointCertificateIsValid())
-    .register(DirectoryBindCredentialsAreValid())
-    .register(DirectoryUsersResolveUnderSearchBase())
+    .register(DirectoryService())
 )

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/result.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/result.py
@@ -38,6 +38,23 @@ FAILED_STATUSES = (Status.FAILURE, Status.CHECK_ERROR)
 INTERNAL_ERROR_CODE = 0
 
 
+def _is_unexpected_error(finding) -> bool:
+    """Return whether ``finding`` is an unexpected-error finding (carries the reserved E0 code)."""
+    return finding.code == "E{}".format(INTERNAL_ERROR_CODE)
+
+
+def _dedupe(findings):
+    """Return ``findings`` with exact duplicates (same code and message) removed, preserving order."""
+    seen = set()
+    unique = []
+    for finding in findings:
+        key = (finding.code, finding.message)
+        if key not in seen:
+            seen.add(key)
+            unique.append(finding)
+    return unique
+
+
 @dataclass
 class Result:
     """The outcome of executing a Check.
@@ -69,6 +86,38 @@ class Result:
             check_id=check.identifier,
             check_description=check.description,
             status=Status.PASSED,
+        )
+
+    @staticmethod
+    def from_findings(check, errors=None, warnings=None, infos=None) -> "Result":
+        """Build a Result for ``check`` whose status is derived from its findings by severity precedence.
+
+        The severity precedence is FAILURE > CHECK_ERROR > WARNING > PASSED:
+
+        - FAILURE when any *expected* error is present (a real problem the check detected);
+        - else CHECK_ERROR when the only errors are *unexpected* ones (code E0, from an isolated probe
+          crash) -- the check could not fully complete, but no real problem was confirmed;
+        - else WARNING when any warning is present;
+        - else PASSED.
+        """
+        errors = _dedupe(errors or [])
+        warnings = _dedupe(warnings or [])
+        infos = _dedupe(infos or [])
+        if any(not _is_unexpected_error(error) for error in errors):
+            status = Status.FAILURE
+        elif errors:
+            status = Status.CHECK_ERROR
+        elif warnings:
+            status = Status.WARNING
+        else:
+            status = Status.PASSED
+        return Result(
+            check_id=check.identifier,
+            check_description=check.description,
+            status=status,
+            errors=errors or None,
+            warnings=warnings or None,
+            infos=infos or None,
         )
 
     @staticmethod

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_directory_lookup.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_directory_lookup.py
@@ -10,26 +10,18 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for the directory-service checks: lookup latency, cluster-config management, resiliency."""
+"""Unit tests for the merged DirectoryService check: aggregate Result plus per-probe behavior."""
 
 import pytest
 
 from pcluster_diag.checks import directory_lookup
-from pcluster_diag.checks.directory_lookup import (
-    DirectoryBackendIsReachable,
-    DirectoryBindCredentialsAreValid,
-    DirectoryEndpointCertificateIsValid,
-    DirectoryLookupLatency,
-    DirectoryLookupResiliencySettings,
-    DirectoryServiceManagedByClusterConfig,
-    DirectoryUsersResolveUnderSearchBase,
-)
+from pcluster_diag.checks.directory_lookup import DirectoryService
 from pcluster_diag.core.constants import (
     DIRECTORY_LOOKUP_FAIL_THRESHOLD_SECONDS,
     DIRECTORY_LOOKUP_WARN_THRESHOLD_SECONDS,
 )
 from pcluster_diag.models.context import NodeType
-from pcluster_diag.models.result import Status
+from pcluster_diag.models.result import INTERNAL_ERROR_CODE, Status
 from pcluster_diag.models.sssd_backend_status import SssdBackendStatus
 from pcluster_diag.util.ldap import LDAP_INVALID_CREDENTIALS_CODE, ProbeResult
 from pcluster_diag.util.shell import TimedCommand
@@ -65,109 +57,194 @@ def _context_with_directory_service(directory_service=None):
 
 
 def _use_targets(monkeypatch, groups, users):
-    monkeypatch.setattr(DirectoryLookupLatency, "_derive_targets", lambda self, context: (groups, users))
+    monkeypatch.setattr(DirectoryService, "_derive_targets", lambda self, context: (groups, users))
 
 
-# --- DirectoryLookupLatency: description / should_run ----------------------------------
+# --- DirectoryService: description / should_run ---------------------------------------
 
 
 def test_description():
-    assert DirectoryLookupLatency().description == (
-        "Measure directory service (NSS/SSSD/AD) lookup latency for cluster users and groups."
-    )
+    assert DirectoryService().description == "Verify that the directory service (NSS/SSSD/AD) integration is healthy."
 
 
 def test_should_run_when_directory_service_in_cluster_config():
-    assert DirectoryLookupLatency().should_run(_context_with_directory_service()) is True
+    assert DirectoryService().should_run(_context_with_directory_service()) is True
 
 
 def test_should_run_when_ad_configured_only_in_sssd(tmp_path):
     _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\n")
-    assert DirectoryLookupLatency().should_run(sample_context(NodeType.HEAD)) is True
+    assert DirectoryService().should_run(sample_context(NodeType.HEAD)) is True
 
 
 def test_should_not_run_without_any_directory_integration():
     # No DirectoryService in cluster config and no (isolated) sssd.conf on disk.
-    assert DirectoryLookupLatency().should_run(sample_context(NodeType.HEAD)) is False
+    assert DirectoryService().should_run(sample_context(NodeType.HEAD)) is False
 
 
-# --- DirectoryLookupLatency: run -------------------------------------------------------
+# --- DirectoryService.run: aggregation and finding-derived status ---------------------
 
 
-def test_run_not_applicable_when_no_targets_derivable(monkeypatch):
-    _use_targets(monkeypatch, [], [])
+@pytest.fixture
+def _silence_backend_and_nss(monkeypatch):
+    """Make the backend and NSS-plugin probes contribute nothing, so other findings are isolated."""
+    monkeypatch.setattr(
+        directory_lookup, "_sssd_backend_status", lambda: SssdBackendStatus("default: Online status: Online", True)
+    )
+    monkeypatch.setattr(directory_lookup, "_nss_slurm_enabled", lambda context: True)
 
-    result = DirectoryLookupLatency().run(_context_with_directory_service())
 
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
-    assert [info.code for info in result.infos] == [DirectoryLookupLatency.NO_LOOKUP_TARGETS.code]
+def test_run_passes_when_capability_clean(tmp_path, _silence_backend_and_nss):
+    # AD managed by cluster config, caching on, no ldaps/creds/users/targets => every probe is silent.
+    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\ncache_credentials = True\n")
 
-
-def test_run_passes_when_all_lookups_fast(monkeypatch):
-    _use_targets(monkeypatch, ["hpc-users"], ["alice"])
-    monkeypatch.setattr(directory_lookup, "time_command", lambda command, timeout: _timed(elapsed=0.2))
-
-    result = DirectoryLookupLatency().run(_context_with_directory_service())
+    result = DirectoryService().run(_context_with_directory_service())
 
     assert result.status is Status.PASSED
     assert result.errors is None
+    assert result.warnings is None
 
 
-def test_run_warns_when_latency_between_thresholds(monkeypatch):
-    # Elevated-but-tolerable latency (between warn and fail thresholds) surfaces as a WARNING.
+def test_run_warns_when_backend_status_cannot_be_assessed(tmp_path, monkeypatch):
+    # sssctl unavailable / no parseable status => cannot assess => WARNING (not silent, not failure).
+    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\ncache_credentials = True\n")
+    monkeypatch.setattr(directory_lookup, "_nss_slurm_enabled", lambda context: True)
+    monkeypatch.setattr(directory_lookup, "_sssd_backend_status", lambda: None)
+
+    result = DirectoryService().run(_context_with_directory_service())
+
+    assert result.status is Status.WARNING
+    assert DirectoryService.BACKEND_STATUS_UNAVAILABLE.code in [warning.code for warning in result.warnings]
+
+
+def test_run_isolates_unexpected_probe_crash_and_keeps_sibling_findings(tmp_path, monkeypatch):
+    # A probe that raises unexpectedly must not sink the other probes' findings: it becomes the shared
+    # E0 finding. With no expected error present, the aggregate is CHECK_ERROR, and a sibling warning
+    # still rides along.
+    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\n")  # caching off => resiliency warns
+    monkeypatch.setattr(directory_lookup, "_nss_slurm_enabled", lambda context: True)
+    monkeypatch.setattr(
+        directory_lookup,
+        "_sssd_backend_status",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    result = DirectoryService().run(_context_with_directory_service())
+
+    assert result.status is Status.CHECK_ERROR
+    assert "E{}".format(INTERNAL_ERROR_CODE) in [error.code for error in result.errors]
+    # The credential-caching advisory from a sibling probe survives the crash.
+    assert DirectoryService.SSSD_CACHE_CREDENTIALS_DISABLED.code in [warning.code for warning in result.warnings]
+
+
+def test_run_failure_dominates_a_concurrent_probe_crash(tmp_path, monkeypatch):
+    # An expected error (backend offline) plus an unexpected crash in another probe: FAILURE wins over
+    # CHECK_ERROR, and both findings are present in errors.
+    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\ncache_credentials = True\n")
+    monkeypatch.setattr(directory_lookup, "_nss_slurm_enabled", lambda context: True)
+    monkeypatch.setattr(directory_lookup, "_sssd_backend_status", lambda: SssdBackendStatus("default: Offline", False))
+    # Make the resiliency probe crash unexpectedly.
+    monkeypatch.setattr(
+        directory_lookup, "_cache_credentials_enabled", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+
+    result = DirectoryService().run(_context_with_directory_service())
+
+    assert result.status is Status.FAILURE
+    codes = [error.code for error in result.errors]
+    assert DirectoryService.BACKEND_OFFLINE.code in codes  # the expected error
+    assert "E{}".format(INTERNAL_ERROR_CODE) in codes  # the crash still recorded
+
+
+def test_run_fails_when_any_probe_reports_an_error(tmp_path, monkeypatch):
+    # A backend-offline error dominates: the aggregate status is FAILURE regardless of warnings.
+    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\n")  # caching off => a warning is also present
+    monkeypatch.setattr(directory_lookup, "_nss_slurm_enabled", lambda context: True)
+    monkeypatch.setattr(directory_lookup, "_sssd_backend_status", lambda: SssdBackendStatus("default: Offline", False))
+
+    result = DirectoryService().run(_context_with_directory_service())
+
+    assert result.status is Status.FAILURE
+    assert DirectoryService.BACKEND_OFFLINE.code in [error.code for error in result.errors]
+    # The credential-caching warning still rides along on the FAILURE result.
+    assert DirectoryService.SSSD_CACHE_CREDENTIALS_DISABLED.code in [warning.code for warning in result.warnings]
+
+
+# --- lookup-latency probe -------------------------------------------------------------
+
+
+def test_latency_probe_silent_when_no_targets(monkeypatch):
+    _use_targets(monkeypatch, [], [])
+    errors, warnings = [], []
+
+    DirectoryService()._probe_lookup_latency(_context_with_directory_service(), errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+def test_latency_probe_silent_when_all_lookups_fast(monkeypatch):
+    _use_targets(monkeypatch, ["hpc-users"], ["alice"])
+    monkeypatch.setattr(directory_lookup, "time_command", lambda command, timeout: _timed(elapsed=0.2))
+    errors, warnings = [], []
+
+    DirectoryService()._probe_lookup_latency(_context_with_directory_service(), errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+def test_latency_probe_warns_between_thresholds(monkeypatch):
     _use_targets(monkeypatch, ["hpc-users"], [])
     elapsed = DIRECTORY_LOOKUP_WARN_THRESHOLD_SECONDS + 1
     monkeypatch.setattr(directory_lookup, "time_command", lambda command, timeout: _timed(elapsed=elapsed))
+    errors, warnings = [], []
 
-    result = DirectoryLookupLatency().run(_context_with_directory_service())
+    DirectoryService()._probe_lookup_latency(_context_with_directory_service(), errors, warnings)
 
-    assert result.status is Status.WARNING
-    assert [warning.code for warning in result.warnings] == [DirectoryLookupLatency.ELEVATED_OR_UNRESOLVED_LOOKUPS.code]
-    assert "elevated or unresolved" in result.warnings[0].message
+    assert errors == []
+    assert [warning.code for warning in warnings] == [DirectoryService.LOOKUP_ELEVATED.code]
+    assert "elevated or unresolved" in warnings[0].message
 
 
-def test_run_fails_when_latency_exceeds_fail_threshold(monkeypatch):
+def test_latency_probe_fails_above_fail_threshold(monkeypatch):
     _use_targets(monkeypatch, ["hpc-users"], [])
     elapsed = DIRECTORY_LOOKUP_FAIL_THRESHOLD_SECONDS + 1
     monkeypatch.setattr(directory_lookup, "time_command", lambda command, timeout: _timed(elapsed=elapsed))
+    errors, warnings = [], []
 
-    result = DirectoryLookupLatency().run(_context_with_directory_service())
+    DirectoryService()._probe_lookup_latency(_context_with_directory_service(), errors, warnings)
 
-    assert result.status is Status.FAILURE
-    assert [error.code for error in result.errors] == [DirectoryLookupLatency.SLOW_OR_FAILING_LOOKUPS.code]
-    assert "slow or failing" in result.errors[0].message
+    assert [error.code for error in errors] == [DirectoryService.LOOKUP_SLOW_OR_FAILING.code]
+    assert "slow or failing" in errors[0].message
 
 
-def test_run_fails_when_lookup_times_out(monkeypatch):
+def test_latency_probe_fails_on_timeout(monkeypatch):
     _use_targets(monkeypatch, [], ["alice"])
     monkeypatch.setattr(
         directory_lookup,
         "time_command",
         lambda command, timeout: _timed(returncode=None, timed_out=True, elapsed=30.0),
     )
+    errors, warnings = [], []
 
-    result = DirectoryLookupLatency().run(_context_with_directory_service())
+    DirectoryService()._probe_lookup_latency(_context_with_directory_service(), errors, warnings)
 
-    assert result.status is Status.FAILURE
-    assert [error.code for error in result.errors] == [DirectoryLookupLatency.SLOW_OR_FAILING_LOOKUPS.code]
-    assert "timed out" in result.errors[0].message
+    assert [error.code for error in errors] == [DirectoryService.LOOKUP_SLOW_OR_FAILING.code]
+    assert "timed out" in errors[0].message
 
 
-def test_run_warns_when_name_not_resolvable(monkeypatch):
+def test_latency_probe_warns_when_name_not_resolvable(monkeypatch):
     _use_targets(monkeypatch, [], ["ghost"])
-    # Fast but non-zero exit / empty output => name not resolvable, classified as warn => WARNING.
     monkeypatch.setattr(
         directory_lookup, "time_command", lambda command, timeout: _timed(returncode=2, stdout="", elapsed=0.05)
     )
+    errors, warnings = [], []
 
-    result = DirectoryLookupLatency().run(_context_with_directory_service())
+    DirectoryService()._probe_lookup_latency(_context_with_directory_service(), errors, warnings)
 
-    assert result.status is Status.WARNING
-    assert [warning.code for warning in result.warnings] == [DirectoryLookupLatency.ELEVATED_OR_UNRESOLVED_LOOKUPS.code]
-    assert "no entry resolved" in result.warnings[0].message
+    assert [warning.code for warning in warnings] == [DirectoryService.LOOKUP_ELEVATED.code]
+    assert "no entry resolved" in warnings[0].message
 
 
-def test_run_issues_expected_lookup_commands(monkeypatch):
+def test_latency_probe_issues_expected_lookup_commands(monkeypatch):
     _use_targets(monkeypatch, ["hpc-users"], ["alice"])
     commands = []
 
@@ -177,7 +254,7 @@ def test_run_issues_expected_lookup_commands(monkeypatch):
 
     monkeypatch.setattr(directory_lookup, "time_command", fake_time_command)
 
-    DirectoryLookupLatency().run(_context_with_directory_service())
+    DirectoryService()._probe_lookup_latency(_context_with_directory_service(), [], [])
 
     assert commands == [
         ["getent", "group", "hpc-users"],
@@ -186,7 +263,22 @@ def test_run_issues_expected_lookup_commands(monkeypatch):
     ]
 
 
-# --- DirectoryLookupLatency: target derivation and fallback ----------------------------
+def test_latency_probe_uses_fallback_user(monkeypatch):
+    context = _context_with_directory_service({"DomainReadOnlyUser": "svc-bind"})
+    commands = []
+
+    def fake_time_command(command, timeout):
+        commands.append(command)
+        return _timed()
+
+    monkeypatch.setattr(directory_lookup, "time_command", fake_time_command)
+
+    DirectoryService()._probe_lookup_latency(context, [], [])
+
+    assert commands == [["getent", "passwd", "svc-bind"], ["id", "svc-bind"]]
+
+
+# --- lookup-target derivation ---------------------------------------------------------
 
 
 def test_derive_targets_reads_sssd_and_filters_local_accounts(tmp_path):
@@ -197,168 +289,467 @@ def test_derive_targets_reads_sssd_and_filters_local_accounts(tmp_path):
         "simple_allow_users = alice, root, nobody, bob\n",
     )
 
-    groups, users = DirectoryLookupLatency()._derive_targets(sample_context(NodeType.HEAD))
+    groups, users = DirectoryService()._derive_targets(sample_context(NodeType.HEAD))
 
     assert groups == ["hpc-users", "admins"]
     assert users == ["alice", "bob"]  # root and nobody filtered out
 
 
 def test_derive_targets_falls_back_to_domain_read_only_user_from_cluster_config():
-    # No simple_allow_* in sssd.conf; the cluster config manages the integration, so DomainReadOnlyUser
-    # (a DN) is used, reduced to its CN component.
     context = _context_with_directory_service(
         {"DomainReadOnlyUser": "CN=ReadOnlyUser,OU=Users,DC=corp,DC=example,DC=com"}
     )
 
-    groups, users = DirectoryLookupLatency()._derive_targets(context)
+    groups, users = DirectoryService()._derive_targets(context)
 
     assert groups == []
     assert users == ["ReadOnlyUser"]
 
 
 def test_derive_targets_falls_back_to_bind_dn_when_not_managed_by_cluster_config(tmp_path):
-    # No DirectoryService in cluster config and no simple_allow_*: fall back to sssd's ldap_default_bind_dn.
     _write_sssd(
         tmp_path,
         "[domain/default]\nid_provider = ldap\nldap_default_bind_dn = CN=svc-bind,OU=Svc,DC=corp,DC=com\n",
     )
 
-    groups, users = DirectoryLookupLatency()._derive_targets(sample_context(NodeType.HEAD))
+    groups, users = DirectoryService()._derive_targets(sample_context(NodeType.HEAD))
 
     assert groups == []
     assert users == ["svc-bind"]
 
 
 def test_derive_targets_returns_empty_when_no_source_available():
-    # No simple_allow_*, no DirectoryService, no sssd.conf on disk => nothing to probe.
-    assert DirectoryLookupLatency()._derive_targets(sample_context(NodeType.HEAD)) == ([], [])
+    assert DirectoryService()._derive_targets(sample_context(NodeType.HEAD)) == ([], [])
 
 
-def test_run_uses_fallback_user_to_issue_probes(monkeypatch):
-    context = _context_with_directory_service({"DomainReadOnlyUser": "svc-bind"})
-    commands = []
-
-    def fake_time_command(command, timeout):
-        commands.append(command)
-        return _timed()
-
-    monkeypatch.setattr(directory_lookup, "time_command", fake_time_command)
-
-    result = DirectoryLookupLatency().run(context)
-
-    assert result.status is Status.PASSED
-    assert commands == [["getent", "passwd", "svc-bind"], ["id", "svc-bind"]]
+# --- managed-by-cluster-config probe --------------------------------------------------
 
 
-# --- DirectoryServiceManagedByClusterConfig -------------------------------------------
+def test_managed_probe_silent_when_declared_in_cluster_config():
+    warnings = []
+
+    DirectoryService()._probe_managed_by_cluster_config(_context_with_directory_service(), warnings)
+
+    assert warnings == []
 
 
-def test_managed_check_description():
-    assert DirectoryServiceManagedByClusterConfig().description == (
-        "Verify that an Active Directory integration is managed through the cluster configuration."
-    )
-
-
-def test_managed_check_should_run_matches_ad_presence(tmp_path):
-    check = DirectoryServiceManagedByClusterConfig()
-    # DirectoryService in cluster config.
-    assert check.should_run(_context_with_directory_service()) is True
-    # No integration at all.
-    assert check.should_run(sample_context(NodeType.HEAD)) is False
-    # AD only in sssd.conf.
-    _write_sssd(tmp_path, "[domain/default]\nid_provider = ad\n")
-    assert check.should_run(sample_context(NodeType.HEAD)) is True
-
-
-def test_managed_check_passes_when_declared_in_cluster_config():
-    result = DirectoryServiceManagedByClusterConfig().run(_context_with_directory_service())
-
-    assert result.status is Status.PASSED
-    assert result.errors is None
-
-
-def test_managed_check_warns_when_ad_not_in_cluster_config(tmp_path):
+def test_managed_probe_warns_when_ad_not_in_cluster_config(tmp_path):
     _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\n")
+    warnings = []
 
-    result = DirectoryServiceManagedByClusterConfig().run(sample_context(NodeType.HEAD))
+    DirectoryService()._probe_managed_by_cluster_config(sample_context(NodeType.HEAD), warnings)
 
-    assert result.status is Status.WARNING
-    assert [warning.code for warning in result.warnings] == [
-        DirectoryServiceManagedByClusterConfig.AD_NOT_MANAGED_BY_CLUSTER_CONFIG.code
-    ]
-    assert "has no DirectoryService section" in result.warnings[0].message
+    assert [warning.code for warning in warnings] == [DirectoryService.AD_NOT_MANAGED_BY_CLUSTER_CONFIG.code]
+    assert "has no DirectoryService section" in warnings[0].message
 
 
-# --- DirectoryLookupResiliencySettings ------------------------------------------------
+# --- resiliency-settings probe --------------------------------------------------------
 
 
-def test_resiliency_check_description():
-    assert DirectoryLookupResiliencySettings().description == (
-        "Verify the settings that reduce directory-lookup load (Slurm NSS plugin, SSSD credential caching)."
-    )
-
-
-def test_resiliency_check_should_run_matches_ad_presence():
-    check = DirectoryLookupResiliencySettings()
-    assert check.should_run(_context_with_directory_service()) is True
-    assert check.should_run(sample_context(NodeType.HEAD)) is False
-
-
-def test_resiliency_check_passes_when_both_mitigations_enabled(monkeypatch):
+def test_resiliency_probe_silent_when_both_mitigations_enabled(monkeypatch):
     monkeypatch.setattr(directory_lookup, "_nss_slurm_enabled", lambda context: True)
     monkeypatch.setattr(directory_lookup, "_cache_credentials_enabled", lambda: True)
+    warnings = []
 
-    result = DirectoryLookupResiliencySettings().run(_context_with_directory_service())
+    DirectoryService()._probe_resiliency_settings(_context_with_directory_service(), warnings)
 
-    assert result.status is Status.PASSED
-    assert result.errors is None
+    assert warnings == []
 
 
-def test_resiliency_check_warns_when_nss_slurm_disabled(monkeypatch):
+def test_resiliency_probe_warns_when_nss_slurm_disabled(monkeypatch):
     monkeypatch.setattr(directory_lookup, "_nss_slurm_enabled", lambda context: False)
     monkeypatch.setattr(directory_lookup, "_cache_credentials_enabled", lambda: True)
+    warnings = []
 
-    result = DirectoryLookupResiliencySettings().run(_context_with_directory_service())
+    DirectoryService()._probe_resiliency_settings(_context_with_directory_service(), warnings)
 
-    assert result.status is Status.WARNING
-    assert [warning.code for warning in result.warnings] == [
-        DirectoryLookupResiliencySettings.NSS_SLURM_PLUGIN_DISABLED.code
-    ]
+    assert [warning.code for warning in warnings] == [DirectoryService.NSS_SLURM_PLUGIN_DISABLED.code]
 
 
-def test_resiliency_check_warns_when_cache_credentials_disabled(monkeypatch):
+def test_resiliency_probe_warns_when_cache_credentials_disabled(monkeypatch):
     monkeypatch.setattr(directory_lookup, "_nss_slurm_enabled", lambda context: True)
     monkeypatch.setattr(directory_lookup, "_cache_credentials_enabled", lambda: False)
+    warnings = []
 
-    result = DirectoryLookupResiliencySettings().run(_context_with_directory_service())
+    DirectoryService()._probe_resiliency_settings(_context_with_directory_service(), warnings)
 
-    assert result.status is Status.WARNING
-    assert [warning.code for warning in result.warnings] == [
-        DirectoryLookupResiliencySettings.SSSD_CACHE_CREDENTIALS_DISABLED.code
-    ]
+    assert [warning.code for warning in warnings] == [DirectoryService.SSSD_CACHE_CREDENTIALS_DISABLED.code]
 
 
-def test_resiliency_check_warns_with_both_advisories(monkeypatch):
+def test_resiliency_probe_warns_with_both_advisories(monkeypatch):
     monkeypatch.setattr(directory_lookup, "_nss_slurm_enabled", lambda context: False)
     monkeypatch.setattr(directory_lookup, "_cache_credentials_enabled", lambda: False)
+    warnings = []
 
-    result = DirectoryLookupResiliencySettings().run(_context_with_directory_service())
+    DirectoryService()._probe_resiliency_settings(_context_with_directory_service(), warnings)
 
-    assert result.status is Status.WARNING
-    assert [warning.code for warning in result.warnings] == [
-        DirectoryLookupResiliencySettings.NSS_SLURM_PLUGIN_DISABLED.code,
-        DirectoryLookupResiliencySettings.SSSD_CACHE_CREDENTIALS_DISABLED.code,
+    assert [warning.code for warning in warnings] == [
+        DirectoryService.NSS_SLURM_PLUGIN_DISABLED.code,
+        DirectoryService.SSSD_CACHE_CREDENTIALS_DISABLED.code,
     ]
 
 
-def test_resiliency_check_no_nss_advisory_when_slurm_conf_unreadable(monkeypatch):
-    # When slurm.conf cannot be read, nss_slurm state is unknown (None) and must not raise a false warning.
+def test_resiliency_probe_no_nss_advisory_when_slurm_conf_unreadable(monkeypatch):
     monkeypatch.setattr(directory_lookup, "_nss_slurm_enabled", lambda context: None)
     monkeypatch.setattr(directory_lookup, "_cache_credentials_enabled", lambda: True)
+    warnings = []
 
-    result = DirectoryLookupResiliencySettings().run(_context_with_directory_service())
+    DirectoryService()._probe_resiliency_settings(_context_with_directory_service(), warnings)
 
-    assert result.status is Status.PASSED
+    assert warnings == []
+
+
+# --- backend-reachability probe -------------------------------------------------------
+
+
+def _backend(summary, online):
+    return SssdBackendStatus(summary=summary, online=online)
+
+
+def test_backend_probe_fails_when_offline(monkeypatch):
+    monkeypatch.setattr(
+        directory_lookup, "_sssd_backend_status", lambda: _backend("default: Online status: Offline", False)
+    )
+    errors, warnings = [], []
+
+    DirectoryService()._probe_backend_reachable(errors, warnings)
+
+    assert [error.code for error in errors] == [DirectoryService.BACKEND_OFFLINE.code]
+    assert "offline" in errors[0].message
+
+
+def test_backend_probe_silent_when_online(monkeypatch):
+    monkeypatch.setattr(
+        directory_lookup, "_sssd_backend_status", lambda: _backend("default: Online status: Online", True)
+    )
+    errors, warnings = [], []
+
+    DirectoryService()._probe_backend_reachable(errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+def test_backend_probe_silent_when_status_unknown(monkeypatch):
+    monkeypatch.setattr(directory_lookup, "_sssd_backend_status", lambda: _backend("default: some status", None))
+    errors, warnings = [], []
+
+    DirectoryService()._probe_backend_reachable(errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+def test_backend_probe_warns_when_status_undeterminable(monkeypatch):
+    # sssctl unavailable / errored / no AD domain => cannot assess => WARNING.
+    monkeypatch.setattr(directory_lookup, "_sssd_backend_status", lambda: None)
+    errors, warnings = [], []
+
+    DirectoryService()._probe_backend_reachable(errors, warnings)
+
+    assert errors == []
+    assert [warning.code for warning in warnings] == [DirectoryService.BACKEND_STATUS_UNAVAILABLE.code]
+
+
+# --- endpoint-certificate probe -------------------------------------------------------
+
+
+def _probe(returncode=0, stdout="", stderr="", timed_out=False):
+    """Build a util.ldap.ProbeResult stub."""
+    return ProbeResult(returncode=returncode, stdout=stdout, stderr=stderr, timed_out=timed_out)
+
+
+# A real Amazon Linux 2023 (OpenSSL 3.x) failure: the trailing "Verify return code" line is a
+# misleading 0, the true failure is only in the "verify error" / "Verification error" lines.
+_AL2023_BAD_CERT_OUTPUT = (
+    "CONNECTED(00000003)\n"
+    "depth=0 CN=microsoftad.example.pcluster\n"
+    "verify error:num=18:self-signed certificate\n"
+    "Verification error: self-signed certificate\n"
+    "---\n"
+    "SSL handshake has read 964 bytes and written 362 bytes\n"
+    "Verify return code: 0 (ok)\n"
+)
+
+
+def test_cert_probe_silent_when_certificate_validates(tmp_path, monkeypatch):
+    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\n")
+    monkeypatch.setattr(
+        directory_lookup.ldap,
+        "verify_tls_certificate",
+        lambda *a, **k: _probe(0, "depth=0 CN=ad\nverify return:1\nVerify return code: 0 (ok)"),
+    )
+    errors, warnings = [], []
+
+    DirectoryService()._probe_endpoint_certificate(errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+def test_cert_probe_fails_on_al2023_bad_cert_despite_verify_return_code_zero(tmp_path, monkeypatch):
+    # reqcert unset defaults to hard => an invalid cert is fatal, despite the trailing "return code: 0".
+    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\n")
+    monkeypatch.setattr(
+        directory_lookup.ldap, "verify_tls_certificate", lambda *a, **k: _probe(1, _AL2023_BAD_CERT_OUTPUT)
+    )
+    errors, warnings = [], []
+
+    DirectoryService()._probe_endpoint_certificate(errors, warnings)
+
+    assert [error.code for error in errors] == [DirectoryService.CERTIFICATE_INVALID.code]
+    assert "self-signed certificate" in errors[0].message
+
+
+def test_cert_probe_silent_when_invalid_but_reqcert_relaxed(tmp_path, monkeypatch):
+    _write_sssd(
+        tmp_path,
+        "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\nldap_tls_reqcert = allow\n",
+    )
+    monkeypatch.setattr(
+        directory_lookup.ldap, "verify_tls_certificate", lambda *a, **k: _probe(1, _AL2023_BAD_CERT_OUTPUT)
+    )
+    errors, warnings = [], []
+
+    DirectoryService()._probe_endpoint_certificate(errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+def test_cert_probe_warns_when_openssl_missing(tmp_path, monkeypatch):
+    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\n")
+
+    def raise_not_found(*a, **k):
+        raise FileNotFoundError("openssl")
+
+    monkeypatch.setattr(directory_lookup.ldap, "verify_tls_certificate", raise_not_found)
+    errors, warnings = [], []
+
+    DirectoryService()._probe_endpoint_certificate(errors, warnings)
+
+    assert errors == []
+    assert [warning.code for warning in warnings] == [DirectoryService.CERTIFICATE_NOT_VALIDATED.code]
+
+
+def test_cert_probe_silent_when_no_handshake(tmp_path, monkeypatch):
+    # A timeout means the endpoint was unreachable: reachability, not a certificate answer.
+    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\n")
+    monkeypatch.setattr(directory_lookup.ldap, "verify_tls_certificate", lambda *a, **k: _probe(None, timed_out=True))
+    errors, warnings = [], []
+
+    DirectoryService()._probe_endpoint_certificate(errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+def test_cert_probe_silent_when_connection_refused(tmp_path, monkeypatch):
+    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\n")
+    monkeypatch.setattr(
+        directory_lookup.ldap, "verify_tls_certificate", lambda *a, **k: _probe(1, stderr="connect:errno=111")
+    )
+    errors, warnings = [], []
+
+    DirectoryService()._probe_endpoint_certificate(errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+def test_cert_probe_silent_when_no_ldaps_endpoint(tmp_path):
+    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldap://ad.example.com\n")
+    errors, warnings = [], []
+
+    DirectoryService()._probe_endpoint_certificate(errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+# --- bind-credentials probe -----------------------------------------------------------
+
+_BIND_SSSD = (
+    "[domain/default]\n"
+    "id_provider = ldap\n"
+    "ldap_uri = ldaps://ad.example.com\n"
+    "ldap_default_bind_dn = CN=svc,DC=corp,DC=com\n"
+    "ldap_default_authtok = s3cret\n"
+)
+
+
+def test_bind_probe_silent_when_bind_succeeds(tmp_path, monkeypatch):
+    _write_sssd(tmp_path, _BIND_SSSD)
+    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", lambda *a, **k: _probe(0, "dn: DC=corp,DC=com"))
+    errors, warnings = [], []
+
+    DirectoryService()._probe_bind_credentials(errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+def test_bind_probe_fails_on_invalid_credentials(tmp_path, monkeypatch):
+    _write_sssd(tmp_path, _BIND_SSSD)
+    monkeypatch.setattr(
+        directory_lookup.ldap,
+        "ldap_bind_search",
+        lambda *a, **k: _probe(LDAP_INVALID_CREDENTIALS_CODE, stderr="bind failed"),
+    )
+    errors, warnings = [], []
+
+    DirectoryService()._probe_bind_credentials(errors, warnings)
+
+    assert [error.code for error in errors] == [DirectoryService.BIND_CREDENTIALS_INVALID.code]
+
+
+def test_bind_probe_fails_on_other_bind_error(tmp_path, monkeypatch):
+    _write_sssd(tmp_path, _BIND_SSSD)
+    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", lambda *a, **k: _probe(None, timed_out=True))
+    errors, warnings = [], []
+
+    DirectoryService()._probe_bind_credentials(errors, warnings)
+
+    assert [error.code for error in errors] == [DirectoryService.BIND_ERROR.code]
+    assert "timed out" in errors[0].message
+
+
+def test_bind_probe_tries_next_endpoint_when_first_unreachable(tmp_path, monkeypatch):
+    _write_sssd(
+        tmp_path,
+        _BIND_SSSD.replace(
+            "ldap_uri = ldaps://ad.example.com", "ldap_uri = ldaps://a.example.com ldaps://b.example.com"
+        ),
+    )
+    seen = []
+
+    def fake_search(uri, *a, **k):
+        seen.append(uri)
+        return _probe(None, timed_out=True) if uri == "ldaps://a.example.com" else _probe(0, "dn: DC=corp,DC=com")
+
+    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", fake_search)
+    errors, warnings = [], []
+
+    DirectoryService()._probe_bind_credentials(errors, warnings)
+
+    assert errors == [] and warnings == []
+    assert seen == ["ldaps://a.example.com", "ldaps://b.example.com"]
+
+
+def test_bind_probe_silent_when_authtok_obfuscated(tmp_path):
+    _write_sssd(tmp_path, _BIND_SSSD + "ldap_default_authtok_type = obfuscated_password\n")
+    errors, warnings = [], []
+
+    DirectoryService()._probe_bind_credentials(errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+def test_bind_probe_warns_when_ldapsearch_missing(tmp_path, monkeypatch):
+    _write_sssd(tmp_path, _BIND_SSSD)
+
+    def raise_not_found(*a, **k):
+        raise FileNotFoundError("ldapsearch")
+
+    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", raise_not_found)
+    errors, warnings = [], []
+
+    DirectoryService()._probe_bind_credentials(errors, warnings)
+
+    assert errors == []
+    assert [warning.code for warning in warnings] == [DirectoryService.BIND_LDAPSEARCH_UNAVAILABLE.code]
+
+
+def test_bind_probe_silent_when_no_endpoint(tmp_path):
+    _write_sssd(
+        tmp_path,
+        "[domain/default]\nid_provider = ldap\nldap_default_bind_dn = CN=svc,DC=corp\nldap_default_authtok = s3cret\n",
+    )
+    errors, warnings = [], []
+
+    DirectoryService()._probe_bind_credentials(errors, warnings)
+
+    assert errors == [] and warnings == []
+
+
+# --- search-base membership probe -----------------------------------------------------
+
+_MEMBERSHIP_SSSD = _BIND_SSSD + "ldap_search_base = DC=corp,DC=com\nsimple_allow_users = alice, bob\n"
+
+
+def test_membership_probe_silent_when_all_users_found(tmp_path, monkeypatch):
+    _write_sssd(tmp_path, _MEMBERSHIP_SSSD)
+    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", lambda *a, **k: _probe(0, "dn: CN=x,DC=corp,DC=com"))
+    warnings = []
+
+    DirectoryService()._probe_users_under_search_base(warnings)
+
+    assert warnings == []
+
+
+def test_membership_probe_warns_when_user_missing(tmp_path, monkeypatch):
+    _write_sssd(tmp_path, _MEMBERSHIP_SSSD)
+    calls = {"n": 0}
+
+    def fake_search(*a, **k):
+        calls["n"] += 1
+        return _probe(0, "dn: CN=alice,DC=corp,DC=com") if calls["n"] == 1 else _probe(0, "")
+
+    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", fake_search)
+    warnings = []
+
+    DirectoryService()._probe_users_under_search_base(warnings)
+
+    assert [warning.code for warning in warnings] == [DirectoryService.USER_NOT_UNDER_SEARCH_BASE.code]
+    assert "bob" in warnings[0].message and "alice" not in warnings[0].message
+
+
+def test_membership_probe_silent_when_search_errors(tmp_path, monkeypatch):
+    # A bind/connectivity error is reported by the bind/backend probes, not here.
+    _write_sssd(tmp_path, _MEMBERSHIP_SSSD)
+    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", lambda *a, **k: _probe(1, stderr="server down"))
+    warnings = []
+
+    DirectoryService()._probe_users_under_search_base(warnings)
+
+    assert warnings == []
+
+
+def test_membership_probe_tries_next_endpoint_when_first_search_errors(tmp_path, monkeypatch):
+    _write_sssd(
+        tmp_path,
+        _MEMBERSHIP_SSSD.replace(
+            "ldap_uri = ldaps://ad.example.com", "ldap_uri = ldaps://a.example.com ldaps://b.example.com"
+        ),
+    )
+    seen = []
+
+    def fake_search(uri, *a, **k):
+        seen.append(uri)
+        return _probe(1, stderr="server down") if uri == "ldaps://a.example.com" else _probe(0, "dn: CN=x,DC=corp")
+
+    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", fake_search)
+    warnings = []
+
+    DirectoryService()._probe_users_under_search_base(warnings)
+
+    assert warnings == []
+    assert seen == ["ldaps://a.example.com", "ldaps://b.example.com", "ldaps://b.example.com"]
+
+
+def test_membership_probe_silent_when_no_base_or_users(tmp_path):
+    _write_sssd(tmp_path, _BIND_SSSD)
+    warnings = []
+
+    DirectoryService()._probe_users_under_search_base(warnings)
+
+    assert warnings == []
+
+
+def test_membership_probe_warns_when_ldapsearch_missing(tmp_path, monkeypatch):
+    _write_sssd(tmp_path, _MEMBERSHIP_SSSD)
+
+    def raise_not_found(*a, **k):
+        raise FileNotFoundError("ldapsearch")
+
+    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", raise_not_found)
+    warnings = []
+
+    DirectoryService()._probe_users_under_search_base(warnings)
+
+    assert [warning.code for warning in warnings] == [DirectoryService.SEARCH_BASE_LDAPSEARCH_UNAVAILABLE.code]
 
 
 # --- module-level helpers -------------------------------------------------------------
@@ -442,73 +833,6 @@ def test_parse_online_status(output, expected):
     assert directory_lookup._parse_online_status(output) is expected
 
 
-# --- DirectoryBackendIsReachable ------------------------------------------------------
-
-
-def _backend(summary, online):
-    """Build an SssdBackendStatus stub for monkeypatching _sssd_backend_status."""
-    return SssdBackendStatus(summary=summary, online=online)
-
-
-def test_backend_check_description():
-    assert DirectoryBackendIsReachable().description == (
-        "Verify that SSSD reports the directory backend (AD/LDAP) online."
-    )
-
-
-def test_backend_check_should_run_matches_ad_presence(tmp_path):
-    check = DirectoryBackendIsReachable()
-    assert check.should_run(_context_with_directory_service()) is True
-    assert check.should_run(sample_context(NodeType.HEAD)) is False
-    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\n")
-    assert check.should_run(sample_context(NodeType.HEAD)) is True
-
-
-def test_backend_check_failures_when_backend_offline(monkeypatch):
-    monkeypatch.setattr(
-        directory_lookup, "_sssd_backend_status", lambda: _backend("default: Online status: Offline", False)
-    )
-
-    result = DirectoryBackendIsReachable().run(_context_with_directory_service())
-
-    assert result.status is Status.FAILURE
-    assert [error.code for error in result.errors] == [DirectoryBackendIsReachable.BACKEND_OFFLINE.code]
-    assert "offline" in result.errors[0].message
-
-
-def test_backend_check_passes_when_backend_online(monkeypatch):
-    monkeypatch.setattr(
-        directory_lookup, "_sssd_backend_status", lambda: _backend("default: Online status: Online", True)
-    )
-
-    result = DirectoryBackendIsReachable().run(_context_with_directory_service())
-
-    assert result.status is Status.PASSED
-    assert result.errors is None
-
-
-def test_backend_check_passes_when_status_unknown(monkeypatch):
-    # online=None (sssctl responded but reported no parseable status) must not warn.
-    monkeypatch.setattr(directory_lookup, "_sssd_backend_status", lambda: _backend("default: some status", None))
-
-    result = DirectoryBackendIsReachable().run(_context_with_directory_service())
-
-    assert result.status is Status.PASSED
-
-
-def test_backend_check_skipped_when_status_undeterminable(monkeypatch):
-    # sssctl unavailable / errored / no AD domain -> _sssd_backend_status returns None -> cannot assess.
-    monkeypatch.setattr(directory_lookup, "_sssd_backend_status", lambda: None)
-
-    result = DirectoryBackendIsReachable().run(_context_with_directory_service())
-
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
-    assert [info.code for info in result.infos] == [DirectoryBackendIsReachable.STATUS_UNAVAILABLE.code]
-
-
-# --- sssctl backend-status helpers ----------------------------------------------------
-
-
 def _sssctl_output(stdout, returncode=0, timed_out=False):
     """Build a TimedCommand as if returned by an sssctl domain-status invocation."""
     return TimedCommand(
@@ -533,7 +857,6 @@ def test_ad_domain_names_returns_only_ldap_ad_domains(tmp_path):
 
 
 def test_ad_domain_names_empty_when_sssd_missing():
-    # The autouse fixture points SSSD_CONF_PATH at a file that does not exist.
     assert directory_lookup._ad_domain_names() == []
 
 
@@ -607,340 +930,13 @@ def test_sssd_backend_status_none_when_output_blank(tmp_path, monkeypatch):
     assert directory_lookup._sssd_backend_status() is None
 
 
-# --- DirectoryEndpointCertificateIsValid ----------------------------------------------
-
-
-def _probe(returncode=0, stdout="", stderr="", timed_out=False):
-    """Build a util.ldap.ProbeResult stub."""
-    return ProbeResult(returncode=returncode, stdout=stdout, stderr=stderr, timed_out=timed_out)
-
-
-def test_cert_check_should_run_only_with_ldaps_endpoint(tmp_path):
-    check = DirectoryEndpointCertificateIsValid()
-    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\n")
-    assert check.should_run(sample_context(NodeType.HEAD)) is True
-    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldap://ad.example.com\n")
-    assert check.should_run(sample_context(NodeType.HEAD)) is False
-
-
-# A real Amazon Linux 2023 (OpenSSL 3.x) failure: the trailing "Verify return code" line is a
-# misleading 0, the true failure is only in the "verify error" / "Verification error" lines.
-_AL2023_BAD_CERT_OUTPUT = (
-    "CONNECTED(00000003)\n"
-    "depth=0 CN=microsoftad.example.pcluster\n"
-    "verify error:num=18:self-signed certificate\n"
-    "Verification error: self-signed certificate\n"
-    "---\n"
-    "SSL handshake has read 964 bytes and written 362 bytes\n"
-    "Verify return code: 0 (ok)\n"
-)
-
-
-def test_cert_check_passes_when_certificate_validates(tmp_path, monkeypatch):
-    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\n")
-    monkeypatch.setattr(
-        directory_lookup.ldap,
-        "verify_tls_certificate",
-        lambda *a, **k: _probe(0, "depth=0 CN=ad\nverify return:1\nVerify return code: 0 (ok)"),
-    )
-
-    result = DirectoryEndpointCertificateIsValid().run(sample_context(NodeType.HEAD))
-
-    assert result.status is Status.PASSED
-    assert result.errors is None
-
-
-def test_cert_check_fails_on_al2023_bad_cert_despite_verify_return_code_zero(tmp_path, monkeypatch):
-    # reqcert unset defaults to hard => an invalid cert is fatal. The AL2023 output ends with
-    # "Verify return code: 0 (ok)" but is a genuine failure: the check must not be fooled.
-    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\n")
-    monkeypatch.setattr(
-        directory_lookup.ldap, "verify_tls_certificate", lambda *a, **k: _probe(1, _AL2023_BAD_CERT_OUTPUT)
-    )
-
-    result = DirectoryEndpointCertificateIsValid().run(sample_context(NodeType.HEAD))
-
-    assert result.status is Status.FAILURE
-    assert [error.code for error in result.errors] == [DirectoryEndpointCertificateIsValid.INVALID_CERTIFICATE.code]
-    assert "self-signed certificate" in result.errors[0].message
-
-
-def test_cert_check_passes_when_invalid_but_reqcert_relaxed(tmp_path, monkeypatch):
-    # With a relaxed ldap_tls_reqcert (allow/never/try) SSSD proceeds despite the invalid certificate,
-    # so the check passes rather than flagging it.
-    _write_sssd(
-        tmp_path,
-        "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\nldap_tls_reqcert = allow\n",
-    )
-    monkeypatch.setattr(
-        directory_lookup.ldap, "verify_tls_certificate", lambda *a, **k: _probe(1, _AL2023_BAD_CERT_OUTPUT)
-    )
-
-    result = DirectoryEndpointCertificateIsValid().run(sample_context(NodeType.HEAD))
-
-    assert result.status is Status.PASSED
-    assert result.warnings is None
-
-
-def test_cert_check_skipped_when_openssl_missing(tmp_path, monkeypatch):
-    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\n")
-
-    def raise_not_found(*a, **k):
-        raise FileNotFoundError("openssl")
-
-    monkeypatch.setattr(directory_lookup.ldap, "verify_tls_certificate", raise_not_found)
-
-    result = DirectoryEndpointCertificateIsValid().run(sample_context(NodeType.HEAD))
-
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
-    assert [info.code for info in result.infos] == [DirectoryEndpointCertificateIsValid.OPENSSL_UNAVAILABLE.code]
-
-
-def test_cert_check_skipped_when_no_handshake(tmp_path, monkeypatch):
-    # A timeout means the endpoint was unreachable: not this check's concern.
-    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\n")
-    monkeypatch.setattr(directory_lookup.ldap, "verify_tls_certificate", lambda *a, **k: _probe(None, timed_out=True))
-
-    result = DirectoryEndpointCertificateIsValid().run(sample_context(NodeType.HEAD))
-
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
-    assert [info.code for info in result.infos] == [DirectoryEndpointCertificateIsValid.NOT_VALIDATED.code]
-
-
-def test_cert_check_skipped_when_connection_refused(tmp_path, monkeypatch):
-    # No TLS handshake evidence (connection refused) => reachability, not a certificate answer.
-    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldaps://ad.example.com\n")
-    monkeypatch.setattr(
-        directory_lookup.ldap, "verify_tls_certificate", lambda *a, **k: _probe(1, stderr="connect:errno=111")
-    )
-
-    result = DirectoryEndpointCertificateIsValid().run(sample_context(NodeType.HEAD))
-
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
-    assert [info.code for info in result.infos] == [DirectoryEndpointCertificateIsValid.NOT_VALIDATED.code]
-
-
-# --- DirectoryBindCredentialsAreValid -------------------------------------------------
-
-_BIND_SSSD = (
-    "[domain/default]\n"
-    "id_provider = ldap\n"
-    "ldap_uri = ldaps://ad.example.com\n"
-    "ldap_default_bind_dn = CN=svc,DC=corp,DC=com\n"
-    "ldap_default_authtok = s3cret\n"
-)
-
-
-def test_bind_check_passes_when_bind_succeeds(tmp_path, monkeypatch):
-    _write_sssd(tmp_path, _BIND_SSSD)
-    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", lambda *a, **k: _probe(0, "dn: DC=corp,DC=com"))
-
-    result = DirectoryBindCredentialsAreValid().run(_context_with_directory_service())
-
-    assert result.status is Status.PASSED
-
-
-def test_bind_check_fails_on_invalid_credentials(tmp_path, monkeypatch):
-    _write_sssd(tmp_path, _BIND_SSSD)
-    monkeypatch.setattr(
-        directory_lookup.ldap,
-        "ldap_bind_search",
-        lambda *a, **k: _probe(LDAP_INVALID_CREDENTIALS_CODE, stderr="bind failed"),
-    )
-
-    result = DirectoryBindCredentialsAreValid().run(_context_with_directory_service())
-
-    assert result.status is Status.FAILURE
-    assert [error.code for error in result.errors] == [DirectoryBindCredentialsAreValid.INVALID_CREDENTIALS.code]
-
-
-def test_bind_check_fails_on_other_bind_error(tmp_path, monkeypatch):
-    _write_sssd(tmp_path, _BIND_SSSD)
-    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", lambda *a, **k: _probe(None, timed_out=True))
-
-    result = DirectoryBindCredentialsAreValid().run(_context_with_directory_service())
-
-    assert result.status is Status.FAILURE
-    assert [error.code for error in result.errors] == [DirectoryBindCredentialsAreValid.BIND_ERROR.code]
-    assert "timed out" in result.errors[0].message
-
-
-def test_bind_check_tries_next_endpoint_when_first_unreachable(tmp_path, monkeypatch):
-    # Two endpoints: the first is unreachable (times out); the bind must still pass on the second.
-    _write_sssd(
-        tmp_path,
-        _BIND_SSSD.replace(
-            "ldap_uri = ldaps://ad.example.com", "ldap_uri = ldaps://a.example.com ldaps://b.example.com"
-        ),
-    )
-    seen = []
-
-    def fake_search(uri, *a, **k):
-        seen.append(uri)
-        return _probe(None, timed_out=True) if uri == "ldaps://a.example.com" else _probe(0, "dn: DC=corp,DC=com")
-
-    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", fake_search)
-
-    result = DirectoryBindCredentialsAreValid().run(_context_with_directory_service())
-
-    assert result.status is Status.PASSED
-    assert seen == ["ldaps://a.example.com", "ldaps://b.example.com"]
-
-
-def test_bind_check_skipped_when_authtok_obfuscated(tmp_path):
-    _write_sssd(tmp_path, _BIND_SSSD + "ldap_default_authtok_type = obfuscated_password\n")
-
-    result = DirectoryBindCredentialsAreValid().run(_context_with_directory_service())
-
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
-    assert [info.code for info in result.infos] == [DirectoryBindCredentialsAreValid.CANNOT_VERIFY.code]
-
-
-def test_bind_check_skipped_when_ldapsearch_missing(tmp_path, monkeypatch):
-    _write_sssd(tmp_path, _BIND_SSSD)
-
-    def raise_not_found(*a, **k):
-        raise FileNotFoundError("ldapsearch")
-
-    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", raise_not_found)
-
-    result = DirectoryBindCredentialsAreValid().run(_context_with_directory_service())
-
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
-
-
-def test_bind_check_skipped_when_no_endpoint(tmp_path):
-    # Credentials present but no ldap_uri => cannot bind.
-    _write_sssd(
-        tmp_path,
-        "[domain/default]\nid_provider = ldap\nldap_default_bind_dn = CN=svc,DC=corp\nldap_default_authtok = s3cret\n",
-    )
-
-    result = DirectoryBindCredentialsAreValid().run(_context_with_directory_service())
-
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
-
-
-# --- DirectoryUsersResolveUnderSearchBase ---------------------------------------------
-
-_MEMBERSHIP_SSSD = _BIND_SSSD + "ldap_search_base = DC=corp,DC=com\nsimple_allow_users = alice, bob\n"
-
-
-def test_membership_check_passes_when_all_users_found(tmp_path, monkeypatch):
-    _write_sssd(tmp_path, _MEMBERSHIP_SSSD)
-    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", lambda *a, **k: _probe(0, "dn: CN=x,DC=corp,DC=com"))
-
-    result = DirectoryUsersResolveUnderSearchBase().run(_context_with_directory_service())
-
-    assert result.status is Status.PASSED
-
-
-def test_membership_check_warns_when_user_missing(tmp_path, monkeypatch):
-    _write_sssd(tmp_path, _MEMBERSHIP_SSSD)
-    # alice resolves (dn present); bob returns an empty (but successful) search => not under base.
-    calls = {"n": 0}
-
-    def fake_search(*a, **k):
-        calls["n"] += 1
-        return _probe(0, "dn: CN=alice,DC=corp,DC=com") if calls["n"] == 1 else _probe(0, "")
-
-    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", fake_search)
-
-    result = DirectoryUsersResolveUnderSearchBase().run(_context_with_directory_service())
-
-    assert result.status is Status.WARNING
-    assert [warning.code for warning in result.warnings] == [
-        DirectoryUsersResolveUnderSearchBase.USER_NOT_UNDER_BASE.code
-    ]
-    assert "bob" in result.warnings[0].message and "alice" not in result.warnings[0].message
-
-
-def test_membership_check_skipped_when_search_errors(tmp_path, monkeypatch):
-    _write_sssd(tmp_path, _MEMBERSHIP_SSSD)
-    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", lambda *a, **k: _probe(1, stderr="server down"))
-
-    result = DirectoryUsersResolveUnderSearchBase().run(_context_with_directory_service())
-
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
-    assert [info.code for info in result.infos] == [DirectoryUsersResolveUnderSearchBase.SEARCH_INCOMPLETE.code]
-
-
-def test_membership_check_tries_next_endpoint_when_first_search_errors(tmp_path, monkeypatch):
-    # Two endpoints: the first cannot complete a search; the second resolves every user => PASSED.
-    _write_sssd(
-        tmp_path,
-        _MEMBERSHIP_SSSD.replace(
-            "ldap_uri = ldaps://ad.example.com", "ldap_uri = ldaps://a.example.com ldaps://b.example.com"
-        ),
-    )
-    seen = []
-
-    def fake_search(uri, *a, **k):
-        seen.append(uri)
-        return _probe(1, stderr="server down") if uri == "ldaps://a.example.com" else _probe(0, "dn: CN=x,DC=corp")
-
-    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", fake_search)
-
-    result = DirectoryUsersResolveUnderSearchBase().run(_context_with_directory_service())
-
-    assert result.status is Status.PASSED
-    # First endpoint aborts after one failed search; the second resolves both users.
-    assert seen == ["ldaps://a.example.com", "ldaps://b.example.com", "ldaps://b.example.com"]
-
-
-def test_membership_check_skipped_when_no_base_or_users(tmp_path):
-    # Credentials + endpoint but no search base and no allow-listed users.
-    _write_sssd(tmp_path, _BIND_SSSD)
-
-    result = DirectoryUsersResolveUnderSearchBase().run(_context_with_directory_service())
-
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
-
-
-# --- LDAP helper functions ------------------------------------------------------------
-
-
 def test_ldap_endpoints_parses_scheme_host_port(tmp_path):
-    # A malformed token (no hostname) is skipped; valid ldaps/ldap tokens are parsed with default ports.
     _write_sssd(tmp_path, "[domain/default]\nldap_uri = ldaps://a.example.com garbage ldap://b.example.com:1389\n")
 
     assert directory_lookup._ldap_endpoints() == [
         ("ldaps://a.example.com", "a.example.com", 636, "ldaps"),
         ("ldap://b.example.com:1389", "b.example.com", 1389, "ldap"),
     ]
-
-
-@pytest.mark.parametrize(
-    "check_cls",
-    [DirectoryBindCredentialsAreValid, DirectoryUsersResolveUnderSearchBase],
-)
-def test_ldap_checks_should_run_matches_ad_presence(check_cls, tmp_path):
-    assert check_cls().should_run(_context_with_directory_service()) is True
-    assert check_cls().should_run(sample_context(NodeType.HEAD)) is False
-    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\n")
-    assert check_cls().should_run(sample_context(NodeType.HEAD)) is True
-
-
-def test_cert_check_skipped_when_no_ldaps_endpoint(tmp_path):
-    # run() called directly with only a non-TLS endpoint -> nothing to validate.
-    _write_sssd(tmp_path, "[domain/default]\nid_provider = ldap\nldap_uri = ldap://ad.example.com\n")
-
-    result = DirectoryEndpointCertificateIsValid().run(sample_context(NodeType.HEAD))
-
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
-
-
-def test_membership_check_skipped_when_ldapsearch_missing(tmp_path, monkeypatch):
-    _write_sssd(tmp_path, _MEMBERSHIP_SSSD)
-
-    def raise_not_found(*a, **k):
-        raise FileNotFoundError("ldapsearch")
-
-    monkeypatch.setattr(directory_lookup.ldap, "ldap_bind_search", raise_not_found)
-
-    result = DirectoryUsersResolveUnderSearchBase().run(_context_with_directory_service())
-
-    assert result.status is Status.SKIPPED_NOT_APPLICABLE
 
 
 def test_ldap_bind_credentials_none_when_obfuscated(tmp_path):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_probe.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_probe.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the probe helpers: unexpected_error_finding and run_probe isolation."""
+
+from pcluster_diag.core.probe import run_probe, unexpected_error_finding
+from pcluster_diag.models.finding import CheckError
+from pcluster_diag.models.result import INTERNAL_ERROR_CODE
+
+
+def test_unexpected_error_finding_uses_reserved_e0_code():
+    finding = unexpected_error_finding("backend probe (RuntimeError: boom)")
+
+    assert finding.code == "E{}".format(INTERNAL_ERROR_CODE)
+    assert "backend probe (RuntimeError: boom)" in finding.message
+
+
+def test_run_probe_adds_nothing_when_probe_succeeds():
+    errors = []
+
+    run_probe("healthy probe", lambda: None, errors)
+
+    assert errors == []
+
+
+def test_run_probe_isolates_unexpected_exception_as_e0_error():
+    errors = [CheckError(1, "a pre-existing expected error")]
+
+    def crashing_probe():
+        raise RuntimeError("boom")
+
+    run_probe("backend probe", crashing_probe, errors)
+
+    # The pre-existing finding is preserved and a single E0 finding is appended for the crash.
+    assert [error.code for error in errors] == ["E1", "E{}".format(INTERNAL_ERROR_CODE)]
+    assert "backend probe" in errors[1].message
+    assert "RuntimeError: boom" in errors[1].message

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_result.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_result.py
@@ -14,6 +14,7 @@
 
 import pytest
 
+from pcluster_diag.core.probe import unexpected_error_finding
 from pcluster_diag.models.finding import CheckError, CheckInfo, CheckWarning
 from pcluster_diag.models.result import FAILED_STATUSES, INTERNAL_ERROR_CODE, Result, Status
 from tests.sample_data import FakeCheck, sample_result
@@ -142,3 +143,34 @@ def test_warning_factory_builds_result_with_warnings():
 def test_warning_status_is_not_a_failed_status():
     # A WARNING is advisory: it does not make the run unsuccessful.
     assert Status.WARNING not in FAILED_STATUSES
+
+
+@pytest.mark.parametrize(
+    "errors, warnings, expected_status",
+    [
+        ([], [], Status.PASSED),
+        ([], [CheckWarning(1, "heads up")], Status.WARNING),
+        ([CheckError(1, "boom")], [], Status.FAILURE),
+        ([unexpected_error_finding("probe crashed")], [], Status.CHECK_ERROR),
+        # An unexpected crash alongside only a warning is still CHECK_ERROR (crash dominates warning).
+        ([unexpected_error_finding("probe crashed")], [CheckWarning(1, "heads up")], Status.CHECK_ERROR),
+        # A real (expected) error dominates a concurrent crash.
+        ([CheckError(1, "boom"), unexpected_error_finding("probe crashed")], [], Status.FAILURE),
+    ],
+    ids=["passed", "warning", "failure", "check-error", "check-error-over-warning", "failure-over-check-error"],
+)
+def test_from_findings_derives_status_by_precedence(errors, warnings, expected_status):
+    result = Result.from_findings(_SAMPLE_CHECK, errors=errors, warnings=warnings)
+
+    assert result.status is expected_status
+    # Every supplied error is preserved regardless of the aggregate label.
+    assert (result.errors or []) == errors
+
+
+def test_from_findings_collapses_duplicate_findings():
+    duplicate = CheckWarning(1, "same message")
+
+    result = Result.from_findings(_SAMPLE_CHECK, warnings=[duplicate, CheckWarning(1, "same message")])
+
+    assert result.status is Status.WARNING
+    assert result.warnings == [duplicate]


### PR DESCRIPTION
### Description of changes
This change make the `pcluster-diag` output shorter, therefore improves readability of the output.

Moreover, this commit improves `pcluster-diag` framework:
- Result.from_findings derives the aggregate status from the accumulated
  findings by severity precedence: FAILURE (an expected error) >
  CHECK_ERROR (only unexpected errors) > WARNING > PASSED. Duplicate findings are collapsed.
- Add the shared unexpected_error_finding (reserved E0 code) and a run_probe helper that runs each probe in isolation: an unexpected exception becomes an E0 finding for that probe alone (surfacing as CHECK_ERROR) instead of aborting the whole check and discarding the other probes' findings.

Reporting semantics for the merged check:
- A probe whose sub-feature is not enabled (e.g. no ldaps:// endpoint, no allow-listed users, no verifiable bind) contributes nothing.
- A probe that is relevant but cannot reach a verdict because a required tool is unavailable (openssl / ldapsearch / sssctl) records a WARNING, so the coverage gap is visible without failing the run.

### Tests
* Manually run `pcluster-diag run` and verified the output.
* I didn't test any error cases because this PR only does refactor.

### Example output
Before the PR
```
    {
      "check_id": "DirectoryServiceManagedByClusterConfig",
      "check_description": "Verify that an Active Directory integration is managed through the cluster configuration.",
      "status": "PASSED"
    },
    {
      "check_id": "DirectoryLookupResiliencySettings",
      "check_description": "Verify the settings that reduce directory-lookup load (Slurm NSS plugin, SSSD credential caching).",
      "status": "PASSED"
    },
    {
      "check_id": "DirectoryLookupLatency",
      "check_description": "Measure directory service (NSS/SSSD/AD) lookup latency for cluster users and groups.",
      "status": "PASSED"
    },
    {
      "check_id": "DirectoryBackendIsReachable",
      "check_description": "Verify that SSSD reports the directory backend (AD/LDAP) online.",
      "status": "PASSED"
    },
    {
      "check_id": "DirectoryEndpointCertificateIsValid",
      "check_description": "Verify that the directory endpoint's TLS certificate validates against the configured CA.",
      "status": "SKIPPED_NOT_APPLICABLE"
    },
    {
      "check_id": "DirectoryBindCredentialsAreValid",
      "check_description": "Verify that SSSD's configured bind DN and password authenticate against the directory.",
      "status": "SKIPPED_NOT_APPLICABLE",
      "infos": [
        {
          "code": "I2",
          "message": "ldapsearch is not available to verify the bind credentials."
        }
      ]
    },
    {
      "check_id": "DirectoryUsersResolveUnderSearchBase",
      "check_description": "Verify that allow-listed users are found under the configured LDAP search base.",
      "status": "SKIPPED_NOT_APPLICABLE",
      "infos": [
        {
          "code": "I1",
          "message": "Cannot verify search-base membership: a plaintext bind (ldap_default_bind_dn/authtok), a search base (ldap_search_base/ldap_user_search_base), an ldap_uri, and simple_allow_users are all required."
        }
      ]
    }
```
After this PR:
```
    {
      "check_id": "DirectoryService",
      "check_description": "Verify that the directory service (NSS/SSSD/AD) integration is healthy.",
      "status": "WARNING",
      "warnings": [
        {
          "code": "W8",
          "message": "Could not verify the directory bind credentials: ldapsearch is not available."
        }
      ]
    }
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
