### PR TITLE
Add Chef attribute to be able to disable GDRcopy installation during build-image

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -43,6 +43,7 @@ default['cluster']['nvidia']['cuda']['version'] = '13.3.1'
 default['cluster']['nvidia']['cuda']['driver_version_suffix'] = '610.43.02'
 
 # GDRCopy
+default['cluster']['nvidia']['gdrcopy']['enabled'] = true
 default['cluster']['nvidia']['gdrcopy']['version'] = '2.6'
 default['cluster']['nvidia']['gdrcopy']['sha256'] = 'c9eaf0593567ac5765d04c48cf7923dacb2644240b35bb5f025edb3bde1d5b4f'
 default['cluster']['nvidia']['gdrcopy']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/gdr_copy/v#{node['cluster']['nvidia']['gdrcopy']['version']}.tar.gz"

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_alinux2023.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_alinux2023.rb
@@ -19,10 +19,6 @@ end
 use 'partial/_gdrcopy_common.rb'
 use 'partial/_gdrcopy_common_rhel.rb'
 
-def gdrcopy_enabled?
-  nvidia_enabled?
-end
-
 def gdrcopy_build_dependencies
   %w(dkms rpm-build make check check-devel) # Subunit is not available in Al2023
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_redhat8.rb
@@ -19,10 +19,6 @@ end
 use 'partial/_gdrcopy_common.rb'
 use 'partial/_gdrcopy_common_rhel.rb'
 
-def gdrcopy_enabled?
-  nvidia_enabled?
-end
-
 def gdrcopy_build_dependencies
   if aws_region.start_with?("us-iso")
     %w(rpm-build make check check-devel)

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_rocky8.rb
@@ -19,10 +19,6 @@ end
 use 'partial/_gdrcopy_common.rb'
 use 'partial/_gdrcopy_common_rhel.rb'
 
-def gdrcopy_enabled?
-  nvidia_enabled?
-end
-
 def gdrcopy_platform
   "el#{node['platform_version'].to_i}"
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_ubuntu22+.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/gdrcopy_ubuntu22+.rb
@@ -36,10 +36,6 @@ def installation_code
   COMMAND
 end
 
-def gdrcopy_enabled?
-  nvidia_enabled?
-end
-
 def gdrcopy_service
   'gdrdrv'
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/gdrcopy/partial/_gdrcopy_common.rb
@@ -16,6 +16,14 @@ def gdrcopy_version
   node['cluster']['nvidia']['gdrcopy']['version']
 end
 
+def gdrcopy_enabled?
+  nvidia_enabled? && gdrcopy_config_enabled?
+end
+
+def gdrcopy_config_enabled?
+  ['yes', true, 'true'].include?(node['cluster']['nvidia']['gdrcopy']['enabled'])
+end
+
 # True if gdrcopy is installed (regardless of version). Like nvidia-smi for the
 # driver, the gdrcopy_sanity binary is the one of the test commands that are
 # installed by GDRCopy and we use it as signal of a healthy install

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/gdrcopy_spec.rb
@@ -176,6 +176,24 @@ describe 'gdrcopy:setup' do
       end
     end
 
+    context "on #{platform}#{version} when gdrcopy is disabled via attribute" do
+      # NVIDIA is enabled, but the gdrcopy escape-hatch attribute is off, so
+      # gdrcopy_enabled? must be false and nothing is installed.
+      cached(:chef_run) do
+        stubs_for_resource('gdrcopy') do |res|
+          allow(res).to receive(:nvidia_enabled?).and_return(true)
+        end
+        runner = runner(platform: platform, version: version, step_into: ['gdrcopy']) do |node|
+          node.override['cluster']['nvidia']['gdrcopy']['enabled'] = false
+        end
+        ConvergeGdrcopy.setup(runner)
+      end
+
+      it 'does not install gdrcopy' do
+        is_expected.not_to run_bash('Install NVIDIA GDRCopy')
+      end
+    end
+
     context "on #{platform}#{version} when gdrcopy enabled" do
       cached(:sources_dir) { 'sources_dir' }
       cached(:gdrcopy_service) { platform == 'ubuntu' ? 'gdrdrv' : 'gdrcopy' }


### PR DESCRIPTION
### Description of changes
* This PR also includes refactor to reduce duplication of "gdrcopy_enabled?"

### Tests
Build image on all OS with the following DevSettings is successful:
```
    ExtraChefAttributes: '{"cluster": {"tmp_noexec": "true", "nvidia": {"gdrcopy":{"enabled":
      "false"}}}}'
```
Create cluster on all OS with the following DevSettings is successful:
```
    ExtraChefAttributes: '{"cluster": {"tmp_noexec": "true"}}'
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
