### PR TITLE
Make node['cluster']['tmp_noexec'] effective on cluster creation too

### DIFF
--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/init.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/init.rb
@@ -16,6 +16,8 @@ include_recipe "aws-parallelcluster-platform::enable_chef_error_handler"
 
 include_recipe "aws-parallelcluster-shared::setup_envars"
 
+include_recipe "aws-parallelcluster-shared::remount_tmp_noexec"
+
 os_type 'Validate OS type specified by the user is the same as the OS identified by Ohai'
 
 # Validate init system

--- a/cookbooks/aws-parallelcluster-entrypoints/recipes/install.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/recipes/install.rb
@@ -16,12 +16,7 @@ os_type 'Validate OS type specified by the user is the same as the OS identified
 
 return if node['conditions']['ami_bootstrapped']
 
-if node['cluster']['tmp_noexec'] == 'true'
-  execute 'TEST ONLY - remount /tmp as noexec' do
-    command 'mount --bind /tmp /tmp && mount -o remount,bind,noexec,nosuid,nodev /tmp'
-    not_if 'findmnt -no OPTIONS /tmp | grep -qw noexec'
-  end
-end
+include_recipe "aws-parallelcluster-shared::remount_tmp_noexec"
 
 include_recipe "aws-parallelcluster-shared::setup_envars"
 include_recipe "aws-parallelcluster-shared::setup_proxy" if node['cluster']['install_http_proxy_address']

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/init_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/init_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Copyright:: 2026 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'ostruct'
+
+describe 'aws-parallelcluster-entrypoints::init' do
+  all_recipes = %w(
+    aws-parallelcluster-platform::enable_chef_error_handler
+    aws-parallelcluster-shared::setup_envars
+    aws-parallelcluster-shared::remount_tmp_noexec
+    aws-parallelcluster-environment::init
+    aws-parallelcluster-computefleet::init
+    aws-parallelcluster-slurm::init
+  )
+
+  remount_tmp_noexec_recipe = 'aws-parallelcluster-shared::remount_tmp_noexec'
+
+  before do
+    allow_any_instance_of(Chef::Recipe).to receive(:systemd?).and_return(true)
+    allow_any_instance_of(Object).to receive(:fetch_config).and_return(OpenStruct.new)
+
+    @included_recipes = []
+    all_recipes.each do |recipe_name|
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with(recipe_name) do
+        @included_recipes << recipe_name
+      end
+    end
+  end
+
+  for_all_oses do |platform, version|
+    context "on #{platform}#{version}" do
+      cached(:chef_run) do
+        runner(platform: platform, version: version).converge(described_recipe)
+      end
+
+      it "includes the remount_tmp_noexec recipe right after setup_envars" do
+        chef_run
+        expect(@included_recipes).to include(remount_tmp_noexec_recipe)
+        expect(@included_recipes.index(remount_tmp_noexec_recipe))
+          .to eq(@included_recipes.index('aws-parallelcluster-shared::setup_envars') + 1)
+      end
+    end
+  end
+end

--- a/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/install_spec.rb
+++ b/cookbooks/aws-parallelcluster-entrypoints/spec/unit/recipes/install_spec.rb
@@ -15,6 +15,7 @@ require 'spec_helper'
 
 describe 'aws-parallelcluster-entrypoints::install' do
   all_recipes = %w(
+    aws-parallelcluster-shared::remount_tmp_noexec
     aws-parallelcluster-shared::setup_envars
     aws-parallelcluster-platform::install
     aws-parallelcluster-environment::install
@@ -23,6 +24,7 @@ describe 'aws-parallelcluster-entrypoints::install' do
   )
 
   setup_proxy_recipe = 'aws-parallelcluster-shared::setup_proxy'
+  remount_tmp_noexec_recipe = 'aws-parallelcluster-shared::remount_tmp_noexec'
 
   before do
     @included_recipes = []
@@ -50,6 +52,18 @@ describe 'aws-parallelcluster-entrypoints::install' do
       end
 
       context "when ami is not bootstrapped" do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['conditions']['ami_bootstrapped'] = false
+          end
+          runner.converge(described_recipe)
+        end
+
+        it "includes the remount_tmp_noexec recipe" do
+          chef_run
+          expect(@included_recipes).to include(remount_tmp_noexec_recipe)
+        end
+
         context "when install_http_proxy_address is set" do
           cached(:chef_run) do
             runner = runner(platform: platform, version: version) do |node|

--- a/cookbooks/aws-parallelcluster-shared/recipes/remount_tmp_noexec.rb
+++ b/cookbooks/aws-parallelcluster-shared/recipes/remount_tmp_noexec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Copyright:: 2026 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TEST ONLY. Do not set in production builds.
+# This is a test knob to validate noexec compliance during build-image and create-cluster;
+# ParallelCluster does not enforce noexec on /tmp by default.
+if node['cluster']['tmp_noexec'] == 'true'
+  execute 'TEST ONLY - remount /tmp as noexec' do
+    command 'mount --bind /tmp /tmp && mount -o remount,bind,noexec,nosuid,nodev /tmp'
+    not_if 'findmnt -no OPTIONS /tmp | grep -qw noexec'
+  end
+end

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/recipes/remount_tmp_noexec_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/recipes/remount_tmp_noexec_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Copyright:: 2026 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'aws-parallelcluster-shared::remount_tmp_noexec' do
+  remount_command = 'mount --bind /tmp /tmp && mount -o remount,bind,noexec,nosuid,nodev /tmp'
+  guard = 'findmnt -no OPTIONS /tmp | grep -qw noexec'
+
+  context "when tmp_noexec is 'true'" do
+    cached(:chef_run) do
+      stub_command(guard).and_return(false)
+      runner(platform: 'redhat', version: '8') do |node|
+        node.override['cluster']['tmp_noexec'] = 'true'
+      end.converge(described_recipe)
+    end
+
+    it 'remounts /tmp as noexec' do
+      is_expected.to run_execute('TEST ONLY - remount /tmp as noexec')
+        .with(command: remount_command)
+    end
+  end
+
+  context "when tmp_noexec is 'false'" do
+    cached(:chef_run) do
+      runner(platform: 'redhat', version: '8') do |node|
+        node.override['cluster']['tmp_noexec'] = 'false'
+      end.converge(described_recipe)
+    end
+
+    it 'does not remount /tmp' do
+      is_expected.not_to run_execute('TEST ONLY - remount /tmp as noexec')
+    end
+  end
+
+  context "when tmp_noexec is not set (defaults to 'false')" do
+    cached(:chef_run) do
+      runner(platform: 'redhat', version: '8').converge(described_recipe)
+    end
+
+    it 'does not remount /tmp' do
+      is_expected.not_to run_execute('TEST ONLY - remount /tmp as noexec')
+    end
+  end
+end


### PR DESCRIPTION
### Description of changes
With https://github.com/aws/aws-parallelcluster-cookbook/pull/3221, the chef attribute is only effective during build-image. This commit makes it effective during cluster-creation.

This commit will enable easier testing of pcluster's compliance with `noexec` on `/tmp`

### Tests
* A simple build image and cluster creation with the attribute set to true is successful for all OSes. After this commit is merged, I will run more automated tests

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
