### PR TITLE
[Test] Pass -y to the aws-fsx repolist check to avoid the efs-utils GPG prompt

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
+++ b/cookbooks/aws-parallelcluster-environment/test/controls/lustre_spec.rb
@@ -23,7 +23,9 @@ control 'tag:install_lustre_client_installed' do
       end
 
       describe yum.repo('aws-fsx') do
-        before { retry_helpers.wait_for_command("yum -v repolist all 2>/dev/null | grep -q 'aws-fsx'") rescue nil } # rubocop:disable Style/RescueModifier
+        # -y so the efs-utils repo's repo_gpgcheck metadata-key import is auto-accepted; without it
+        # dnf prompts interactively ("Is this ok [y/N]") and this repolist hangs the check.
+        before { retry_helpers.wait_for_command("yum -v repolist all -y 2>/dev/null | grep -q 'aws-fsx'") rescue nil } # rubocop:disable Style/RescueModifier
         it { should exist }
         it { should be_enabled }
         its('baseurl') { should include 'fsx-lustre-client-repo.s3.amazonaws.com' }


### PR DESCRIPTION
### Description of changes

lustre_spec's aws-fsx check runs `yum -v repolist all`, which refreshes every repo including efs-utils. efs-utils has repo_gpgcheck=true, so on a fresh node dnf verifies the repo metadata signature and prompts interactively ("Is this ok [y/N]") to import the metadata-signing key into its own keyring (separate from the rpm keyring, which the recipe's `rpm --import` populates for package gpgcheck). Non-interactively the prompt hangs and the aws-fsx assertions fail with a nil baseurl.




### Tests
* test instance

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
