### PR TITLE
[Build] Speed the build-image up by enabling parallelization for Python and Nvidia compilation.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/templates/nvidia/amazon/dkms/nvidia.conf.erb
+++ b/cookbooks/aws-parallelcluster-platform/templates/nvidia/amazon/dkms/nvidia.conf.erb
@@ -1,1 +1,1 @@
-MAKE[0]="'make' -j2 NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} modules <%= @compiler_path %>"
+MAKE[0]="'make' -j$(nproc) NV_EXCLUDE_BUILD_MODULES='' KERNEL_UNAME=${kernelver} modules <%= @compiler_path %>"

--- a/cookbooks/aws-parallelcluster-shared/resources/install_pyenv.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/install_pyenv.rb
@@ -53,7 +53,8 @@ action :run do
     tar -xzf Python-#{python_version}.tgz
     cd Python-#{python_version}
     ./configure --prefix=#{prefix}/versions/#{python_version}
-    make
+    CORES=$(grep processor /proc/cpuinfo | wc -l)
+    make -j $CORES
     make install
     VENV
     not_if { Dir.glob("#{prefix}/versions/#{python_version}/bin/python*").any? }


### PR DESCRIPTION
### Description of changes
Speed the build-image up by enabling parallelization for Python and Nvidia compilation.
We are making this change now because we now install nvidia software using a method (the suggested one) which increases the duration of the build (https://github.com/aws/aws-parallelcluster-cookbook/pull/3207).

Recorded benefit comparing the timing in 2nd stage build before/after the fix on g4dn.2xlarge.
On RHEKL/Rocky we see no benefit in the change for nvidia dkms compilation because they do not use the configuration we changed, they have always used the default setting. 

| OS / arch          | Python before (s) | Python after (s) | NVIDIA before (s) | NVIDIA after (s) |
|--------------------|-------------------|------------------|-------------------|------------------|
| alinux2023 arm64   | 340               | 86               | 379               | 161              |
| alinux2023 x86_64  | 280               | 97               | 330               | 194              |
| rhel8 arm64        | 296               | 74               | 250               | 242              |
| rhel8 x86_64       | 287               | 93               | 344               | 327              |
| rhel9 arm64        | 368               | 96               | 303               | 293              |
| rhel9 x86_64       | 300               | 100              | 318               | 315              |
| rocky8 arm64       | 282               | 75               | 222               | 225              |
| rocky8 x86_64      | 261               | 95               | 322               | 323              |
| rocky9 arm64       | 352               | 93               | 250               | 247              |
| rocky9 x86_64      | 296               | 98               | 324               | 292              |
| ubuntu2204 arm64   | 341               | 82               | 234               | 136              |
| ubuntu2204 x86_64  | 286               | 92               | 197               | 131              |
| ubuntu2404 arm64   | 349               | 85               | 269               | 106              |
| ubuntu2404 x86_64  | 298               | 93               | 180               | 100              |


### Tests
* Build succeeded on all OSs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
