### PR TITLE
[Diag] Add Diagnostic checks for EFA with Fsx Lustre

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/.flake8
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/.flake8
@@ -4,6 +4,9 @@
 # D102 Missing docstring in public method
 # D103 Missing docstring in public function
 # D104 Missing docstring in public package
+# E203 (whitespace before ':') conflicts with Black's slice formatting (e.g. `x[a :b]`); Black is the
+# formatter of record here, so E203 is disabled per Black's own guidance.
+extend-ignore = E203
 per-file-ignores =
     */__init__.py: D104
     tests/*: D100, D101, D102, D103

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -23,14 +23,16 @@ executes each probe in isolation and aggregates their findings. The probes are:
 
 - **client** -- the ``lustre``/``lnet`` kernel modules are available for the running kernel (so a broken
   client is reported as its own root cause) and loaded, plus the client version as info, and -- when the
-  client version is known -- that it meets the minimum the official FSx EFA-Lustre client setup enforces;
+  client version is known -- that it meets the per-``base_os`` minimum (rhel8/rocky8 ship the 2.12 client,
+  every other supported OS ships 2.15); this is a general Lustre floor, applied to every FsxLustre mount;
 - **mount presence** -- each configured Lustre ``MountDir`` is actually mounted (a cheap, non-hanging
   ``/proc/mounts`` check, so "not mounted" is not misreported downstream as "unreachable");
 - **filesystem reachability** -- ``lfs df -h`` per mount (the recommended first-line reachability command),
   classifying a hang, an error, or a down target;
 - **LNet transport** -- ``lnetctl net show`` reporting the active LNDs (tcp/efa/o2ib), surfacing the
   EFA-vs-TCP transport state;
-- **EFA mount** -- run whenever EFA-for-Lustre is *expected* (an ``@efa`` LNet net is configured, or the
+- **EFA mount** -- skipped entirely on a ``base_os`` where EFA-for-Lustre is unsupported (rhel8/rocky8).
+  Otherwise run whenever EFA-for-Lustre is *expected* (an ``@efa`` LNet net is configured, or the
   ``configure-efa-fsx-lustre-client`` systemd service is installed on this node). It first verifies the
   EFA prerequisites the way the official FSx EFA-Lustre client setup does -- the ``kefalnd`` module (that
   setup's own definition of "the Lustre client supports EFA"), the EFA driver version, and, on the p6+
@@ -62,14 +64,16 @@ from pcluster_diag.core.constants import (
     EFA_KEFALND_KERNEL_MODULE,
     EFA_LNET_NET,
     EFA_LUSTRE_SYSTEMD_SERVICE,
+    EFA_LUSTRE_UNSUPPORTED_OSES,
     FSX_LFS_CHECK_TIMEOUT_SECONDS,
     FSX_LFS_DF_TIMEOUT_SECONDS,
     FSX_LNET_SHOW_TIMEOUT_SECONDS,
     FSX_OST_QUERY_TIMEOUT_SECONDS,
     HEALTHY_TARGET_STATE,
+    LUSTRE_CLIENT_MIN_VERSION_BY_OS,
+    LUSTRE_CLIENT_MIN_VERSION_DEFAULT,
     MIN_EFA_DRIVER_VERSION,
     MIN_KEFALND_VERSION_P6,
-    MIN_LUSTRE_CLIENT_VERSION,
 )
 from pcluster_diag.core.probe import run_probe
 from pcluster_diag.models.check import Check
@@ -85,6 +89,11 @@ logger = logging.getLogger(__name__)
 def _has_lustre(context: Context) -> bool:
     """Return whether the cluster configuration declares at least one FsxLustre mount."""
     return bool(shared_storage.lustre_mounts(context))
+
+
+def _base_os(context: Context):
+    """Return the cluster ``base_os`` token from dna.json (e.g. ``alinux2023``, ``rhel8``), or None."""
+    return ((context.dna_json or {}).get("cluster") or {}).get("base_os")
 
 
 @dataclass
@@ -241,6 +250,11 @@ class LustreFilesystem(Check):
         "lnetctl is not available on this node, so the LNet transport and EFA probes were skipped "
         "(the Lustre client may not be installed).",
     )
+    EFA_NOT_SUPPORTED_ON_OS = CheckInfo(
+        10,
+        "EFA-for-Lustre is not supported on this OS ({}), so the EFA probes were skipped. EFA-for-Lustre "
+        "requires Amazon Linux 2023, RHEL 9.5+, or Ubuntu 22.04+.",
+    )
 
     @property
     def description(self) -> str:
@@ -261,7 +275,7 @@ class LustreFilesystem(Check):
         lnet = self._lnet_snapshot()
 
         probes = (
-            ("lustre client", lambda: self._probe_client(errors, infos)),
+            ("lustre client", lambda: self._probe_client(context, errors, infos)),
             ("mount presence", lambda: self._probe_mounts(context, errors)),
             ("filesystem reachability", lambda: self._probe_reachable(context, errors)),
             ("lnet transport", lambda: self._probe_lnet(lnet, errors, warnings, infos)),
@@ -292,7 +306,7 @@ class LustreFilesystem(Check):
         nets = lustre.parse_lnet_net_show(result.stdout) if result.returncode == 0 else []
         return _LnetSnapshot(timed_out=False, nets=nets)
 
-    def _probe_client(self, errors: List[CheckError], infos: List[CheckInfo]) -> None:
+    def _probe_client(self, context: Context, errors: List[CheckError], infos: List[CheckInfo]) -> None:
         """Fail when the Lustre kernel modules are unavailable, or available but not loaded.
 
         The kernel module is the authoritative signal: Lustre can only mount if the ``lustre`` and
@@ -313,16 +327,17 @@ class LustreFilesystem(Check):
         version = lustre.lustre_client_version()
         if version:
             infos.append(self.CLIENT_VERSION.format(version))
-            # The FSx EFA-Lustre setup enforces a client-version floor. version_at_least is tri-state:
-            # True (>= floor), False (definitely below -> FAILURE), or None (version present but
-            # unparseable). We do not mask the None case: rather than silently skip it, we report a
-            # CHECK_ERROR (reserved E0) saying the floor could not be evaluated -- distinct from a definite
-            # too-old FAILURE.
-            at_least = kernel_module.version_at_least(version, MIN_LUSTRE_CLIENT_VERSION)
+            # The client-version floor is per base_os (rhel8/rocky8 ship 2.12, others 2.15); an unknown/
+            # missing base_os uses the default. version_at_least is tri-state: True (>= floor), False
+            # (definitely below -> FAILURE), or None (version present but unparseable). We do not mask the
+            # None case: rather than silently skip it, we report a CHECK_ERROR (reserved E0) saying the
+            # floor could not be evaluated -- distinct from a definite too-old FAILURE.
+            minimum = LUSTRE_CLIENT_MIN_VERSION_BY_OS.get(_base_os(context), LUSTRE_CLIENT_MIN_VERSION_DEFAULT)
+            at_least = kernel_module.version_at_least(version, minimum)
             if at_least is None:
-                errors.append(self.CLIENT_VERSION_UNDETERMINABLE.format(version, MIN_LUSTRE_CLIENT_VERSION))
+                errors.append(self.CLIENT_VERSION_UNDETERMINABLE.format(version, minimum))
             elif at_least is False:
-                errors.append(self.CLIENT_TOO_OLD.format(version, MIN_LUSTRE_CLIENT_VERSION))
+                errors.append(self.CLIENT_TOO_OLD.format(version, minimum))
 
     def _probe_mounts(self, context: Context, errors: List[CheckError]) -> None:
         """Fail listing any configured Lustre mount absent from /proc/mounts (a non-hanging check)."""
@@ -408,6 +423,12 @@ class LustreFilesystem(Check):
         """
         if lnet.timed_out or lnet.unavailable:
             # The LNet probe already reported the hang / missing lnetctl; there is nothing to inspect here.
+            return
+        base_os = _base_os(context)
+        if base_os in EFA_LUSTRE_UNSUPPORTED_OSES:
+            # EFA-for-Lustre is not supported on this OS (e.g. rhel8/rocky8), so none of the EFA
+            # prerequisites/data-path probes apply here. Report why and skip.
+            infos.append(self.EFA_NOT_SUPPORTED_ON_OS.format(base_os))
             return
         efa_net = lustre.lnet_net(lnet.nets, EFA_LNET_NET)
         # Query the service once (like the shared lnet snapshot) and reuse it for both the gate and the

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -18,28 +18,64 @@ therefore run through :func:`pcluster_diag.util.shell.time_command` with a bound
 timeout is treated as a distinct, first-class failure mode rather than an exception. The fast, local
 queries (kernel-module presence, reading ``/proc/mounts``) go through ``run_command``.
 
-Three checks, in execution order:
+The always-on Lustre verifications are consolidated into one :class:`LustreFilesystem` check whose ``run``
+executes each probe in isolation and aggregates their findings. The probes are:
 
-- ``LustreClientIsInstalled`` verifies the node can actually speak Lustre (kernel modules available)
-  before connectivity is probed, so a broken client is reported as its own root cause.
-- ``FsxMountsArePresent`` is a cheap, non-hanging pre-flight confirming each configured Lustre mount is
-  actually mounted, so a "not mounted" problem is not misreported downstream as "unreachable".
-- ``FsxFilesystemsAreReachable`` runs ``lfs df -h`` per mount (the FSx-team-recommended first-line
-  command) and classifies a hang, an error, or a down target.
+- **client** -- the ``lustre``/``lnet`` kernel modules are available for the running kernel (so a broken
+  client is reported as its own root cause) and loaded, plus the client version as info, and -- when the
+  client version is known -- that it meets the minimum the official FSx EFA-Lustre client setup enforces;
+- **mount presence** -- each configured Lustre ``MountDir`` is actually mounted (a cheap, non-hanging
+  ``/proc/mounts`` check, so "not mounted" is not misreported downstream as "unreachable");
+- **filesystem reachability** -- ``lfs df -h`` per mount (the recommended first-line reachability command),
+  classifying a hang, an error, or a down target;
+- **LNet transport** -- ``lnetctl net show`` reporting the active LNDs (tcp/efa/o2ib), surfacing the
+  EFA-vs-TCP transport state;
+- **EFA mount** -- run whenever EFA-for-Lustre is *expected* (an ``@efa`` LNet net is configured, or the
+  ``configure-efa-fsx-lustre-client`` systemd service is installed on this node). It first verifies the
+  EFA prerequisites the way the official FSx EFA-Lustre client setup does -- the ``kefalnd`` module (that
+  setup's own definition of "the Lustre client supports EFA"), the EFA driver version, and, on the p6+
+  instance families, the kefalnd version -- then the state of the ``configure-efa-fsx-lustre-client.service``
+  that (re)configures LNet on every boot, then detects common root causes: no EFA device bound to LNet at
+  all (so Lustre falls back to TCP), fewer devices bound than the instance type is expected to bind (the
+  expected count comes from a per-instance-family table, NOT the raw device count -- several families bind
+  only a subset by design, and instance types with no known/static expectation are not flagged beyond the
+  "none bound" case), and a non-working EFA data path (typically a missing self-referencing security-group
+  rule).
+  See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html
 
-All three run on every node type that has a FsxLustre mount configured, and skip (SKIPPED_NOT_APPLICABLE)
-when the cluster configures no FsxLustre filesystem. Every probe is read-only.
+:class:`FsxTargetsAreReachable` is kept separate because it is a heavier, opt-in
+(``approval_required``) deep probe (``lfs check servers`` + per-target import state); the framework's
+approval gate is per-check, so folding it into the always-on check would either force the deep probe to
+run every time or gate the whole check behind a prompt.
+
+Both checks run on every node type that has a FsxLustre mount configured, and skip
+(SKIPPED_NOT_APPLICABLE) when the cluster configures no FsxLustre filesystem. Every probe is read-only.
 """
 
 import logging
+from dataclasses import dataclass, field
 from typing import List
 
-from pcluster_diag.core.constants import FSX_LFS_DF_TIMEOUT_SECONDS
+from pcluster_diag.core.constants import (
+    EFA_INFINIBAND_SYSFS,
+    EFA_KEFALND_KERNEL_MODULE,
+    EFA_LNET_NET,
+    EFA_LUSTRE_SYSTEMD_SERVICE,
+    FSX_LFS_CHECK_TIMEOUT_SECONDS,
+    FSX_LFS_DF_TIMEOUT_SECONDS,
+    FSX_LNET_SHOW_TIMEOUT_SECONDS,
+    FSX_OST_QUERY_TIMEOUT_SECONDS,
+    HEALTHY_TARGET_STATE,
+    MIN_EFA_DRIVER_VERSION,
+    MIN_KEFALND_VERSION_P6,
+    MIN_LUSTRE_CLIENT_VERSION,
+)
+from pcluster_diag.core.probe import run_probe
 from pcluster_diag.models.check import Check
 from pcluster_diag.models.context import Context
-from pcluster_diag.models.finding import CheckError, CheckInfo
-from pcluster_diag.models.result import Result
-from pcluster_diag.util import kernel_module, lustre, shared_storage
+from pcluster_diag.models.finding import CheckError, CheckInfo, CheckWarning
+from pcluster_diag.models.result import INTERNAL_ERROR_CODE, Result
+from pcluster_diag.util import efa, kernel_module, lustre, services, shared_storage
 from pcluster_diag.util.shell import time_command
 
 logger = logging.getLogger(__name__)
@@ -50,15 +86,32 @@ def _has_lustre(context: Context) -> bool:
     return bool(shared_storage.lustre_mounts(context))
 
 
-class LustreClientIsInstalled(Check):
-    """Verify the Lustre client is present so the node can speak Lustre.
+@dataclass
+class _LnetSnapshot:
+    """One shared ``lnetctl net show -v`` result, consumed by both the LNet and EFA probes.
 
-    The kernel module is the authoritative signal: Lustre can only mount if the ``lustre`` and ``lnet``
-    modules are available for the running kernel. We check ``modinfo`` for those modules rather than a
-    package name (package names vary by OS/install source, and a package can be present while the module
-    is not built for the current kernel -- in which case Lustre still cannot mount).
+    ``lnetctl net show -v`` is run once per check invocation (it is the input for both the transport
+    probe and the EFA probe), so the two probes share this snapshot instead of each shelling out.
+
+    Attributes:
+        timed_out: Whether the ``lnetctl`` call exceeded its bounded timeout (LNet may be wedged).
+        nets: The parsed LNet nets (empty when the command timed out or returned non-zero).
     """
 
+    timed_out: bool
+    nets: list = field(default_factory=list)
+
+
+class LustreFilesystem(Check):
+    """Diagnose FSx for Lustre client health, mount presence, server reachability, and the EFA transport.
+
+    Runs a sequence of read-only probes (client, mount presence, ``lfs df`` reachability, LNet transport,
+    EFA mount) and aggregates their findings into a single Result. Each probe runs in isolation so one
+    probe's crash does not sink its siblings. See the module docstring for the failure class and the
+    per-probe rationale.
+    """
+
+    # --- Errors: client -----------------------------------------------------------------------
     NOT_INSTALLED = CheckError(
         1,
         "Lustre client is not installed though a FsxLustre filesystem is configured: the lustre/lnet "
@@ -66,22 +119,173 @@ class LustreClientIsInstalled(Check):
         "have rebuilt after a kernel update).",
     )
     MODULES_NOT_LOADED = CheckError(2, "Lustre kernel modules are available but not loaded: {}.")
-    CLIENT_VERSION = CheckInfo(2, "Lustre client version: {}.")
+
+    # --- Errors: undeterminable checks (reserved E0 -> CHECK_ERROR, not FAILURE) ---------------
+    # A version/family the check could not evaluate is reported as a CHECK_ERROR (the check could not
+    # complete its assertion), distinct from a FAILURE (the assertion definitively failed). All carry the
+    # reserved E0 code, which Result.from_findings maps to CHECK_ERROR when no real failure is also present.
+    CLIENT_VERSION_UNDETERMINABLE = CheckError(
+        INTERNAL_ERROR_CODE,
+        "Could not determine the Lustre client version (version string {!r} is unparseable): the "
+        "minimum-version check (>= {}) was not evaluated.",
+    )
+    EFA_DRIVER_VERSION_UNDETERMINABLE = CheckError(
+        INTERNAL_ERROR_CODE,
+        "Could not determine the EFA driver version: the minimum-version check (>= {}) was not evaluated.",
+    )
+    KEFALND_VERSION_UNDETERMINABLE = CheckError(
+        INTERNAL_ERROR_CODE,
+        "Could not determine the kefalnd version: the p6+ minimum-version check (>= {}) was not evaluated.",
+    )
+    INSTANCE_TYPE_UNDETERMINABLE = CheckError(
+        INTERNAL_ERROR_CODE,
+        "Could not determine the instance type (an IMDS error at startup): the p6+ kefalnd "
+        "minimum-version check ({} >= {}) was not evaluated.",
+    )
+
+    # --- Errors: mount presence ---------------------------------------------------------------
+    NOT_MOUNTED = CheckError(3, "'{}' ({}) is configured but not mounted.")
+
+    # --- Errors: filesystem reachability ------------------------------------------------------
+    LFS_DF_TIMED_OUT = CheckError(
+        4,
+        "lfs df -h on '{}' did not return within {}s -- the filesystem is hanging (server/OST unreachable).",
+    )
+    LFS_DF_FAILED = CheckError(5, "lfs df -h on '{}' failed: {}")
+    TARGET_UNAVAILABLE = CheckError(6, "target {} on '{}' is not available (possible OST/MDT down).")
+
+    # --- Errors: LNet transport ---------------------------------------------------------------
+    LNETCTL_TIMED_OUT = CheckError(
+        7, "lnetctl net show did not return within {}s -- LNet is not responding (transport may be wedged)."
+    )
+    LNET_NOT_CONFIGURED = CheckError(
+        8, "LNet is not configured though a FsxLustre filesystem is configured (no LNet networks are present)."
+    )
+
+    # --- Errors: EFA mount --------------------------------------------------------------------
+    NO_EFA_DEVICES = CheckError(
+        9, "An EFA LNet net is configured but no EFA devices are exposed under {} -- EFA is not available."
+    )
+    NO_DEVICES_BOUND = CheckError(
+        10,
+        "{} EFA devices are exposed but none are bound to LNet -- Lustre will fall back to TCP. "
+        "Re-run the EFA-Lustre client configuration.",
+    )
+    UNDERBOUND_DEVICES = CheckError(
+        17,
+        "Only {} of {} expected EFA devices are bound to LNet on {} -- Lustre will not use the full EFA "
+        "fabric. Re-run the EFA-Lustre client configuration.",
+    )
+    EFA_PING_FAILED = CheckError(
+        11,
+        "EFA ping from {} to {} failed -- the EFA data path is not working. Check the security group "
+        "has a self-referencing rule by SG-ID (EFA's SRD-over-MAC is not authorized by a 0.0.0.0/0 rule).",
+    )
+
+    # --- Errors: EFA prerequisites (checked before the EFA data-path probes) ------------------
+    KEFALND_MISSING = CheckError(
+        12,
+        "EFA-for-Lustre is expected on this node but the kefalnd module is not available: the Lustre "
+        "client does not support EFA (install a Lustre client with EFA support). See "
+        "https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html.",
+    )
+    EFA_DRIVER_TOO_OLD = CheckError(13, "EFA driver version {} is below the minimum {} required for EFA-for-Lustre.")
+    KEFALND_TOO_OLD = CheckError(14, "kefalnd version {} is below the minimum {} required on p6+ instances ({}).")
+    EFA_SERVICE_FAILED = CheckError(
+        15,
+        "The EFA-Lustre configuration service {} is in the failed state -- LNet was not configured for "
+        "EFA (check `journalctl -u {}`); Lustre will fall back to TCP.",
+    )
+    CLIENT_TOO_OLD = CheckError(
+        16, "Lustre client version {} is below the minimum {} the FSx EFA-Lustre setup requires."
+    )
+
+    # --- Warnings -----------------------------------------------------------------------------
+    HEALTH_DEGRADED = CheckWarning(
+        1, "LNet interface {} (net {}) shows connection-health degradation (health value {})."
+    )
+    NO_TRAFFIC = CheckWarning(
+        2,
+        "EFA LNet interface {} shows no traffic yet (send_count=0, recv_count=0). This is expected on an "
+        "idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent "
+        "TCP fallback.",
+    )
+    TCP_FALLBACK = CheckWarning(3, "target {} is connected over @tcp despite EFA being configured (TCP fallback).")
+
+    # --- Infos --------------------------------------------------------------------------------
+    CLIENT_VERSION = CheckInfo(1, "Lustre client version: {}.")
+    ACTIVE_LNDS = CheckInfo(2, "Active LNet transports: {}.")
+    EFA_SERVICE_ABSENT = CheckInfo(
+        3,
+        "The EFA-Lustre configuration service {} is not installed -- LNet is configured at runtime by the "
+        "bootstrap script (expected when the EFA-Lustre client package is not used).",
+    )
+    EFA_SERVICE_ACTIVE = CheckInfo(4, "The EFA-Lustre configuration service {} is installed and not failed.")
+    BOUND_DEVICES = CheckInfo(
+        5,
+        "{} of {} EFA devices are bound to LNet (some instance families bind a subset by design).",
+    )
+    EFA_DRIVER_VERSION = CheckInfo(6, "EFA driver version: {}.")
+    KEFALND_VERSION = CheckInfo(7, "kefalnd (EFA LND) version: {}.")
+    EFA_BINDING_REFERENCE = CheckInfo(
+        8,
+        "EFA-for-Lustre binding follows the FSx guide -- the expected number of EFA devices bound to LNet "
+        "is instance-type-specific (some families bind a subset by design). See "
+        "https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html",
+    )
 
     @property
     def description(self) -> str:
         """Return the human-readable description of this Check."""
-        return "Verify that the Lustre client is installed."
+        return "Verify that FsxLustre filesystems are installed, mounted, reachable, and riding EFA."
 
     def should_run(self, context: Context) -> bool:
         """Run only when a FsxLustre filesystem is configured."""
         return _has_lustre(context)
 
     def run(self, context: Context) -> Result:
-        """Fail when the Lustre kernel modules are unavailable, or available but not loaded."""
+        """Run every Lustre probe in isolation, accumulate findings, and derive the aggregate Result."""
         errors: List[CheckError] = []
+        warnings: List[CheckWarning] = []
         infos: List[CheckInfo] = []
 
+        # lnetctl net show -v is fetched once here; both the LNet and EFA probes read this snapshot.
+        lnet = self._lnet_snapshot()
+
+        probes = (
+            ("lustre client", lambda: self._probe_client(errors, infos)),
+            ("mount presence", lambda: self._probe_mounts(context, errors)),
+            ("filesystem reachability", lambda: self._probe_reachable(context, errors)),
+            ("lnet transport", lambda: self._probe_lnet(lnet, errors, warnings, infos)),
+            ("efa mount", lambda: self._probe_efa(context, lnet, errors, warnings, infos)),
+        )
+        for label, probe in probes:
+            run_probe(label, probe, errors)
+
+        return Result.from_findings(self, errors=errors, warnings=warnings, infos=infos)
+
+    # --- Probes -------------------------------------------------------------------------------
+
+    def _lnet_snapshot(self) -> _LnetSnapshot:
+        """Fetch ``lnetctl net show -v`` once, returning a snapshot both LNet/EFA probes consume.
+
+        ``-v`` is used so per-NI statistics and health values are available; the non-verbose fields (net
+        type, nid, interfaces) are a subset, so one verbose call serves both probes.
+        """
+        result = time_command(["lnetctl", "net", "show", "-v"], timeout=FSX_LNET_SHOW_TIMEOUT_SECONDS)
+        if result.timed_out:
+            return _LnetSnapshot(timed_out=True)
+        nets = lustre.parse_lnet_net_show(result.stdout) if result.returncode == 0 else []
+        return _LnetSnapshot(timed_out=False, nets=nets)
+
+    def _probe_client(self, errors: List[CheckError], infos: List[CheckInfo]) -> None:
+        """Fail when the Lustre kernel modules are unavailable, or available but not loaded.
+
+        The kernel module is the authoritative signal: Lustre can only mount if the ``lustre`` and
+        ``lnet`` modules are available for the running kernel. We check ``modinfo`` rather than a package
+        name (names vary by OS/install source, and a package can be present while the module is not built
+        for the current kernel -- in which case Lustre still cannot mount).
+        """
         module_available = all(kernel_module.kernel_module_available(m) for m in lustre.LUSTRE_KERNEL_MODULES)
         if not module_available:
             # An unavailable module cannot be loaded, so reporting "not loaded" too would just restate the
@@ -95,69 +299,351 @@ class LustreClientIsInstalled(Check):
         version = lustre.lustre_client_version()
         if version:
             infos.append(self.CLIENT_VERSION.format(version))
+            # The FSx EFA-Lustre setup enforces a client-version floor. version_at_least is tri-state:
+            # True (>= floor), False (definitely below -> FAILURE), or None (version present but
+            # unparseable). We do not mask the None case: rather than silently skip it, we report a
+            # CHECK_ERROR (reserved E0) saying the floor could not be evaluated -- distinct from a definite
+            # too-old FAILURE.
+            at_least = kernel_module.version_at_least(version, MIN_LUSTRE_CLIENT_VERSION)
+            if at_least is None:
+                errors.append(self.CLIENT_VERSION_UNDETERMINABLE.format(version, MIN_LUSTRE_CLIENT_VERSION))
+            elif at_least is False:
+                errors.append(self.CLIENT_TOO_OLD.format(version, MIN_LUSTRE_CLIENT_VERSION))
 
-        return Result.from_findings(self, errors=errors, infos=infos)
-
-
-class FsxMountsArePresent(Check):
-    """Verify each configured FsxLustre MountDir is actually mounted (a non-hanging mount-table check)."""
-
-    NOT_MOUNTED = CheckError(1, "'{}' ({}) is configured but not mounted.")
-
-    @property
-    def description(self) -> str:
-        """Return the human-readable description of this Check."""
-        return "Verify that configured FsxLustre filesystems are mounted."
-
-    def should_run(self, context: Context) -> bool:
-        """Run only when a FsxLustre filesystem is configured."""
-        return _has_lustre(context)
-
-    def run(self, context: Context) -> Result:
-        """Pass when every configured Lustre mount is present in /proc/mounts; fail listing those absent."""
+    def _probe_mounts(self, context: Context, errors: List[CheckError]) -> None:
+        """Fail listing any configured Lustre mount absent from /proc/mounts (a non-hanging check)."""
         mounts = shared_storage.read_mounts()
-        errors: List[CheckError] = []
         for configured in shared_storage.lustre_mounts(context):
             if not shared_storage.is_mounted(mounts, configured.mount_dir, shared_storage.LUSTRE_FS_TYPE):
                 errors.append(self.NOT_MOUNTED.format(configured.mount_dir, configured.storage_type))
-        return Result.from_findings(self, errors=errors)
+
+    def _probe_reachable(self, context: Context, errors: List[CheckError]) -> None:
+        """Aggregate ``lfs df -h`` per Lustre mount, classifying a hang, an error, or a down target."""
+        for configured in shared_storage.lustre_mounts(context):
+            errors.extend(self._probe_mount(configured.mount_dir))
+
+    def _probe_mount(self, mount_dir: str) -> List[CheckError]:
+        """Return the CheckErrors for one Lustre mount: empty when it is reachable and all targets are up."""
+        result = time_command(["lfs", "df", "-h", mount_dir], timeout=FSX_LFS_DF_TIMEOUT_SECONDS)
+        if result.timed_out:
+            return [self.LFS_DF_TIMED_OUT.format(mount_dir, FSX_LFS_DF_TIMEOUT_SECONDS)]
+        if result.returncode != 0:
+            return [self.LFS_DF_FAILED.format(mount_dir, result.stderr.strip())]
+
+        return [
+            self.TARGET_UNAVAILABLE.format(target.uuid, mount_dir)
+            for target in lustre.unavailable_targets(result.stdout)
+        ]
+
+    def _probe_lnet(
+        self,
+        lnet: _LnetSnapshot,
+        errors: List[CheckError],
+        warnings: List[CheckWarning],
+        infos: List[CheckInfo],
+    ) -> None:
+        """Report the active LNDs; fail when LNet is unresponsive or unconfigured while Lustre is present.
+
+        Parses ``lnetctl net show`` and reports which LNDs are active (``tcp``, ``efa``, ``o2ib``). A node
+        still carrying an ``@efa`` net after an intended TCP cutover -- or, the reverse, no LNet at all
+        while a Lustre filesystem is mounted -- is immediately visible. Read-only; never mutates LNet.
+        """
+        if lnet.timed_out:
+            errors.append(self.LNETCTL_TIMED_OUT.format(FSX_LNET_SHOW_TIMEOUT_SECONDS))
+            return
+
+        active = lustre.active_lnds(lnet.nets)
+        if not active:
+            errors.append(self.LNET_NOT_CONFIGURED)
+        else:
+            infos.append(self.ACTIVE_LNDS.format(", ".join(active)))
+            warnings.extend(self._health_warnings(lnet.nets))
+
+    def _probe_efa(
+        self,
+        context: Context,
+        lnet: _LnetSnapshot,
+        errors: List[CheckError],
+        warnings: List[CheckWarning],
+        infos: List[CheckInfo],
+    ) -> None:
+        """Detect the EFA-for-Lustre root causes, after verifying the EFA prerequisites are in place.
+
+        Acts only when EFA-for-Lustre is *expected* on this node. "Expected" is signalled by EITHER an
+        ``@efa`` LNet net being configured OR the ``configure-efa-fsx-lustre-client`` systemd service being
+        installed on this node. The service is essential to the gate: if ``kefalnd`` failed to load, no
+        ``@efa`` net is ever added, so gating on the ``@efa`` net alone would skip the very node the
+        ``kefalnd`` check exists to catch -- the service (installed by the setup script, independent of
+        whether kefalnd loaded) is the node-local "EFA was set up here" signal that survives that failure.
+        We deliberately do not infer "expected" from the cluster config's OnNodeStart custom actions: the
+        config carries the actions for every node type, and mapping those back to *this* node is unreliable.
+
+        When expected, it first verifies the prerequisites the official FSx EFA-Lustre client setup
+        enforces before configuring EFA -- the ``kefalnd`` module (that setup's own definition of "the
+        client supports EFA"), the EFA driver version, and on the p6+ families the kefalnd version. A
+        missing ``kefalnd`` is reported (``KEFALND_MISSING``) and short-circuits the rest: without it there
+        can be no working ``@efa`` net, so the follow-on probes would add nothing. Then it reports the
+        systemd service state and, when a live ``@efa`` net exists, automates the FSx tutorial's "Validate
+        FSx with EFA is working" commands (``lnetctl net show --net efa -v``, ``lnetctl ping ...@efa``) and
+        the client-side import state, to name -- not fix -- the failures. Read-only: never re-binds devices
+        or edits the security group.
+        """
+        if lnet.timed_out:
+            # The LNet probe already reported the hang; there is nothing to inspect here.
+            return
+        efa_net = lustre.lnet_net(lnet.nets, EFA_LNET_NET)
+        # Query the service once (like the shared lnet snapshot) and reuse it for both the gate and the
+        # service-state report. This is the signal that survives a kefalnd load failure (which leaves no
+        # @efa net), so it -- not the @efa net alone -- decides whether EFA is expected on this node.
+        service_installed = services.systemd_unit_exists(EFA_LUSTRE_SYSTEMD_SERVICE)
+        if efa_net is None and not service_installed:
+            # Neither an @efa net nor the EFA-Lustre service on this node: EFA is not expected; nothing to check.
+            return
+
+        # Prerequisites first (mirrors the official setup's ordering), BEFORE bailing on a missing @efa net:
+        # a missing kefalnd is exactly why the @efa net would be absent, and it is the root cause to report.
+        if not self._probe_efa_prerequisites(context, errors, infos):
+            return
+
+        # The systemd service is how this delivery vehicle persists the EFA/LNet config across reboots.
+        self._probe_efa_service(service_installed, errors, infos)
+
+        if efa_net is None:
+            # The service is installed but no @efa net came up (e.g. the config service failed): the
+            # prerequisite/service findings above localize why. There is no live net to probe for
+            # devices/traffic, so stop here.
+            return
+
+        bound = lustre.lnet_bound_interfaces(lnet.nets, EFA_LNET_NET)
+        available = efa.efa_device_count()
+        expected = efa.expected_bound_device_count(context.instance_type, available)
+        # Note (once) that the expected binding is instance-type-specific per the FSx guide, so an operator
+        # reading the device-count findings knows "fewer than all bound" can be intentional.
+        infos.append(self.EFA_BINDING_REFERENCE)
+        if available == 0:
+            errors.append(self.NO_EFA_DEVICES.format(EFA_INFINIBAND_SYSFS))
+        elif not bound:
+            # EFA devices exist but none are bound at all: Lustre cannot ride EFA on any family.
+            errors.append(self.NO_DEVICES_BOUND.format(available))
+        elif expected is not None and len(bound) < expected:
+            # We know how many this instance type should bind, and fewer are bound -- a genuine shortfall
+            # (e.g. the p6-b300 "bind all" family with only a subset bound). Compared against the expected
+            # count, NOT the raw device count, so families that bind a subset by design do not false-fire.
+            errors.append(self.UNDERBOUND_DEVICES.format(len(bound), expected, context.instance_type))
+        else:
+            # All expected devices are bound, or we have no static expectation for this instance type
+            # (unknown/dynamic selection) -- report the count as context and pass.
+            infos.append(self.BOUND_DEVICES.format(len(bound), available))
+
+        warnings.extend(self._traffic_warnings(efa_net))
+        errors.extend(self._efa_ping_errors(lnet.nets))
+        warnings.extend(self._tcp_fallback_warnings(lnet.nets))
+
+    def _probe_efa_prerequisites(self, context: Context, errors: List[CheckError], infos: List[CheckInfo]) -> bool:
+        """Verify the EFA-for-Lustre client prerequisites; return whether kefalnd is present.
+
+        A False return (kefalnd missing) means the client fundamentally cannot ride EFA, so the caller
+        skips the data-path probes. The EFA driver and (on the p6+ families) kefalnd version floors are
+        reported here too. A version/family that cannot be determined -- an unparseable module version, or
+        (for the p6+ gate) an instance type IMDS could not report -- is not masked: it is surfaced as a
+        CHECK_ERROR (reserved E0) noting the check could not be evaluated, distinct from a definite too-old
+        FAILURE.
+        """
+        if not efa.efa_kefalnd_supported():
+            errors.append(self.KEFALND_MISSING)
+            return False
+
+        self._check_efa_driver_version(errors, infos)
+        self._check_kefalnd_version(context, errors, infos)
+        return True
+
+    def _check_efa_driver_version(self, errors: List[CheckError], infos: List[CheckInfo]) -> None:
+        """Report the EFA driver version; flag definitely-too-old as FAILURE and undeterminable as E0."""
+        driver_version = efa.efa_driver_version()
+        if not driver_version:
+            errors.append(self.EFA_DRIVER_VERSION_UNDETERMINABLE.format(MIN_EFA_DRIVER_VERSION))
+            return
+        infos.append(self.EFA_DRIVER_VERSION.format(driver_version))
+        at_least = kernel_module.version_at_least(driver_version, MIN_EFA_DRIVER_VERSION)
+        if at_least is None:
+            # Present but unparseable -- the floor could not be evaluated; report it, do not assume too-old.
+            errors.append(self.EFA_DRIVER_VERSION_UNDETERMINABLE.format(MIN_EFA_DRIVER_VERSION))
+        elif at_least is False:
+            errors.append(self.EFA_DRIVER_TOO_OLD.format(driver_version, MIN_EFA_DRIVER_VERSION))
+
+    def _check_kefalnd_version(self, context: Context, errors: List[CheckError], infos: List[CheckInfo]) -> None:
+        """Report the kefalnd version and, on the p6+ families only, flag it when definitely below the floor.
+
+        The p6+ gate needs the instance type. When it is unknown (IMDS could not report it at startup),
+        is_p6plus_instance returns None: we cannot tell whether the p6+ floor applies, so we surface a
+        CHECK_ERROR (reserved E0) that the check could not be evaluated rather than silently passing.
+        """
+        kefalnd_version = efa.efa_kefalnd_version()
+        if kefalnd_version:
+            infos.append(self.KEFALND_VERSION.format(kefalnd_version))
+
+        p6plus = efa.is_p6plus_instance(context.instance_type)
+        if p6plus is None:
+            errors.append(self.INSTANCE_TYPE_UNDETERMINABLE.format(EFA_KEFALND_KERNEL_MODULE, MIN_KEFALND_VERSION_P6))
+            return
+        if not p6plus:
+            # Known non-p6 family: the kefalnd version floor does not apply.
+            return
+
+        # p6+ family: the floor applies.
+        if not kefalnd_version:
+            errors.append(self.KEFALND_VERSION_UNDETERMINABLE.format(MIN_KEFALND_VERSION_P6))
+            return
+        at_least = kernel_module.version_at_least(kefalnd_version, MIN_KEFALND_VERSION_P6)
+        if at_least is None:
+            errors.append(self.KEFALND_VERSION_UNDETERMINABLE.format(MIN_KEFALND_VERSION_P6))
+        elif at_least is False:
+            errors.append(self.KEFALND_TOO_OLD.format(kefalnd_version, MIN_KEFALND_VERSION_P6, context.instance_type))
+
+    def _probe_efa_service(self, service_installed: bool, errors: List[CheckError], infos: List[CheckInfo]) -> None:
+        """Report the state of the ``configure-efa-fsx-lustre-client`` service that (re)configures LNet on boot.
+
+        ``service_installed`` is passed in (already queried by the caller for the EFA-expected gate) to
+        avoid a second ``systemctl`` call. Failed -> error (LNet was not configured for EFA); installed and
+        not failed -> info; not installed -> info (LNet is configured at runtime by the bootstrap script
+        rather than this service).
+        """
+        efa_service = EFA_LUSTRE_SYSTEMD_SERVICE
+        if not service_installed:
+            infos.append(self.EFA_SERVICE_ABSENT.format(efa_service))
+        elif services.systemd_unit_failed(efa_service):
+            errors.append(self.EFA_SERVICE_FAILED.format(efa_service, efa_service))
+        else:
+            infos.append(self.EFA_SERVICE_ACTIVE.format(efa_service))
+
+    def _health_warnings(self, nets) -> List[CheckWarning]:
+        """Return a warning per NI whose health value has decayed below the healthy maximum (1000)."""
+        warnings: List[CheckWarning] = []
+        for net in nets:
+            for ni in net.local_nis:
+                if ni.health_value is not None and ni.health_value < 1000:
+                    warnings.append(self.HEALTH_DEGRADED.format(ni.nid, net.net_type, ni.health_value))
+        return warnings
+
+    def _traffic_warnings(self, efa_net) -> List[CheckWarning]:
+        """Return a warning per EFA NI that reports zero send and zero receive traffic.
+
+        This is a single-shot counter snapshot, so zero traffic is expected on an idle or freshly-booted
+        node -- the warning is worded as "no traffic yet" and stays a non-fatal warning for that reason.
+        """
+        warnings: List[CheckWarning] = []
+        for ni in efa_net.local_nis:
+            if ni.send_count == 0 and ni.recv_count == 0:
+                warnings.append(self.NO_TRAFFIC.format(ni.nid))
+        return warnings
+
+    def _efa_ping_errors(self, nets) -> List[CheckError]:
+        """Ping an @efa peer over EFA (the tutorial's own validation); error when the data path fails.
+
+        Automates ``lnetctl ping --source <local>@efa <peer>@efa``. Discovers a local @efa nid and a peer
+        @efa nid from ``lnetctl``; when either is unavailable there is nothing to ping, so the probe is
+        skipped (a missing peer/local nid is not itself proof the data path is broken).
+        """
+        local = lustre.local_nids(nets, EFA_LNET_NET)
+        if not local:
+            return []
+        peer_nid = lustre.efa_peer_nid()
+        if peer_nid is None:
+            return []
+        source = local[0]
+        if not lustre.efa_ping_works(source, peer_nid):
+            return [self.EFA_PING_FAILED.format(source, peer_nid)]
+        return []
+
+    def _tcp_fallback_warnings(self, nets) -> List[CheckWarning]:
+        """Return a warning per target connected over @tcp while an @efa net is configured."""
+        if lustre.lnet_net(nets, EFA_LNET_NET) is None:
+            return []
+        result = time_command(
+            ["lctl", "get_param", "osc.*.import", "mdc.*.import"], timeout=FSX_OST_QUERY_TIMEOUT_SECONDS
+        )
+        if result.timed_out or result.returncode != 0:
+            return []
+        return [
+            self.TCP_FALLBACK.format(state.target or state.param)
+            for state in lustre.parse_lctl_import(result.stdout)
+            if state.connected_over == "tcp"
+        ]
 
 
-class FsxFilesystemsAreReachable(Check):
-    """Verify each Lustre mount answers ``lfs df -h`` (server/OST reachability) without hanging."""
+class FsxTargetsAreReachable(Check):
+    """Opt-in deep check pinpointing an unreachable OST/MDT -- a common cause of a hung directory listing.
 
-    LFS_DF_TIMED_OUT = CheckError(
+    Runs ``lfs check servers`` (the per-target reachability diagnostic) via ``time_command`` and inspects
+    client-side import state (``lctl get_param osc.*.import`` / ``mdc.*.import``). Because probing
+    individual targets is heavier and can itself block, this check is gated behind ``approval_required`` so
+    it runs only when the operator opts in (or passes ``--yes``). It is kept separate from
+    :class:`LustreFilesystem` because the approval gate is per-check.
+    """
+
+    LFS_CHECK_TIMED_OUT = CheckError(
         1,
-        "lfs df -h on '{}' did not return within {}s -- the filesystem is hanging (server/OST unreachable).",
+        "lfs check servers did not return within {}s -- the client is blocked on an unreachable target.",
     )
-    LFS_DF_FAILED = CheckError(2, "lfs df -h on '{}' failed: {}")
-    TARGET_UNAVAILABLE = CheckError(3, "target {} on '{}' is not available (possible OST/MDT down).")
+    LFS_CHECK_FAILED = CheckError(2, "lfs check servers failed: {}")
+    TARGET_UNREACHABLE = CheckError(3, "target {} is unreachable (lfs check servers: {}).")
+    IMPORT_NOT_FULL = CheckError(4, "target {} import state is {} (not {}) -- the client is not fully connected.")
+    FAILOVER_PINNED = CheckInfo(
+        1,
+        "target {} current_connection {} equals its failover_nids -- no distinct failover NID "
+        "(a primary-server failure has no real failover).",
+    )
 
     @property
     def description(self) -> str:
         """Return the human-readable description of this Check."""
-        return "Verify that configured FsxLustre filesystems are reachable via lfs df."
+        return "Deep-probe each FsxLustre OST/MDT for reachability (lfs check servers + import state)."
 
     def should_run(self, context: Context) -> bool:
         """Run only when a FsxLustre filesystem is configured."""
         return _has_lustre(context)
 
+    def approval_required(self, context: Context) -> bool:
+        """Require confirmation: probing every target is heavier and can itself block."""
+        return True
+
     def run(self, context: Context) -> Result:
-        """Aggregate ``lfs df -h`` per Lustre mount, classifying a hang, an error, or a down target."""
+        """Aggregate ``lfs check servers`` and import-state findings across every Lustre target."""
         errors: List[CheckError] = []
-        for configured in shared_storage.lustre_mounts(context):
-            errors.extend(self._probe_mount(configured.mount_dir))
-        return Result.from_findings(self, errors=errors)
+        infos: List[CheckInfo] = []
 
-    def _probe_mount(self, mount_dir: str) -> List[CheckError]:
-        """Return the CheckErrors for one Lustre mount: empty when it is reachable and all targets are up."""
-        timed = time_command(["lfs", "df", "-h", mount_dir], timeout=FSX_LFS_DF_TIMEOUT_SECONDS)
-        if timed.timed_out:
-            return [self.LFS_DF_TIMED_OUT.format(mount_dir, FSX_LFS_DF_TIMEOUT_SECONDS)]
-        if timed.returncode != 0:
-            return [self.LFS_DF_FAILED.format(mount_dir, timed.stderr.strip())]
+        errors.extend(self._check_servers())
+        import_errors, import_infos = self._check_imports()
+        errors.extend(import_errors)
+        infos.extend(import_infos)
 
+        return Result.from_findings(self, errors=errors, infos=infos)
+
+    def _check_servers(self) -> List[CheckError]:
+        """Return CheckErrors from ``lfs check servers``: a hang, a command failure, or per-target errors."""
+        result = time_command(["lfs", "check", "servers"], timeout=FSX_LFS_CHECK_TIMEOUT_SECONDS)
+        if result.timed_out:
+            return [self.LFS_CHECK_TIMED_OUT.format(FSX_LFS_CHECK_TIMEOUT_SECONDS)]
+        if result.returncode != 0:
+            return [self.LFS_CHECK_FAILED.format(result.stderr.strip())]
         return [
-            self.TARGET_UNAVAILABLE.format(target.uuid, mount_dir)
-            for target in lustre.unavailable_targets(timed.stdout)
+            self.TARGET_UNREACHABLE.format(server.target, server.detail)
+            for server in lustre.unreachable_servers(result.stdout)
         ]
+
+    def _check_imports(self):
+        """Return (errors, infos) from client-side import state: non-FULL targets and failover pinning."""
+        errors: List[CheckError] = []
+        infos: List[CheckInfo] = []
+        result = time_command(
+            ["lctl", "get_param", "osc.*.import", "mdc.*.import"], timeout=FSX_OST_QUERY_TIMEOUT_SECONDS
+        )
+        if result.timed_out or result.returncode != 0:
+            return errors, infos
+        for state in lustre.parse_lctl_import(result.stdout):
+            name = state.target or state.param
+            if not state.healthy:
+                errors.append(self.IMPORT_NOT_FULL.format(name, state.state or "unknown", HEALTHY_TARGET_STATE))
+            if state.current_connection and state.failover_nids == [state.current_connection]:
+                infos.append(self.FAILOVER_PINNED.format(name, state.current_connection))
+        return errors, infos

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -53,6 +53,7 @@ Both checks run on every node type that has a FsxLustre mount configured, and sk
 """
 
 import logging
+import shutil
 from dataclasses import dataclass, field
 from typing import List
 
@@ -95,10 +96,12 @@ class _LnetSnapshot:
 
     Attributes:
         timed_out: Whether the ``lnetctl`` call exceeded its bounded timeout (LNet may be wedged).
-        nets: The parsed LNet nets (empty when the command timed out or returned non-zero).
+        unavailable: Whether ``lnetctl`` could not be run at all (e.g. the binary is not installed).
+        nets: The parsed LNet nets (empty when the command timed out, was unavailable, or returned non-zero).
     """
 
     timed_out: bool
+    unavailable: bool = False
     nets: list = field(default_factory=list)
 
 
@@ -233,6 +236,11 @@ class LustreFilesystem(Check):
         "is instance-type-specific (some families bind a subset by design). See "
         "https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html",
     )
+    LNETCTL_UNAVAILABLE = CheckInfo(
+        9,
+        "lnetctl is not available on this node, so the LNet transport and EFA probes were skipped "
+        "(the Lustre client may not be installed).",
+    )
 
     @property
     def description(self) -> str:
@@ -272,6 +280,12 @@ class LustreFilesystem(Check):
         ``-v`` is used so per-NI statistics and health values are available; the non-verbose fields (net
         type, nid, interfaces) are a subset, so one verbose call serves both probes.
         """
+        # Check the binary is present before running it: lnetctl is absent when the Lustre client is not
+        # installed, and running a missing binary would raise out of this call (which is outside the
+        # per-probe isolation loop) and sink the whole check. This gate covers both the LNet and EFA
+        # probes, since both only reach lnetctl through this snapshot.
+        if shutil.which("lnetctl") is None:
+            return _LnetSnapshot(timed_out=False, unavailable=True)
         result = time_command(["lnetctl", "net", "show", "-v"], timeout=FSX_LNET_SHOW_TIMEOUT_SECONDS)
         if result.timed_out:
             return _LnetSnapshot(timed_out=True)
@@ -351,6 +365,10 @@ class LustreFilesystem(Check):
         if lnet.timed_out:
             errors.append(self.LNETCTL_TIMED_OUT.format(FSX_LNET_SHOW_TIMEOUT_SECONDS))
             return
+        if lnet.unavailable:
+            # lnetctl is not installed -- report it as info and skip; not a Lustre-health failure by itself.
+            infos.append(self.LNETCTL_UNAVAILABLE)
+            return
 
         active = lustre.active_lnds(lnet.nets)
         if not active:
@@ -388,8 +406,8 @@ class LustreFilesystem(Check):
         the client-side import state, to name -- not fix -- the failures. Read-only: never re-binds devices
         or edits the security group.
         """
-        if lnet.timed_out:
-            # The LNet probe already reported the hang; there is nothing to inspect here.
+        if lnet.timed_out or lnet.unavailable:
+            # The LNet probe already reported the hang / missing lnetctl; there is nothing to inspect here.
             return
         efa_net = lustre.lnet_net(lnet.nets, EFA_LNET_NET)
         # Query the service once (like the shared lnet snapshot) and reuse it for both the gate and the

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
@@ -138,10 +138,23 @@ EFA_DRIVER_KERNEL_MODULE = "efa"
 # supports EFA" (it verifies that ``modinfo kefalnd`` succeeds), so it is a prerequisite for any
 # EFA-for-Lustre probing, checked before the data-path probes run.
 EFA_KEFALND_KERNEL_MODULE = "kefalnd"
-# Minimum versions the setup enforces before configuring EFA.
+# Minimum EFA-path versions the setup enforces before configuring EFA.
 MIN_EFA_DRIVER_VERSION = "2.12.1"
 MIN_KEFALND_VERSION_P6 = "1.1.1"  # kefalnd floor, enforced on p6+ instances only
-MIN_LUSTRE_CLIENT_VERSION = "2.15"
+
+# Minimum Lustre *client* version per cluster base_os (dna.json cluster.base_os). This is a general Lustre
+# floor -- NOT the EFA floor -- so it applies to every FsxLustre mount, EFA or not. rhel8/rocky8 ship the
+# 2.12 client (older 4.18 kernel); every other supported base_os ships 2.15. A base_os not in the map (or
+# unknown) uses the default. Source: https://docs.aws.amazon.com/fsx/latest/LustreGuide/lustre-client-matrix.html
+LUSTRE_CLIENT_MIN_VERSION_DEFAULT = "2.15"
+LUSTRE_CLIENT_MIN_VERSION_BY_OS = {
+    "rhel8": "2.12",
+    "rocky8": "2.12",
+}
+# base_os values where EFA-for-Lustre is NOT supported: EFA-for-Lustre requires AL2023 / RHEL 9.5+ /
+# Ubuntu 22.04+ (per configure-efa-clients.html); rhel8/rocky8 run the older 4.18 kernel and are excluded,
+# so the EFA probes are skipped on them.
+EFA_LUSTRE_UNSUPPORTED_OSES = ("rhel8", "rocky8")
 # Instance-family prefixes that require the kefalnd version check (the p6+ families).
 P6PLUS_INSTANCE_PREFIXES = ("p6-b200", "p6e-gb200", "p6-b300")
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
@@ -158,20 +158,21 @@ EFA_LUSTRE_UNSUPPORTED_OSES = ("rhel8", "rocky8")
 # Instance-family prefixes that require the kefalnd version check (the p6+ families).
 P6PLUS_INSTANCE_PREFIXES = ("p6-b200", "p6e-gb200", "p6-b300")
 
-# How many EFA devices the setup binds to LNet, keyed by exact instance type. It binds an
-# instance-type-specific SUBSET on some families (not always all devices), so the "expected bound" count is
-# this table -- NOT the raw device count. Value semantics:
-#   int   -> exactly this many devices are bound (capped at the number actually present)
-#   "all" -> all present EFA devices are bound
-# An instance type NOT in this table has no static expected count -- either its selection is dynamic
-# (e.g. p6e-gb200 binds only host-connected devices, which we cannot count statically) or we have no data
-# for it -- so the underbinding check is skipped for it (only a total absence of bound devices is flagged).
+# How many EFA devices the FSx-for-Lustre EFA client setup binds to LNet by default, keyed by exact
+# instance type. Values mirror the "Default Number of EFA Interfaces" table in
+# https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html#add-efa-interfaces --
+# these are the counts the setup script configures automatically per instance type. An int is exactly the
+# number of devices bound (capped at devices actually present). An instance type NOT in this table follows
+# the doc's dynamic fallback ("Other instances with multiple/single network cards" -> 2/1); we do not
+# encode that fallback because it depends on live NIC count, so unknown types get no static expectation
+# here and the underbinding check only flags a total absence of bound devices.
 EFA_EXPECTED_BOUND_DEVICES = {
     "p5.48xlarge": 8,
     "p5e.48xlarge": 8,
     "p5en.48xlarge": 8,
-    "p6-b200.48xlarge": "all",
-    "p6-b300.48xlarge": "all",
+    "p6-b200.48xlarge": 8,
+    "p6-b300.48xlarge": 16,
+    "p6e-gb200.36xlarge": 8,
 }
 # The systemd oneshot service the FSx EFA-Lustre client setup installs to (re)configure LNet on every
 # boot. Its state is the persistence/health signal for this delivery vehicle.

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
@@ -107,10 +107,62 @@ DIRECTORY_LOOKUP_COMMAND_TIMEOUT_SECONDS = 30
 # FSx / shared-storage diagnostics
 # `lfs df -h` must return within this or the filesystem is treated as hanging (server/OST unreachable).
 FSX_LFS_DF_TIMEOUT_SECONDS = 30
+# `lfs check servers` probes every target, so allow it longer than a plain `lfs df`.
+FSX_LFS_CHECK_TIMEOUT_SECONDS = 60
+# `lnetctl net show` is a fast, local query; cap it low so a wedged LNet cannot stall the check.
+FSX_LNET_SHOW_TIMEOUT_SECONDS = 15
+# `lctl get_param` reads client-side import state; bound it so a stuck import cannot hang the check.
+FSX_OST_QUERY_TIMEOUT_SECONDS = 30
+# `lnetctl ping` over EFA; a hang here is the signal the EFA data path is not working.
+FSX_EFA_PING_TIMEOUT_SECONDS = 15
 # The StorageType value a FSx for Lustre mount carries in the cluster configuration's SharedStorage.
 LUSTRE_STORAGE_TYPE = "FsxLustre"
-# NFS-based shared-storage types, handled with shallow reachability only (not in scope for PR1).
+# NFS-based shared-storage types. Reserved for a future NFS reachability check (a sibling of the Lustre
+# checks); not consumed yet.
 NFS_STORAGE_TYPES = ("FsxOntap", "FsxOpenZfs", "Efs")
+# The osc/mdc import ``state:`` value indicating a reachable, fully-connected target.
+HEALTHY_TARGET_STATE = "FULL"
+# --- EFA-for-Lustre client parameters -----------------------------------------------------
+# TODO/TO-CHECK: every value in this section mirrors the FSx EFA-Lustre client setup, which we cannot
+# import. If that setup bumps a version floor, adds/renames a p6+ family, or changes how many EFA devices a
+# family binds, re-sync the constants below or these checks will drift and under/over-report. Source:
+# https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html
+#
+# The LNet net type for the EFA LND (kefalnd).
+EFA_LNET_NET = "efa"
+# EFA/RDMA devices surface here; the count is compared against the devices bound to LNet.
+EFA_INFINIBAND_SYSFS = "/sys/class/infiniband"
+# The EFA driver kernel module (its version gates the EFA-Lustre path).
+EFA_DRIVER_KERNEL_MODULE = "efa"
+# The kefalnd kernel module (the EFA LND). Its presence is how the setup defines "this Lustre client
+# supports EFA" (it verifies that ``modinfo kefalnd`` succeeds), so it is a prerequisite for any
+# EFA-for-Lustre probing, checked before the data-path probes run.
+EFA_KEFALND_KERNEL_MODULE = "kefalnd"
+# Minimum versions the setup enforces before configuring EFA.
+MIN_EFA_DRIVER_VERSION = "2.12.1"
+MIN_KEFALND_VERSION_P6 = "1.1.1"  # kefalnd floor, enforced on p6+ instances only
+MIN_LUSTRE_CLIENT_VERSION = "2.15"
+# Instance-family prefixes that require the kefalnd version check (the p6+ families).
+P6PLUS_INSTANCE_PREFIXES = ("p6-b200", "p6e-gb200", "p6-b300")
+
+# How many EFA devices the setup binds to LNet, keyed by exact instance type. It binds an
+# instance-type-specific SUBSET on some families (not always all devices), so the "expected bound" count is
+# this table -- NOT the raw device count. Value semantics:
+#   int   -> exactly this many devices are bound (capped at the number actually present)
+#   "all" -> all present EFA devices are bound
+# An instance type NOT in this table has no static expected count -- either its selection is dynamic
+# (e.g. p6e-gb200 binds only host-connected devices, which we cannot count statically) or we have no data
+# for it -- so the underbinding check is skipped for it (only a total absence of bound devices is flagged).
+EFA_EXPECTED_BOUND_DEVICES = {
+    "p5.48xlarge": 8,
+    "p5e.48xlarge": 8,
+    "p5en.48xlarge": 8,
+    "p6-b200.48xlarge": "all",
+    "p6-b300.48xlarge": "all",
+}
+# The systemd oneshot service the FSx EFA-Lustre client setup installs to (re)configure LNet on every
+# boot. Its state is the persistence/health signal for this delivery vehicle.
+EFA_LUSTRE_SYSTEMD_SERVICE = "configure-efa-fsx-lustre-client.service"
 
 # Slurm accounting
 SLURM_ETC_DIR = DEFAULT_SLURM_INSTALL_DIR + "/etc"

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/context_builder.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/context_builder.py
@@ -65,6 +65,7 @@ class ContextBuilder:
                 pcluster_diag_version=self._pcluster_diag_version(),
                 pcluster_version=self._pcluster_version(),
                 instance_id=instance_id,
+                instance_type=self._instance_type(),
                 node_type=node_type,
                 cluster_config=self._cluster_config(),
                 dna_json=dna_json,
@@ -97,6 +98,19 @@ class ContextBuilder:
             return imds.get_instance_id()
         except Exception as error:  # best-effort: a failure must not abort the build
             logger.error("Could not determine the current instance id from IMDS: %s", error)
+            return None
+
+    def _instance_type(self) -> Optional[str]:
+        """Return the current instance type from IMDS, or None (logging an error) if it cannot be determined.
+
+        The instance type is not carried in dna.json (neither the head-node nor the compute-node cluster
+        dict includes it), so it is resolved from IMDS -- the same source the official EFA-Lustre config
+        script uses. Best-effort: a failure must not abort the build.
+        """
+        try:
+            return imds.get_instance_type()
+        except Exception as error:
+            logger.error("Could not determine the current instance type from IMDS: %s", error)
             return None
 
     def _node_type(self, dna_json: dict) -> NodeType:

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/registry.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/registry.py
@@ -24,11 +24,7 @@ from pcluster_diag.checks.cfn_hup import CfnHupRunsOnlyOnHeadNode
 from pcluster_diag.checks.critical_paths import CriticalPathsHaveExpectedPermissions
 from pcluster_diag.checks.daemon_health import ClusterDaemonsAreRunning, ClustermgtdHeartbeatIsHealthy
 from pcluster_diag.checks.directory_lookup import DirectoryService
-from pcluster_diag.checks.fsx_connectivity import (
-    FsxFilesystemsAreReachable,
-    FsxMountsArePresent,
-    LustreClientIsInstalled,
-)
+from pcluster_diag.checks.fsx_connectivity import FsxTargetsAreReachable, LustreFilesystem
 from pcluster_diag.checks.imds import Imds
 from pcluster_diag.checks.instance_profile import ImdsRoleMatchesCfnHupConfig
 from pcluster_diag.checks.reserved_users import ReservedUsersAndGroups
@@ -144,8 +140,7 @@ DEFAULT_REGISTRY = (
     .register(ClusterDaemonsAreRunning())
     .register(ClustermgtdHeartbeatIsHealthy())
     .register(DirectoryService())
-    .register(LustreClientIsInstalled())
-    .register(FsxMountsArePresent())
-    .register(FsxFilesystemsAreReachable())
     .register(SlurmAccounting())
+    .register(LustreFilesystem())
+    .register(FsxTargetsAreReachable())  # approval_required: heavier per-target probe
 )

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/context.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/context.py
@@ -38,6 +38,9 @@ class Context:
         pcluster_diag_version: The pcluster-diag package version (``1.0.0`` initially).
         pcluster_version: The installed ParallelCluster version.
         instance_id: The id of the instance the tool is running on, or None if it cannot be determined.
+        instance_type: The EC2 instance type the tool runs on (e.g. ``t3.xlarge``), or None if it
+            cannot be determined. Used to gate instance-family-specific checks (e.g. the p6+ kefalnd
+            version requirement).
         node_type: The node type the tool runs on (HEAD, COMPUTE, or LOGIN).
         cluster_config: The deployed cluster configuration.
         dna_json: The node's ``dna.json`` contents.
@@ -48,6 +51,7 @@ class Context:
     pcluster_diag_version: str
     pcluster_version: str
     instance_id: Optional[str]
+    instance_type: Optional[str]
     node_type: NodeType
     cluster_config: dict
     dna_json: dict

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/efa.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/efa.py
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""EFA capability helpers: is EFA present and usable on this instance?
+"""EFA capability helpers: checks if EFA is present and usable on this instance.
 
 The home for EFA-capability probing, so new EFA checks can build on it: the ``kefalnd`` module (the EFA
 LND), the EFA driver and ``kefalnd`` module versions, the number of EFA devices the kernel exposes, and
@@ -79,22 +79,18 @@ def _is_efa_device(name: str) -> bool:
 
 
 def expected_bound_device_count(instance_type: Optional[str], available: int) -> Optional[int]:
-    """Return how many EFA devices the official setup binds on ``instance_type``, or None when unknown.
+    """Return how many EFA devices the FSx-for-Lustre EFA setup binds on ``instance_type``, or None.
 
-    ``available`` is the number of EFA devices actually present (an explicit integer count is capped at it,
-    so we never expect more than exist). Returns:
-      - an int: the expected number of bound devices for this instance type;
-      - None: no static expectation -- the type is not in the table, its selection is dynamic (e.g.
-        p6e-gb200 binds only host-connected devices), or the instance type is unknown. The caller then
-        makes no underbinding assertion beyond "at least one device must be bound".
+    Values come from EFA_EXPECTED_BOUND_DEVICES (mirroring the FSx-for-Lustre configure-efa-clients doc).
+    ``available`` is the number of EFA devices actually present; the expected count is capped at it, so we
+    never expect more than exist. Returns None when the instance type is unknown or not in the table -- the
+    caller then makes no underbinding assertion beyond "at least one device must be bound".
     """
     if not instance_type:
         return None
     expected = EFA_EXPECTED_BOUND_DEVICES.get(instance_type)
     if expected is None:
         return None
-    if expected == "all":
-        return available
     return min(expected, available)
 
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/efa.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/efa.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EFA capability helpers: is EFA present and usable on this instance?
+
+The home for EFA-capability probing, so new EFA checks can build on it: the ``kefalnd`` module (the EFA
+LND), the EFA driver and ``kefalnd`` module versions, the number of EFA devices the kernel exposes, and
+whether the running instance is a p6+ family (which carries a higher ``kefalnd`` version floor).
+"""
+
+import logging
+import os
+from typing import Optional
+
+from pcluster_diag.core.constants import (
+    EFA_DRIVER_KERNEL_MODULE,
+    EFA_EXPECTED_BOUND_DEVICES,
+    EFA_INFINIBAND_SYSFS,
+    EFA_KEFALND_KERNEL_MODULE,
+    P6PLUS_INSTANCE_PREFIXES,
+)
+from pcluster_diag.util import kernel_module
+
+logger = logging.getLogger(__name__)
+
+
+def efa_kefalnd_supported() -> bool:
+    """Return whether the Lustre client supports EFA, i.e. the ``kefalnd`` module is available.
+
+    This mirrors the official FSx EFA-Lustre client setup's definition of EFA support (it verifies that
+    ``modinfo kefalnd`` succeeds): a Lustre client with no ``kefalnd`` module cannot ride EFA no matter how
+    LNet is configured.
+    """
+    return kernel_module.kernel_module_available(EFA_KEFALND_KERNEL_MODULE)
+
+
+def efa_driver_version() -> Optional[str]:
+    """Return the EFA driver kernel module version (``modinfo efa``), or None when unavailable."""
+    return kernel_module.module_version(EFA_DRIVER_KERNEL_MODULE)
+
+
+def efa_kefalnd_version() -> Optional[str]:
+    """Return the ``kefalnd`` (EFA LND) kernel module version, or None when unavailable."""
+    return kernel_module.module_version(EFA_KEFALND_KERNEL_MODULE)
+
+
+def efa_device_count() -> int:
+    """Return the number of EFA devices exposed under ``/sys/class/infiniband`` (0 when none).
+
+    Only devices whose ``device/driver`` resolves to ``efa`` are counted. ``/sys/class/infiniband`` can
+    also hold non-EFA RDMA devices, so a bare directory listing would over-count; filtering by driver
+    mirrors how the official EFA-Lustre setup enumerates EFA interfaces.
+    """
+    try:
+        entries = os.listdir(EFA_INFINIBAND_SYSFS)
+    except OSError as error:
+        logger.warning("Could not list %s: %s", EFA_INFINIBAND_SYSFS, error)
+        return 0
+    return sum(1 for name in entries if _is_efa_device(name))
+
+
+def _is_efa_device(name: str) -> bool:
+    """Return whether the ``/sys/class/infiniband`` entry ``name`` is backed by the ``efa`` driver."""
+    driver_link = os.path.join(EFA_INFINIBAND_SYSFS, name, "device", "driver")
+    try:
+        return os.path.basename(os.path.realpath(driver_link)) == EFA_DRIVER_KERNEL_MODULE
+    except OSError as error:
+        logger.warning("Could not resolve the driver for %s: %s", name, error)
+        return False
+
+
+def expected_bound_device_count(instance_type: Optional[str], available: int) -> Optional[int]:
+    """Return how many EFA devices the official setup binds on ``instance_type``, or None when unknown.
+
+    ``available`` is the number of EFA devices actually present (an explicit integer count is capped at it,
+    so we never expect more than exist). Returns:
+      - an int: the expected number of bound devices for this instance type;
+      - None: no static expectation -- the type is not in the table, its selection is dynamic (e.g.
+        p6e-gb200 binds only host-connected devices), or the instance type is unknown. The caller then
+        makes no underbinding assertion beyond "at least one device must be bound".
+    """
+    if not instance_type:
+        return None
+    expected = EFA_EXPECTED_BOUND_DEVICES.get(instance_type)
+    if expected is None:
+        return None
+    if expected == "all":
+        return available
+    return min(expected, available)
+
+
+def is_p6plus_instance(instance_type: Optional[str]) -> Optional[bool]:
+    """Return whether ``instance_type`` is a p6+ family requiring the kefalnd version check.
+
+    Returns True/False for a known instance type, and ``None`` when the instance type is unknown (e.g. IMDS
+    could not be reached at context-build time). ``None`` lets the caller distinguish "known non-p6" (skip
+    the p6-only kefalnd version floor cleanly) from "could not determine the family" (report that the check
+    was skipped for lack of the instance type), rather than silently treating an unknown type as non-p6.
+
+    The kefalnd minimum-version requirement applies only to the p6+ families (see
+    ``P6PLUS_INSTANCE_PREFIXES``).
+    """
+    if not instance_type:
+        return None
+    return any(instance_type.startswith(prefix) for prefix in P6PLUS_INSTANCE_PREFIXES)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/imds.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/imds.py
@@ -27,6 +27,7 @@ IMDS_V2 = "v2.0"  # HttpTokens required: only token-backed IMDSv2 requests are a
 _BASE_URL = "http://169.254.169.254/latest"  # nosec B104  link-local IMDS endpoint
 _TOKEN_URL = _BASE_URL + "/api/token"
 _INSTANCE_ID_URL = _BASE_URL + "/meta-data/instance-id"
+_INSTANCE_TYPE_URL = _BASE_URL + "/meta-data/instance-type"
 _METADATA_URL = _BASE_URL + "/meta-data/"
 _INSTANCE_TAGS_URL = _BASE_URL + "/meta-data/tags/instance"
 _IAM_SECURITY_CREDENTIALS_URL = _BASE_URL + "/meta-data/iam/security-credentials/"
@@ -38,6 +39,12 @@ def get_instance_id() -> str:
     """Return the id of the current instance, fetched from IMDSv2."""
     token = fetch_token()
     return _get(_INSTANCE_ID_URL, token)
+
+
+def get_instance_type() -> str:
+    """Return the EC2 instance type of the current instance (e.g. ``t3.xlarge``), from IMDSv2."""
+    token = fetch_token()
+    return _get(_INSTANCE_TYPE_URL, token)
 
 
 def get_iam_role_name() -> Optional[str]:

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/kernel_module.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/kernel_module.py
@@ -13,12 +13,13 @@
 """Kernel-module and kernel probing.
 
 Thin wrappers over ``modinfo``/``lsmod`` (kernel module availability and load state) and ``uname``
-(running kernel release). These are used by the Lustre client checks but contain nothing
-Lustre-specific. Every external command is routed through :mod:`pcluster_diag.util.shell`; a missing
-binary is treated as a negative answer, never an exception.
+(running kernel release), plus a small dotted-version comparison for module versions. Every external
+command is routed through the shell helper; a missing binary is treated as a negative answer, never an
+exception.
 """
 
 import logging
+import re
 from typing import List, Optional
 
 from pcluster_diag.util.shell import run_command
@@ -76,3 +77,31 @@ def module_version(module: str) -> Optional[str]:
     if result.returncode != 0:
         return None
     return result.stdout.strip() or None
+
+
+def version_at_least(actual: Optional[str], minimum: str) -> Optional[bool]:
+    """Return whether dotted version ``actual`` is >= ``minimum``, or ``None`` when it cannot be determined.
+
+    Returns True/False for a comparable ``actual``, and ``None`` when ``actual`` is missing or unparseable
+    (rather than conflating "could not determine the version" with "below the minimum"). This lets the
+    caller surface an unparseable version as an undeterminable check instead of a false below-minimum
+    result. Only the leading dotted-numeric prefix is compared (e.g. ``2.15.6-1.fsx23`` -> ``[2, 15, 6]``).
+    """
+    parsed_actual = _numeric_version(actual)
+    parsed_min = _numeric_version(minimum)
+    if parsed_actual is None or parsed_min is None:
+        return None
+    length = max(len(parsed_actual), len(parsed_min))
+    parsed_actual += [0] * (length - len(parsed_actual))
+    parsed_min += [0] * (length - len(parsed_min))
+    return parsed_actual >= parsed_min
+
+
+def _numeric_version(version: Optional[str]) -> Optional[List[int]]:
+    """Return the leading dotted-numeric components of ``version`` (e.g. ``2.15.6-1`` -> ``[2, 15, 6]``)."""
+    if not version:
+        return None
+    match = re.match(r"(\d+(?:\.\d+)*)", version.strip())
+    if not match:
+        return None
+    return [int(part) for part in match.group(1).split(".")]

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
@@ -422,5 +422,5 @@ def _scan_field(line: str, key: str) -> Optional[str]:
     """Return the value of ``key: value`` in ``line`` (stripped), or None when the line is not that field."""
     prefix = key + ":"
     if line.startswith(prefix):
-        return line[len(prefix):].strip()
+        return line[len(prefix) :].strip()
     return None

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
@@ -10,27 +10,40 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Lustre-specific helpers: ``lfs df`` parsing and Lustre client detection.
+"""Lustre helpers: ``lfs``/``lctl`` protocol parsing plus the LNet transport layer.
 
-This module holds only the genuinely Lustre-specific logic. Shared-storage enumeration and the
-``/proc/mounts`` table live in :mod:`pcluster_diag.util.shared_storage`; the kernel-module probes this
-module builds on live in :mod:`pcluster_diag.util.kernel_module`.
+Holds the Lustre-side logic: the ``lfs df`` / ``lfs check servers`` / ``lctl ...import`` protocol parsing,
+and the LNet transport layer (parsing ``lnetctl net show`` / ``lnetctl peer show`` and the ``lnetctl
+ping`` reachability probe) -- LNet is Lustre's own networking layer, driven by ``lnetctl``.
 """
 
+import logging
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
+import yaml
+
+from pcluster_diag.core.constants import EFA_LNET_NET, FSX_EFA_PING_TIMEOUT_SECONDS, FSX_LNET_SHOW_TIMEOUT_SECONDS
 from pcluster_diag.util import kernel_module
+from pcluster_diag.util.shell import time_command
+
+logger = logging.getLogger(__name__)
 
 # The out-of-tree kernel modules the Lustre client needs to speak Lustre.
 LUSTRE_KERNEL_MODULES = ("lustre", "lnet")
+
+# The loopback LNet net; never a real transport, so it is ignored when reporting active LNDs.
+LOOPBACK_LNET_NET = "lo"
 
 # Matches the target role (MDT/OST) embedded in a `lfs df` UUID or the `[OST:0]`/`[MDT:0]` mount tag.
 _ROLE_RE = re.compile(r"(MDT|OST)", re.IGNORECASE)
 
 # Matches a `lfs df -h` size column (e.g. "10.0T", "512", "1.5G"); healthy target rows start with one.
 _SIZE_RE = re.compile(r"^\d[\d.]*[KMGTPE]?$")
+
+# Matches the header line that opens each `lctl get_param ...import` block: e.g. `osc.fs-OST0000-osc-ffff.import=`.
+_IMPORT_HEADER_RE = re.compile(r"^(?P<param>\S+)\.import=\s*$")
 
 
 @dataclass
@@ -95,3 +108,319 @@ def _parse_target_line(line: str) -> Optional[LustreTarget]:
 def lustre_client_version() -> Optional[str]:
     """Return the Lustre client version (from the ``lustre`` kernel module), or None when unavailable."""
     return kernel_module.module_version("lustre")
+
+
+# --- LNet transport: lnetctl net show parsing -----------------------------------------
+
+
+@dataclass
+class LnetNi:
+    """A single local network interface (NI) parsed from ``lnetctl net show``.
+
+    Attributes:
+        nid: The Lustre network id (e.g. ``10.0.0.1@efa``).
+        status: The interface status string (e.g. ``up``), or None when absent.
+        interfaces: The underlying device names bound to this NI (e.g. ``["efa0"]``).
+        send_count: Packets sent, from ``lnetctl net show -v`` statistics (None when not verbose).
+        recv_count: Packets received, from ``lnetctl net show -v`` statistics (None when not verbose).
+        health_value: The NI health value, from ``-v`` health stats (None when not verbose/absent).
+    """
+
+    nid: str
+    status: Optional[str] = None
+    interfaces: List[str] = field(default_factory=list)
+    send_count: Optional[int] = None
+    recv_count: Optional[int] = None
+    health_value: Optional[int] = None
+
+
+@dataclass
+class LnetNet:
+    """A configured LNet network parsed from ``lnetctl net show``.
+
+    Attributes:
+        net_type: The LND net type (e.g. ``tcp``, ``efa``, ``o2ib``, or ``lo`` for loopback).
+        local_nis: The local network interfaces configured on this net.
+    """
+
+    net_type: str
+    local_nis: List[LnetNi] = field(default_factory=list)
+
+
+def parse_lnet_net_show(output: str) -> List[LnetNet]:
+    """Parse ``lnetctl net show`` (or ``-v``) YAML into ``LnetNet`` entries (empty when unparseable).
+
+    ``lnetctl`` emits YAML with a top-level ``net`` list; each entry carries a ``net type`` and a
+    ``local NI(s)`` list. Malformed output is treated as "no nets" rather than raising, so a broken
+    ``lnetctl`` never wedges the check.
+    """
+    try:
+        data = yaml.safe_load(output)
+    except yaml.YAMLError as error:
+        logger.warning("Could not parse lnetctl net show output as YAML: %s", error)
+        return []
+    if not isinstance(data, dict):
+        return []
+    nets: List[LnetNet] = []
+    for entry in data.get("net") or []:
+        if not isinstance(entry, dict):
+            continue
+        net_type = entry.get("net type")
+        if not net_type:
+            continue
+        nis = [_parse_lnet_ni(ni) for ni in (entry.get("local NI(s)") or []) if isinstance(ni, dict)]
+        nets.append(LnetNet(net_type=str(net_type), local_nis=nis))
+    return nets
+
+
+def _parse_lnet_ni(ni: dict) -> LnetNi:
+    """Parse one ``local NI(s)`` mapping from ``lnetctl net show`` into an ``LnetNi``."""
+    raw_interfaces = ni.get("interfaces")
+    if isinstance(raw_interfaces, dict):
+        interfaces = [str(value) for value in raw_interfaces.values()]
+    elif isinstance(raw_interfaces, list):
+        interfaces = [str(value) for value in raw_interfaces]
+    else:
+        interfaces = []
+    statistics = ni.get("statistics") or {}
+    health_stats = ni.get("health stats") or {}
+    status = ni.get("status")
+    return LnetNi(
+        nid=str(ni.get("nid") or ""),
+        status=str(status) if status is not None else None,
+        interfaces=interfaces,
+        send_count=_as_int(statistics.get("send_count")),
+        recv_count=_as_int(statistics.get("recv_count")),
+        health_value=_as_int(health_stats.get("health value")),
+    )
+
+
+def active_lnds(nets: List[LnetNet]) -> List[str]:
+    """Return the active LND net types (in order), excluding the loopback net."""
+    return [net.net_type for net in nets if net.net_type != LOOPBACK_LNET_NET]
+
+
+def lnet_net(nets: List[LnetNet], net_type: str) -> Optional[LnetNet]:
+    """Return the ``LnetNet`` with ``net_type``, or None when it is not configured."""
+    return next((net for net in nets if net.net_type == net_type), None)
+
+
+def lnet_bound_interfaces(nets: List[LnetNet], net_type: str) -> List[str]:
+    """Return the underlying device names bound to ``net_type`` across all its NIs (empty when none)."""
+    net = lnet_net(nets, net_type)
+    if net is None:
+        return []
+    interfaces: List[str] = []
+    for ni in net.local_nis:
+        interfaces.extend(ni.interfaces)
+    return interfaces
+
+
+def local_nids(nets: List[LnetNet], net_type: str) -> List[str]:
+    """Return the local nids configured on ``net_type`` (empty when the net is absent)."""
+    net = lnet_net(nets, net_type)
+    if net is None:
+        return []
+    return [ni.nid for ni in net.local_nis if ni.nid]
+
+
+# --- LNet transport: lnetctl peer show parsing ----------------------------------------
+
+
+def parse_lnet_peer_show(output: str) -> List[str]:
+    """Return the peer nids parsed from ``lnetctl peer show`` YAML (empty when unparseable/none).
+
+    ``lnetctl peer show`` emits a top-level ``peer`` list; each entry carries a ``primary nid`` and a
+    ``peer ni`` list of ``nid`` mappings. Both are collected so callers can pick, e.g., the ``@efa`` nids.
+    """
+    try:
+        data = yaml.safe_load(output)
+    except yaml.YAMLError as error:
+        logger.warning("Could not parse lnetctl peer show output as YAML: %s", error)
+        return []
+    if not isinstance(data, dict):
+        return []
+    nids: List[str] = []
+    for entry in data.get("peer") or []:
+        if not isinstance(entry, dict):
+            continue
+        primary = entry.get("primary nid")
+        if primary:
+            nids.append(str(primary))
+        for peer_ni in entry.get("peer ni") or []:
+            if isinstance(peer_ni, dict) and peer_ni.get("nid"):
+                nids.append(str(peer_ni["nid"]))
+    return nids
+
+
+def nids_on_net(nids: List[str], net_type: str) -> List[str]:
+    """Return the nids in ``nids`` whose LND suffix matches ``net_type`` (e.g. ``efa``), de-duplicated."""
+    suffix = "@" + net_type
+    seen = set()
+    matched: List[str] = []
+    for nid in nids:
+        if nid.endswith(suffix) and nid not in seen:
+            seen.add(nid)
+            matched.append(nid)
+    return matched
+
+
+# --- LNet transport: the lnetctl ping reachability probe ------------------------------
+
+
+def efa_peer_nid() -> Optional[str]:
+    """Return an ``@efa`` peer nid from ``lnetctl peer show``, or None when none is available."""
+    result = time_command(["lnetctl", "peer", "show"], timeout=FSX_LNET_SHOW_TIMEOUT_SECONDS)
+    if result.timed_out or result.returncode != 0:
+        return None
+    efa_peers = nids_on_net(parse_lnet_peer_show(result.stdout), EFA_LNET_NET)
+    return efa_peers[0] if efa_peers else None
+
+
+def efa_ping_works(source_nid: str, peer_nid: str) -> bool:
+    """Return whether ``lnetctl ping --source <source_nid> <peer_nid>`` succeeds within the timeout.
+
+    A hang or a non-zero exit both mean the EFA data path is not working; only a clean success is True.
+    """
+    result = time_command(["lnetctl", "ping", "--source", source_nid, peer_nid], timeout=FSX_EFA_PING_TIMEOUT_SECONDS)
+    return not (result.timed_out or result.returncode != 0)
+
+
+def _as_int(value) -> Optional[int]:
+    """Coerce ``value`` to an int, or None when it is missing or not an integer."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+# --- lfs check servers parsing --------------------------------------------------------
+
+# Matches an error line such as: check 'fs-OST0001-osc-ffff': Input/output error (5)
+_CHECK_ERROR_RE = re.compile(r"check '(?P<target>[^']+)':\s*(?P<detail>.*)")
+
+
+@dataclass
+class ServerCheck:
+    """A single per-target line parsed from ``lfs check servers``.
+
+    Attributes:
+        target: The target (obd) name (e.g. ``fs-OST0001-osc-ffff``).
+        active: Whether the target reported ``active`` (reachable).
+        detail: The raw error/status text for a non-active target (empty for an active one).
+    """
+
+    target: str
+    active: bool
+    detail: str = ""
+
+
+def parse_lfs_check_servers(output: str) -> List[ServerCheck]:
+    """Parse ``lfs check servers`` output into per-target ``ServerCheck`` rows.
+
+    ``lfs check servers`` reports each target either as ``<target> active.`` or as an error line such as
+    ``check '<target>': Input/output error (5)``. Both shapes are parsed; unrecognized lines are ignored.
+    """
+    results: List[ServerCheck] = []
+    for raw in output.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        error_match = _CHECK_ERROR_RE.search(line)
+        if error_match:
+            detail = error_match.group("detail").strip()
+            results.append(ServerCheck(target=error_match.group("target"), active=False, detail=detail))
+            continue
+        tokens = line.split()
+        if len(tokens) < 2:
+            continue
+        status = " ".join(tokens[1:])
+        active = "active" in status.lower()
+        results.append(ServerCheck(target=tokens[0], active=active, detail="" if active else status))
+    return results
+
+
+def unreachable_servers(output: str) -> List[ServerCheck]:
+    """Return the ``lfs check servers`` targets that did not report active (reachable)."""
+    return [server for server in parse_lfs_check_servers(output) if not server.active]
+
+
+# --- lctl get_param ...import parsing -------------------------------------------------
+
+# A Lustre network id (e.g. 10.0.0.2@tcp, 10.0.0.2@efa), used to extract connection/failover nids.
+_NID_RE = re.compile(r"[\w.:\-]+@\w+")
+
+
+@dataclass
+class ImportState:
+    """Client-side import state for one target, parsed from ``lctl get_param osc.*.import`` / ``mdc.*.import``.
+
+    Attributes:
+        param: The parameter path identifying the target (e.g. ``osc.fs-OST0000-osc-ffff``).
+        target: The target UUID reported in the import block, or None when absent.
+        state: The import ``state:`` (e.g. ``FULL``, ``DISCONN``, ``RECOVER``), or None when absent.
+        current_connection: The nid the client is currently connected to, or None when absent.
+        failover_nids: The failover nids advertised for the target (may equal ``current_connection``).
+    """
+
+    param: str
+    target: Optional[str] = None
+    state: Optional[str] = None
+    current_connection: Optional[str] = None
+    failover_nids: List[str] = field(default_factory=list)
+
+    @property
+    def healthy(self) -> bool:
+        """Return whether the import reported a fully-connected state (case-insensitive ``FULL``)."""
+        return (self.state or "").upper() == "FULL"
+
+    @property
+    def connected_over(self) -> Optional[str]:
+        """Return the LND net type of the current connection (e.g. ``tcp``, ``efa``), or None."""
+        if not self.current_connection or "@" not in self.current_connection:
+            return None
+        return self.current_connection.rsplit("@", 1)[1]
+
+
+def parse_lctl_import(output: str) -> List[ImportState]:
+    """Parse ``lctl get_param osc.*.import`` / ``mdc.*.import`` output into per-target ``ImportState`` rows.
+
+    The output is a sequence of blocks, each opened by a ``<param>.import=`` header followed by indented
+    fields. Rather than YAML-parse the (not always YAML-clean) import blob, the loanable fields --
+    ``state``, ``target``, ``current_connection``, ``failover_nids`` -- are scanned line by line.
+    """
+    imports: List[ImportState] = []
+    current: Optional[ImportState] = None
+    for raw in output.splitlines():
+        header = _IMPORT_HEADER_RE.match(raw.strip())
+        if header:
+            current = ImportState(param=header.group("param"))
+            imports.append(current)
+            continue
+        if current is None:
+            continue
+        line = raw.strip()
+        target = _scan_field(line, "target")
+        if target is not None:
+            current.target = target
+        state = _scan_field(line, "state")
+        if state is not None:
+            current.state = state
+        connection = _scan_field(line, "current_connection")
+        if connection is not None:
+            nids = _NID_RE.findall(connection)
+            current.current_connection = nids[0] if nids else connection or None
+        failover = _scan_field(line, "failover_nids")
+        if failover is not None:
+            current.failover_nids = _NID_RE.findall(failover)
+    return imports
+
+
+def _scan_field(line: str, key: str) -> Optional[str]:
+    """Return the value of ``key: value`` in ``line`` (stripped), or None when the line is not that field."""
+    prefix = key + ":"
+    if line.startswith(prefix):
+        return line[len(prefix):].strip()
+    return None

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/services.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/services.py
@@ -10,13 +10,16 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Helpers for querying the state of supervisord-managed programs."""
+"""Helpers for querying the state of supervisord-managed programs and systemd services."""
 
 import glob
+import logging
 from typing import Optional
 
 from pcluster_diag.core.constants import SUPERVISORCTL_GLOB, SUPERVISORD_RUNNING_STATE
 from pcluster_diag.util.shell import run_command
+
+logger = logging.getLogger(__name__)
 
 
 def get_supervisord_program_state(program: str) -> str:
@@ -44,6 +47,39 @@ def is_supervisord_program_running(program: str) -> bool:
         RuntimeError: If supervisorctl cannot report the program status.
     """
     return get_supervisord_program_state(program) == SUPERVISORD_RUNNING_STATE
+
+
+def systemd_unit_exists(unit: str) -> bool:
+    """Return whether systemd knows about ``unit`` (installed), regardless of its active/failed state.
+
+    ``systemctl list-unit-files <unit>`` lists the unit when it is installed and prints nothing when it is
+    not. A missing ``systemctl`` (non-systemd host) counts as "not installed".
+    """
+    result = _systemctl(["list-unit-files", unit])
+    if result is None or result.returncode != 0:
+        return False
+    return any(line.split()[:1] == [unit] for line in result.stdout.splitlines() if line.strip())
+
+
+def systemd_unit_failed(unit: str) -> bool:
+    """Return whether ``unit`` is in the systemd ``failed`` state (``systemctl is-failed`` prints ``failed``).
+
+    ``is-failed`` exits non-zero for non-failed units, so the textual answer -- not the exit code -- is
+    authoritative. A missing ``systemctl`` counts as "not failed".
+    """
+    result = _systemctl(["is-failed", unit])
+    if result is None:
+        return False
+    return result.stdout.strip() == "failed"
+
+
+def _systemctl(args):
+    """Run ``systemctl <args>`` and return the CompletedProcess, or None when systemctl is unavailable."""
+    try:
+        return run_command(["systemctl", *args])
+    except OSError as error:
+        logger.warning("Could not run systemctl %s: %s", args, error)
+        return None
 
 
 def _resolve_supervisorctl() -> str:

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/shared_storage.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/shared_storage.py
@@ -84,12 +84,23 @@ def shared_storage_mounts(context: Context) -> List[SharedStorageMount]:
         mounts.append(
             SharedStorageMount(
                 storage_type=storage_type,
-                mount_dir=mount_dir,
+                mount_dir=_absolute_mount_dir(mount_dir),
                 name=entry.get("Name"),
                 file_system_id=settings.get("FileSystemId"),
             )
         )
     return mounts
+
+
+def _absolute_mount_dir(mount_dir: str) -> str:
+    """Return ``mount_dir`` as an absolute path, matching how ParallelCluster mounts shared storage.
+
+    ``MountDir`` in the cluster configuration may be relative (e.g. ``fsx``); ParallelCluster prepends a
+    leading ``/`` when it is not already absolute (see the cookbook's shared-storage mount logic), so a
+    configured ``fsx`` is mounted at ``/fsx``. The checks compare against ``/proc/mounts`` and pass the
+    path to ``lfs df``, both of which use the absolute path, so normalize here.
+    """
+    return mount_dir if mount_dir.startswith("/") else "/" + mount_dir
 
 
 def lustre_mounts(context: Context) -> List[SharedStorageMount]:

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -10,16 +10,16 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for the FSx for Lustre client, mount-presence, and reachability checks."""
+"""Unit tests for the consolidated LustreFilesystem check and the opt-in FsxTargetsAreReachable check.
+
+Each probe of the consolidated ``LustreFilesystem`` check is exercised directly (``_probe_*`` with its own
+finding lists), plus a few ``run``-level tests covering aggregation and probe-crash isolation.
+"""
 
 import pytest
 
 from pcluster_diag.checks import fsx_connectivity
-from pcluster_diag.checks.fsx_connectivity import (
-    FsxFilesystemsAreReachable,
-    FsxMountsArePresent,
-    LustreClientIsInstalled,
-)
+from pcluster_diag.checks.fsx_connectivity import FsxTargetsAreReachable, LustreFilesystem, _LnetSnapshot
 from pcluster_diag.models.context import NodeType
 from pcluster_diag.models.result import Status
 from pcluster_diag.util.shell import TimedCommand
@@ -34,6 +34,11 @@ _PROC_MOUNTS_BOTH = """\
 
 _PROC_MOUNTS_ONLY_FSX = "10.0.0.1@tcp:/a /fsx lustre rw 0 0\n"
 
+# Placeholder instance types for the family-gate tests. The p6+ one only needs to start with a known p6+
+# family prefix (the gate matches on prefix), and the non-p6 one only needs to not; neither is a real size.
+_FAKE_P6PLUS_INSTANCE_TYPE = "p6-b200.fake"
+_FAKE_NON_P6_INSTANCE_TYPE = "fake.large"
+
 
 def _timed(returncode=0, stdout="", stderr="", timed_out=False, elapsed=0.01):
     return TimedCommand(
@@ -46,37 +51,67 @@ def _timed(returncode=0, stdout="", stderr="", timed_out=False, elapsed=0.01):
     )
 
 
-def _codes(result):
-    return [finding.code for finding in (result.errors or [])]
+def _codes(findings):
+    return [finding.code for finding in (findings or [])]
 
 
-def _warn_codes(result):
-    return [finding.code for finding in (result.warnings or [])]
+def _messages(findings):
+    return " | ".join(finding.message for finding in (findings or []))
 
 
 def _info_codes(result):
     return [finding.code for finding in (result.infos or [])]
 
 
-def _messages(result):
-    return " | ".join(finding.message for finding in (result.errors or []))
+def _snapshot(stdout):
+    """Build an _LnetSnapshot from parsed ``lnetctl net show -v`` output (as the check would fetch it)."""
+    from pcluster_diag.util import lustre
+
+    return _LnetSnapshot(timed_out=False, nets=lustre.parse_lnet_net_show(stdout))
 
 
-# --- should_run gating (shared by all three checks) -----------------------------------
+def _patch_efa_prereqs(
+    monkeypatch,
+    *,
+    kefalnd_available=True,
+    efa_driver_version="2.12.1",
+    kefalnd_version="1.1.1",
+    service_exists=False,
+    service_failed=False,
+):
+    """Patch the EFA-prerequisite and systemd-service probes to healthy defaults for the data-path tests.
+
+    The data-path EFA tests focus on device count / ping / traffic, so by default the kefalnd module is
+    present, the versions meet the floors, and the systemd service is absent (the common PC compute-node
+    case). Individual tests override a single kwarg to exercise a prerequisite/service failure.
+    """
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_kefalnd_supported", lambda: kefalnd_available)
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_driver_version", lambda: efa_driver_version)
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_kefalnd_version", lambda: kefalnd_version)
+    monkeypatch.setattr(fsx_connectivity.services, "systemd_unit_exists", lambda unit: service_exists)
+    monkeypatch.setattr(fsx_connectivity.services, "systemd_unit_failed", lambda unit: service_failed)
 
 
-@pytest.mark.parametrize("check", [LustreClientIsInstalled(), FsxMountsArePresent(), FsxFilesystemsAreReachable()])
+# --- should_run gating ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("check", [LustreFilesystem(), FsxTargetsAreReachable()])
 @pytest.mark.parametrize("node_type", list(NodeType), ids=lambda nt: nt.name)
 def test_should_run_true_on_all_node_types_when_lustre_configured(check, node_type):
     assert check.should_run(sample_context_with_lustre(node_type)) is True
 
 
-@pytest.mark.parametrize("check", [LustreClientIsInstalled(), FsxMountsArePresent(), FsxFilesystemsAreReachable()])
+@pytest.mark.parametrize("check", [LustreFilesystem(), FsxTargetsAreReachable()])
 def test_should_run_false_when_no_lustre_configured(check):
     assert check.should_run(sample_context(NodeType.HEAD)) is False
 
 
-# --- LustreClientIsInstalled ----------------------------------------------------------
+def test_description():
+    description = LustreFilesystem().description
+    assert "FsxLustre" in description or "Lustre" in description
+
+
+# --- client probe ---------------------------------------------------------------------
 
 
 def _patch_client(monkeypatch, *, available=True, loaded=True, version="2.15.6"):
@@ -86,78 +121,64 @@ def _patch_client(monkeypatch, *, available=True, loaded=True, version="2.15.6")
     monkeypatch.setattr(fsx_connectivity.lustre, "lustre_client_version", lambda: version)
 
 
-def test_client_description():
-    assert "Lustre client" in LustreClientIsInstalled().description
-
-
-def test_client_modules_available_passes_with_version_info(monkeypatch):
+def test_client_modules_available_reports_version_and_no_error(monkeypatch):
     _patch_client(monkeypatch)
+    errors, infos = [], []
 
-    result = LustreClientIsInstalled().run(sample_context_with_lustre(NodeType.COMPUTE))
+    LustreFilesystem()._probe_client(errors, infos)
 
-    assert result.status is Status.PASSED
-    assert _info_codes(result) == [LustreClientIsInstalled.CLIENT_VERSION.code]
-    assert "2.15.6" in result.infos[0].message
+    assert errors == []
+    assert _codes(infos) == [LustreFilesystem.CLIENT_VERSION.code]
+    assert "2.15.6" in infos[0].message
 
 
-def test_client_modules_unavailable_fails_naming_kernel(monkeypatch):
-    # An unavailable module cannot be loaded either; the check must report only the NOT_INSTALLED error
-    # and NOT also the MODULES_NOT_LOADED warning for the same root cause.
+def test_client_modules_unavailable_reports_only_not_installed(monkeypatch):
+    # An unavailable module cannot be loaded either; the probe must report only the NOT_INSTALLED error
+    # and NOT also MODULES_NOT_LOADED for the same root cause.
     _patch_client(monkeypatch, available=False, loaded=False, version=None)
+    errors, infos = [], []
 
-    result = LustreClientIsInstalled().run(sample_context_with_lustre(NodeType.HEAD))
+    LustreFilesystem()._probe_client(errors, infos)
 
-    assert result.status is Status.FAILURE
-    assert _codes(result) == [LustreClientIsInstalled.NOT_INSTALLED.code]
-    assert "6.1.0-amzn2023" in _messages(result)
-    assert _warn_codes(result) == []
+    assert _codes(errors) == [LustreFilesystem.NOT_INSTALLED.code]
+    assert "6.1.0-amzn2023" in _messages(errors)
 
 
 def test_client_modules_available_but_not_loaded_fails(monkeypatch):
     _patch_client(monkeypatch, loaded=False)
+    errors, infos = [], []
 
-    result = LustreClientIsInstalled().run(sample_context_with_lustre(NodeType.COMPUTE))
+    LustreFilesystem()._probe_client(errors, infos)
 
-    assert result.status is Status.FAILURE
-    assert _codes(result) == [LustreClientIsInstalled.MODULES_NOT_LOADED.code]
+    assert _codes(errors) == [LustreFilesystem.MODULES_NOT_LOADED.code]
     # The error names the specific modules that are available but not loaded.
-    error_message = result.errors[0].message
-    assert "lustre" in error_message and "lnet" in error_message
+    assert "lustre" in errors[0].message and "lnet" in errors[0].message
 
 
-# --- FsxMountsArePresent --------------------------------------------------------------
+def test_client_too_old_version_fails(monkeypatch):
+    _patch_client(monkeypatch, version="2.14.0")
+    errors, infos = [], []
+
+    LustreFilesystem()._probe_client(errors, infos)
+
+    assert LustreFilesystem.CLIENT_TOO_OLD.code in _codes(errors)
 
 
-def test_mounts_description():
-    assert "mounted" in FsxMountsArePresent().description
+def test_client_unparseable_version_reports_undeterminable_not_too_old(monkeypatch):
+    # An unparseable (but present) version is not masked and not reported as too-old: it is surfaced as a
+    # CHECK_ERROR (reserved E0) saying the floor could not be evaluated.
+    _patch_client(monkeypatch, version="unknown")
+    errors, infos = [], []
+
+    LustreFilesystem()._probe_client(errors, infos)
+
+    assert LustreFilesystem.CLIENT_VERSION_UNDETERMINABLE.code in _codes(errors)
+    assert LustreFilesystem.CLIENT_TOO_OLD.code not in _codes(errors)
+    # The undeterminable finding carries the reserved E0 code -> CHECK_ERROR, not a real FAILURE.
+    assert LustreFilesystem.CLIENT_VERSION_UNDETERMINABLE.code == "E0"
 
 
-def test_mounts_all_present_passes(monkeypatch):
-    monkeypatch.setattr(fsx_connectivity.shared_storage, "read_mounts", _mounts_from(_PROC_MOUNTS_BOTH))
-
-    result = FsxMountsArePresent().run(sample_context_with_lustre(NodeType.HEAD))
-
-    assert result.status is Status.PASSED
-
-
-def test_mounts_missing_one_fails_naming_only_that_mount(monkeypatch):
-    monkeypatch.setattr(fsx_connectivity.shared_storage, "read_mounts", _mounts_from(_PROC_MOUNTS_ONLY_FSX))
-
-    result = FsxMountsArePresent().run(sample_context_with_lustre(NodeType.HEAD))
-
-    assert result.status is Status.FAILURE
-    assert _codes(result) == [FsxMountsArePresent.NOT_MOUNTED.code]
-    assert "/fsx-efa" in _messages(result)
-    assert "'/fsx'" not in _messages(result)
-
-
-def test_mounts_none_present_fails_for_all(monkeypatch):
-    monkeypatch.setattr(fsx_connectivity.shared_storage, "read_mounts", _mounts_from(""))
-
-    result = FsxMountsArePresent().run(sample_context_with_lustre(NodeType.HEAD))
-
-    assert result.status is Status.FAILURE
-    assert _codes(result) == [FsxMountsArePresent.NOT_MOUNTED.code, FsxMountsArePresent.NOT_MOUNTED.code]
+# --- mount-presence probe -------------------------------------------------------------
 
 
 def _mounts_from(proc_mounts):
@@ -167,7 +188,36 @@ def _mounts_from(proc_mounts):
     return lambda: parsed
 
 
-# --- FsxFilesystemsAreReachable -------------------------------------------------------
+def test_mounts_all_present_no_error(monkeypatch):
+    monkeypatch.setattr(fsx_connectivity.shared_storage, "read_mounts", _mounts_from(_PROC_MOUNTS_BOTH))
+    errors = []
+
+    LustreFilesystem()._probe_mounts(sample_context_with_lustre(NodeType.HEAD), errors)
+
+    assert errors == []
+
+
+def test_mounts_missing_one_fails_naming_only_that_mount(monkeypatch):
+    monkeypatch.setattr(fsx_connectivity.shared_storage, "read_mounts", _mounts_from(_PROC_MOUNTS_ONLY_FSX))
+    errors = []
+
+    LustreFilesystem()._probe_mounts(sample_context_with_lustre(NodeType.HEAD), errors)
+
+    assert _codes(errors) == [LustreFilesystem.NOT_MOUNTED.code]
+    assert "/fsx-efa" in _messages(errors)
+    assert "'/fsx'" not in _messages(errors)
+
+
+def test_mounts_none_present_fails_for_all(monkeypatch):
+    monkeypatch.setattr(fsx_connectivity.shared_storage, "read_mounts", _mounts_from(""))
+    errors = []
+
+    LustreFilesystem()._probe_mounts(sample_context_with_lustre(NodeType.HEAD), errors)
+
+    assert _codes(errors) == [LustreFilesystem.NOT_MOUNTED.code, LustreFilesystem.NOT_MOUNTED.code]
+
+
+# --- filesystem-reachability probe ----------------------------------------------------
 
 
 def _patch_lfs(monkeypatch, results_by_mount):
@@ -180,19 +230,16 @@ def _patch_lfs(monkeypatch, results_by_mount):
     monkeypatch.setattr(fsx_connectivity, "time_command", fake_time_command)
 
 
-def test_reachable_description():
-    assert "reachable" in FsxFilesystemsAreReachable().description
-
-
-def test_reachable_all_healthy_passes(monkeypatch):
+def test_reachable_all_healthy_no_error(monkeypatch):
     _patch_lfs(
         monkeypatch,
         {"/fsx": _timed(stdout=_HEALTHY_LFS_DF), "/fsx-efa": _timed(stdout=_HEALTHY_LFS_DF)},
     )
+    errors = []
 
-    result = FsxFilesystemsAreReachable().run(sample_context_with_lustre(NodeType.LOGIN))
+    LustreFilesystem()._probe_reachable(sample_context_with_lustre(NodeType.LOGIN), errors)
 
-    assert result.status is Status.PASSED
+    assert errors == []
 
 
 def test_reachable_hang_reports_timeout_for_only_that_mount(monkeypatch):
@@ -203,13 +250,13 @@ def test_reachable_hang_reports_timeout_for_only_that_mount(monkeypatch):
             "/fsx-efa": _timed(returncode=None, timed_out=True, elapsed=30.0),
         },
     )
+    errors = []
 
-    result = FsxFilesystemsAreReachable().run(sample_context_with_lustre(NodeType.COMPUTE))
+    LustreFilesystem()._probe_reachable(sample_context_with_lustre(NodeType.COMPUTE), errors)
 
-    assert result.status is Status.FAILURE
-    assert _codes(result) == [FsxFilesystemsAreReachable.LFS_DF_TIMED_OUT.code]
-    assert "/fsx-efa" in _messages(result)
-    assert "hanging" in _messages(result)
+    assert _codes(errors) == [LustreFilesystem.LFS_DF_TIMED_OUT.code]
+    assert "/fsx-efa" in _messages(errors)
+    assert "hanging" in _messages(errors)
 
 
 def test_reachable_nonzero_exit_reports_error(monkeypatch):
@@ -220,12 +267,12 @@ def test_reachable_nonzero_exit_reports_error(monkeypatch):
             "/fsx-efa": _timed(stdout=_HEALTHY_LFS_DF),
         },
     )
+    errors = []
 
-    result = FsxFilesystemsAreReachable().run(sample_context_with_lustre(NodeType.HEAD))
+    LustreFilesystem()._probe_reachable(sample_context_with_lustre(NodeType.HEAD), errors)
 
-    assert result.status is Status.FAILURE
-    assert _codes(result) == [FsxFilesystemsAreReachable.LFS_DF_FAILED.code]
-    assert "transport endpoint shutdown" in _messages(result)
+    assert _codes(errors) == [LustreFilesystem.LFS_DF_FAILED.code]
+    assert "transport endpoint shutdown" in _messages(errors)
 
 
 def test_reachable_down_target_reports_target_unavailable(monkeypatch):
@@ -233,13 +280,13 @@ def test_reachable_down_target_reports_target_unavailable(monkeypatch):
         monkeypatch,
         {"/fsx": _timed(stdout=_DEGRADED_LFS_DF), "/fsx-efa": _timed(stdout=_HEALTHY_LFS_DF)},
     )
+    errors = []
 
-    result = FsxFilesystemsAreReachable().run(sample_context_with_lustre(NodeType.HEAD))
+    LustreFilesystem()._probe_reachable(sample_context_with_lustre(NodeType.HEAD), errors)
 
-    assert result.status is Status.FAILURE
-    assert _codes(result) == [FsxFilesystemsAreReachable.TARGET_UNAVAILABLE.code]
-    assert "fs-abc-OST0001_UUID" in _messages(result)
-    assert "/fsx" in _messages(result)
+    assert _codes(errors) == [LustreFilesystem.TARGET_UNAVAILABLE.code]
+    assert "fs-abc-OST0001_UUID" in _messages(errors)
+    assert "/fsx" in _messages(errors)
 
 
 def test_reachable_aggregates_multiple_mount_failures(monkeypatch):
@@ -250,11 +297,747 @@ def test_reachable_aggregates_multiple_mount_failures(monkeypatch):
             "/fsx-efa": _timed(returncode=2, stderr="No such device"),
         },
     )
+    errors = []
 
-    result = FsxFilesystemsAreReachable().run(sample_context_with_lustre(NodeType.HEAD))
+    LustreFilesystem()._probe_reachable(sample_context_with_lustre(NodeType.HEAD), errors)
+
+    assert _codes(errors) == [
+        LustreFilesystem.LFS_DF_TIMED_OUT.code,
+        LustreFilesystem.LFS_DF_FAILED.code,
+    ]
+
+
+# --- shared fixtures for the LNet / EFA / target probes -------------------------------
+
+_LNET_TCP_EFA = """\
+net:
+    - net type: lo
+      local NI(s):
+        - nid: 0@lo
+          status: up
+    - net type: tcp
+      local NI(s):
+        - nid: 10.0.0.1@tcp
+          status: up
+          interfaces:
+              0: eth0
+          statistics:
+              send_count: 100
+              recv_count: 100
+          health stats:
+              health value: 1000
+    - net type: efa
+      local NI(s):
+        - nid: 10.0.0.1@efa
+          status: up
+          interfaces:
+              0: efa0
+          statistics:
+              send_count: 900
+              recv_count: 800
+          health stats:
+              health value: 1000
+"""
+
+_LNET_TCP_ONLY = """\
+net:
+    - net type: lo
+      local NI(s):
+        - nid: 0@lo
+          status: up
+    - net type: tcp
+      local NI(s):
+        - nid: 10.0.0.1@tcp
+          status: up
+          interfaces:
+              0: eth0
+          statistics:
+              send_count: 100
+              recv_count: 100
+          health stats:
+              health value: 1000
+"""
+
+# An @efa net with one device bound (efa0). A "partial bind" relative to a multi-device instance.
+_LNET_EFA_PARTIAL_BIND = """\
+net:
+    - net type: efa
+      local NI(s):
+        - nid: 10.0.0.1@efa
+          status: up
+          interfaces:
+              0: efa0
+          statistics:
+              send_count: 900
+              recv_count: 800
+          health stats:
+              health value: 1000
+"""
+
+# An @efa net present but with no device bound to it (no interfaces): Lustre cannot ride EFA.
+_LNET_EFA_NONE_BOUND = """\
+net:
+    - net type: efa
+      local NI(s):
+        - nid: 10.0.0.1@efa
+          status: up
+          statistics:
+              send_count: 0
+              recv_count: 0
+          health stats:
+              health value: 1000
+"""
+
+_LNET_EFA_NO_TRAFFIC = """\
+net:
+    - net type: efa
+      local NI(s):
+        - nid: 10.0.0.1@efa
+          status: up
+          interfaces:
+              0: efa0
+          statistics:
+              send_count: 0
+              recv_count: 0
+          health stats:
+              health value: 1000
+        - nid: 10.0.0.2@efa
+          status: up
+          interfaces:
+              0: efa1
+          statistics:
+              send_count: 10
+              recv_count: 10
+          health stats:
+              health value: 1000
+"""
+
+_LNET_PEER_EFA = """\
+peer:
+    - primary nid: 10.0.1.5@efa
+      peer ni:
+        - nid: 10.0.1.5@efa
+"""
+
+_IMPORT_EFA = """\
+osc.fs-OST0000-osc-ffff.import=
+    import:
+        target: fs-OST0000_UUID
+        state: FULL
+        connection:
+            current_connection: 10.0.1.5@efa
+            failover_nids: [ 10.0.1.5@efa ]
+"""
+
+_IMPORT_TCP_FALLBACK = """\
+osc.fs-OST0000-osc-ffff.import=
+    import:
+        target: fs-OST0000_UUID
+        state: FULL
+        connection:
+            current_connection: 10.0.1.5@tcp
+            failover_nids: [ 10.0.1.5@tcp ]
+"""
+
+_IMPORT_DISCONN = """\
+osc.fs-OST0000-osc-ffff.import=
+    import:
+        target: fs-OST0000_UUID
+        state: DISCONN
+        connection:
+            current_connection: 10.0.1.5@efa
+            failover_nids: [ 10.0.1.5@efa ]
+"""
+
+_LFS_CHECK_HEALTHY = "fs-OST0000-osc-ffff active.\nfs-MDT0000-mdc-ffff active.\n"
+_LFS_CHECK_BAD = "fs-OST0000-osc-ffff active.\ncheck 'fs-OST000b-osc-ffff': Input/output error (5)\n"
+
+
+def _route_time_command(monkeypatch, routes, default=None):
+    """Patch time_command in every module that runs one, dispatching by substring match on the command.
+
+    ``routes`` maps a substring (e.g. "net show", "peer show", "lfs check") to the TimedCommand to
+    return. The first matching route wins; ``default`` (or a zero-exit empty result) is used otherwise.
+    The check runs ``lfs``/``lctl`` commands via ``fsx_connectivity.time_command`` and the LNet peer/ping
+    commands via ``lustre.time_command``, so both are patched with the same router.
+    """
+    from pcluster_diag.util import lustre
+
+    def fake_time_command(command, timeout):
+        joined = " ".join(command)
+        for needle, timed in routes.items():
+            if needle in joined:
+                return timed
+        return default if default is not None else _timed()
+
+    monkeypatch.setattr(fsx_connectivity, "time_command", fake_time_command)
+    monkeypatch.setattr(lustre, "time_command", fake_time_command)
+
+
+# --- LNet-transport probe -------------------------------------------------------------
+
+
+def test_lnet_reports_active_lnds_no_error(monkeypatch):
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_lnet(_snapshot(_LNET_TCP_EFA), errors, warnings, infos)
+
+    assert errors == []
+    active_info = next(i for i in infos if i.code == LustreFilesystem.ACTIVE_LNDS.code)
+    assert "tcp" in active_info.message and "efa" in active_info.message
+    # loopback is not reported as an active transport
+    assert "lo" not in active_info.message.split("transports:")[1]
+
+
+def test_lnet_no_nets_fails(monkeypatch):
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_lnet(_snapshot("net:\n"), errors, warnings, infos)
+
+    assert _codes(errors) == [LustreFilesystem.LNET_NOT_CONFIGURED.code]
+
+
+def test_lnet_timeout_fails_with_timeout_code():
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_lnet(_LnetSnapshot(timed_out=True), errors, warnings, infos)
+
+    assert _codes(errors) == [LustreFilesystem.LNETCTL_TIMED_OUT.code]
+
+
+def test_lnet_health_decay_is_warning(monkeypatch):
+    decayed = _LNET_EFA_NO_TRAFFIC.replace("health value: 1000", "health value: 500", 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_lnet(_snapshot(decayed), errors, warnings, infos)
+
+    assert _codes(warnings) == [LustreFilesystem.HEALTH_DEGRADED.code]
+
+
+# --- EFA-mount probe ------------------------------------------------------------------
+
+
+def test_efa_probe_noop_without_efa_net_or_service(monkeypatch):
+    # Neither an @efa net nor the EFA-Lustre service on this node: EFA is not expected, so record nothing.
+    monkeypatch.setattr(fsx_connectivity.services, "systemd_unit_exists", lambda unit: False)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_ONLY), errors, warnings, infos
+    )
+
+    assert errors == [] and warnings == [] and infos == []
+
+
+def test_efa_missing_kefalnd_caught_when_service_installed_but_no_efa_net(monkeypatch):
+    # The regression this guards: kefalnd failed to load -> no @efa net is ever added. Gating on the @efa
+    # net alone would skip the node. The installed systemd service is the node-local "EFA expected" signal
+    # that survives the kefalnd failure, so KEFALND_MISSING is still reported despite there being no @efa net.
+    _patch_efa_prereqs(monkeypatch, kefalnd_available=False, service_exists=True)
+
+    def _boom_device_count():
+        raise AssertionError("data-path probe must not run when kefalnd is missing")
+
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", _boom_device_count)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_ONLY), errors, warnings, infos
+    )
+
+    assert _codes(errors) == [LustreFilesystem.KEFALND_MISSING.code]
+
+
+def test_efa_probe_noop_when_lnet_timed_out():
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _LnetSnapshot(timed_out=True), errors, warnings, infos
+    )
+
+    assert errors == [] and warnings == [] and infos == []
+
+
+def test_efa_all_bound_and_pinging_no_error(monkeypatch):
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(stdout="ping ok"),
+            "import": _timed(stdout=_IMPORT_EFA),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert errors == []
+    assert LustreFilesystem.BOUND_DEVICES.code in _codes(infos)
+
+
+def test_efa_partial_bind_on_unknown_instance_type_is_not_an_error(monkeypatch):
+    # 1 of 16 bound on an instance type with no expected-count entry (the sample context's fake type):
+    # we make no underbinding assertion, so it is an info + pass, not an error.
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(stdout="ping ok"),
+            "import": _timed(stdout=_IMPORT_EFA),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 16)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_EFA_PARTIAL_BIND), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.NO_DEVICES_BOUND.code not in _codes(errors)
+    assert LustreFilesystem.UNDERBOUND_DEVICES.code not in _codes(errors)
+    assert LustreFilesystem.BOUND_DEVICES.code in _codes(infos)
+    assert "1 of 16" in _messages(infos)
+
+
+def test_efa_underbound_fails_on_bind_all_family(monkeypatch):
+    # A "bind all" family (expected == available) with only 1 of 16 bound: the incident signature -> error.
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(stdout="ping ok"),
+            "import": _timed(stdout=_IMPORT_EFA),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 16)
+    context = sample_context_with_lustre(NodeType.COMPUTE)
+    context.instance_type = "p6-b300.48xlarge"
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(context, _snapshot(_LNET_EFA_PARTIAL_BIND), errors, warnings, infos)
+
+    assert LustreFilesystem.UNDERBOUND_DEVICES.code in _codes(errors)
+    assert "1 of 16" in _messages(errors)
+
+
+def test_efa_subset_bind_family_meeting_expected_passes(monkeypatch):
+    # p5.48xlarge binds 8 by design. With 8 of 16 bound, the expected count is met -> pass, no error.
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(stdout="ping ok"),
+            "import": _timed(stdout=_IMPORT_EFA),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 16)
+    eight_bound = ["efa%d" % i for i in range(8)]
+    monkeypatch.setattr(fsx_connectivity.lustre, "lnet_bound_interfaces", lambda nets, net_type: eight_bound)
+    context = sample_context_with_lustre(NodeType.COMPUTE)
+    context.instance_type = "p5.48xlarge"
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(context, _snapshot(_LNET_EFA_PARTIAL_BIND), errors, warnings, infos)
+
+    assert LustreFilesystem.UNDERBOUND_DEVICES.code not in _codes(errors)
+    assert LustreFilesystem.NO_DEVICES_BOUND.code not in _codes(errors)
+    assert LustreFilesystem.BOUND_DEVICES.code in _codes(infos)
+
+
+def test_efa_no_devices_bound_fails(monkeypatch):
+    # EFA devices exist but none are bound to LNet: Lustre falls back to TCP -- a real failure on any family.
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(stdout="ping ok"),
+            "import": _timed(stdout=_IMPORT_EFA),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 16)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_EFA_NONE_BOUND), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.NO_DEVICES_BOUND.code in _codes(errors)
+    assert "16" in _messages(errors)
+
+
+def test_efa_ping_failure_points_at_security_group(monkeypatch):
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(returncode=1, stderr="cannot reach"),
+            "import": _timed(stdout=_IMPORT_EFA),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.EFA_PING_FAILED.code in _codes(errors)
+    assert "security group" in _messages(errors)
+
+
+def test_efa_no_traffic_is_warning(monkeypatch):
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(stdout="ok"),
+            "import": _timed(stdout=_IMPORT_EFA),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 2)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_EFA_NO_TRAFFIC), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.NO_TRAFFIC.code in _codes(warnings)
+
+
+def test_efa_tcp_fallback_is_warning(monkeypatch):
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(stdout="ok"),
+            "import": _timed(stdout=_IMPORT_TCP_FALLBACK),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.TCP_FALLBACK.code in _codes(warnings)
+
+
+# --- EFA prerequisites & systemd service (checked before the data-path probes) --------
+
+
+def test_efa_missing_kefalnd_fails_and_skips_data_path(monkeypatch):
+    # kefalnd absent: the client cannot ride EFA; report KEFALND_MISSING and do not probe devices/ping.
+    _patch_efa_prereqs(monkeypatch, kefalnd_available=False)
+
+    def _boom_device_count():
+        raise AssertionError("data-path probe must not run when kefalnd is missing")
+
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", _boom_device_count)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert _codes(errors) == [LustreFilesystem.KEFALND_MISSING.code]
+
+
+def test_efa_driver_too_old_fails(monkeypatch):
+    _patch_efa_prereqs(monkeypatch, efa_driver_version="2.10.0")
+    _route_time_command(
+        monkeypatch,
+        {"peer show": _timed(stdout=_LNET_PEER_EFA), "ping": _timed(stdout="ok"), "import": _timed(stdout=_IMPORT_EFA)},
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.EFA_DRIVER_TOO_OLD.code in _codes(errors)
+
+
+def test_efa_kefalnd_too_old_only_on_p6(monkeypatch):
+    # kefalnd below the p6 floor: flagged on a p6 instance, not on a non-p6 instance.
+    _patch_efa_prereqs(monkeypatch, kefalnd_version="1.0.0")
+    _route_time_command(
+        monkeypatch,
+        {"peer show": _timed(stdout=_LNET_PEER_EFA), "ping": _timed(stdout="ok"), "import": _timed(stdout=_IMPORT_EFA)},
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+
+    p6 = sample_context_with_lustre(NodeType.COMPUTE)
+    p6.instance_type = _FAKE_P6PLUS_INSTANCE_TYPE
+    errors, warnings, infos = [], [], []
+    LustreFilesystem()._probe_efa(p6, _snapshot(_LNET_TCP_EFA), errors, warnings, infos)
+    assert LustreFilesystem.KEFALND_TOO_OLD.code in _codes(errors)
+
+    non_p6 = sample_context_with_lustre(NodeType.COMPUTE)
+    non_p6.instance_type = _FAKE_NON_P6_INSTANCE_TYPE
+    errors, warnings, infos = [], [], []
+    LustreFilesystem()._probe_efa(non_p6, _snapshot(_LNET_TCP_EFA), errors, warnings, infos)
+    assert LustreFilesystem.KEFALND_TOO_OLD.code not in _codes(errors)
+
+
+def test_efa_unknown_instance_type_reports_undeterminable_not_too_old(monkeypatch):
+    # Instance type unknown (IMDS failed at startup): the p6+ kefalnd floor cannot be evaluated. The probe
+    # must surface a CHECK_ERROR (reserved E0) rather than flag a too-old error or silently pass.
+    _patch_efa_prereqs(monkeypatch, kefalnd_version="1.0.0")
+    _route_time_command(
+        monkeypatch,
+        {"peer show": _timed(stdout=_LNET_PEER_EFA), "ping": _timed(stdout="ok"), "import": _timed(stdout=_IMPORT_EFA)},
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+
+    unknown = sample_context_with_lustre(NodeType.COMPUTE)
+    unknown.instance_type = None
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(unknown, _snapshot(_LNET_TCP_EFA), errors, warnings, infos)
+
+    assert LustreFilesystem.INSTANCE_TYPE_UNDETERMINABLE.code in _codes(errors)
+    assert LustreFilesystem.INSTANCE_TYPE_UNDETERMINABLE.code == "E0"
+    assert LustreFilesystem.KEFALND_TOO_OLD.code not in _codes(errors)
+
+
+def test_efa_driver_version_unparseable_reports_undeterminable_not_too_old(monkeypatch):
+    # A present-but-unparseable EFA driver version is surfaced as a CHECK_ERROR (E0), not a too-old error.
+    _patch_efa_prereqs(monkeypatch, efa_driver_version="unknown")
+    _route_time_command(
+        monkeypatch,
+        {"peer show": _timed(stdout=_LNET_PEER_EFA), "ping": _timed(stdout="ok"), "import": _timed(stdout=_IMPORT_EFA)},
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.EFA_DRIVER_VERSION_UNDETERMINABLE.code in _codes(errors)
+    assert LustreFilesystem.EFA_DRIVER_TOO_OLD.code not in _codes(errors)
+
+
+def test_efa_service_failed_is_error(monkeypatch):
+    _patch_efa_prereqs(monkeypatch, service_exists=True, service_failed=True)
+    _route_time_command(
+        monkeypatch,
+        {"peer show": _timed(stdout=_LNET_PEER_EFA), "ping": _timed(stdout="ok"), "import": _timed(stdout=_IMPORT_EFA)},
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.EFA_SERVICE_FAILED.code in _codes(errors)
+
+
+def test_efa_service_failed_without_efa_net_reports_service_and_skips_data_path(monkeypatch):
+    # The config service is installed but failed, so no @efa net came up. The service failure is reported
+    # and the data-path probes are skipped (there is no live net to inspect).
+    _patch_efa_prereqs(monkeypatch, service_exists=True, service_failed=True)
+
+    def _boom_device_count():
+        raise AssertionError("data-path probe must not run when there is no @efa net")
+
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", _boom_device_count)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_ONLY), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.EFA_SERVICE_FAILED.code in _codes(errors)
+
+
+def test_efa_service_present_and_healthy_is_info(monkeypatch):
+    _patch_efa_prereqs(monkeypatch, service_exists=True, service_failed=False)
+    _route_time_command(
+        monkeypatch,
+        {"peer show": _timed(stdout=_LNET_PEER_EFA), "ping": _timed(stdout="ok"), "import": _timed(stdout=_IMPORT_EFA)},
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.EFA_SERVICE_ACTIVE.code in _codes(infos)
+
+
+# --- run-level aggregation & isolation ------------------------------------------------
+
+
+def test_run_passes_when_all_probes_clean(monkeypatch):
+    _patch_client(monkeypatch)
+    _patch_efa_prereqs(monkeypatch)
+    monkeypatch.setattr(fsx_connectivity.shared_storage, "read_mounts", _mounts_from(_PROC_MOUNTS_BOTH))
+    _route_time_command(
+        monkeypatch,
+        {
+            "net show": _timed(stdout=_LNET_TCP_EFA),
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(stdout="ok"),
+            "import": _timed(stdout=_IMPORT_EFA),
+            "df": _timed(stdout=_HEALTHY_LFS_DF),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+
+    result = LustreFilesystem().run(sample_context_with_lustre(NodeType.COMPUTE))
+
+    assert result.status is Status.PASSED
+
+
+def test_run_is_check_error_not_failure_when_only_undeterminable(monkeypatch):
+    # Everything healthy except the instance type is unknown (IMDS error). The undeterminable finding is an
+    # E0 error, so the aggregate status is CHECK_ERROR (the check could not fully evaluate), NOT FAILURE
+    # (no real assertion failed) -- error and failure are distinct sections.
+    _patch_client(monkeypatch)
+    _patch_efa_prereqs(monkeypatch, kefalnd_version="1.0.0")
+    monkeypatch.setattr(fsx_connectivity.shared_storage, "read_mounts", _mounts_from(_PROC_MOUNTS_BOTH))
+    _route_time_command(
+        monkeypatch,
+        {
+            "net show": _timed(stdout=_LNET_TCP_EFA),
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(stdout="ok"),
+            "import": _timed(stdout=_IMPORT_EFA),
+            "df": _timed(stdout=_HEALTHY_LFS_DF),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+
+    unknown = sample_context_with_lustre(NodeType.COMPUTE)
+    unknown.instance_type = None  # IMDS could not report the instance type
+    result = LustreFilesystem().run(unknown)
+
+    assert result.status is Status.CHECK_ERROR
+    assert LustreFilesystem.INSTANCE_TYPE_UNDETERMINABLE.code in _codes(result.errors)
+
+
+def test_run_fails_when_any_probe_reports_an_error(monkeypatch):
+    _patch_client(monkeypatch, available=False, version=None)  # client probe fails
+    _patch_efa_prereqs(monkeypatch)
+    monkeypatch.setattr(fsx_connectivity.shared_storage, "read_mounts", _mounts_from(_PROC_MOUNTS_BOTH))
+    _route_time_command(
+        monkeypatch,
+        {"net show": _timed(stdout=_LNET_TCP_ONLY), "df": _timed(stdout=_HEALTHY_LFS_DF)},
+    )
+
+    result = LustreFilesystem().run(sample_context_with_lustre(NodeType.COMPUTE))
 
     assert result.status is Status.FAILURE
-    assert _codes(result) == [
-        FsxFilesystemsAreReachable.LFS_DF_TIMED_OUT.code,
-        FsxFilesystemsAreReachable.LFS_DF_FAILED.code,
-    ]
+    assert LustreFilesystem.NOT_INSTALLED.code in _codes(result.errors)
+
+
+def test_run_isolates_unexpected_probe_crash_and_keeps_sibling_findings(monkeypatch):
+    # The client probe crashes; its siblings must still run and their findings survive.
+    def _boom(errors, infos):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(LustreFilesystem, "_probe_client", lambda self, errors, infos: _boom(errors, infos))
+    _patch_efa_prereqs(monkeypatch)
+    monkeypatch.setattr(fsx_connectivity.shared_storage, "read_mounts", _mounts_from(_PROC_MOUNTS_ONLY_FSX))
+    _route_time_command(
+        monkeypatch,
+        {"net show": _timed(stdout=_LNET_TCP_EFA), "df": _timed(stdout=_HEALTHY_LFS_DF)},
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+
+    result = LustreFilesystem().run(sample_context_with_lustre(NodeType.COMPUTE))
+
+    # The mount probe still reported the missing /fsx-efa mount despite the client probe crashing.
+    assert result.status is Status.FAILURE
+    assert LustreFilesystem.NOT_MOUNTED.code in _codes(result.errors)
+
+
+# --- FsxTargetsAreReachable (unchanged, still its own gated check) --------------------
+
+
+def test_targets_description():
+    assert "OST" in FsxTargetsAreReachable().description
+
+
+def test_targets_requires_approval():
+    assert FsxTargetsAreReachable().approval_required(sample_context_with_lustre(NodeType.HEAD)) is True
+
+
+def test_targets_all_active_and_full_passes(monkeypatch):
+    _route_time_command(
+        monkeypatch,
+        {"lfs check": _timed(stdout=_LFS_CHECK_HEALTHY), "import": _timed(stdout=_IMPORT_EFA)},
+    )
+
+    result = FsxTargetsAreReachable().run(sample_context_with_lustre(NodeType.COMPUTE))
+
+    assert result.status is Status.PASSED
+
+
+def test_targets_unreachable_server_fails(monkeypatch):
+    _route_time_command(
+        monkeypatch,
+        {"lfs check": _timed(stdout=_LFS_CHECK_BAD), "import": _timed(stdout=_IMPORT_EFA)},
+    )
+
+    result = FsxTargetsAreReachable().run(sample_context_with_lustre(NodeType.COMPUTE))
+
+    assert result.status is Status.FAILURE
+    assert FsxTargetsAreReachable.TARGET_UNREACHABLE.code in _codes(result.errors)
+    assert "fs-OST000b-osc-ffff" in _messages(result.errors)
+
+
+def test_targets_lfs_check_timeout_fails(monkeypatch):
+    _route_time_command(
+        monkeypatch,
+        {
+            "lfs check": _timed(returncode=None, timed_out=True, elapsed=60.0),
+            "import": _timed(stdout=_IMPORT_EFA),
+        },
+    )
+
+    result = FsxTargetsAreReachable().run(sample_context_with_lustre(NodeType.COMPUTE))
+
+    assert result.status is Status.FAILURE
+    assert _codes(result.errors) == [FsxTargetsAreReachable.LFS_CHECK_TIMED_OUT.code]
+
+
+def test_targets_non_full_import_fails(monkeypatch):
+    _route_time_command(
+        monkeypatch,
+        {"lfs check": _timed(stdout=_LFS_CHECK_HEALTHY), "import": _timed(stdout=_IMPORT_DISCONN)},
+    )
+
+    result = FsxTargetsAreReachable().run(sample_context_with_lustre(NodeType.COMPUTE))
+
+    assert result.status is Status.FAILURE
+    assert FsxTargetsAreReachable.IMPORT_NOT_FULL.code in _codes(result.errors)
+    assert "DISCONN" in _messages(result.errors)
+
+
+def test_targets_failover_pin_is_info(monkeypatch):
+    _route_time_command(
+        monkeypatch,
+        {"lfs check": _timed(stdout=_LFS_CHECK_HEALTHY), "import": _timed(stdout=_IMPORT_EFA)},
+    )
+
+    result = FsxTargetsAreReachable().run(sample_context_with_lustre(NodeType.COMPUTE))
+
+    assert result.status is Status.PASSED
+    assert FsxTargetsAreReachable.FAILOVER_PINNED.code in _info_codes(result)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -472,6 +472,9 @@ def _route_time_command(monkeypatch, routes, default=None):
 
     monkeypatch.setattr(fsx_connectivity, "time_command", fake_time_command)
     monkeypatch.setattr(lustre, "time_command", fake_time_command)
+    # Tests that route commands through time_command intend for those binaries to be present, so make the
+    # lnetctl presence gate in _lnet_snapshot pass (the real which() would depend on the test host).
+    monkeypatch.setattr(fsx_connectivity.shutil, "which", lambda name: "/usr/sbin/" + name)
 
 
 # --- LNet-transport probe -------------------------------------------------------------
@@ -503,6 +506,30 @@ def test_lnet_timeout_fails_with_timeout_code():
     LustreFilesystem()._probe_lnet(_LnetSnapshot(timed_out=True), errors, warnings, infos)
 
     assert _codes(errors) == [LustreFilesystem.LNETCTL_TIMED_OUT.code]
+
+
+def test_lnet_unavailable_lnetctl_is_info_not_error():
+    # lnetctl not installed: report an info and skip, without failing the check.
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_lnet(_LnetSnapshot(timed_out=False, unavailable=True), errors, warnings, infos)
+
+    assert errors == []
+    assert LustreFilesystem.LNETCTL_UNAVAILABLE.code in _codes(infos)
+
+
+def test_efa_probe_noop_when_lnetctl_unavailable():
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE),
+        _LnetSnapshot(timed_out=False, unavailable=True),
+        errors,
+        warnings,
+        infos,
+    )
+
+    assert errors == [] and warnings == [] and infos == []
 
 
 def test_lnet_health_decay_is_warning(monkeypatch):
@@ -966,6 +993,24 @@ def test_run_isolates_unexpected_probe_crash_and_keeps_sibling_findings(monkeypa
     # The mount probe still reported the missing /fsx-efa mount despite the client probe crashing.
     assert result.status is Status.FAILURE
     assert LustreFilesystem.NOT_MOUNTED.code in _codes(result.errors)
+
+
+def test_run_missing_lnetctl_does_not_sink_other_probes(monkeypatch):
+    # lnetctl is not installed (shutil.which returns None). This must NOT abort the whole check: the LNet
+    # snapshot is marked unavailable, the LNet probe records an info and skips, the EFA probe no-ops, and
+    # the mount/reachability probes still run and report their findings.
+    _patch_client(monkeypatch)
+    monkeypatch.setattr(fsx_connectivity.shared_storage, "read_mounts", _mounts_from(_PROC_MOUNTS_BOTH))
+    _route_time_command(monkeypatch, {"df": _timed(stdout=_HEALTHY_LFS_DF)})
+    # Override the helper's truthy which(): lnetctl is not installed on this node.
+    monkeypatch.setattr(fsx_connectivity.shutil, "which", lambda name: None)
+
+    result = LustreFilesystem().run(sample_context_with_lustre(NodeType.COMPUTE))
+
+    # The check completed (was not aborted by the missing binary) and surfaced the lnetctl-unavailable info.
+    assert LustreFilesystem.LNETCTL_UNAVAILABLE.code in _codes(result.infos)
+    # A sibling probe (mount presence) still ran: both /fsx and /fsx-efa are present, so no NOT_MOUNTED.
+    assert LustreFilesystem.NOT_MOUNTED.code not in _codes(result.errors)
 
 
 # --- FsxTargetsAreReachable (unchanged, still its own gated check) --------------------

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -682,8 +682,8 @@ def test_efa_partial_bind_on_unknown_instance_type_is_not_an_error(monkeypatch):
     assert "1 of 16" in _messages(infos)
 
 
-def test_efa_underbound_fails_on_bind_all_family(monkeypatch):
-    # A "bind all" family (expected == available) with only 1 of 16 bound: the incident signature -> error.
+def test_efa_underbound_fails_when_expected_equals_available(monkeypatch):
+    # p6-b300.48xlarge expects 16 bound (per the FSx doc); only 1 of 16 bound is the incident signature.
     _patch_efa_prereqs(monkeypatch)
     _route_time_command(
         monkeypatch,

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -125,7 +125,7 @@ def test_client_modules_available_reports_version_and_no_error(monkeypatch):
     _patch_client(monkeypatch)
     errors, infos = [], []
 
-    LustreFilesystem()._probe_client(errors, infos)
+    LustreFilesystem()._probe_client(sample_context_with_lustre(NodeType.HEAD), errors, infos)
 
     assert errors == []
     assert _codes(infos) == [LustreFilesystem.CLIENT_VERSION.code]
@@ -138,7 +138,7 @@ def test_client_modules_unavailable_reports_only_not_installed(monkeypatch):
     _patch_client(monkeypatch, available=False, loaded=False, version=None)
     errors, infos = [], []
 
-    LustreFilesystem()._probe_client(errors, infos)
+    LustreFilesystem()._probe_client(sample_context_with_lustre(NodeType.HEAD), errors, infos)
 
     assert _codes(errors) == [LustreFilesystem.NOT_INSTALLED.code]
     assert "6.1.0-amzn2023" in _messages(errors)
@@ -148,7 +148,7 @@ def test_client_modules_available_but_not_loaded_fails(monkeypatch):
     _patch_client(monkeypatch, loaded=False)
     errors, infos = [], []
 
-    LustreFilesystem()._probe_client(errors, infos)
+    LustreFilesystem()._probe_client(sample_context_with_lustre(NodeType.HEAD), errors, infos)
 
     assert _codes(errors) == [LustreFilesystem.MODULES_NOT_LOADED.code]
     # The error names the specific modules that are available but not loaded.
@@ -156,10 +156,41 @@ def test_client_modules_available_but_not_loaded_fails(monkeypatch):
 
 
 def test_client_too_old_version_fails(monkeypatch):
+    # Default base_os (alinux2023) floor is 2.15; a 2.14 client is below it.
     _patch_client(monkeypatch, version="2.14.0")
     errors, infos = [], []
 
-    LustreFilesystem()._probe_client(errors, infos)
+    LustreFilesystem()._probe_client(sample_context_with_lustre(NodeType.HEAD), errors, infos)
+
+    assert LustreFilesystem.CLIENT_TOO_OLD.code in _codes(errors)
+
+
+def test_client_rhel8_2_12_meets_its_lower_floor(monkeypatch):
+    # rhel8 ships the 2.12 client; the floor for rhel8 is 2.12, so 2.12.x must NOT be flagged too-old.
+    _patch_client(monkeypatch, version="2.12.8")
+    errors, infos = [], []
+
+    LustreFilesystem()._probe_client(sample_context_with_lustre(NodeType.HEAD, base_os="rhel8"), errors, infos)
+
+    assert LustreFilesystem.CLIENT_TOO_OLD.code not in _codes(errors)
+
+
+def test_client_rhel8_below_2_12_fails(monkeypatch):
+    # Below even the rhel8 2.12 floor -> too old.
+    _patch_client(monkeypatch, version="2.11.0")
+    errors, infos = [], []
+
+    LustreFilesystem()._probe_client(sample_context_with_lustre(NodeType.HEAD, base_os="rhel8"), errors, infos)
+
+    assert LustreFilesystem.CLIENT_TOO_OLD.code in _codes(errors)
+
+
+def test_client_unknown_base_os_uses_default_floor(monkeypatch):
+    # An unknown/missing base_os falls back to the 2.15 default, so a 2.14 client is flagged too-old.
+    _patch_client(monkeypatch, version="2.14.0")
+    errors, infos = [], []
+
+    LustreFilesystem()._probe_client(sample_context_with_lustre(NodeType.HEAD, base_os="mystery"), errors, infos)
 
     assert LustreFilesystem.CLIENT_TOO_OLD.code in _codes(errors)
 
@@ -170,7 +201,7 @@ def test_client_unparseable_version_reports_undeterminable_not_too_old(monkeypat
     _patch_client(monkeypatch, version="unknown")
     errors, infos = [], []
 
-    LustreFilesystem()._probe_client(errors, infos)
+    LustreFilesystem()._probe_client(sample_context_with_lustre(NodeType.HEAD), errors, infos)
 
     assert LustreFilesystem.CLIENT_VERSION_UNDETERMINABLE.code in _codes(errors)
     assert LustreFilesystem.CLIENT_TOO_OLD.code not in _codes(errors)
@@ -530,6 +561,26 @@ def test_efa_probe_noop_when_lnetctl_unavailable():
     )
 
     assert errors == [] and warnings == [] and infos == []
+
+
+def test_efa_probe_skipped_on_efa_unsupported_os(monkeypatch):
+    # rhel8 does not support EFA-for-Lustre: the probe reports an info and runs no EFA data-path probes.
+    def _boom_device_count():
+        raise AssertionError("EFA data-path probe must not run on an EFA-unsupported OS")
+
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", _boom_device_count)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE, base_os="rhel8"),
+        _snapshot(_LNET_TCP_EFA),
+        errors,
+        warnings,
+        infos,
+    )
+
+    assert errors == [] and warnings == []
+    assert LustreFilesystem.EFA_NOT_SUPPORTED_ON_OS.code in _codes(infos)
 
 
 def test_lnet_health_decay_is_warning(monkeypatch):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_context_builder.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_context_builder.py
@@ -22,7 +22,7 @@ from pcluster_diag import __version__
 from pcluster_diag.core.context_builder import ContextBuilder
 from pcluster_diag.models.context import Context, NodeType
 from pcluster_diag.models.exceptions import ContextBuildError
-from tests.sample_data import SAMPLE_HEAD_NODE_INSTANCE_ID, SAMPLE_INSTANCE_ID
+from tests.sample_data import SAMPLE_HEAD_NODE_INSTANCE_ID, SAMPLE_INSTANCE_ID, SAMPLE_INSTANCE_TYPE
 from tests.stubs import stub_raising, stub_returning
 
 # Shared node_type token -> NodeType mapping exercised by the classification and build tests.
@@ -54,6 +54,7 @@ def _builder_from_fixtures(tmp_path, node_type_token="HeadNode", cluster_config=
     )
     # Stub the network-backed resolvers (IMDS / CloudFormation) so build() stays offline here.
     builder._instance_id = stub_returning(SAMPLE_INSTANCE_ID)
+    builder._instance_type = stub_returning(SAMPLE_INSTANCE_TYPE)
     builder._head_node_instance_id = stub_returning(SAMPLE_HEAD_NODE_INSTANCE_ID)
     return builder
 
@@ -168,6 +169,23 @@ def test_instance_id_reads_from_imds(monkeypatch):
     assert ContextBuilder()._instance_id() == "i-abc123"
 
 
+def test_instance_type_reads_from_imds(monkeypatch):
+    monkeypatch.setattr("pcluster_diag.core.context_builder.imds.get_instance_type", lambda: "fake.large")
+
+    assert ContextBuilder()._instance_type() == "fake.large"
+
+
+def test_instance_type_returns_none_and_logs_on_error(monkeypatch, caplog):
+    monkeypatch.setattr("pcluster_diag.core.context_builder.imds.get_instance_type", stub_raising("imds boom"))
+
+    with caplog.at_level(logging.ERROR, logger="pcluster_diag.core.context_builder"):
+        result = ContextBuilder()._instance_type()
+
+    # A failure to reach IMDS yields None instead of raising, and is logged at error level.
+    assert result is None
+    assert any("instance type" in record.getMessage().lower() for record in caplog.records)
+
+
 def test_head_node_instance_id_reads_stack_output(monkeypatch):
     captured = {}
 
@@ -264,6 +282,7 @@ def _builder_with_failures(failing):
             stub = stub_returning(_VALID_RETURNS[attribute])
         setattr(builder, _ATTRIBUTE_METHOD[attribute], stub)
     builder._instance_id = stub_returning(SAMPLE_INSTANCE_ID)
+    builder._instance_type = stub_returning(SAMPLE_INSTANCE_TYPE)
     builder._head_node_instance_id = stub_returning(SAMPLE_HEAD_NODE_INSTANCE_ID)
     return builder
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/sample_data.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/sample_data.py
@@ -27,6 +27,7 @@ SAMPLE_PCLUSTER_DIAG_VERSION = "1.0.0"
 SAMPLE_INSTANCE_ID = "i-0123456789abcdef0"
 SAMPLE_HEAD_NODE_INSTANCE_ID = "i-000000000headnode"
 SAMPLE_INSTANCE_TYPE = "fake.large"
+SAMPLE_BASE_OS = "alinux2023"
 SAMPLE_CLUSTER_CONFIG = {"Region": "us-east-1"}
 
 # Two FsxLustre SharedStorage mounts (/fsx and /fsx-efa), as a cluster with a plain and an EFA-enabled FSx.
@@ -46,15 +47,21 @@ SAMPLE_FSX_LUSTRE_SHARED_STORAGE = [
 ]
 
 
-def sample_context_with_lustre(node_type: NodeType = NodeType.HEAD, shared_storage=None) -> Context:
+def sample_context_with_lustre(
+    node_type: NodeType = NodeType.HEAD, shared_storage=None, base_os: str = SAMPLE_BASE_OS
+) -> Context:
     """Return a sample Context whose cluster config carries FsxLustre SharedStorage mounts."""
-    context = sample_context(node_type)
+    context = sample_context(node_type, base_os=base_os)
     storage = SAMPLE_FSX_LUSTRE_SHARED_STORAGE if shared_storage is None else shared_storage
     context.cluster_config = dict(SAMPLE_CLUSTER_CONFIG, SharedStorage=storage)
     return context
 
 
-def sample_context(node_type: NodeType = NodeType.HEAD, instance_type: str = SAMPLE_INSTANCE_TYPE) -> Context:
+def sample_context(
+    node_type: NodeType = NodeType.HEAD,
+    instance_type: str = SAMPLE_INSTANCE_TYPE,
+    base_os: str = SAMPLE_BASE_OS,
+) -> Context:
     """Return a fully-resolved sample Context for ``node_type`` (defaults to the head node)."""
     return Context(
         timestamp=SAMPLE_TIMESTAMP,
@@ -64,7 +71,7 @@ def sample_context(node_type: NodeType = NodeType.HEAD, instance_type: str = SAM
         instance_id=SAMPLE_INSTANCE_ID,
         instance_type=instance_type,
         cluster_config=dict(SAMPLE_CLUSTER_CONFIG),
-        dna_json={"cluster": {"node_type": node_type.value}},
+        dna_json={"cluster": {"node_type": node_type.value, "base_os": base_os}},
         pcluster_diag_version=SAMPLE_PCLUSTER_DIAG_VERSION,
     )
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/sample_data.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/sample_data.py
@@ -26,9 +26,10 @@ SAMPLE_PCLUSTER_VERSION = "3.16.0"
 SAMPLE_PCLUSTER_DIAG_VERSION = "1.0.0"
 SAMPLE_INSTANCE_ID = "i-0123456789abcdef0"
 SAMPLE_HEAD_NODE_INSTANCE_ID = "i-000000000headnode"
+SAMPLE_INSTANCE_TYPE = "fake.large"
 SAMPLE_CLUSTER_CONFIG = {"Region": "us-east-1"}
 
-# Two FsxLustre SharedStorage mounts, mirroring the recursive-prod-gpu cluster (/fsx and /fsx-efa).
+# Two FsxLustre SharedStorage mounts (/fsx and /fsx-efa), as a cluster with a plain and an EFA-enabled FSx.
 SAMPLE_FSX_LUSTRE_SHARED_STORAGE = [
     {
         "Name": "fsx",
@@ -53,7 +54,7 @@ def sample_context_with_lustre(node_type: NodeType = NodeType.HEAD, shared_stora
     return context
 
 
-def sample_context(node_type: NodeType = NodeType.HEAD) -> Context:
+def sample_context(node_type: NodeType = NodeType.HEAD, instance_type: str = SAMPLE_INSTANCE_TYPE) -> Context:
     """Return a fully-resolved sample Context for ``node_type`` (defaults to the head node)."""
     return Context(
         timestamp=SAMPLE_TIMESTAMP,
@@ -61,6 +62,7 @@ def sample_context(node_type: NodeType = NodeType.HEAD) -> Context:
         pcluster_version=SAMPLE_PCLUSTER_VERSION,
         head_node_instance_id=SAMPLE_HEAD_NODE_INSTANCE_ID,
         instance_id=SAMPLE_INSTANCE_ID,
+        instance_type=instance_type,
         cluster_config=dict(SAMPLE_CLUSTER_CONFIG),
         dna_json={"cluster": {"node_type": node_type.value}},
         pcluster_diag_version=SAMPLE_PCLUSTER_DIAG_VERSION,

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_efa.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_efa.py
@@ -95,15 +95,16 @@ def test_is_p6plus_instance(instance_type, expected):
 @pytest.mark.parametrize(
     "instance_type, available, expected",
     [
-        # "bind all" families expect every present device.
+        # Fixed per-instance-type counts from the FSx-for-Lustre configure-efa-clients doc table.
         ("p6-b300.48xlarge", 16, 16),
         ("p6-b200.48xlarge", 8, 8),
-        # subset-binding families expect a fixed count, capped at what is present.
+        ("p6e-gb200.36xlarge", 8, 8),
         ("p5.48xlarge", 16, 8),
         ("p5en.48xlarge", 16, 8),
-        ("p5.48xlarge", 4, 4),  # capped at available when fewer devices are present than the fixed count
-        # no static expectation -> None (dynamic selection, unlisted type, or unknown type).
-        ("p6e-gb200.36xlarge", 16, None),
+        # Expected count is capped at devices actually present.
+        ("p5.48xlarge", 4, 4),
+        ("p6-b300.48xlarge", 8, 8),
+        # Instance types not in the table have no static expectation.
         ("c5n.18xlarge", 2, None),
         (None, 16, None),
     ],

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_efa.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_efa.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the EFA capability helpers (kefalnd/driver modules, versions, device count, p6+)."""
+
+import pytest
+
+from pcluster_diag.util import efa
+
+
+def test_efa_kefalnd_supported_delegates_to_modinfo(monkeypatch):
+    monkeypatch.setattr(efa.kernel_module, "kernel_module_available", lambda module: module == "kefalnd")
+    assert efa.efa_kefalnd_supported() is True
+    monkeypatch.setattr(efa.kernel_module, "kernel_module_available", lambda module: False)
+    assert efa.efa_kefalnd_supported() is False
+
+
+def test_efa_driver_version_delegates_to_modinfo(monkeypatch):
+    monkeypatch.setattr(efa.kernel_module, "module_version", lambda module: "2.12.1" if module == "efa" else None)
+    assert efa.efa_driver_version() == "2.12.1"
+
+
+def test_efa_kefalnd_version_delegates_to_modinfo(monkeypatch):
+    monkeypatch.setattr(efa.kernel_module, "module_version", lambda module: "1.1.1" if module == "kefalnd" else None)
+    assert efa.efa_kefalnd_version() == "1.1.1"
+
+
+def _patch_infiniband(monkeypatch, drivers):
+    """Simulate /sys/class/infiniband: ``drivers`` maps each device name to its resolved driver name.
+
+    ``os.listdir`` returns the device names; ``os.path.realpath`` on ``<dev>/device/driver`` resolves to a
+    path whose basename is the mapped driver (so efa_device_count's driver filter can be exercised).
+    """
+    monkeypatch.setattr(efa.os, "listdir", lambda path: list(drivers))
+    monkeypatch.setattr(efa.os.path, "realpath", lambda link: "/sys/bus/pci/drivers/" + drivers[link.split("/")[-3]])
+
+
+def test_efa_device_count_counts_only_efa_driver_devices(monkeypatch):
+    # Two efa devices and one non-EFA RDMA device (e.g. an ib device) under /sys/class/infiniband.
+    _patch_infiniband(monkeypatch, {"efa0": "efa", "efa1": "efa", "mlx5_0": "mlx5_core"})
+    assert efa.efa_device_count() == 2
+
+
+def test_efa_device_count_zero_when_no_efa_devices(monkeypatch):
+    _patch_infiniband(monkeypatch, {"mlx5_0": "mlx5_core"})
+    assert efa.efa_device_count() == 0
+
+
+def test_efa_device_count_zero_when_sysfs_absent(monkeypatch):
+    def _raise(path):
+        raise OSError("no such directory")
+
+    monkeypatch.setattr(efa.os, "listdir", _raise)
+    assert efa.efa_device_count() == 0
+
+
+def test_efa_device_count_skips_device_whose_driver_is_unreadable(monkeypatch):
+    monkeypatch.setattr(efa.os, "listdir", lambda path: ["efa0", "broken"])
+
+    def _realpath(link):
+        if "broken" in link:
+            raise OSError("dangling symlink")
+        return "/sys/bus/pci/drivers/efa"
+
+    monkeypatch.setattr(efa.os.path, "realpath", _realpath)
+    assert efa.efa_device_count() == 1
+
+
+@pytest.mark.parametrize(
+    "instance_type, expected",
+    [
+        ("p6-b300.48xlarge", True),
+        ("p6-b200.48xlarge", True),
+        ("p6e-gb200.36xlarge", True),
+        ("p5.48xlarge", False),
+        ("c5n.18xlarge", False),
+        # An unknown instance type (e.g. IMDS unavailable at startup) is undeterminable, not "non-p6".
+        ("", None),
+        (None, None),
+    ],
+)
+def test_is_p6plus_instance(instance_type, expected):
+    assert efa.is_p6plus_instance(instance_type) is expected
+
+
+@pytest.mark.parametrize(
+    "instance_type, available, expected",
+    [
+        # "bind all" families expect every present device.
+        ("p6-b300.48xlarge", 16, 16),
+        ("p6-b200.48xlarge", 8, 8),
+        # subset-binding families expect a fixed count, capped at what is present.
+        ("p5.48xlarge", 16, 8),
+        ("p5en.48xlarge", 16, 8),
+        ("p5.48xlarge", 4, 4),  # capped at available when fewer devices are present than the fixed count
+        # no static expectation -> None (dynamic selection, unlisted type, or unknown type).
+        ("p6e-gb200.36xlarge", 16, None),
+        ("c5n.18xlarge", 2, None),
+        (None, 16, None),
+    ],
+)
+def test_expected_bound_device_count(instance_type, available, expected):
+    assert efa.expected_bound_device_count(instance_type, available) == expected

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_imds.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_imds.py
@@ -53,6 +53,22 @@ def test_get_instance_id_uses_token_then_reads_instance_id(monkeypatch):
     # A PUT fetches the token first, then the instance-id GET carries that token.
     assert calls[0][0] == "PUT" and calls[0][1].endswith("/api/token")
     assert calls[1][1].endswith("/meta-data/instance-id")
+
+
+def test_get_instance_type_uses_token_then_reads_instance_type(monkeypatch):
+    calls = []
+
+    def fake_urlopen(request, timeout=None):
+        calls.append((request.get_method(), request.full_url, dict(request.header_items())))
+        if request.full_url.endswith("/api/token"):
+            return _FakeResponse(b"the-token")
+        return _FakeResponse(b"fake.large\n")
+
+    monkeypatch.setattr(imds.urllib.request, "urlopen", fake_urlopen)
+
+    assert imds.get_instance_type() == "fake.large"
+    assert calls[0][0] == "PUT" and calls[0][1].endswith("/api/token")
+    assert calls[1][1].endswith("/meta-data/instance-type")
     assert calls[1][2]["X-aws-ec2-metadata-token"] == "the-token"
 
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_kernel_module.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_kernel_module.py
@@ -80,3 +80,22 @@ def test_module_version_none_when_modinfo_missing(monkeypatch):
     monkeypatch.setattr(kernel_module, "run_command", _raise_oserror)
 
     assert kernel_module.module_version("lustre") is None
+
+
+@pytest.mark.parametrize(
+    "actual, minimum, expected",
+    [
+        ("2.15.6", "2.15", True),
+        ("2.15", "2.15", True),
+        ("2.14.9", "2.15", False),
+        ("2.15.6-1.fsx23.el9", "2.15", True),  # only the leading numeric prefix is compared
+        ("1.1.1", "1.1.1", True),
+        ("1.0.0", "1.1.1", False),
+        ("2.12.1", "2.12.1", True),
+        # A version that cannot be determined yields None (undeterminable), not False (below-minimum).
+        (None, "2.15", None),
+        ("not-a-version", "2.15", None),
+    ],
+)
+def test_version_at_least(actual, minimum, expected):
+    assert kernel_module.version_at_least(actual, minimum) is expected

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_lustre.py
@@ -73,3 +73,237 @@ def test_lustre_client_version_none_on_failure(monkeypatch):
     monkeypatch.setattr(kernel_module, "run_command", lambda command: _completed(returncode=1))
 
     assert lustre.lustre_client_version() is None
+
+
+# --- lnetctl net show parsing ---------------------------------------------------------
+
+# `lnetctl net show -v` with a loopback net, a tcp net, and an EFA net (two bound devices) with stats.
+_LNET_NET_SHOW = """\
+net:
+    - net type: lo
+      local NI(s):
+        - nid: 0@lo
+          status: up
+    - net type: tcp
+      local NI(s):
+        - nid: 10.0.0.1@tcp
+          status: up
+          interfaces:
+              0: eth0
+          statistics:
+              send_count: 1200
+              recv_count: 1500
+          health stats:
+              health value: 1000
+    - net type: efa
+      local NI(s):
+        - nid: 10.0.0.1@efa
+          status: up
+          interfaces:
+              0: efa0
+          statistics:
+              send_count: 900
+              recv_count: 800
+          health stats:
+              health value: 1000
+        - nid: 10.0.0.2@efa
+          status: up
+          interfaces:
+              0: efa1
+          statistics:
+              send_count: 0
+              recv_count: 0
+          health stats:
+              health value: 640
+"""
+
+
+def test_parse_lnet_net_show_lists_nets_and_nis():
+    nets = lustre.parse_lnet_net_show(_LNET_NET_SHOW)
+
+    assert [net.net_type for net in nets] == ["lo", "tcp", "efa"]
+    efa = lustre.lnet_net(nets, "efa")
+    assert [ni.nid for ni in efa.local_nis] == ["10.0.0.1@efa", "10.0.0.2@efa"]
+    assert efa.local_nis[0].send_count == 900
+    assert efa.local_nis[1].health_value == 640
+
+
+def test_active_lnds_excludes_loopback():
+    nets = lustre.parse_lnet_net_show(_LNET_NET_SHOW)
+
+    assert lustre.active_lnds(nets) == ["tcp", "efa"]
+
+
+def test_lnet_bound_interfaces_collects_devices():
+    nets = lustre.parse_lnet_net_show(_LNET_NET_SHOW)
+
+    assert lustre.lnet_bound_interfaces(nets, "efa") == ["efa0", "efa1"]
+    assert lustre.lnet_bound_interfaces(nets, "o2ib") == []
+
+
+def test_local_nids_returns_net_nids():
+    nets = lustre.parse_lnet_net_show(_LNET_NET_SHOW)
+
+    assert lustre.local_nids(nets, "efa") == ["10.0.0.1@efa", "10.0.0.2@efa"]
+    assert lustre.local_nids(nets, "o2ib") == []
+
+
+def test_parse_lnet_net_show_empty_on_no_nets():
+    assert lustre.parse_lnet_net_show("net:\n") == []
+
+
+def test_parse_lnet_net_show_empty_on_garbage():
+    assert lustre.parse_lnet_net_show(": : not yaml : :\n- [") == []
+
+
+# --- lnetctl peer show parsing --------------------------------------------------------
+
+_LNET_PEER_SHOW = """\
+peer:
+    - primary nid: 10.0.1.5@efa
+      peer ni:
+        - nid: 10.0.1.5@efa
+        - nid: 10.0.1.5@tcp
+    - primary nid: 10.0.1.6@tcp
+      peer ni:
+        - nid: 10.0.1.6@tcp
+"""
+
+
+def test_parse_lnet_peer_show_collects_nids():
+    nids = lustre.parse_lnet_peer_show(_LNET_PEER_SHOW)
+
+    assert "10.0.1.5@efa" in nids
+    assert "10.0.1.6@tcp" in nids
+
+
+def test_nids_on_net_filters_and_dedupes():
+    nids = lustre.parse_lnet_peer_show(_LNET_PEER_SHOW)
+
+    assert lustre.nids_on_net(nids, "efa") == ["10.0.1.5@efa"]
+
+
+def test_parse_lnet_peer_show_empty_on_garbage():
+    assert lustre.parse_lnet_peer_show("- [") == []
+
+
+# --- lfs check servers parsing --------------------------------------------------------
+
+_LFS_CHECK_SERVERS = """\
+fs-MDT0000-mdc-ffff active.
+fs-OST0000-osc-ffff active.
+check 'fs-OST000b-osc-ffff': Input/output error (5)
+"""
+
+
+def test_parse_lfs_check_servers_classifies_active_and_errored():
+    servers = lustre.parse_lfs_check_servers(_LFS_CHECK_SERVERS)
+
+    assert [s.target for s in servers] == [
+        "fs-MDT0000-mdc-ffff",
+        "fs-OST0000-osc-ffff",
+        "fs-OST000b-osc-ffff",
+    ]
+    assert [s.active for s in servers] == [True, True, False]
+
+
+def test_unreachable_servers_flags_only_errored():
+    unreachable = lustre.unreachable_servers(_LFS_CHECK_SERVERS)
+
+    assert [s.target for s in unreachable] == ["fs-OST000b-osc-ffff"]
+    assert "Input/output error" in unreachable[0].detail
+
+
+def test_unreachable_servers_empty_when_all_active():
+    assert lustre.unreachable_servers("fs-OST0000-osc-ffff active.\n") == []
+
+
+# --- lctl get_param import parsing ----------------------------------------------------
+
+_LCTL_IMPORT = """\
+osc.fs-OST0000-osc-ffff.import=
+    import:
+        target: fs-OST0000_UUID
+        state: FULL
+        connection:
+            current_connection: 10.0.1.5@efa
+            failover_nids: [ 10.0.1.5@efa ]
+mdc.fs-MDT0000-mdc-ffff.import=
+    import:
+        target: fs-MDT0000_UUID
+        state: DISCONN
+        connection:
+            current_connection: 10.0.1.6@tcp
+            failover_nids: [ 10.0.1.7@tcp ]
+"""
+
+
+def test_parse_lctl_import_extracts_state_and_connection():
+    imports = lustre.parse_lctl_import(_LCTL_IMPORT)
+
+    assert [i.param for i in imports] == ["osc.fs-OST0000-osc-ffff", "mdc.fs-MDT0000-mdc-ffff"]
+    assert imports[0].state == "FULL"
+    assert imports[0].healthy is True
+    assert imports[0].current_connection == "10.0.1.5@efa"
+    assert imports[0].connected_over == "efa"
+    assert imports[0].failover_nids == ["10.0.1.5@efa"]
+
+
+def test_parse_lctl_import_flags_non_full_state():
+    imports = lustre.parse_lctl_import(_LCTL_IMPORT)
+
+    mdt = imports[1]
+    assert mdt.state == "DISCONN"
+    assert mdt.healthy is False
+    assert mdt.connected_over == "tcp"
+    assert mdt.failover_nids == ["10.0.1.7@tcp"]
+
+
+def test_parse_lctl_import_empty_when_no_blocks():
+    assert lustre.parse_lctl_import("some noise\nno import here\n") == []
+
+
+# --- LNet ping (lnetctl peer show + ping) ---------------------------------------------
+
+
+def test_efa_peer_nid_returns_first_efa_peer(monkeypatch):
+    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(stdout=_LNET_PEER_SHOW))
+    assert lustre.efa_peer_nid() == "10.0.1.5@efa"
+
+
+def test_efa_peer_nid_none_when_no_efa_peer(monkeypatch):
+    tcp_only_peer = "peer:\n    - primary nid: 1.2.3.4@tcp\n"
+    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(stdout=tcp_only_peer))
+    assert lustre.efa_peer_nid() is None
+
+
+def test_efa_peer_nid_none_on_command_failure(monkeypatch):
+    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(returncode=1))
+    assert lustre.efa_peer_nid() is None
+
+
+def test_efa_ping_works_true_on_success(monkeypatch):
+    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(stdout="ok"))
+    assert lustre.efa_ping_works("10.0.0.1@efa", "10.0.1.5@efa") is True
+
+
+def test_efa_ping_works_false_on_nonzero_or_timeout(monkeypatch):
+    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(returncode=1))
+    assert lustre.efa_ping_works("10.0.0.1@efa", "10.0.1.5@efa") is False
+    hung = _completed_timed(timed_out=True, returncode=None)
+    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: hung)
+    assert lustre.efa_ping_works("10.0.0.1@efa", "10.0.1.5@efa") is False
+
+
+def _completed_timed(returncode=0, stdout="", stderr="", timed_out=False):
+    """Build a TimedCommand double for the lnetctl peer/ping helpers."""
+    from pcluster_diag.util.shell import TimedCommand
+
+    return TimedCommand(
+        command=["lnetctl"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+        elapsed_seconds=0.01,
+        timed_out=timed_out,
+    )

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_services.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_services.py
@@ -127,3 +127,61 @@ def test_get_supervisord_program_state_raises_when_undeterminable(monkeypatch):
 
     with pytest.raises(RuntimeError):
         services.get_supervisord_program_state("cfn-hup")
+
+
+# --- systemd unit helpers -------------------------------------------------------------
+
+_UNIT = "configure-efa-fsx-lustre-client.service"
+
+
+def _fake_systemctl(monkeypatch, returncode, stdout):
+    """Patch services.run_command to answer any ``systemctl`` invocation with the given result."""
+    monkeypatch.setattr(
+        services,
+        "run_command",
+        lambda command: subprocess.CompletedProcess(command, returncode, stdout=stdout, stderr=""),
+    )
+
+
+@pytest.mark.parametrize(
+    "returncode, stdout, expected",
+    [
+        (0, "{}                          enabled\n".format(_UNIT), True),
+        (0, "UNIT FILE                   STATE\n", False),  # header only, unit not listed
+        (1, "", False),  # systemctl error / unit unknown
+    ],
+    ids=["installed", "not-listed", "error"],
+)
+def test_systemd_unit_exists(monkeypatch, returncode, stdout, expected):
+    _fake_systemctl(monkeypatch, returncode, stdout)
+    assert services.systemd_unit_exists(_UNIT) is expected
+
+
+def test_systemd_unit_exists_false_when_systemctl_missing(monkeypatch):
+    def _raise(command):
+        raise OSError("systemctl not found")
+
+    monkeypatch.setattr(services, "run_command", _raise)
+    assert services.systemd_unit_exists(_UNIT) is False
+
+
+@pytest.mark.parametrize(
+    "returncode, stdout, expected",
+    [
+        (1, "failed\n", True),  # is-failed exits non-zero even when the unit IS failed
+        (0, "active\n", False),
+        (3, "inactive\n", False),
+    ],
+    ids=["failed", "active", "inactive"],
+)
+def test_systemd_unit_failed(monkeypatch, returncode, stdout, expected):
+    _fake_systemctl(monkeypatch, returncode, stdout)
+    assert services.systemd_unit_failed(_UNIT) is expected
+
+
+def test_systemd_unit_failed_false_when_systemctl_missing(monkeypatch):
+    def _raise(command):
+        raise OSError("systemctl not found")
+
+    monkeypatch.setattr(services, "run_command", _raise)
+    assert services.systemd_unit_failed(_UNIT) is False

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_shared_storage.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_shared_storage.py
@@ -57,6 +57,21 @@ def test_lustre_mounts_filters_out_non_lustre_types():
     assert [m.mount_dir for m in mounts] == ["/fsx"]
 
 
+def test_shared_storage_mounts_normalizes_relative_mount_dir():
+    # ParallelCluster accepts a relative MountDir (e.g. "fsx") and mounts it at "/fsx"; the mounts we
+    # return must be absolute so they match /proc/mounts and the path passed to `lfs df`.
+    storage = [
+        {"Name": "fsx", "StorageType": "FsxLustre", "MountDir": "fsx"},
+        {"Name": "efs", "StorageType": "Efs", "MountDir": "shared/efs"},
+        {"Name": "abs", "StorageType": "FsxLustre", "MountDir": "/already/abs"},
+    ]
+    context = sample_context_with_lustre(NodeType.HEAD, shared_storage=storage)
+
+    mounts = shared_storage.shared_storage_mounts(context)
+
+    assert [m.mount_dir for m in mounts] == ["/fsx", "/shared/efs", "/already/abs"]
+
+
 def test_shared_storage_mounts_skips_malformed_entries():
     storage = [
         {"StorageType": "FsxLustre"},  # no MountDir


### PR DESCRIPTION
### Description of changes
Add read-only diagnostics for FSx for Lustre clients, including the EFA
  transport path. Two checks:

  - LustreFilesystem (always-on): one check running isolated probes and
    aggregating their findings (AD DirectoryService pattern) --
      * client: lustre/lnet kernel modules available for the running kernel
        and loaded, plus the client version and its minimum-version floor;
      * mount presence: each configured MountDir is mounted (/proc/mounts);
      * reachability: `lfs df -h` per mount, classifying hang vs error vs
        down target;
      * LNet transport: `lnetctl net show` reports the active LNDs (tcp/efa);
      * EFA: run when an `efa` net is configured OR the
        configure-efa-fsx-lustre-client service is installed (so a failed
        service that left no `efa` net is still caught). Verifies kefalnd,
        EFA driver / kefalnd (p6+) versions, and service state, then the
        EFA data path -- device binding vs a per-instance-family expected
        count, `lnetctl ping`, and TCP-fallback.
  - FsxTargetsAreReachable (opt-in, approval_required): `lfs check servers`
    plus client-side osc/mdc import state to pinpoint an unreachable
    OST/MDT.

  Every external command runs through time_command so a hang is reported,
  not propagated. An assertion that cannot be evaluated (unparseable
  version, instance type unknown via IMDS) is a CHECK_ERROR, distinct from a
  definite FAILURE, and never silently passed.

  Utilities are split by concern: util/efa.py (EFA capability: modules,
  versions, device count filtered by driver, p6+ family + expected bound
  count), util/lustre.py (Lustre protocol + LNet parsing/ping),
  util/kernel_module.py (module version + comparison), util/services.py
  (systemd unit state). Instance type resolved from IMDS. Version floors,
  p6+ families, and expected bound counts mirror the FSx EFA-Lustre client
  setup (documented drift risk; cannot be imported). Registered in
  core/registry.py; unit tests per module and per probe.

  See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html

### Tests
* Diag checks on HeadNode 
```
 pcluster-diag run
2026-08-04 20:00:47,967 [INFO] pcluster_diag.core.registry: The following checks require your confirmation before they run:
2026-08-04 20:00:47,967 [INFO] pcluster_diag.core.registry:   - FsxTargetsAreReachable: Deep-probe each FsxLustre OST/MDT for reachability (lfs check servers + import state).
Run check 'FsxTargetsAreReachable'? [y/N]: y
2026-08-04 20:00:50,292 [INFO] pcluster_diag.core.runner: Check LustreFilesystem: started
2026-08-04 20:00:50,294 [INFO] pcluster_diag.util.shell: Timed command ['lnetctl', 'net', 'show', '-v']: timed_out=False, returncode=0, elapsed=0.002s
2026-08-04 20:00:50,299 [INFO] pcluster_diag.util.shell: Executed command ['modinfo', 'lustre']: exit code 0, stdout='filename:       /lib/modules/6.17.0-1019-aws/updates/kernel/fs/lustre.ko\nlicense:        GPL\nversion:        2.15.6\ndescription:    Lustre Client File System\nauthor:         OpenSFS, Inc. <http://www.lustre.org/>\nalias:          fs-lustre\nsrcversion:     A9C56AFF77D13198E6CCA9A\ndepends:        obdclass,ptlrpc,libcfs,lmv,lnet,lov,mdc\nname:           lustre\nretpoline:      Y\nvermagic:       6.17.0-1019-aws SMP mod_unload modversions \n', stderr=''
2026-08-04 20:00:50,301 [INFO] pcluster_diag.util.shell: Executed command ['modinfo', 'lnet']: exit code 0, stdout="filename:       /lib/modules/6.17.0-1019-aws/updates/kernel/net/lnet.ko\nlicense:        GPL\nversion:        0.7.0\ndescription:    Lustre Networking layer\nauthor:         OpenSFS, Inc. <http://www.lustre.org/>\nsrcversion:     64064DD19CBDABE034BB138\ndepends:        libcfs,sunrpc\nname:           lnet\nretpoline:      Y\nvermagic:       6.17.0-1019-aws SMP mod_unload modversions \nparm:           cpu_npartitions:# of CPU partitions (int)\nparm:           cpu_pattern:CPU partitions pattern (charp)\nparm:   accept:Accept connections (secure|all|none) (charp)\nparm:           accept_port:Acceptor's port (same on all nodes) (int)\nparm:           accept_backlog:Acceptor's listen backlog (int)\nparm:           accept_timeout:Acceptor's timeout (seconds) (int)\nparm:           forwarding:Explicitly enable/disable forwarding between networks (charp)\nparm:           tiny_router_buffers:# of 0 payload messages to buffer in the router (int)\nparm:           small_router_buffers:# of small (1 page) messages to buffer in the router (int)\nparm:           large_router_buffers:# of large messages to buffer in the router (int)\nparm:    peer_buffer_credits:# router buffer credits per peer (int)\nparm:           auto_down:Automatically mark peers down on comms error (int)\nparm:           check_routers_before_use:Assume routers are down and ping them before use (int)\nparm:           avoid_asym_router_failure:Avoid asymmetrical router failures (0 to disable) (int)\nparm:           dead_router_check_interval:(DEPRECATED - Use alive_router_check_interval) (int)\nparm:           live_router_check_interval:(DEPRECATED - Use alive_router_check_interval) (int)\nparm:           alive_router_check_interval:Seconds between live router health checks (<= 0 to disable)(int)\nparm:           router_ping_timeout:Seconds to wait for the reply to a router health query (int)\nparm:           router_sensitivity_percentage:How healthy a gateway should be to be used in percent (rtr_sensitivity)\nparm:           config_on_load:configure network at module load (int)\nparm:           local_nid_dist_zero:Reserved (int)\nparm:           portal_rotor:redirect PUTs to different cpu-partitions (int)\nparm:           ip2nets:LNET network <- IP table (charp)\nparm:           networks:local networks (charp)\nparm:           routes:routes to non-local networks (charp)\nparm:           rnet_htable_size:size of remote network hash table (int)\nparm:           use_tcp_bonding:use_tcp_bonding parameter has been removed (int)\nparm:           lnet_numa_range:NUMA range to consider during Multi-Rail selection (uint)\nparm:           lnet_health_sensitivity:Value to decrement the health value by on error (health_sensitivity)\nparm:           lnet_recovery_interval:DEPRECATED - Interval to recover unhealthy interfaces in seconds (recovery_interval)\nparm:           lnet_recovery_limit:How long to attempt recovery of unhealthy peer interfaces in seconds. Set to 0 to allow indefinite recovery (uint)\nparm:           lnet_interfaces_max:Maximum number of interfaces in a node. (interfaces_max)\nparm:           lnet_peer_discovery_disabled:Set to 1 to disable peer discovery on this node. (discovery_disabled)\nparm:           lnet_drop_asym_route:Set to 1 to drop asymmetrical route messages. (drop_asym_route)\nparm:           lnet_transaction_timeout:Maximum number of seconds to wait for a peer response. (transaction_timeout)\nparm:           lnet_retry_count:Maximum number of times to retry transmitting a message (retry_count)\nparm:           lnet_response_tracking:(0|1|2|3) LNet Internal Only|GET Reply only|PUT ACK only|Full Tracking (default) (response_tracking)\nparm:           lock_prim_nid:Whether nid passed down by Lustre is locked as primary (int)\n", stderr=''
2026-08-04 20:00:50,304 [INFO] pcluster_diag.util.shell: Executed command ['lsmod']: exit code 0, stdout='Module                  Size  Used by\nmgc                    81920  1\nlustre               1163264  4\nmdc                   299008  2 lustre\nfid                    40960  1 mdc\nlov                   3727365 mdc,lustre\nosc                   491520  4 mdc\nlmv                   237568  2 lustre\nfld                    53248  2 lov,lmv\nksocklnd              196608  1\nptlrpc               1560576  8 fld,osc,fid,mgc,lov,mdc,lmv,lustre\nobdclass             3416064  13 fld,osc,fid,ptlrpc,mgc,lov,mdc,lmv,lustre\nnfsd             983040  5\nauth_rpcgss           180224  1 nfsd\nnfs_acl                12288  1 nfsd\nip6t_REJECT            12288  1\nnf_reject_ipv6         24576  1 ip6t_REJECT\nipt_REJECT             12288  1\nnf_reject_ipv4         12288  1 ipt_REJECT\nxt_owner               12288  6\nnft_compat             204808\nnf_tables             385024  39 nft_compat\ntls                   155648  3\nqrtr                   53248  2\ncfg80211             1449984  0\n8021q                  45056  0\ngarp                   20480  1 8021q\nmrp                    20480  1 8021q\nstp                    12288  1 garp\nllc 16384  2 stp,garp\nbinfmt_misc            24576  1\nnls_iso8859_1          12288  1\nsch_fq_codel           24576  9\nib_umad                45056  0\nnf_conntrack          192512  0\nnf_defrag_ipv6         24576  1 nf_conntrack\nnf_defrag_ipv4         12288  1 nf_conntrack\nlockd                 143360  1 nfsd\ngrace                  12288  2 nfsd,lockd\nlnet                  839680  7 osc,obdclass,ptlrpc,mgc,ksocklnd,lmv,lustre\ncrc32_cryptoapi        12288  0\nlibcfs                233472  12 fld,lnet,osc,fid,obdclass,ptlrpc,mgc,ksocklnd,lov,mdc,lmv,lustre\nintel_rapl_msr         20480  0\nintel_rapl_common      53248  1 intel_rapl_msr\nintel_uncore_frequency_common    20480  0\nskx_edac_common        24576  0\nnfit                   81920  1 skx_edac_common\nsunrpc                811008  16 lnet,nfsd,auth_rpcgss,lockd,nfs_acl\ni2c_piix4              32768  0\npolyval_clmulni        12288  0\nghash_clmulni_intel    12288  0\naesni_intel            98304  0\nrapl                   20480  0\nptp_vmclock            20480  0\ninput_leds             12288  0\nmac_hid                12288  0\npsmouse               217088  0\nserio_raw              20480  0\ni2c_smbus              20480  1 i2c_piix4\nmsr                    12288  0\ndm_multipath 45056  0\nefa                   131072  0\nib_uverbs             200704  1 efa\nib_core               524288  3 efa,ib_umad,ib_uverbs\nparport_pc             53248  0\nppdev                  24576  0\nlp                     32768  0\nparport                73728  3 parport_pc,lp,ppdev\nefi_pstore             122880\nnfnetlink              20480  4 nft_compat,nf_tables\ndmi_sysfs              20480  0\nip_tables              32768  0\nx_tables               65536  5 nft_compat,xt_owner,ipt_REJECT,ip_tables,ip6t_REJECT\nautofs4                57344  2\n', stderr=''
2026-08-04 20:00:50,308 [INFO] pcluster_diag.util.shell: Executed command ['lsmod']: exit code 0, stdout='Module                  Size  Used by\nmgc                    81920  1\nlustre               1163264  4\nmdc                   299008  2 lustre\nfid                    40960  1 mdc\nlov                   3727365 mdc,lustre\nosc                   491520  4 mdc\nlmv                   237568  2 lustre\nfld                    53248  2 lov,lmv\nksocklnd              196608  1\nptlrpc               1560576  8 fld,osc,fid,mgc,lov,mdc,lmv,lustre\nobdclass             3416064  13 fld,osc,fid,ptlrpc,mgc,lov,mdc,lmv,lustre\nnfsd             983040  5\nauth_rpcgss           180224  1 nfsd\nnfs_acl                12288  1 nfsd\nip6t_REJECT            12288  1\nnf_reject_ipv6         24576  1 ip6t_REJECT\nipt_REJECT             12288  1\nnf_reject_ipv4         12288  1 ipt_REJECT\nxt_owner               12288  6\nnft_compat             204808\nnf_tables             385024  39 nft_compat\ntls                   155648  3\nqrtr                   53248  2\ncfg80211             1449984  0\n8021q                  45056  0\ngarp                   20480  1 8021q\nmrp                    20480  1 8021q\nstp                    12288  1 garp\nllc 16384  2 stp,garp\nbinfmt_misc            24576  1\nnls_iso8859_1          12288  1\nsch_fq_codel           24576  9\nib_umad                45056  0\nnf_conntrack          192512  0\nnf_defrag_ipv6         24576  1 nf_conntrack\nnf_defrag_ipv4         12288  1 nf_conntrack\nlockd                 143360  1 nfsd\ngrace                  12288  2 nfsd,lockd\nlnet                  839680  7 osc,obdclass,ptlrpc,mgc,ksocklnd,lmv,lustre\ncrc32_cryptoapi        12288  0\nlibcfs                233472  12 fld,lnet,osc,fid,obdclass,ptlrpc,mgc,ksocklnd,lov,mdc,lmv,lustre\nintel_rapl_msr         20480  0\nintel_rapl_common      53248  1 intel_rapl_msr\nintel_uncore_frequency_common    20480  0\nskx_edac_common        24576  0\nnfit                   81920  1 skx_edac_common\nsunrpc                811008  16 lnet,nfsd,auth_rpcgss,lockd,nfs_acl\ni2c_piix4              32768  0\npolyval_clmulni        12288  0\nghash_clmulni_intel    12288  0\naesni_intel            98304  0\nrapl                   20480  0\nptp_vmclock            20480  0\ninput_leds             12288  0\nmac_hid                12288  0\npsmouse               217088  0\nserio_raw              20480  0\ni2c_smbus              20480  1 i2c_piix4\nmsr                    12288  0\ndm_multipath 45056  0\nefa                   131072  0\nib_uverbs             200704  1 efa\nib_core               524288  3 efa,ib_umad,ib_uverbs\nparport_pc             53248  0\nppdev                  24576  0\nlp                     32768  0\nparport                73728  3 parport_pc,lp,ppdev\nefi_pstore             122880\nnfnetlink              20480  4 nft_compat,nf_tables\ndmi_sysfs              20480  0\nip_tables              32768  0\nx_tables               65536  5 nft_compat,xt_owner,ipt_REJECT,ip_tables,ip6t_REJECT\nautofs4                57344  2\n', stderr=''
2026-08-04 20:00:50,310 [INFO] pcluster_diag.util.shell: Executed command ['modinfo', '-F', 'version', 'lustre']: exit code 0, stdout='2.15.6\n', stderr=''
2026-08-04 20:00:50,312 [INFO] pcluster_diag.util.shell: Executed command ['cat', '/proc/mounts']: exit code 0, stdout='/dev/root / ext4 rw,relatime,discard,errors=remount-ro,commit=30 0 0\ndevtmpfs /dev devtmpfs rw,nosuid,noexec,relatime,size=7926356k,nr_inodes=1981589,mode=755,inode64 0 0\nproc /proc proc rw,nosuid,nodev,noexec,relatime 0 0\nsysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0\nsecurityfs /sys/kernel/security securityfs rw,nosuid,nodev,noexec,relatime 0 0\ntmpfs /dev/shm tmpfs rw,nosuid,nodev,inode64 0 0\ndevpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0\ntmpfs /run tmpfs rw,nosuid,nodev,size=3175216k,nr_inodes=819200,mode=755,inode64 0 0\ntmpfs /run/lock tmpfs rw,nosuid,nodev,noexec,relatime,size=5120k,inode64 0 0\ncgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot 0 0\nnone /sys/fs/pstore pstore rw,nosuid,nodev,noexec,relatime 0 0\nefivarfs /sys/firmware/efi/efivars efivarfs rw,nosuid,nodev,noexec,relatime 0 0\nbpf /sys/fs/bpf bpf rw,nosuid,nodev,noexec,relatime,mode=700 0 0\nsystemd-1 /proc/sys/fs/binfmt_misc autofs rw,relatime,fd=32,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=6463 0 0\ntracefs /sys/kernel/tracing tracefs rw,nosuid,nodev,noexec,relatime 0 0\nmqueue /dev/mqueue mqueue rw,nosuid,nodev,noexec,relatime 0 0\ndebugfs /sys/kernel/debug debugfs rw,nosuid,nodev,noexec,relatime 0 0\nfusectl /sys/fs/fuse/connections fusectl rw,nosuid,nodev,noexec,relatime 0 0\nconfigfs /sys/kernel/config configfs rw,nosuid,nodev,noexec,relatime 0 0\n/dev/loop1 /snap/bare/5 squashfs ro,nodev,relatime,errors=continue,threads=single 0 0\n/dev/loop0 /snap/amazon-ssm-agent/13349 squashfs ro,nodev,relatime,errors=continue,threads=single 0 0\n/dev/loop2 /snap/core22/2411 squashfs ro,nodev,relatime,errors=continue,threads=single 0 0\n/dev/loop3 /snap/core24/1643 squashfs ro,nodev,relatime,errors=continue,threads=single 0 0\nhugetlbfs /dev/hugepages hugetlbfs rw,nosuid,nodev,relatime,pagesize=2M 0 0\n/dev/loop7 /snap/mesa-2404/1839 squashfs ro,nodev,relatime,errors=continue,threads=single 0 0\n/dev/loop4 /snap/firefox/8702 squashfs ro,nodev,relatime,errors=continue,threads=single 0 0\n/dev/loop8 /snap/snapd/27406 squashfs ro,nodev,relatime,errors=continue,threads=single 0 0\n/dev/loop6 /snap/gtk-common-themes/1535 squashfs ro,nodev,relatime,errors=continue,threads=single 0 0\n/dev/loop5 /snap/gnome-46-2404/164 squashfs ro,nodev,relatime,errors=continue,threads=single 0 0\n/dev/loop9 /snap/thunderbird/1201 squashfs ro,nodev,relatime,errors=continue,threads=single 0 0\n/dev/nvme0n1p16 /boot ext4 rw,relatime 0 0\n/dev/nvme0n1p15 /boot/efi vfat rw,relatime,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0\nbinfmt_misc /proc/sys/fs/binfmt_misc binfmt_misc rw,nosuid,nodev,noexec,relatime0 0\nsunrpc /run/rpc_pipefs rpc_pipefs rw,relatime 0 0\nnfsd /proc/fs/nfsd nfsd rw,relatime 0 0\n192.168.48.254@tcp:/jpgqnb4v /fsx lustre rw,noatime,checksum,flock,user_xattr,lruresize,lazystatfs,nouser_fid2path,verbose,encrypt 0 0\ntmpfs /run/user/0 tmpfs rw,nosuid,nodev,relatime,size=1587604k,nr_inodes=396901,mode=700,inode64 0 0\n', stderr=''
2026-08-04 20:00:50,315 [INFO] pcluster_diag.util.shell: Timed command ['lfs', 'df', '-h', '/fsx']: timed_out=False, returncode=0, elapsed=0.003s
2026-08-04 20:00:50,321 [INFO] pcluster_diag.util.shell: Executed command ['systemctl', 'list-unit-files', 'configure-efa-fsx-lustre-client.service']: exit code 1, stdout='UNIT FILE STATE PRESET\n\n0 unit files listed.\n', stderr=''
2026-08-04 20:00:50,321 [INFO] pcluster_diag.core.runner: Check LustreFilesystem: finished
2026-08-04 20:00:50,321 [INFO] pcluster_diag.core.runner: LustreFilesystem: PASSED
2026-08-04 20:00:50,321 [INFO] pcluster_diag.core.runner: Check FsxTargetsAreReachable: started
2026-08-04 20:00:50,324 [INFO] pcluster_diag.util.shell: Timed command ['lfs', 'check', 'servers']: timed_out=False, returncode=0, elapsed=0.003s
2026-08-04 20:00:50,325 [INFO] pcluster_diag.util.shell: Timed command ['lctl', 'get_param', 'osc.*.import', 'mdc.*.import']: timed_out=False, returncode=0, elapsed=0.002s
2026-08-04 20:00:50,325 [INFO] pcluster_diag.core.runner: Check FsxTargetsAreReachable: finished
2026-08-04 20:00:50,326 [INFO] pcluster_diag.core.runner: FsxTargetsAreReachable: PASSED
2026-08-04 20:00:50,326 [INFO] pcluster_diag.commands.run: Report written to /root/pcluster-diag-output/pcluster-diag-report-2026-08-04T20-00-47.json
....................

  "results": [
    {
      "check_id": "LustreFilesystem",
      "check_description": "Verify that FsxLustre filesystems are installed, mounted, reachable, and riding EFA.",
      "status": "PASSED",
      "infos": [
        {
          "code": "I1",
          "message": "Lustre client version: 2.15.6."
        },
        {
          "code": "I2",
          "message": "Active LNet transports: tcp."
        }
      ]
    },
    {
      "check_id": "FsxTargetsAreReachable",
      "check_description": "Deep-probe each FsxLustre OST/MDT for reachability (lfs check servers + import state).",
      "status": "PASSED",
      "infos": [
        {
          "code": "I1",
          "message": "target jpgqnb4v-OST0000_UUID current_connection 192.168.62.1@tcp equals its failover_nids -- no distinct failover NID (a primary-server failure has no real failover)."
        },
        {
          "code": "I1",
          "message": "target jpgqnb4v-MDT0000_UUID current_connection 192.168.48.254@tcp equals its failover_nids -- no distinct failover NID (a primary-server failure has no real failover)."
        }
      ]
    }
  ]
}
root@ip-192-168-3-109:~#
```

* On compute node of p5.48xlarge but EFA setup failure (so TCP is configured)
```
}
  },
  "results": [
    {
      "check_id": "LustreFilesystem",
      "check_description": "Verify that FsxLustre filesystems are installed, mounted, reachable, and riding EFA.",
      "status": "FAILURE",
      "errors": [
        {
          "code": "E15",
          "message": "The EFA-Lustre configuration service configure-efa-fsx-lustre-client.service is in the failed state -- LNet was not configured for EFA (check `journalctl -u configure-efa-fsx-lustre-client.service`); Lustre will fall back to TCP."
        },
        {
          "code": "E17",
          "message": "Only 2 of 8 expected EFA devices are bound to LNet on p5.48xlarge -- Lustre will not use the full EFA fabric. Re-run the EFA-Lustre client configuration."
        },
        {
          "code": "E11",
          "message": "EFA ping from 50.135.113.0@efa to 192.168.48.254@efa failed -- the EFA data path is not working. Check the security group has a self-referencing rule by SG-ID (EFA's SRD-over-MAC is not authorized by a 0.0.0.0/0 rule)."
        }
      ],
      "warnings": [
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.113.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.130.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W3",
          "message": "target jpgqnb4v-OST0000_UUID is connected over @tcp despite EFA being configured (TCP fallback)."
        },
        {
          "code": "W3",
          "message": "target jpgqnb4v-MDT0000_UUID is connected over @tcp despite EFA being configured (TCP fallback)."
        }
      ],
      "infos": [
        {
          "code": "I1",
          "message": "Lustre client version: 2.15.6."
        },
        {
          "code": "I2",
          "message": "Active LNet transports: tcp, efa."
        },
        {
          "code": "I6",
          "message": "EFA driver version: 3.1.0g."
        },
        {
          "code": "I7",
          "message": "kefalnd (EFA LND) version: 1.2.2."
        },
        {
          "code": "I8",
          "message": "EFA-for-Lustre binding follows the FSx guide -- the expected number of EFA devices bound to LNet is instance-type-specific (some families bind a subset by design). See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html"
        }
      ]
    },
    {
      "check_id": "FsxTargetsAreReachable",
      "check_description": "Deep-probe each FsxLustre OST/MDT for reachability (lfs check servers + import state).",
      "status": "PASSED",
      "infos": [
        {
          "code": "I1",
          "message": "target jpgqnb4v-OST0000_UUID current_connection 192.168.62.1@tcp equals its failover_nids -- no distinct failover NID (a primary-server failure has no real failover)."
        },
        {
          "code": "I1",
          "message": "target jpgqnb4v-MDT0000_UUID current_connection 192.168.48.254@tcp equals its failover_nids -- no distinct failover NID (a primary-server failure has no real failover)."
        }
      ]
    }
  ]
}
```

* p5.48xlareg compute node where EFA with Lustre was correctly setup but i unmounted Fsx

``` 
  "results": [
    {
      "check_id": "LustreFilesystem",
      "check_description": "Verify that FsxLustre filesystems are installed, mounted, reachable, and riding EFA.",
      "status": "FAILURE",
      "errors": [
        {
          "code": "E3",
          "message": "'/fsx' (FsxLustre) is configured but not mounted."
        },
        {
          "code": "E5",
          "message": "lfs df -h on '/fsx' failed: "
        }
      ],
      "warnings": [
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.113.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.130.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.181.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.147.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.198.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.164.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.79.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.96.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        }
      ],
      "infos": [
        {
          "code": "I1",
          "message": "Lustre client version: 2.15.6."
        },
        {
          "code": "I2",
          "message": "Active LNet transports: tcp, efa."
        },
        {
          "code": "I6",
          "message": "EFA driver version: 3.1.0g."
        },
        {
          "code": "I7",
          "message": "kefalnd (EFA LND) version: 1.2.2."
        },
        {
          "code": "I4",
          "message": "The EFA-Lustre configuration service configure-efa-fsx-lustre-client.service is installed and not failed."
        },
        {
          "code": "I8",
          "message": "EFA-for-Lustre binding follows the FSx guide -- the expected number of EFA devices bound to LNet is instance-type-specific (some families bind a subset by design). See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html"
        },
        {
          "code": "I5",
          "message": "8 of 32 EFA devices are bound to LNet (some instance families bind a subset by design)."
        }
      ]
    },
    {
      "check_id": "FsxTargetsAreReachable",
      "check_description": "Deep-probe each FsxLustre OST/MDT for reachability (lfs check servers + import state).",
      "status": "FAILURE",
      "errors": [
        {
          "code": "E2",
          "message": "lfs check servers failed: lfs check: cannot find mounted Lustre filesystem: No such device"
        }
      ]
    }
  ]
}
root@efa-enabled-st-efa-enabled-i1-1:~#
```

* Compute p5 instance where FSx was mounted but a few of the Nics fallback on TCp instaed of EFA
```
  "results": [
    {
      "check_id": "LustreFilesystem",
      "check_description": "Verify that FsxLustre filesystems are installed, mounted, reachable, and riding EFA.",
      "status": "WARNING",
      "warnings": [
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.181.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.147.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.198.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.164.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.79.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W2",
          "message": "EFA LNet interface 50.135.96.0@efa shows no traffic yet (send_count=0, recv_count=0). This is expected on an idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent TCP fallback."
        },
        {
          "code": "W3",
          "message": "target jpgqnb4v-OST0000_UUID is connected over @tcp despite EFA being configured (TCP fallback)."
        },
        {
          "code": "W3",
          "message": "target jpgqnb4v-MDT0000_UUID is connected over @tcp despite EFA being configured (TCP fallback)."
        }
      ],
      "infos": [
        {
          "code": "I1",
          "message": "Lustre client version: 2.15.6."
        },
        {
          "code": "I2",
          "message": "Active LNet transports: tcp, efa."
        },
        {
          "code": "I6",
          "message": "EFA driver version: 3.1.0g."
        },
        {
          "code": "I7",
          "message": "kefalnd (EFA LND) version: 1.2.2."
        },
        {
          "code": "I4",
          "message": "The EFA-Lustre configuration service configure-efa-fsx-lustre-client.service is installed and not failed."
        },
        {
          "code": "I8",
          "message": "EFA-for-Lustre binding follows the FSx guide -- the expected number of EFA devices bound to LNet is instance-type-specific (some families bind a subset by design). See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html"
        },
        {
          "code": "I5",
          "message": "8 of 32 EFA devices are bound to LNet (some instance families bind a subset by design)."
        }
      ]
    },
    {
      "check_id": "FsxTargetsAreReachable",
      "check_description": "Deep-probe each FsxLustre OST/MDT for reachability (lfs check servers + import state).",
      "status": "PASSED",
      "infos": [
        {
          "code": "I1",
          "message": "target jpgqnb4v-OST0000_UUID current_connection 192.168.62.1@tcp equals its failover_nids -- no distinct failover NID (a primary-server failure has no real failover)."
        },
        {
          "code": "I1",
          "message": "target jpgqnb4v-MDT0000_UUID current_connection 192.168.48.254@tcp equals its failover_nids -- no distinct failover NID (a primary-server failure has no real failover)."
        }
      ]
    }
  ]
}
root@efa-enabled-st-efa-enabled-i1-1:~#
```
### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
