### PR TITLE
[Build] Expand usage of robust package to further reduce failures on RHEL/Rocky

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/resources/ephemeral_drives/partial/_ephemeral_drives_common.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/ephemeral_drives/partial/_ephemeral_drives_common.rb
@@ -20,10 +20,8 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  package "install Logical Volume Manager 2 utilities" do
-    package_name "lvm2"
-    retries 3
-    retry_delay 5
+  robust_package "install Logical Volume Manager 2 utilities" do
+    packages "lvm2"
   end
 
   cookbook_file 'setup-ephemeral-drives.sh' do

--- a/cookbooks/aws-parallelcluster-environment/resources/raid/partial/_raid_common.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/raid/partial/_raid_common.rb
@@ -18,10 +18,7 @@ property :raid_vol_array, Array, required: %i(mount unmount)
 property :mode, String, default: "1777"
 
 action :setup do
-  package 'mdadm' do
-    retries 3
-    retry_delay 5
-  end unless redhat_on_docker?
+  robust_package 'mdadm' unless redhat_on_docker?
 end
 
 action :mount do

--- a/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_common.rb
+++ b/cookbooks/aws-parallelcluster-environment/resources/system_authentication/partial/_system_authentication_common.rb
@@ -20,8 +20,5 @@ action :setup do
     action :update
   end
 
-  package required_packages do
-    retries 3
-    retry_delay 5
-  end unless redhat_on_docker?
+  robust_package packages required_packages unless redhat_on_docker?
 end

--- a/cookbooks/aws-parallelcluster-environment/spec/unit/resources/ephemeral_drives_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/spec/unit/resources/ephemeral_drives_spec.rb
@@ -24,10 +24,8 @@ describe 'ephemeral_drives:setup' do
       end
 
       it 'installs Logical Volume Manager 2 utilities' do
-        is_expected.to install_package('install Logical Volume Manager 2 utilities').with(
-          package_name: 'lvm2',
-          retries: 3,
-          retry_delay: 5
+        is_expected.to install_robust_package('install Logical Volume Manager 2 utilities').with(
+          packages: 'lvm2'
         )
       end
 

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/sudo_install.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/sudo_install.rb
@@ -16,10 +16,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-package "sudo" do
-  retries 3
-  retry_delay 5
-end
+robust_package "sudo"
 
 # secure_path must include the below set of directories
 secure_path_required_directories = %w(/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin)

--- a/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_rhel_common.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/dcv/partial/_rhel_common.rb
@@ -82,10 +82,7 @@ action_class do
       retry_delay 5
     end
     # Install X Window System (required when using GPU acceleration)
-    package "xorg-x11-server-Xorg" do
-      retries 3
-      retry_delay 5
-    end
+    robust_package "xorg-x11-server-Xorg"
 
     # libvirtd service creates virtual bridge interfaces.
     # It's provided by libvirt-daemon, installed as requirement for gnome-boxes, included in @gnome.

--- a/cookbooks/aws-parallelcluster-platform/resources/package_lock/partial/_package_lock_rhel.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/package_lock/partial/_package_lock_rhel.rb
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 action :lock do
-  package 'yum-plugin-versionlock'
+  robust_package 'yum-plugin-versionlock'
   execute "yum versionlock #{new_resource.package_name}" do
     retries 3
     retry_delay 5

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/sudo_install_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/sudo_install_spec.rb
@@ -8,7 +8,7 @@ describe 'aws-parallelcluster-platform::sudo_install' do
       end
 
       it 'installs sudo package' do
-        is_expected.to install_package('sudo')
+        is_expected.to install_robust_package('sudo').with(packages: 'sudo')
       end
 
       it 'creates the template with the correct attributes' do

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/dcv_spec.rb
@@ -497,7 +497,7 @@ describe 'dcv:setup' do
             end
           else
             is_expected.to run_execute('Install gnome desktop').with_command('yum -y install @gnome').with_retries(3).with_retry_delay(5)
-            is_expected.to install_package('xorg-x11-server-Xorg').with_retries(3).with_retry_delay(5)
+            is_expected.to install_robust_package('xorg-x11-server-Xorg').with(packages: 'xorg-x11-server-Xorg')
             is_expected.to disable_service('libvirtd').with_action(%i(disable stop))
           end
         end

--- a/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_redhat8.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_redhat8.rb
@@ -31,10 +31,7 @@ action :setup do
     include_recipe "yum-epel"
   end
 
-  package 'yum-utils' do
-    retries 3
-    retry_delay 5
-  end
+  robust_package 'yum-utils'
 
   execute 'yum-config-manager-rhel' do
     # Needed by hwloc-devel blas-devel libedit-devel and glibc-static packages

--- a/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_rocky8.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/package_repos/package_repos_rocky8.rb
@@ -38,10 +38,7 @@ action :setup do
   end
   include_recipe "yum-epel"
 
-  package 'yum-utils' do
-    retries 3
-    retry_delay 5
-  end
+  robust_package 'yum-utils'
 
   execute 'yum-config-manager-powertools' do
     # Needed by hwloc-devel blas-devel libedit-devel and glibc-static packages

--- a/cookbooks/aws-parallelcluster-shared/resources/robust_package.rb
+++ b/cookbooks/aws-parallelcluster-shared/resources/robust_package.rb
@@ -28,11 +28,18 @@
 #     packages prerequisites
 #   end
 #
+# @example
+#   # When `packages` is omitted, the resource name is used as the package name,
+#   # mirroring the convenience of the stock Chef `package` resource.
+#   robust_package 'mdadm'
+#
 
 provides :robust_package
 unified_mode true
 
-property :packages, [String, Array], required: true, name_property: false
+# When `packages` is not specified, the resource name is used as the package
+# name (name_property), so `robust_package 'mdadm'` installs the `mdadm` package.
+property :packages, [String, Array], name_property: true
 property :max_retries, Integer, default: 10
 property :retry_delay, Integer, default: 5
 

--- a/cookbooks/aws-parallelcluster-shared/spec/unit/resources/package_repos_spec.rb
+++ b/cookbooks/aws-parallelcluster-shared/spec/unit/resources/package_repos_spec.rb
@@ -35,7 +35,7 @@ describe 'package_repos:setup' do
         end
 
         it 'installs yum-utils' do
-          is_expected.to install_package('yum-utils').with(retries: 3).with(retry_delay: 5)
+          is_expected.to install_robust_package('yum-utils').with(packages: 'yum-utils')
         end
 
         it 'skips unavailable repos' do
@@ -63,7 +63,7 @@ describe 'package_repos:setup' do
         end
 
         it 'installs yum-utils' do
-          is_expected.to install_package('yum-utils').with(retries: 3).with(retry_delay: 5)
+          is_expected.to install_robust_package('yum-utils').with(packages: 'yum-utils')
         end
 
         it 'enables powertools' do

--- a/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/partial/_dns_domain_common.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/dns_domain/partial/_dns_domain_common.rb
@@ -12,10 +12,7 @@ unified_mode true
 default_action :setup
 
 action :setup do
-  package "hostname" do
-    retries 3
-    retry_delay 5
-  end
+  robust_package "hostname"
 end
 
 action :configure do

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/resources/dns_domain_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/resources/dns_domain_spec.rb
@@ -31,7 +31,7 @@ describe 'dns_domain:setup' do
       end
 
       it 'installs hostname package' do
-        is_expected.to install_package('hostname').with_retries(3).with_retry_delay(5)
+        is_expected.to install_robust_package('hostname').with(packages: 'hostname')
       end
     end
   end


### PR DESCRIPTION
### Description of changes
This commit expand the usage of `robust_package` defined in https://github.com/aws/aws-parallelcluster-cookbook/pull/3187

### Tests
Build image on all OSes has passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
