### PR TITLE
[Dependencies] Upgrade NVIDIA driver to 595.71.05 and CUDA to 13.2.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Install the NVIDIA driver, CUDA toolkit, Fabric Manager, NVLSM, and IMEX from the distribution package manager using NVIDIA local repo packages instead of the run file installers.
 - On RHEL-family OSes, install the Xorg driver for DCV GPU acceleration and disable Wayland so that GDM always starts Xorg.
   This is now required after switching NVIDIA driver installation to local repo packages; previously it was needed only on Ubuntu.
-- Upgrade NVIDIA driver, Fabric Manager, and IMEX to version 580.173.02 (from 580.126.20).
-- Upgrade CUDA Toolkit to version 13.3.1 (from 13.0.2).
+- Upgrade NVIDIA driver, Fabric Manager, and IMEX to version 595.71.05 (from 580.126.20).
+- Upgrade CUDA Toolkit to version 13.2.2 (from 13.0.2).
 - Upgrade DCGM to version 4.6.0 (from 4.5.1).
 - In GPU Health Check, skip DCGM diagnostics when NVIDIA MIG is enabled because dcgmi diag does not support MIG.
 - Upgrade Slurm to version 25.11.6 (from 25.11.4).

--- a/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
+++ b/cookbooks/aws-parallelcluster-platform/attributes/platform.rb
@@ -25,7 +25,7 @@ default['cluster']['enroot']['persistent_dir'] = '/var/enroot'
 
 # NVidia
 default['cluster']['nvidia']['enabled'] = 'no'
-default['cluster']['nvidia']['driver_version'] = '580.173.02'
+default['cluster']['nvidia']['driver_version'] = '595.71.05'
 default['cluster']['nvidia']['dcgm_version'] = '4.6.0-1'
 default['cluster']['nvidia']['driver_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_driver"
 default['cluster']['nvidia']['dcgm_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/nvidia_dcgm"
@@ -33,8 +33,8 @@ default['cluster']['nvidia']['dcgm_base_url'] = "#{node['cluster']['artifacts_s3
 # CUDA
 default['cluster']['nvidia']['cuda']['base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda"
 default['cluster']['nvidia']['cuda']['samples_base_url'] = "#{node['cluster']['artifacts_s3_url']}/dependencies/cuda/samples"
-default['cluster']['nvidia']['cuda']['version'] = '13.3.1'
-default['cluster']['nvidia']['cuda']['driver_version_suffix'] = '610.43.02'
+default['cluster']['nvidia']['cuda']['version'] = '13.2.2'
+default['cluster']['nvidia']['cuda']['driver_version_suffix'] = '595.71.05'
 
 # GDRCopy
 default['cluster']['nvidia']['gdrcopy']['enabled'] = true


### PR DESCRIPTION
**CANNOT MERGE UNTIL WE PUBLISH THE ARTIFACTS IN OUR BUCKETS**

### Description of changes
Upgrade NVIDIA driver to 595.71.05 and CUDA to 13.2.2.
* 595.71.05 is the latest driver in production branch.
* 13.2.2 is the recommended version for drivers 595.

### Tests
ONGOING Build image on all OSs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
