### PR TITLE
[Nvidia] Install nvidia cuda repo after the driver stack is installed, to prevent silent upgrades of the driver through the cuda repo.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
+++ b/cookbooks/aws-parallelcluster-platform/kitchen.platform-install.yml
@@ -110,7 +110,7 @@ suites:
         - resource:package_repos
         - 'resource:package { "package_name": "dkms" }'
         - resource:build_tools
-        - resource:nvidia_repo:add
+        - resource:nvidia_repo:add_driver_repo
       cluster:
         nvidia:
           enabled: true
@@ -143,8 +143,9 @@ suites:
         - resource:package_repos
         - 'resource:package { "package_name": "dkms" }'
         - resource:build_tools
-        - resource:nvidia_repo:add
+        - resource:nvidia_repo:add_driver_repo
         - resource:nvidia_driver
+        - resource:nvidia_repo:add_cuda_repo
         - resource:nvidia_cuda
       cluster:
         nvidia:
@@ -157,7 +158,9 @@ suites:
       controls:
         - tag:nvidia_local_repos_added
     attributes:
-      resource: nvidia_repo:add
+      resource: nvidia_repo:add_cuda_repo
+      dependencies:
+        - resource:nvidia_repo:add_driver_repo
       cluster:
         nvidia:
           enabled: true
@@ -169,9 +172,11 @@ suites:
       controls:
         - tag:install_nvidia_local_repos_removed
     attributes:
-      resource: nvidia_repo:remove
+      resource: nvidia_repo:remove_cuda_repo
       dependencies:
-        - resource:nvidia_repo:add
+        - resource:nvidia_repo:add_driver_repo
+        - resource:nvidia_repo:remove_driver_repo
+        - resource:nvidia_repo:add_cuda_repo
       cluster:
         nvidia:
           enabled: true
@@ -284,7 +289,7 @@ suites:
         - resource:package_repos
         - 'resource:package { "package_name": "dkms" }'
         - resource:build_tools
-        - resource:nvidia_repo:add
+        - resource:nvidia_repo:add_cuda_repo
       cluster:
         nvidia:
           enabled: true

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/nvidia_install.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/nvidia_install.rb
@@ -15,26 +15,32 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Register the NVIDIA local repos (driver and CUDA) up front so that the
-# nvidia_driver and nvidia_cuda resources can install their packages from them.
-# Versions and URLs default to node attributes and can be overridden there.
-nvidia_repo 'Install NVIDIA local repos'
+nvidia_repo 'Add NVIDIA driver local repo' do
+  action :add_driver_repo
+end
 
 nvidia_driver 'Install Nvidia driver'
-
-nvidia_cuda 'Install Nvidia CUDA'
-
-gdrcopy 'Install Nvidia gdrcopy'
 
 nvidia_nvlsm 'Install Nvidia NVLink Subnet Manager'
 
 fabric_manager 'Install Nvidia Fabric Manager'
 
-nvidia_dcgm 'install Nvidia datacenter-gpu-manager'
-
 nvidia_imex 'Install nvidia-imex'
 
-# Remove the NVIDIA local repos now that all NVIDIA packages have been installed
-nvidia_repo 'Remove NVIDIA local repos' do
-  action :remove
+nvidia_repo 'Remove NVIDIA driver local repo' do
+  action :remove_driver_repo
 end
+
+nvidia_repo 'Add NVIDIA CUDA local repo' do
+  action :add_cuda_repo
+end
+
+nvidia_cuda 'Install Nvidia CUDA'
+
+nvidia_repo 'Remove NVIDIA CUDA local repo' do
+  action :remove_cuda_repo
+end
+
+gdrcopy 'Install Nvidia gdrcopy'
+
+nvidia_dcgm 'install Nvidia datacenter-gpu-manager'

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_repo/partial/_nvidia_repo_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_repo/partial/_nvidia_repo_common.rb
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 unified_mode true
-default_action :add
+default_action :add_driver_repo
 
-# node.run_state keys recording which local repos this run actually added,
-# so :remove only cleans up what :add installed.
+# The CUDA repo bundles its own driver stack, so the two local repos must never be registered at the same time (see nvidia_install recipe).
+
+# run_state keys tracking the repos this run added, so :remove_* only cleans up what :add_* installed.
 DRIVER_REPO_ADDED = 'nvidia_driver_repo_added'
 CUDA_REPO_ADDED = 'nvidia_cuda_repo_added'
 
@@ -27,69 +28,73 @@ CUDA_REPO_ADDED = 'nvidia_cuda_repo_added'
 property :driver_version, String, default: lazy { node['cluster']['nvidia']['driver_version'] }
 property :cuda_version, String, default: lazy { node['cluster']['nvidia']['cuda']['version'] }
 
-action :add do
+# Register the driver local repo unless the driver is already installed (e.g. pre-baked AMI).
+action :add_driver_repo do
   return unless nvidia_enabled?
   return if on_docker?
+  return if ::File.exist?('/usr/bin/nvidia-smi')
 
-  # Register the NVIDIA driver local repo unless the driver is already installed
-  # (e.g. pre-baked AMI). Track it so :remove only cleans up what this run added.
-  unless ::File.exist?('/usr/bin/nvidia-smi')
-    remote_file driver_repo_package_path do
-      source driver_repo_source_url
-      mode '0644'
-      retries 3
-      retry_delay 5
-    end
-    action_install_driver_repo
-    node.run_state[DRIVER_REPO_ADDED] = true
+  remote_file driver_repo_package_path do
+    source driver_repo_source_url
+    mode '0644'
+    retries 3
+    retry_delay 5
   end
 
-  # Register the CUDA local repo unless CUDA is already installed.
-  unless ::File.exist?('/usr/local/cuda')
-    remote_file cuda_repo_package_path do
-      source cuda_repo_source_url
-      mode '0644'
-      retries 3
-      retry_delay 5
-    end
-    action_install_cuda_repo
-    node.run_state[CUDA_REPO_ADDED] = true
-  end
+  action_install_driver_repo
+  node.run_state[DRIVER_REPO_ADDED] = true
 
-  # Refresh the package manager metadata once, after all local repos have been
-  # enrolled, so their package lists (and, on RHEL, the driver repo's DKMS
-  # module metadata) are visible to the later nvidia_driver / nvidia_cuda installs.
-  action_refresh_repo_cache if node.run_state[DRIVER_REPO_ADDED] || node.run_state[CUDA_REPO_ADDED]
+  # Make the repo packages visible to the driver-stack installs.
+  action_refresh_repo_cache
 end
 
-action :remove do
-  # Only remove each local repo (and its downloaded installer) if this run added it.
-  # After removal, refresh the package manager metadata so the removed repo's package
-  # list stops advertising NVIDIA packages at the repo's (lower) versions, which would
-  # make later installs (e.g. enroot) attempt unwanted downgrades and fail.
-  if node.run_state[DRIVER_REPO_ADDED]
-    package driver_repo_package_name do
-      action local_repo_remove_action
-    end
+# Register the CUDA local repo unless CUDA is already installed.
+action :add_cuda_repo do
+  return unless nvidia_enabled?
+  return if on_docker?
+  return if ::File.exist?('/usr/local/cuda')
 
-    file driver_repo_package_path do
-      action :delete
-    end
-
-    action_refresh_metadata
+  remote_file cuda_repo_package_path do
+    source cuda_repo_source_url
+    mode '0644'
+    retries 3
+    retry_delay 5
   end
 
-  if node.run_state[CUDA_REPO_ADDED]
-    package cuda_repo_package_name do
-      action local_repo_remove_action
-    end
+  action_install_cuda_repo
+  node.run_state[CUDA_REPO_ADDED] = true
 
-    file cuda_repo_package_path do
-      action :delete
-    end
+  action_refresh_repo_cache
+end
 
-    action_refresh_metadata
+# Remove the driver local repo and its installer if this run added them.
+action :remove_driver_repo do
+  return unless node.run_state[DRIVER_REPO_ADDED]
+
+  package driver_repo_package_name do
+    action local_repo_remove_action
   end
+
+  file driver_repo_package_path do
+    action :delete
+  end
+
+  action_refresh_metadata
+end
+
+# Remove the CUDA local repo and its installer if this run added them.
+action :remove_cuda_repo do
+  return unless node.run_state[CUDA_REPO_ADDED]
+
+  package cuda_repo_package_name do
+    action local_repo_remove_action
+  end
+
+  file cuda_repo_package_path do
+    action :delete
+  end
+
+  action_refresh_metadata
 end
 
 # ---------------------------------------------------------------------------

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/nvidia_install_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/nvidia_install_spec.rb
@@ -9,20 +9,12 @@ describe 'aws-parallelcluster-platform::nvidia_install' do
       end
       cached(:node) { chef_run.node }
 
-      it 'registers the NVIDIA local repos up front' do
-        is_expected.to add_nvidia_repo('Install NVIDIA local repos')
+      it 'adds the NVIDIA driver local repo' do
+        is_expected.to add_driver_repo_nvidia_repo('Add NVIDIA driver local repo')
       end
 
       it 'installs nvidia driver' do
         is_expected.to setup_nvidia_driver('Install Nvidia driver')
-      end
-
-      it 'installs cuda' do
-        is_expected.to setup_nvidia_cuda('Install Nvidia CUDA')
-      end
-
-      it 'installs gdrcopy' do
-        is_expected.to setup_gdrcopy('Install Nvidia gdrcopy')
       end
 
       it 'installs nvidia_nvlsm' do
@@ -33,16 +25,50 @@ describe 'aws-parallelcluster-platform::nvidia_install' do
         is_expected.to setup_fabric_manager('Install Nvidia Fabric Manager')
       end
 
-      it 'installs nvidia_dcgm' do
-        is_expected.to setup_nvidia_dcgm('install Nvidia datacenter-gpu-manager')
-      end
-
       it 'installs nvidia_imex' do
         is_expected.to install_nvidia_imex('Install nvidia-imex')
       end
 
-      it 'removes the NVIDIA local repos as the last step' do
-        is_expected.to remove_nvidia_repo('Remove NVIDIA local repos')
+      it 'removes the NVIDIA driver local repo once the driver stack is installed' do
+        is_expected.to remove_driver_repo_nvidia_repo('Remove NVIDIA driver local repo')
+      end
+
+      it 'adds the NVIDIA CUDA local repo' do
+        is_expected.to add_cuda_repo_nvidia_repo('Add NVIDIA CUDA local repo')
+      end
+
+      it 'installs cuda' do
+        is_expected.to setup_nvidia_cuda('Install Nvidia CUDA')
+      end
+
+      it 'removes the NVIDIA CUDA local repo once CUDA is installed' do
+        is_expected.to remove_cuda_repo_nvidia_repo('Remove NVIDIA CUDA local repo')
+      end
+
+      it 'installs gdrcopy' do
+        is_expected.to setup_gdrcopy('Install Nvidia gdrcopy')
+      end
+
+      it 'installs nvidia_dcgm' do
+        is_expected.to setup_nvidia_dcgm('install Nvidia datacenter-gpu-manager')
+      end
+
+      it 'never registers the driver and CUDA local repos at the same time' do
+        expected_order = [
+          'Add NVIDIA driver local repo',
+          'Install Nvidia driver',
+          'Install Nvidia NVLink Subnet Manager',
+          'Install Nvidia Fabric Manager',
+          'Install nvidia-imex',
+          'Remove NVIDIA driver local repo',
+          'Add NVIDIA CUDA local repo',
+          'Install Nvidia CUDA',
+          'Remove NVIDIA CUDA local repo',
+          'Install Nvidia gdrcopy',
+          'install Nvidia datacenter-gpu-manager',
+        ]
+        actual_order = chef_run.run_context.resource_collection.map(&:name).select { |name| expected_order.include?(name) }
+        expect(actual_order).to eq(expected_order)
       end
     end
   end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_repo_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_repo_spec.rb
@@ -1,20 +1,36 @@
 require 'spec_helper'
 
 class ConvergeNvidiaRepo
-  def self.add(chef_run, driver_version: nil, cuda_version: nil)
+  def self.add_driver_repo(chef_run, driver_version: nil)
     chef_run.converge_dsl('aws-parallelcluster-platform') do
-      nvidia_repo 'add' do
+      nvidia_repo 'add_driver_repo' do
         driver_version driver_version unless driver_version.nil?
-        cuda_version cuda_version unless cuda_version.nil?
-        action :add
+        action :add_driver_repo
       end
     end
   end
 
-  def self.remove(chef_run)
+  def self.add_cuda_repo(chef_run, cuda_version: nil)
     chef_run.converge_dsl('aws-parallelcluster-platform') do
-      nvidia_repo 'remove' do
-        action :remove
+      nvidia_repo 'add_cuda_repo' do
+        cuda_version cuda_version unless cuda_version.nil?
+        action :add_cuda_repo
+      end
+    end
+  end
+
+  def self.remove_driver_repo(chef_run)
+    chef_run.converge_dsl('aws-parallelcluster-platform') do
+      nvidia_repo 'remove_driver_repo' do
+        action :remove_driver_repo
+      end
+    end
+  end
+
+  def self.remove_cuda_repo(chef_run)
+    chef_run.converge_dsl('aws-parallelcluster-platform') do
+      nvidia_repo 'remove_cuda_repo' do
+        action :remove_cuda_repo
       end
     end
   end
@@ -62,11 +78,11 @@ describe 'nvidia_repo helpers' do
           node.override['cluster']['nvidia']['cuda']['driver_version_suffix'] = cuda_suffix
           node.override['cluster']['sources_dir'] = sources_dir
         end
-        ConvergeNvidiaRepo.add(runner)
+        ConvergeNvidiaRepo.add_driver_repo(runner)
       end
 
       cached(:resource) do
-        chef_run.find_resource('nvidia_repo', 'add')
+        chef_run.find_resource('nvidia_repo', 'add_driver_repo')
       end
 
       it 'takes the driver and cuda versions from the attributes' do
@@ -104,8 +120,8 @@ describe 'nvidia_repo:arch_suffix' do
         runner(platform: platform, version: version, step_into: ['nvidia_repo'])
       end
       cached(:resource) do
-        ConvergeNvidiaRepo.add(chef_run)
-        chef_run.find_resource('nvidia_repo', 'add')
+        ConvergeNvidiaRepo.add_driver_repo(chef_run)
+        chef_run.find_resource('nvidia_repo', 'add_driver_repo')
       end
 
       it 'is the rpm/deb arch on x86' do
@@ -121,147 +137,210 @@ describe 'nvidia_repo:arch_suffix' do
   end
 end
 
-describe 'nvidia_repo:add' do
+describe 'nvidia_repo:add_driver_repo' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
-      # Fake versions: tests must not depend on the real versions, they only
-      # verify that the versions configured in the attributes are the ones used.
+      # Fake versions: tests only verify the configured attribute values are used.
       cached(:driver_version) { '9.8.7' }
-      cached(:cuda_version) { '1.2.3' }
-      cached(:cuda_suffix) { '4.5.6' }
       cached(:driver_base_url) { 'https://driver.example/nvidia_driver' }
-      cached(:cuda_base_url) { 'https://cuda.example/cuda' }
       cached(:sources_dir) { '/fake/sources' }
 
       cached(:debian?) { platform == 'ubuntu' }
       cached(:local_repo_platform) { nvidia_local_repo_platform_for(platform, version) }
       cached(:arch) { debian? ? 'amd64' : 'x86_64' }
       cached(:driver_pkg_name) { "nvidia-driver-local-repo-#{local_repo_platform}-#{driver_version}" }
-      cached(:cuda_pkg_name) { "cuda-repo-#{local_repo_platform}-1-2-local" }
       cached(:driver_pkg_file) do
         debian? ? "#{driver_pkg_name}_1.0-1_#{arch}.deb" : "#{driver_pkg_name}-1.0-1.#{arch}.rpm"
       end
-      cached(:cuda_pkg_file) do
-        debian? ? "#{cuda_pkg_name}_#{cuda_version}-#{cuda_suffix}-1_#{arch}.deb" : "#{cuda_pkg_name}-#{cuda_version}_#{cuda_suffix}-1.#{arch}.rpm"
-      end
       cached(:driver_pkg_path) { "#{sources_dir}/#{driver_pkg_file}" }
-      cached(:cuda_pkg_path) { "#{sources_dir}/#{cuda_pkg_file}" }
 
       cached(:chef_run) do
         allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
         allow_any_instance_of(Object).to receive(:on_docker?).and_return(false)
         allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
         mock_file_exists('/usr/bin/nvidia-smi', false)
-        mock_file_exists('/usr/local/cuda', false)
         runner = runner(platform: platform, version: version, step_into: ['nvidia_repo']) do |node|
           node.override['cluster']['nvidia']['driver_version'] = driver_version
           node.override['cluster']['nvidia']['driver_base_url'] = driver_base_url
+          node.override['cluster']['sources_dir'] = sources_dir
+        end
+        ConvergeNvidiaRepo.add_driver_repo(runner)
+      end
+
+      it 'downloads the driver local-repo installer' do
+        is_expected.to create_remote_file(driver_pkg_path).with(
+          source: "#{driver_base_url}/#{driver_pkg_file}", mode: '0644', retries: 3, retry_delay: 5
+        )
+      end
+
+      if platform == 'ubuntu'
+        it 'installs the driver local-repo deb, enrolls its key and refreshes apt' do
+          is_expected.to install_dpkg_package(driver_pkg_name).with(source: driver_pkg_path)
+          is_expected.to run_execute("Install keyring for #{driver_pkg_name}")
+          is_expected.to update_apt_update('Update apt cache for NVIDIA local repos')
+        end
+
+        it 'does not add the cuda local repo' do
+          is_expected.not_to install_dpkg_package(/cuda-repo/)
+        end
+      else
+        it 'installs the driver local-repo rpm and refreshes the dnf cache' do
+          is_expected.to install_rpm_package(driver_pkg_name).with(source: driver_pkg_path)
+          is_expected.to run_execute('Refresh dnf metadata for NVIDIA local repos').with(command: 'dnf clean all')
+          is_expected.to flush_cache_dnf_package('Update dnf cache for NVIDIA local repos')
+        end
+
+        it 'does not add the cuda local repo' do
+          is_expected.not_to install_rpm_package(/cuda-repo/)
+        end
+      end
+
+      it 'records that this run added the driver repo' do
+        expect(chef_run.node.run_state['nvidia_driver_repo_added']).to be(true)
+      end
+    end
+  end
+end
+
+describe 'nvidia_repo:add_cuda_repo' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      # Fake versions: tests only verify the configured attribute values are used.
+      cached(:cuda_version) { '1.2.3' }
+      cached(:cuda_suffix) { '4.5.6' }
+      cached(:cuda_base_url) { 'https://cuda.example/cuda' }
+      cached(:sources_dir) { '/fake/sources' }
+
+      cached(:debian?) { platform == 'ubuntu' }
+      cached(:local_repo_platform) { nvidia_local_repo_platform_for(platform, version) }
+      cached(:arch) { debian? ? 'amd64' : 'x86_64' }
+      cached(:cuda_pkg_name) { "cuda-repo-#{local_repo_platform}-1-2-local" }
+      cached(:cuda_pkg_file) do
+        debian? ? "#{cuda_pkg_name}_#{cuda_version}-#{cuda_suffix}-1_#{arch}.deb" : "#{cuda_pkg_name}-#{cuda_version}_#{cuda_suffix}-1.#{arch}.rpm"
+      end
+      cached(:cuda_pkg_path) { "#{sources_dir}/#{cuda_pkg_file}" }
+
+      cached(:chef_run) do
+        allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
+        allow_any_instance_of(Object).to receive(:on_docker?).and_return(false)
+        allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+        mock_file_exists('/usr/local/cuda', false)
+        runner = runner(platform: platform, version: version, step_into: ['nvidia_repo']) do |node|
           node.override['cluster']['nvidia']['cuda']['version'] = cuda_version
           node.override['cluster']['nvidia']['cuda']['base_url'] = cuda_base_url
           node.override['cluster']['nvidia']['cuda']['driver_version_suffix'] = cuda_suffix
           node.override['cluster']['sources_dir'] = sources_dir
         end
-        ConvergeNvidiaRepo.add(runner)
+        ConvergeNvidiaRepo.add_cuda_repo(runner)
       end
 
-      it 'downloads the driver and cuda local-repo installers' do
-        is_expected.to create_remote_file(driver_pkg_path).with(
-          source: "#{driver_base_url}/#{driver_pkg_file}", mode: '0644', retries: 3, retry_delay: 5
-        )
+      it 'downloads the cuda local-repo installer' do
         is_expected.to create_remote_file(cuda_pkg_path).with(
           source: "#{cuda_base_url}/#{cuda_pkg_file}", mode: '0644', retries: 3, retry_delay: 5
         )
       end
 
       if platform == 'ubuntu'
-        it 'installs the local-repo debs, enrolls keys and refreshes apt once' do
-          is_expected.to install_dpkg_package(driver_pkg_name).with(source: driver_pkg_path)
+        it 'installs the cuda local-repo deb, enrolls its key and refreshes apt' do
           is_expected.to install_dpkg_package(cuda_pkg_name).with(source: cuda_pkg_path)
-          is_expected.to run_execute("Install keyring for #{driver_pkg_name}")
           is_expected.to run_execute("Install keyring for #{cuda_pkg_name}")
           is_expected.to update_apt_update('Update apt cache for NVIDIA local repos')
         end
 
-        it 'refreshes the apt cache only once for all local repos' do
-          apt_updates = chef_run.run_context.resource_collection.select do |r|
-            r.resource_name == :apt_update
-          end
-          expect(apt_updates.size).to eq(1)
+        it 'does not add the driver local repo' do
+          is_expected.not_to install_dpkg_package(/nvidia-driver-local-repo/)
         end
       else
-        it 'installs the local-repo rpms and refreshes the dnf cache once' do
-          is_expected.to install_rpm_package(driver_pkg_name).with(source: driver_pkg_path)
+        it 'installs the cuda local-repo rpm and refreshes the dnf cache' do
           is_expected.to install_rpm_package(cuda_pkg_name).with(source: cuda_pkg_path)
           is_expected.to run_execute('Refresh dnf metadata for NVIDIA local repos').with(command: 'dnf clean all')
           is_expected.to flush_cache_dnf_package('Update dnf cache for NVIDIA local repos')
         end
 
-        it 'runs dnf clean all only once for all local repos' do
-          clean_alls = chef_run.run_context.resource_collection.select do |r|
-            r.resource_name == :execute && r.name == 'Refresh dnf metadata for NVIDIA local repos'
-          end
-          expect(clean_alls.size).to eq(1)
+        it 'does not add the driver local repo' do
+          is_expected.not_to install_rpm_package(/nvidia-driver-local-repo/)
         end
+      end
+
+      it 'records that this run added the cuda repo' do
+        expect(chef_run.node.run_state['nvidia_cuda_repo_added']).to be(true)
       end
     end
   end
 end
 
-describe 'nvidia_repo:add skip conditions' do
-  # Fake version: tests must not depend on the real version, they only verify
-  # that the version configured in the attribute is the one being used.
-  def converge_add(nvidia_enabled:, on_docker:, nvidia_smi:, cuda:)
+describe 'nvidia_repo:add_driver_repo skip conditions' do
+  def converge_add_driver_repo(nvidia_enabled:, on_docker:, nvidia_smi:)
     allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(nvidia_enabled)
     allow_any_instance_of(Object).to receive(:on_docker?).and_return(on_docker)
     allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
     mock_file_exists('/usr/bin/nvidia-smi', nvidia_smi)
-    mock_file_exists('/usr/local/cuda', cuda)
-    runner = runner(platform: 'amazon', version: '2023', step_into: ['nvidia_repo']) do |node|
-      node.override['cluster']['nvidia']['cuda']['version'] = '1.2.3'
-    end
-    ConvergeNvidiaRepo.add(runner)
+    runner = runner(platform: 'amazon', version: '2023', step_into: ['nvidia_repo'])
+    ConvergeNvidiaRepo.add_driver_repo(runner)
   end
 
   context 'when nvidia is not enabled' do
-    cached(:converged) { converge_add(nvidia_enabled: false, on_docker: false, nvidia_smi: false, cuda: false) }
+    cached(:converged) { converge_add_driver_repo(nvidia_enabled: false, on_docker: false, nvidia_smi: false) }
 
-    it 'does not add any repo' do
+    it 'does not add the driver repo' do
       expect(converged).not_to install_rpm_package(/nvidia-driver-local-repo/)
+    end
+  end
+
+  context 'when on docker' do
+    cached(:converged) { converge_add_driver_repo(nvidia_enabled: true, on_docker: true, nvidia_smi: false) }
+
+    it 'does not add the driver repo' do
+      expect(converged).not_to install_rpm_package(/nvidia-driver-local-repo/)
+    end
+  end
+
+  context 'when the driver is already installed' do
+    cached(:converged) { converge_add_driver_repo(nvidia_enabled: true, on_docker: false, nvidia_smi: true) }
+
+    it 'does not add the driver repo' do
+      expect(converged).not_to install_rpm_package(/nvidia-driver-local-repo/)
+    end
+  end
+end
+
+describe 'nvidia_repo:add_cuda_repo skip conditions' do
+  def converge_add_cuda_repo(nvidia_enabled:, on_docker:, cuda:)
+    allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(nvidia_enabled)
+    allow_any_instance_of(Object).to receive(:on_docker?).and_return(on_docker)
+    allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+    mock_file_exists('/usr/local/cuda', cuda)
+    runner = runner(platform: 'amazon', version: '2023', step_into: ['nvidia_repo'])
+    ConvergeNvidiaRepo.add_cuda_repo(runner)
+  end
+
+  context 'when nvidia is not enabled' do
+    cached(:converged) { converge_add_cuda_repo(nvidia_enabled: false, on_docker: false, cuda: false) }
+
+    it 'does not add the cuda repo' do
       expect(converged).not_to install_rpm_package(/cuda-repo/)
     end
   end
 
   context 'when on docker' do
-    cached(:converged) { converge_add(nvidia_enabled: true, on_docker: true, nvidia_smi: false, cuda: false) }
+    cached(:converged) { converge_add_cuda_repo(nvidia_enabled: true, on_docker: true, cuda: false) }
 
-    it 'does not add any repo' do
-      expect(converged).not_to install_rpm_package(/nvidia-driver-local-repo/)
+    it 'does not add the cuda repo' do
       expect(converged).not_to install_rpm_package(/cuda-repo/)
     end
   end
 
-  context 'when the driver is already installed but cuda is not' do
-    cached(:converged) { converge_add(nvidia_enabled: true, on_docker: false, nvidia_smi: true, cuda: false) }
+  context 'when cuda is already installed' do
+    cached(:converged) { converge_add_cuda_repo(nvidia_enabled: true, on_docker: false, cuda: true) }
 
-    it 'skips the driver repo but still adds the cuda repo' do
-      expect(converged).not_to install_rpm_package(/nvidia-driver-local-repo/)
-      expect(converged).to install_rpm_package(/cuda-repo-amzn2023-1-2-local/)
-    end
-  end
-
-  context 'when cuda is already installed but the driver is not' do
-    cached(:converged) { converge_add(nvidia_enabled: true, on_docker: false, nvidia_smi: false, cuda: true) }
-
-    it 'skips the cuda repo but still adds the driver repo' do
-      expect(converged).to install_rpm_package(/nvidia-driver-local-repo/)
-      expect(converged).not_to install_rpm_package(/cuda-repo-amzn2023-1-2-local/)
+    it 'does not add the cuda repo' do
+      expect(converged).not_to install_rpm_package(/cuda-repo/)
     end
   end
 end
 
 describe 'nvidia_repo: overriding base_url to the official NVIDIA URLs' do
-  # Fake versions: tests must not depend on the real versions, they only
-  # verify that the versions configured in the attributes are the ones used.
+  # Fake versions: tests only verify the configured attribute values are used.
   cached(:driver_version) { '9.8.7' }
   cached(:cuda_version) { '1.2.3' }
   cached(:cuda_suffix) { '4.5.6' }
@@ -270,40 +349,48 @@ describe 'nvidia_repo: overriding base_url to the official NVIDIA URLs' do
   cached(:driver_pkg_file) { "nvidia-driver-local-repo-amzn2023-#{driver_version}-1.0-1.x86_64.rpm" }
   cached(:cuda_pkg_file) { "cuda-repo-amzn2023-1-2-local-#{cuda_version}_#{cuda_suffix}-1.x86_64.rpm" }
 
-  cached(:chef_run) do
+  cached(:driver_run) do
     allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
     allow_any_instance_of(Object).to receive(:on_docker?).and_return(false)
     allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
     mock_file_exists('/usr/bin/nvidia-smi', false)
-    mock_file_exists('/usr/local/cuda', false)
     runner = runner(platform: 'amazon', version: '2023', step_into: ['nvidia_repo']) do |node|
       node.override['cluster']['nvidia']['driver_version'] = driver_version
       node.override['cluster']['nvidia']['driver_base_url'] = driver_base_url
+    end
+    ConvergeNvidiaRepo.add_driver_repo(runner)
+  end
+
+  cached(:cuda_run) do
+    allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
+    allow_any_instance_of(Object).to receive(:on_docker?).and_return(false)
+    allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+    mock_file_exists('/usr/local/cuda', false)
+    runner = runner(platform: 'amazon', version: '2023', step_into: ['nvidia_repo']) do |node|
       node.override['cluster']['nvidia']['cuda']['version'] = cuda_version
       node.override['cluster']['nvidia']['cuda']['base_url'] = cuda_base_url
       node.override['cluster']['nvidia']['cuda']['driver_version_suffix'] = cuda_suffix
     end
-    ConvergeNvidiaRepo.add(runner)
+    ConvergeNvidiaRepo.add_cuda_repo(runner)
   end
 
   it 'downloads the driver local repo from the official NVIDIA URL' do
-    is_expected.to create_remote_file(%r{/#{driver_pkg_file}$}).with(
+    expect(driver_run).to create_remote_file(%r{/#{driver_pkg_file}$}).with(
       source: "#{driver_base_url}/#{driver_pkg_file}"
     )
   end
 
   it 'downloads the cuda local repo from the official NVIDIA URL' do
-    is_expected.to create_remote_file(%r{/#{cuda_pkg_file}$}).with(
+    expect(cuda_run).to create_remote_file(%r{/#{cuda_pkg_file}$}).with(
       source: "#{cuda_base_url}/#{cuda_pkg_file}"
     )
   end
 end
 
-describe 'nvidia_repo:remove' do
+describe 'nvidia_repo:remove_driver_repo' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
-      # Fake versions: tests must not depend on the real versions, they only
-      # verify that the versions configured in the attributes are the ones used.
+      # Fake versions: tests only verify the configured attribute values are used.
       cached(:driver_version) { '9.8.7' }
       cached(:cuda_version) { '1.2.3' }
       cached(:cuda_suffix) { '4.5.6' }
@@ -316,11 +403,8 @@ describe 'nvidia_repo:remove' do
       cached(:driver_pkg_file) do
         debian? ? "#{driver_pkg_name}_1.0-1_#{arch}.deb" : "#{driver_pkg_name}-1.0-1.#{arch}.rpm"
       end
-      cached(:cuda_pkg_file) do
-        debian? ? "#{cuda_pkg_name}_#{cuda_version}-#{cuda_suffix}-1_#{arch}.deb" : "#{cuda_pkg_name}-#{cuda_version}_#{cuda_suffix}-1.#{arch}.rpm"
-      end
 
-      context 'when this run added the repos' do
+      context 'when this run added the driver repo' do
         cached(:chef_run) do
           allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
           runner = runner(platform: platform, version: version, step_into: ['nvidia_repo']) do |node|
@@ -330,20 +414,21 @@ describe 'nvidia_repo:remove' do
             node.override['cluster']['sources_dir'] = sources_dir
           end
           runner.node.run_state['nvidia_driver_repo_added'] = true
-          runner.node.run_state['nvidia_cuda_repo_added'] = true
-          ConvergeNvidiaRepo.remove(runner)
+          ConvergeNvidiaRepo.remove_driver_repo(runner)
         end
 
-        it 'removes the local-repo packages and deletes the installers' do
+        it 'removes the driver local-repo package and deletes the installer' do
           if debian?
             is_expected.to purge_package(driver_pkg_name)
-            is_expected.to purge_package(cuda_pkg_name)
           else
             is_expected.to remove_package(driver_pkg_name)
-            is_expected.to remove_package(cuda_pkg_name)
           end
           is_expected.to delete_file("#{sources_dir}/#{driver_pkg_file}")
-          is_expected.to delete_file("#{sources_dir}/#{cuda_pkg_file}")
+        end
+
+        it 'does not touch the cuda local repo' do
+          is_expected.not_to remove_package(cuda_pkg_name)
+          is_expected.not_to purge_package(cuda_pkg_name)
         end
 
         it 'refreshes the package manager metadata after removal' do
@@ -355,29 +440,51 @@ describe 'nvidia_repo:remove' do
             )
           end
         end
-
-        it 'refreshes the package manager metadata after each repo removal' do
-          ordered_names = chef_run.run_context.resource_collection.map(&:name)
-          refresh_name = if debian?
-                           'Refresh apt metadata after removing NVIDIA local repos'
-                         else
-                           'Refresh dnf metadata after removing NVIDIA local repos'
-                         end
-
-          driver_remove_index = ordered_names.index(driver_pkg_name)
-          cuda_remove_index = ordered_names.index(cuda_pkg_name)
-          refresh_indexes = ordered_names.each_index.select { |i| ordered_names[i] == refresh_name }
-
-          expect(driver_remove_index).not_to be_nil
-          expect(cuda_remove_index).not_to be_nil
-          # One refresh per removed repo, and each refresh comes after a removal.
-          expect(refresh_indexes.size).to eq(2)
-          expect(refresh_indexes.any? { |i| i > driver_remove_index }).to be(true)
-          expect(refresh_indexes.any? { |i| i > cuda_remove_index }).to be(true)
-        end
       end
 
-      context 'when this run added only the driver repo' do
+      context 'when this run did not add the driver repo' do
+        cached(:chef_run) do
+          allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
+          runner = runner(platform: platform, version: version, step_into: ['nvidia_repo']) do |node|
+            node.override['cluster']['nvidia']['driver_version'] = driver_version
+            node.override['cluster']['nvidia']['cuda']['version'] = cuda_version
+            node.override['cluster']['nvidia']['cuda']['driver_version_suffix'] = cuda_suffix
+          end
+          ConvergeNvidiaRepo.remove_driver_repo(runner)
+        end
+
+        it 'removes nothing' do
+          is_expected.not_to remove_package(driver_pkg_name)
+          is_expected.not_to purge_package(driver_pkg_name)
+        end
+
+        it 'does not refresh the package manager metadata' do
+          is_expected.not_to update_apt_update('Refresh apt metadata after removing NVIDIA local repos')
+          is_expected.not_to run_execute('Refresh dnf metadata after removing NVIDIA local repos')
+        end
+      end
+    end
+  end
+end
+
+describe 'nvidia_repo:remove_cuda_repo' do
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      # Fake versions: tests only verify the configured attribute values are used.
+      cached(:driver_version) { '9.8.7' }
+      cached(:cuda_version) { '1.2.3' }
+      cached(:cuda_suffix) { '4.5.6' }
+      cached(:sources_dir) { '/fake/sources' }
+      cached(:debian?) { platform == 'ubuntu' }
+      cached(:local_repo_platform) { nvidia_local_repo_platform_for(platform, version) }
+      cached(:arch) { debian? ? 'amd64' : 'x86_64' }
+      cached(:driver_pkg_name) { "nvidia-driver-local-repo-#{local_repo_platform}-#{driver_version}" }
+      cached(:cuda_pkg_name) { "cuda-repo-#{local_repo_platform}-1-2-local" }
+      cached(:cuda_pkg_file) do
+        debian? ? "#{cuda_pkg_name}_#{cuda_version}-#{cuda_suffix}-1_#{arch}.deb" : "#{cuda_pkg_name}-#{cuda_version}_#{cuda_suffix}-1.#{arch}.rpm"
+      end
+
+      context 'when this run added the cuda repo' do
         cached(:chef_run) do
           allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
           runner = runner(platform: platform, version: version, step_into: ['nvidia_repo']) do |node|
@@ -386,21 +493,25 @@ describe 'nvidia_repo:remove' do
             node.override['cluster']['nvidia']['cuda']['driver_version_suffix'] = cuda_suffix
             node.override['cluster']['sources_dir'] = sources_dir
           end
-          runner.node.run_state['nvidia_driver_repo_added'] = true
-          ConvergeNvidiaRepo.remove(runner)
+          runner.node.run_state['nvidia_cuda_repo_added'] = true
+          ConvergeNvidiaRepo.remove_cuda_repo(runner)
         end
 
-        it 'removes only the driver repo, leaving the cuda repo untouched' do
+        it 'removes the cuda local-repo package and deletes the installer' do
           if debian?
-            is_expected.to purge_package(driver_pkg_name)
-            is_expected.not_to purge_package(cuda_pkg_name)
+            is_expected.to purge_package(cuda_pkg_name)
           else
-            is_expected.to remove_package(driver_pkg_name)
-            is_expected.not_to remove_package(cuda_pkg_name)
+            is_expected.to remove_package(cuda_pkg_name)
           end
+          is_expected.to delete_file("#{sources_dir}/#{cuda_pkg_file}")
         end
 
-        it 'still refreshes the package manager metadata after removing the driver repo' do
+        it 'does not touch the driver local repo' do
+          is_expected.not_to remove_package(driver_pkg_name)
+          is_expected.not_to purge_package(driver_pkg_name)
+        end
+
+        it 'refreshes the package manager metadata after removal' do
           if debian?
             is_expected.to update_apt_update('Refresh apt metadata after removing NVIDIA local repos')
           else
@@ -411,7 +522,7 @@ describe 'nvidia_repo:remove' do
         end
       end
 
-      context 'when this run did not add the repos' do
+      context 'when this run did not add the cuda repo' do
         cached(:chef_run) do
           allow_any_instance_of(Object).to receive(:arm_instance?).and_return(false)
           runner = runner(platform: platform, version: version, step_into: ['nvidia_repo']) do |node|
@@ -419,13 +530,11 @@ describe 'nvidia_repo:remove' do
             node.override['cluster']['nvidia']['cuda']['version'] = cuda_version
             node.override['cluster']['nvidia']['cuda']['driver_version_suffix'] = cuda_suffix
           end
-          ConvergeNvidiaRepo.remove(runner)
+          ConvergeNvidiaRepo.remove_cuda_repo(runner)
         end
 
         it 'removes nothing' do
-          is_expected.not_to remove_package(driver_pkg_name)
           is_expected.not_to remove_package(cuda_pkg_name)
-          is_expected.not_to purge_package(driver_pkg_name)
           is_expected.not_to purge_package(cuda_pkg_name)
         end
 

--- a/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_repo_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/nvidia_repo_spec.rb
@@ -24,8 +24,8 @@ nvidia_local_repo_packages = [
   "cuda-repo-#{local_repo_platform}-#{cuda_version_dashed}-local",
 ]
 
-# No tag:install_ prefix on purpose: the added state only holds between nvidia_repo:add and :remove,
-# so full install builds must not select this control.
+# No tag:install_ prefix on purpose: repos only exist between the nvidia_repo
+# add/remove actions, so full install builds must not select this control.
 control 'tag:nvidia_local_repos_added' do
   only_if do
     !os_properties.on_docker? &&


### PR DESCRIPTION
### Description of changes
Install nvidia cuda repo after the driver stack is installed, to prevent silent upgrades of the driver through the cuda repo.

### Tests
SUCCEEDED build on all OSs, except for RHEL9 where the build failed due to an unrelated issue with FSx repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
