### PR TITLE
Fix default node package install shadowed by empty custom_node_package from CLI

### DIFF
--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/parallelcluster_node.rb
@@ -33,9 +33,9 @@ activate_virtual_env node_virtualenv_name do
   not_if { ::File.exist?("#{virtualenv_path}/bin/activate") }
 end
 
-# Install the official node package from S3 in all regions (air-gapped/proxied
-# support), unless the user opts into installing from PyPI via
-# install_node_from_internet. A user-provided custom_node_package always wins.
+# Install the aws-parallelcluster-node package from S3 in all regions
+# (air-gapped/proxied support), unless the user opts into installing from PyPI
+# via install_node_from_internet.
 if node['cluster']['install_node_from_internet']
   # install_node_from_internet was requested: install from PyPI.
   execute "install aws-parallelcluster-node from Pypi" do
@@ -44,5 +44,9 @@ if node['cluster']['install_node_from_internet']
     retry_delay 5
   end
 else
+  # Install from S3: use the customer's custom package when provided via
+  # DevSettings/NodePackage, otherwise fall back to the official S3 package.
+  # custom_parallelcluster_node consumes node['cluster']['custom_node_package'].
+  node.override['cluster']['custom_node_package'] = node['cluster']['official_node_package'] unless is_custom_node?
   include_recipe 'aws-parallelcluster-computefleet::custom_parallelcluster_node'
 end

--- a/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/node_spec.rb
@@ -9,13 +9,13 @@ describe 'aws-parallelcluster-computefleet::parallelcluster_node' do
       cached(:virtualenv_path) { 'system_pyenv_root/versions/python_version/envs/node_virtualenv' }
 
       context "when node virtualenv not installed yet and custom node package is not set" do
-        cached(:s3_url) { 'https://REGION-aws-parallelcluster.s3.REGION.test_aws_domain' }
+        cached(:official_node_package) { 'https://REGION-aws-parallelcluster.s3.REGION.test_aws_domain/node.tgz' }
         cached(:chef_run) do
           runner = runner(platform: platform, version: version) do |node|
             node.override['cluster']['system_pyenv_root'] = system_pyenv_root
             node.override['cluster']['python-version'] = python_version
             node.override['cluster']['parallelcluster-node-version'] = node_version
-            node.override['cluster']['s3_url'] = s3_url
+            node.override['cluster']['official_node_package'] = official_node_package
           end
           runner.converge(described_recipe)
         end
@@ -37,11 +37,11 @@ describe 'aws-parallelcluster-computefleet::parallelcluster_node' do
           is_expected.to write_node_attributes('dump node attributes')
         end
 
-        # By default (install_python_from_internet false) the node package is
-        # installed from S3 in all regions, not from PyPI.
-        it 'points custom_node_package at the S3 node package' do
-          expect(node['cluster']['custom_node_package'])
-            .to eq("#{s3_url}/parallelcluster/#{node_version}/node/aws-parallelcluster-node-#{node_version}.tgz")
+        # By default (install_node_from_internet false) the node package is
+        # installed from S3 in all regions, not from PyPI. When no custom
+        # package is set, custom_node_package falls back to official_node_package.
+        it 'points custom_node_package at the official S3 node package' do
+          expect(node['cluster']['custom_node_package']).to eq(official_node_package)
         end
 
         it 'installs node from S3 via the custom node recipe' do
@@ -50,6 +50,30 @@ describe 'aws-parallelcluster-computefleet::parallelcluster_node' do
 
         it 'does not install the node package from PyPI' do
           is_expected.not_to run_execute('install aws-parallelcluster-node from Pypi')
+        end
+      end
+
+      context "when a custom node package is set" do
+        cached(:custom_node_package) { 'https://example.com/my-custom-node.tgz' }
+        cached(:official_node_package) { 'https://REGION-aws-parallelcluster.s3.REGION.test_aws_domain/node.tgz' }
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['system_pyenv_root'] = system_pyenv_root
+            node.override['cluster']['python-version'] = python_version
+            node.override['cluster']['parallelcluster-node-version'] = node_version
+            node.override['cluster']['official_node_package'] = official_node_package
+            node.override['cluster']['custom_node_package'] = custom_node_package
+          end
+          runner.converge(described_recipe)
+        end
+        cached(:node) { chef_run.node }
+
+        it 'preserves the customer-supplied custom_node_package' do
+          expect(node['cluster']['custom_node_package']).to eq(custom_node_package)
+        end
+
+        it 'installs node via the custom node recipe' do
+          is_expected.to include_recipe('aws-parallelcluster-computefleet::custom_parallelcluster_node')
         end
       end
 

--- a/cookbooks/aws-parallelcluster-shared/attributes/versions.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/versions.rb
@@ -10,10 +10,9 @@ default['cluster']['install_python_from_internet'] = false
 # official S3 bucket.
 default['cluster']['install_node_from_internet'] = false
 
-# Official ParallelCluster Node Package
-default['cluster']['custom_node_package'] = "#{node['cluster']['s3_url']}/parallelcluster/#{node['cluster']['parallelcluster-node-version']}/node/aws-parallelcluster-node-#{node['cluster']['parallelcluster-node-version']}.tgz"
-
 # ParallelCluster versions
 default['cluster']['parallelcluster-version'] = '3.16.0'
 default['cluster']['parallelcluster-cookbook-version'] = '3.16.0'
 default['cluster']['parallelcluster-node-version'] = '3.16.0'
+
+default['cluster']['official_node_package'] = "#{node['cluster']['s3_url']}/parallelcluster/#{node['cluster']['parallelcluster-node-version']}/node/aws-parallelcluster-node-#{node['cluster']['parallelcluster-node-version']}.tgz"

--- a/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-shared/libraries/helpers.rb
@@ -75,17 +75,11 @@ def load_cluster_config(config_path)
 end
 
 #
-# Check if a custom node package is specified in the config using DevSettings.
-# We ship a default custom_node_package (the official S3 package), so we
-# compare the effective value against the full default-precedence value:
-# only a value the customer changed counts as custom.
+# Check if a custom node package is specified in the config via DevSettings/NodePackage.
 #
 def is_custom_node?
   custom_node_package = node['cluster']['custom_node_package']
-  return false if custom_node_package.nil? || custom_node_package.empty?
-  custom = custom_node_package != node.default['cluster']['custom_node_package']
-  Chef::Log.info("is_custom_node?: #{custom} (package: #{custom_node_package})")
-  custom
+  !custom_node_package.nil? && !custom_node_package.empty?
 end
 
 def write_sync_file(path)

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/libraries/helpers_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/libraries/helpers_spec.rb
@@ -46,17 +46,11 @@ end
 
 describe 'is_custom_node?' do
   let(:node) { Chef::Node.new }
-  let(:default_base) { 'DEFAULT_BASE_URL' }
-  let(:default_package) { "#{default_base}/node/DEFAULT_NODE_PACKAGE" }
 
-  before { node.default['cluster']['custom_node_package'] = default_package }
+  # Ensure the cluster attribute namespace exists.
+  before { node.override['cluster'] = {} }
 
-  it 'returns false when the package equals the shipped default' do
-    node.override['cluster']['custom_node_package'] = default_package
-    expect(is_custom_node?).to be false
-  end
-
-  it 'returns false when the package is nil' do
+  it 'returns false when the package is unset' do
     expect(is_custom_node?).to be false
   end
 
@@ -65,13 +59,8 @@ describe 'is_custom_node?' do
     expect(is_custom_node?).to be false
   end
 
-  it 'returns true when the customer supplies a different package' do
+  it 'returns true when the customer supplies a package' do
     node.override['cluster']['custom_node_package'] = 'CUSTOM_NODE_PACKAGE'
-    expect(is_custom_node?).to be true
-  end
-
-  it 'returns true when only the path differs but the base is the same' do
-    node.override['cluster']['custom_node_package'] = "#{default_base}/other/CUSTOM_NODE_PACKAGE"
     expect(is_custom_node?).to be true
   end
 end


### PR DESCRIPTION
### Description of changes

In #3211, the change relied on a default custom_node_package attribute pointing at the official S3 package, but the CLI always injects custom_node_package into dna.json (empty when there is no DevSettings/NodePackage). So the effective value was "", and build-image failed on a cluster without DevSettings/NodePackage.

- Revert the default on custom_node_package. It now means only "customer-supplied override", and revert change in is_custom_node? to a simple non-empty check.
- Add `official_node_package` attribute in `versions.rb`.
- parallelcluster_node recipe selects the source at converge time: PyPI when install_node_from_internet is set, the customer's package when provided, otherwise the official S3 package. Deciding at converge time avoids the precedence trap, so the empty custom_node_package from dna.json is harmless.


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
