### PR TITLE
[pcluster-diag] Normalize MountDir to an absolute path before matching mounts

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/shared_storage.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/shared_storage.py
@@ -37,13 +37,25 @@ PROC_MOUNTS_PATH = "/proc/mounts"
 LUSTRE_FS_TYPE = "lustre"
 
 
+def absolute_mount_dir(mount_dir: str) -> str:
+    """Return ``mount_dir`` as the absolute path the filesystem is actually mounted at.
+
+    ``MountDir`` accepts a relative path: ``MountDir: fsx`` and ``MountDir: /fsx`` are equivalent and both
+    mount at ``/fsx``. The cookbook applies the same normalization before mounting (``format_directory``),
+    so the configured value must be normalized here too before it is compared against ``/proc/mounts`` or
+    passed to a command.
+    """
+    stripped = mount_dir.strip()
+    return stripped if stripped.startswith("/") else "/" + stripped
+
+
 @dataclass
 class SharedStorageMount:
     """A shared-storage mount declared in the cluster configuration.
 
     Attributes:
         storage_type: The ``StorageType`` (e.g. ``FsxLustre``).
-        mount_dir: The ``MountDir`` the filesystem is mounted at.
+        mount_dir: The absolute path the filesystem is mounted at (the normalized ``MountDir``).
         name: The configured ``Name``, or None when absent.
         file_system_id: The FSx filesystem id (from ``FsxLustreSettings``), or None when absent.
     """
@@ -84,7 +96,7 @@ def shared_storage_mounts(context: Context) -> List[SharedStorageMount]:
         mounts.append(
             SharedStorageMount(
                 storage_type=storage_type,
-                mount_dir=mount_dir,
+                mount_dir=absolute_mount_dir(mount_dir),
                 name=entry.get("Name"),
                 file_system_id=settings.get("FileSystemId"),
             )

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_shared_storage.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_shared_storage.py
@@ -57,6 +57,21 @@ def test_lustre_mounts_filters_out_non_lustre_types():
     assert [m.mount_dir for m in mounts] == ["/fsx"]
 
 
+@pytest.mark.parametrize("configured", ["fsx", "/fsx", "  fsx  "])
+def test_lustre_mounts_normalizes_mount_dir_to_an_absolute_path(configured):
+    # MountDir accepts a relative path; the cookbook mounts it at the equivalent absolute path, so the
+    # configured value must be normalized before it is matched against /proc/mounts.
+    storage = [{"Name": "fsx", "StorageType": "FsxLustre", "MountDir": configured}]
+    context = sample_context_with_lustre(NodeType.HEAD, shared_storage=storage)
+
+    mounts = shared_storage.lustre_mounts(context)
+
+    assert [m.mount_dir for m in mounts] == ["/fsx"]
+    assert shared_storage.is_mounted(
+        shared_storage.parse_proc_mounts(_PROC_MOUNTS), mounts[0].mount_dir, shared_storage.LUSTRE_FS_TYPE
+    )
+
+
 def test_shared_storage_mounts_skips_malformed_entries():
     storage = [
         {"StorageType": "FsxLustre"},  # no MountDir


### PR DESCRIPTION
### Description of changes

`MountDir` accepts a relative path: `MountDir: fsx` and `MountDir: /fsx` are equivalent and both mount at `/fsx`. The CLI normalizes it (`SharedStorageMountDirValidator`) and so does the cookbook before mounting (`format_directory`, and `make_absolute` in the Lustre resource), but `shared_storage_mounts` kept the raw configured string.

The FSx checks then compared the configured spelling against the real mount point, so a perfectly healthy cluster was reported as broken:

```
FsxMountsArePresent:        'fsx' (FsxLustre) is configured but not mounted.
FsxFilesystemsAreReachable: lfs df -h on 'fsx' failed: error: invalid path 'fsx':
                            No such file or directory
```

while `/proc/mounts` had the filesystem mounted all along:

```
192.168.67.20@tcp:/jxijrbev /fsx lustre rw,noatime,checksum,flock,...
```

This normalizes `MountDir` in `shared_storage_mounts`, so every storage type and every downstream check sees the path the filesystem is actually mounted at rather than how it happened to be spelled in the config.

The below integ tests use the relative form and are hit by the same false positive:
- `test_update_slurm`
- `test_overwrite_sg`
- `test_cluster_in_no_internet_subnet`

### Tests

* unit tests pass.
* re-run `test_update_slurm` ongoing

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
