### PR TITLE
[Nvidia] Install Xorg driver on RHEL family for DCV GPU acceleration

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -27,12 +27,6 @@ default['cluster']['enroot']['persistent_dir'] = '/var/enroot'
 default['cluster']['nvidia']['enabled'] = 'no'
 default['cluster']['nvidia']['driver_version'] = '580.173.02'
 default['cluster']['nvidia']['dcgm_version'] = '4.6.0-1'
-
-# Extra packages installed from the NVIDIA local repo alongside the driver
-# meta-package, as a comma-separated list.
-# * nvidia-xconfig: required by DCV to generate the X configuration
-default['cluster']['nvidia']['driver_extra_packages'] = 'nvidia-xconfig'
-
 default['cluster']['nvidia']['driver_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_driver"
 default['cluster']['nvidia']['dcgm_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_dcgm"
 

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_dcv_common.rb
@@ -75,6 +75,9 @@ action_class do
     # DO NOT install dcv-gl on non-GPU instances, or will run into a black screen issue
     install_dcv_gl
 
+    # Ensure GDM starts an Xorg server (not Wayland) before launching X
+    disable_wayland
+
     # Configure the X server to start automatically when the Linux server boots and start the X server in background
     bash 'Launch X' do
       user 'root'
@@ -91,6 +94,33 @@ action_class do
       command "pidof X || pidof Xorg"
       retries 10
       retry_delay 5
+    end
+  end
+
+  def gdm_custom_conf
+    '/etc/gdm/custom.conf'
+  end
+
+  # Disable Wayland in GDM so that GDM starts an Xorg server, which DCV GPU
+  # acceleration requires.
+  def disable_wayland
+    conf = gdm_custom_conf
+    bash 'Disable Wayland in GDM' do
+      user 'root'
+      code <<-DISABLEWAYLAND
+        set -e
+        if [ -f #{conf} ]; then
+          sed -i 's/#WaylandEnable=false/WaylandEnable=false/' #{conf}
+          if ! grep -q "^WaylandEnable=false" #{conf}; then
+            sed -i '/\\[daemon\\]/a WaylandEnable=false' #{conf}
+          fi
+        fi
+      DISABLEWAYLAND
+    end
+
+    # Restart GDM so it re-reads the setting and comes up on Xorg.
+    service 'gdm' do
+      action :restart
     end
   end
 

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_ubuntu_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_ubuntu_common.rb
@@ -97,59 +97,7 @@ EOF
     end
   end
 
-  # Disable Wayland in GDM to ensure Xorg is used
-  # This is required for Ubuntu 22.04+ where Wayland is the default
-  # Without this, GDM won't start Xorg on headless GPU instances
-  def disable_wayland
-    bash 'Disable Wayland in GDM' do
-      user 'root'
-      code <<-DISABLEWAYLAND
-        set -e
-        if [ -f /etc/gdm3/custom.conf ]; then
-          sed -i 's/#WaylandEnable=false/WaylandEnable=false/' /etc/gdm3/custom.conf
-          # If the line doesn't exist at all, add it under [daemon] section
-          if ! grep -q "^WaylandEnable=false" /etc/gdm3/custom.conf; then
-            sed -i '/\\[daemon\\]/a WaylandEnable=false' /etc/gdm3/custom.conf
-          fi
-        fi
-      DISABLEWAYLAND
-    end
-  end
-
-  # Override allow_gpu_acceleration to disable Wayland before starting X
-  def allow_gpu_acceleration
-    # Update the xorg.conf to set up NVIDIA drivers.
-    # NOTE: --enable-all-gpus parameter is needed to support servers with more than one NVIDIA GPU.
-    nvidia_xconfig_command = "nvidia-xconfig --preserve-busid --enable-all-gpus"
-    nvidia_xconfig_command += " --use-display-device=none" if node['ec2']['instance_type'].start_with?("g2.")
-    execute "Set up Nvidia drivers for X configuration" do
-      user 'root'
-      command nvidia_xconfig_command
-    end
-
-    # dcvgl package must be installed after NVIDIA and before starting up X
-    # DO NOT install dcv-gl on non-GPU instances, or will run into a black screen issue
-    install_dcv_gl
-
-    # Disable Wayland to ensure GDM starts Xorg
-    disable_wayland
-
-    # Configure the X server to start automatically when the Linux server boots and start the X server in background
-    bash 'Launch X' do
-      user 'root'
-      code <<-SETUPX
-      set -e
-      systemctl set-default graphical.target
-      systemctl isolate graphical.target &
-      SETUPX
-    end
-
-    # Verify that the X server is running
-    execute 'Wait for X to start' do
-      user 'root'
-      command "pidof X || pidof Xorg"
-      retries 10
-      retry_delay 5
-    end
+  def gdm_custom_conf
+    '/etc/gdm3/custom.conf'
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_common.rb
@@ -16,7 +16,6 @@ unified_mode true
 default_action :setup
 
 property :nvidia_driver_version, String, default: node['cluster']['nvidia']['driver_version']
-property :extra_driver_packages, String, default: node['cluster']['nvidia']['driver_extra_packages']
 
 action :setup do
   return unless nvidia_driver_enabled?
@@ -81,8 +80,8 @@ action :setup do
     retry_delay 5
   end
 
-  # Install the extra driver packages from the NVIDIA local repo.
-  new_resource.extra_driver_packages.split(',').each do |pkg|
+  # Install the extra packages from the NVIDIA local repo alongside the driver.
+  extra_driver_packages.each do |pkg|
     package pkg do
       retries 3
       retry_delay 5
@@ -131,4 +130,8 @@ end
 
 def kernel_modules_to_load
   %w(drm_client_lib)
+end
+
+def extra_driver_packages
+  %w(nvidia-xconfig)
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_install_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/nvidia_driver/partial/_nvidia_driver_install_rhel.rb
@@ -31,3 +31,11 @@ end
 def nvidia_driver_module_stream
   nvidia_open_kernel_modules? ? 'open-dkms' : 'latest-dkms'
 end
+
+# On RHEL family the Xorg NVIDIA driver (xorg-x11-nvidia) is a separate package
+# the driver meta-package does not pull in; it is required to start the X server
+# for DCV GPU acceleration. On Debian/Ubuntu the equivalent
+# (xserver-xorg-video-nvidia) is already a dependency of the driver meta-package.
+def extra_driver_packages
+  %w(nvidia-xconfig xorg-x11-nvidia)
+end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -900,6 +900,17 @@ describe 'dcv:configure' do
           )
         end
 
+        it 'disables Wayland in GDM so GDM starts an Xorg server' do
+          gdm_conf = platform == 'ubuntu' ? '/etc/gdm3/custom.conf' : '/etc/gdm/custom.conf'
+          is_expected.to run_bash('Disable Wayland in GDM')
+            .with_user('root')
+            .with_code(/#{Regexp.escape(gdm_conf)}/)
+        end
+
+        it 'restarts GDM so it re-reads the Wayland setting and comes up on Xorg' do
+          is_expected.to restart_service('gdm')
+        end
+
         if platform == 'ubuntu'
           it 'disables RNDFILE from openssl to avoid error during certificate generation' do
             is_expected.to run_execute('No RND')

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_driver_spec.rb
@@ -182,6 +182,10 @@ describe 'nvidia_driver:setup' do
         )
       end
 
+      it 'installs nvidia-xconfig from the NVIDIA local repo on every platform' do
+        is_expected.to install_package('nvidia-xconfig')
+      end
+
       if platform == 'ubuntu'
         it 'installs the open driver meta-package' do
           is_expected.to install_package('nvidia-open')
@@ -198,6 +202,10 @@ describe 'nvidia_driver:setup' do
         it 'rebuilds the initramfs' do
           is_expected.to run_execute('initramfs to remove nouveau').with_command('update-initramfs -u')
         end
+
+        it 'does not install the RHEL-family Xorg NVIDIA driver package' do
+          is_expected.not_to install_package('xorg-x11-nvidia')
+        end
       else
         it 'enables the open-dkms module stream and installs nvidia-open' do
           is_expected.to run_execute('Enable NVIDIA driver module').with(
@@ -208,6 +216,10 @@ describe 'nvidia_driver:setup' do
 
         it 'does not rebuild the initramfs' do
           is_expected.not_to run_execute('initramfs to remove nouveau')
+        end
+
+        it 'installs the Xorg NVIDIA driver package for GPU-accelerated DCV' do
+          is_expected.to install_package('xorg-x11-nvidia')
         end
       end
     end


### PR DESCRIPTION
### Description of changes
We made the following changes to make the DCV configuration work on RHEL/Rocky after changing the way we install nvidia software (https://github.com/aws/aws-parallelcluster-cookbook/pull/3207)
* Install Xorg driver. Apparently, this used to be installed by the runfile and it must be now installed explicitly form the repo.
* Disable Wayland so that GDM always start Xorg. This used to be necessary only in Ubuntu, but with the new installation method it became necessayr on RHEL as well.

### Tests
SUCCESS build+kitchen on all OSS, barring build/kitchen failure on RHEL9 which is broken by an unrelated issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
