### PR TITLE
[pcluster-diag] Judge critical-path modes by what the daemon requires

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/critical_paths.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/critical_paths.py
@@ -12,10 +12,14 @@
 
 """Check asserting ParallelCluster's critical files have their expected ownership and permissions.
 
-When a critical file loses its expected owner or mode, the daemon that relies on it fails in ways that
-are hard to trace back to a permissions problem. For example, a ``computefleet-status.json`` that is no
-longer writable by ``pcluster-admin`` makes ``clusterstatusmgtd`` raise ``[Errno 13] Permission denied``
-and the compute fleet gets stuck mid-transition (e.g. never leaving STOPPING).
+When a critical file loses its expected owner or permissions, the daemon that relies on it fails in
+ways that are hard to trace back to a permissions problem. For example, a ``computefleet-status.json``
+that is no longer writable by ``pcluster-admin`` makes ``clusterstatusmgtd`` raise ``[Errno 13]
+Permission denied`` and the compute fleet gets stuck mid-transition (e.g. never leaving STOPPING).
+
+Each expectation below encodes what the consuming daemon actually enforces, not the mode the cookbook
+currently sets: several modes are usually acceptable, and a path can break both by being loosened
+(insecure) and by being tightened (the daemon loses an access it needs).
 """
 
 from typing import List, Optional
@@ -24,56 +28,73 @@ from pcluster_diag.core.constants import (
     CLUSTER_ADMIN_GROUP,
     CLUSTER_ADMIN_USER,
     COMPUTEFLEET_STATUS_PATH,
+    GROUP_OTHER_READ_WRITE,
+    GROUP_OTHER_WRITE,
     MUNGE_KEY_PATH,
     MUNGE_USER,
+    OWNER_READ,
+    OWNER_TRAVERSE,
+    OWNER_WRITE,
     SLURM_STATE_SAVE_PATH,
     SLURM_USER,
 )
 from pcluster_diag.models.check import Check
 from pcluster_diag.models.context import Context, NodeType
 from pcluster_diag.models.expected_path_permissions import ExpectedPathPermissions
-from pcluster_diag.models.finding import CheckError
+from pcluster_diag.models.finding import CheckError, CheckWarning
 from pcluster_diag.models.result import Result
 from pcluster_diag.util import path_permissions
+from pcluster_diag.util.path_permissions import describe_bits
 
-# The critical paths ParallelCluster provisions, with the ownership/mode set by the cookbook. Add an
-# entry here whenever an investigation traces a failure to a mis-permissioned path.
+# The critical paths ParallelCluster provisions. Add an entry here whenever an investigation traces a
+# failure to a mis-permissioned path.
 CRITICAL_PATHS: List[ExpectedPathPermissions] = [
-    # clusterstatusmgtd runs as pcluster-admin and writes the compute-fleet status here; if it loses
-    # write access, fleet status transitions fail with EACCES.
+    # clusterstatusmgtd (as pcluster-admin) opens this for writing; without owner write it raises
+    # EACCES and the fleet stalls mid-transition. A wider mode does not stop it, so it is an advisory.
     ExpectedPathPermissions(
         path=COMPUTEFLEET_STATUS_PATH,
         owner=CLUSTER_ADMIN_USER,
         group=CLUSTER_ADMIN_GROUP,
-        mode="0755",
         node_types=(NodeType.HEAD,),
+        required_bits=OWNER_WRITE,
+        forbidden_bits=GROUP_OTHER_WRITE,
     ),
-    # Munge underpins Slurm authentication; munged refuses to start if its key is not private to the
-    # munge user, breaking Slurm cluster-wide. Present wherever munge runs (head and compute).
+    # Munge underpins Slurm authentication cluster-wide. munged refuses to start when the key is
+    # group/other readable or writable -- the one path where a wider mode is a failure, not an advisory
+    # -- and, running unprivileged, it also cannot start when it cannot read the key itself. The
+    # cookbook installs the key identically on head, compute and login nodes.
     ExpectedPathPermissions(
         path=MUNGE_KEY_PATH,
         owner=MUNGE_USER,
         group=MUNGE_USER,
-        mode="0600",
-        node_types=(NodeType.HEAD, NodeType.COMPUTE),
+        node_types=(NodeType.HEAD, NodeType.COMPUTE, NodeType.LOGIN),
+        required_bits=OWNER_READ,
+        forbidden_bits=GROUP_OTHER_READ_WRITE,
+        forbidden_bits_break_daemon=True,
     ),
-    # Slurm's StateSaveLocation; slurmctld cannot start if it is not owned by and private to the slurm user.
+    # Slurm's StateSaveLocation. slurmctld drops to SlurmUser and then requires read, write and
+    # traverse here, exiting fatal otherwise -- so tightening to 0600, which drops traverse, breaks it
+    # just as surely as loosening. It starts fine on 0777, so a wider mode is only an advisory.
     ExpectedPathPermissions(
         path=SLURM_STATE_SAVE_PATH,
         owner=SLURM_USER,
         group=SLURM_USER,
-        mode="0700",
         node_types=(NodeType.HEAD,),
+        required_bits=OWNER_READ | OWNER_WRITE | OWNER_TRAVERSE,
+        forbidden_bits=GROUP_OTHER_WRITE,
     ),
 ]
 
 
 class CriticalPathsHaveExpectedPermissions(Check):
-    """Verify ParallelCluster's critical files exist with their expected owner, group, and mode."""
+    """Verify ParallelCluster's critical files exist with their expected ownership and permissions."""
 
     MISSING_PATH = CheckError(1, "'{}' is missing.")
     WRONG_OWNERSHIP = CheckError(2, "'{}' is owned by {}:{} but should be {}:{}.")
-    WRONG_MODE = CheckError(3, "'{}' has mode {} but should be {}.")
+    MISSING_PERMISSIONS = CheckError(3, "'{}' has mode {}, which does not grant {}.")
+    INSECURE_PERMISSIONS = CheckError(4, "'{}' has mode {}, which must not grant {}.")
+    # Reported instead of INSECURE_PERMISSIONS when the daemon keeps running, so it does not fail the run.
+    OVER_PERMISSIVE = CheckWarning(1, "'{}' has mode {}, which should not grant {}.")
 
     def __init__(self, critical_paths: Optional[List[ExpectedPathPermissions]] = None) -> None:
         """Create the Check, optionally overriding the inspected critical paths (used by tests)."""
@@ -85,33 +106,52 @@ class CriticalPathsHaveExpectedPermissions(Check):
         return "Verify that ParallelCluster critical files have their expected owner, group, and permissions."
 
     def run(self, context: Context) -> Result:
-        """Pass when every applicable critical path matches its expected owner/group/mode; fail otherwise."""
-        errors = []
+        """Pass when every applicable critical path has its expected ownership and permissions."""
+        errors: List[CheckError] = []
+        warnings: List[CheckWarning] = []
         for critical in self._applicable(context):
-            errors.extend(self._inspect(critical))
+            self._inspect(critical, errors, warnings)
 
-        if errors:
-            return Result.failure(self, errors=errors)
-        return Result.passed(self)
+        return Result.from_findings(self, errors=errors, warnings=warnings)
 
     def _applicable(self, context: Context) -> List[ExpectedPathPermissions]:
         """Return the critical paths expected on the current node type."""
         return [critical for critical in self._critical_paths if context.node_type in critical.node_types]
 
-    def _inspect(self, critical: ExpectedPathPermissions) -> List[CheckError]:
-        """Return the CheckErrors for ``critical``: empty when it exists with the expected ownership and mode."""
+    def _inspect(
+        self, critical: ExpectedPathPermissions, errors: List[CheckError], warnings: List[CheckWarning]
+    ) -> None:
+        """Collect the findings for ``critical`` into ``errors``/``warnings``."""
         try:
             observed = path_permissions.stat_path(critical.path)
         except FileNotFoundError:
-            return [self.MISSING_PATH.format(critical.path)]
+            errors.append(self.MISSING_PATH.format(critical.path))
+            return
 
-        errors = []
         if observed.owner != critical.owner or observed.group != critical.group:
             errors.append(
                 self.WRONG_OWNERSHIP.format(
                     critical.path, observed.owner, observed.group, critical.owner, critical.group
                 )
             )
-        if observed.mode != critical.mode:
-            errors.append(self.WRONG_MODE.format(critical.path, observed.mode, critical.mode))
-        return errors
+        self._inspect_mode(critical, observed.mode, errors, warnings)
+
+    def _inspect_mode(
+        self,
+        critical: ExpectedPathPermissions,
+        mode: str,
+        errors: List[CheckError],
+        warnings: List[CheckWarning],
+    ) -> None:
+        """Collect the findings for ``mode`` against ``critical``'s permission expectation."""
+        missing = critical.missing_bits(mode)
+        if missing:
+            errors.append(self.MISSING_PERMISSIONS.format(critical.path, mode, describe_bits(missing)))
+
+        offending = critical.offending_bits(mode)
+        if offending:
+            granted = describe_bits(offending)
+            if critical.forbidden_bits_break_daemon:
+                errors.append(self.INSECURE_PERMISSIONS.format(critical.path, mode, granted))
+            else:
+                warnings.append(self.OVER_PERMISSIVE.format(critical.path, mode, granted))

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/slurm_accounting.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/slurm_accounting.py
@@ -27,8 +27,8 @@ from pcluster_diag.core.constants import (
     SLURM_PARALLELCLUSTER_SLURMDBD_CONF_PATH,
     SLURM_STATE_CLUSTERNAME_PATH,
     SLURMCTLD_LOG_PATH,
+    SLURMDBD_CONF_ALLOWED_MODES,
     SLURMDBD_CONF_GROUP,
-    SLURMDBD_CONF_MODE,
     SLURMDBD_CONF_OWNER,
     SLURMDBD_CONF_PATH,
     SLURMDBD_LOG_PATH,
@@ -76,15 +76,15 @@ _ACCOUNTING_CONF_FILES: Tuple[ExpectedPathPermissions, ...] = (
         path=SLURMDBD_CONF_PATH,
         owner=SLURMDBD_CONF_OWNER,
         group=SLURMDBD_CONF_GROUP,
-        mode=SLURMDBD_CONF_MODE,
         node_types=(NodeType.HEAD,),
+        allowed_modes=SLURMDBD_CONF_ALLOWED_MODES,
     ),
     ExpectedPathPermissions(
         path=SLURM_PARALLELCLUSTER_SLURMDBD_CONF_PATH,
         owner=SLURMDBD_CONF_OWNER,
         group=SLURMDBD_CONF_GROUP,
-        mode=SLURMDBD_CONF_MODE,
         node_types=(NodeType.HEAD,),
+        allowed_modes=SLURMDBD_CONF_ALLOWED_MODES,
     ),
 )
 
@@ -422,8 +422,10 @@ class SlurmAccounting(Check):
                     expected.path, observed.owner, observed.group, expected.owner, expected.group
                 )
             )
-        if observed.mode != expected.mode:
-            errors.append(self.CONF_WRONG_MODE.format(expected.path, observed.mode, expected.mode))
+        if expected.is_disallowed_mode(observed.mode):
+            errors.append(
+                self.CONF_WRONG_MODE.format(expected.path, observed.mode, expected.allowed_modes_description())
+            )
         if not _is_readable(expected.path):
             errors.append(self.CONF_FILE_UNREADABLE.format(expected.path))
         return errors

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
@@ -12,6 +12,8 @@
 
 """Shared constants."""
 
+import stat
+
 from pcluster_diag.models.context import NodeType
 
 # General
@@ -36,6 +38,13 @@ MUNGE_KEY_PATH = "/etc/munge/munge.key"
 
 # Slurm's StateSaveLocation directory.
 SLURM_STATE_SAVE_PATH = "/var/spool/slurm.state"
+
+# Permission bit groups the path expectations are written in terms of.
+OWNER_READ = stat.S_IRUSR
+OWNER_WRITE = stat.S_IWUSR
+OWNER_TRAVERSE = stat.S_IXUSR
+GROUP_OTHER_WRITE = stat.S_IWGRP | stat.S_IWOTH
+GROUP_OTHER_READ_WRITE = stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH
 
 # cfn-hup runs as a supervisord program (not a systemd service) managed via the cookbook virtualenv's
 # supervisorctl, reading the supervisord config installed by the cookbook.
@@ -128,4 +137,6 @@ ACCOUNTING_QUERY_LATENCY_WARN_THRESHOLD_SECONDS = 5
 ACCOUNTING_QUERY_LATENCY_FAIL_THRESHOLD_SECONDS = 15
 SLURMDBD_CONF_OWNER = SLURM_USER
 SLURMDBD_CONF_GROUP = SLURM_USER
-SLURMDBD_CONF_MODE = "0600"
+# slurmdbd validates this mode by equality and exits fatal on anything else ("should be 600 or 640"),
+# so both accepted values are listed here rather than only the one the cookbook sets.
+SLURMDBD_CONF_ALLOWED_MODES = frozenset({"0600", "0640"})

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/expected_path_permissions.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/models/expected_path_permissions.py
@@ -10,25 +10,92 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Model describing the ownership and permissions a filesystem path is expected to have."""
+"""Model describing the ownership and permissions a filesystem path is expected to have.
+
+A path's mode is not judged by equality with whatever the cookbook happens to set: the same path
+usually tolerates several modes, and both loosening *and* tightening a mode can break a daemon (e.g.
+tightening Slurm's StateSaveLocation to 0700 is fine, but 0600 drops the traverse bit slurmctld
+needs). A mode expectation is therefore expressed as the bits the consuming daemon needs
+(``required_bits``), the bits that make the path insecure (``forbidden_bits``), or -- where a daemon
+validates the mode by equality -- the exact set of modes it accepts (``allowed_modes``).
+
+Whether an over-permissive mode is a failure is also per path: munged refuses to start from a key
+others can read, while slurmctld runs fine on a world-writable StateSaveLocation.
+"""
 
 from dataclasses import dataclass
+from typing import FrozenSet, Optional
+
+from pcluster_diag.util.path_permissions import format_bits, parse_mode
 
 
 @dataclass(frozen=True)
 class ExpectedPathPermissions:
-    """The ownership and mode a filesystem path is expected to have on given node types.
+    """The ownership and permissions a filesystem path is expected to have on given node types.
 
     Attributes:
         path: The absolute path to inspect.
         owner: The expected owning user name.
         group: The expected owning group name.
-        mode: The expected permission bits as a 4-digit octal string (e.g. ``0755``).
         node_types: The node types the path is expected on; a Check inspects it only on those.
+        required_bits: Permission bits the consuming daemon needs; missing any of them is a failure.
+        forbidden_bits: Permission bits that make the path insecure.
+        allowed_modes: The exact modes accepted, for daemons that validate the mode by equality. When
+            set, ``required_bits``/``forbidden_bits`` are not consulted.
+        forbidden_bits_break_daemon: Whether granting ``forbidden_bits`` stops the consuming daemon,
+            making it a failure rather than an advisory.
+
+    Raises:
+        ValueError: If the expectation would inspect nothing or contradicts itself.
     """
 
     path: str
     owner: str
     group: str
-    mode: str
     node_types: tuple
+    required_bits: int = 0
+    forbidden_bits: int = 0
+    allowed_modes: Optional[FrozenSet[str]] = None
+    forbidden_bits_break_daemon: bool = False
+
+    def __post_init__(self) -> None:
+        """Reject expectations that would silently inspect nothing or contradict themselves."""
+        declares_bits = bool(self.required_bits or self.forbidden_bits)
+        if self.allowed_modes is not None:
+            if not self.allowed_modes:
+                raise ValueError("{}: allowed_modes must not be empty".format(self.path))
+            if declares_bits:
+                raise ValueError(
+                    "{}: allowed_modes cannot be combined with required_bits/forbidden_bits".format(self.path)
+                )
+        elif not declares_bits:
+            raise ValueError(
+                "{}: declare required_bits, forbidden_bits or allowed_modes, otherwise the mode is "
+                "never inspected".format(self.path)
+            )
+        if self.required_bits & self.forbidden_bits:
+            raise ValueError(
+                "{}: {} is both required and forbidden".format(
+                    self.path, format_bits(self.required_bits & self.forbidden_bits)
+                )
+            )
+        if self.forbidden_bits_break_daemon and not self.forbidden_bits:
+            raise ValueError("{}: forbidden_bits_break_daemon without forbidden_bits".format(self.path))
+
+    def missing_bits(self, mode: str) -> int:
+        """Return the ``required_bits`` absent from ``mode`` (0 when none are missing)."""
+        return self.required_bits & ~parse_mode(mode)
+
+    def offending_bits(self, mode: str) -> int:
+        """Return the ``forbidden_bits`` present in ``mode`` (0 when none are present)."""
+        return self.forbidden_bits & parse_mode(mode)
+
+    def is_disallowed_mode(self, mode: str) -> bool:
+        """Return whether ``allowed_modes`` is set and ``mode`` is not one of them."""
+        if self.allowed_modes is None:
+            return False
+        return parse_mode(mode) not in {parse_mode(allowed) for allowed in self.allowed_modes}
+
+    def allowed_modes_description(self) -> str:
+        """Return the accepted modes ordered for a stable message (e.g. ``0600 or 0640``)."""
+        return " or ".join(sorted(self.allowed_modes or (), key=parse_mode))

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/path_permissions.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/path_permissions.py
@@ -44,10 +44,35 @@ def stat_path(path: str) -> PathStat:
     return PathStat(
         owner=users.get_username_for_uid(info.st_uid),
         group=users.get_groupname_for_gid(info.st_gid),
-        mode=_octal_mode(info.st_mode),
+        mode=format_bits(stat.S_IMODE(info.st_mode)),
     )
 
 
-def _octal_mode(mode: int) -> str:
-    """Return the permission bits of ``mode`` as a 4-digit octal string (e.g. ``0755``)."""
-    return format(stat.S_IMODE(mode), "04o")
+def format_bits(bits: int) -> str:
+    """Return permission ``bits`` as a 4-digit octal string (e.g. 0o640 -> ``0640``)."""
+    return format(bits, "04o")
+
+
+def parse_mode(mode: str) -> int:
+    """Return the integer permission bits of an octal ``mode`` string (e.g. ``0640`` -> 0o640)."""
+    return int(mode, 8)
+
+
+# Permission bits in report order, with the wording used in findings. Octal alone ("missing 0100") is
+# not actionable in a report, so findings name the access instead.
+_BIT_DESCRIPTIONS = (
+    (stat.S_IRUSR, "owner read"),
+    (stat.S_IWUSR, "owner write"),
+    (stat.S_IXUSR, "owner execute/traverse"),
+    (stat.S_IRGRP, "group read"),
+    (stat.S_IWGRP, "group write"),
+    (stat.S_IXGRP, "group execute/traverse"),
+    (stat.S_IROTH, "other read"),
+    (stat.S_IWOTH, "other write"),
+    (stat.S_IXOTH, "other execute/traverse"),
+)
+
+
+def describe_bits(bits: int) -> str:
+    """Return ``bits`` as the accesses they grant (e.g. 0o022 -> ``group write, other write``)."""
+    return ", ".join(description for bit, description in _BIT_DESCRIPTIONS if bits & bit)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_critical_paths.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_critical_paths.py
@@ -16,7 +16,16 @@ import pytest
 
 from pcluster_diag.checks import critical_paths
 from pcluster_diag.checks.critical_paths import CriticalPathsHaveExpectedPermissions
-from pcluster_diag.core.constants import COMPUTEFLEET_STATUS_PATH, MUNGE_KEY_PATH, SLURM_STATE_SAVE_PATH
+from pcluster_diag.core.constants import (
+    COMPUTEFLEET_STATUS_PATH,
+    GROUP_OTHER_READ_WRITE,
+    GROUP_OTHER_WRITE,
+    MUNGE_KEY_PATH,
+    OWNER_READ,
+    OWNER_TRAVERSE,
+    OWNER_WRITE,
+    SLURM_STATE_SAVE_PATH,
+)
 from pcluster_diag.models.context import NodeType
 from pcluster_diag.models.expected_path_permissions import ExpectedPathPermissions
 from pcluster_diag.models.result import Status
@@ -28,8 +37,9 @@ _HEAD_PATH = ExpectedPathPermissions(
     path="/opt/parallelcluster/shared/computefleet-status.json",
     owner="pcluster-admin",
     group="pcluster-admin",
-    mode="0755",
     node_types=(NodeType.HEAD,),
+    required_bits=OWNER_WRITE,
+    forbidden_bits=GROUP_OTHER_WRITE,
 )
 
 
@@ -60,17 +70,124 @@ def _messages(result):
 
 
 @pytest.mark.parametrize(
-    "path, owner, group, mode, node_types",
+    "path, owner, group, required_bits, forbidden_bits, node_types",
     [
-        (COMPUTEFLEET_STATUS_PATH, "pcluster-admin", "pcluster-admin", "0755", (NodeType.HEAD,)),
-        (MUNGE_KEY_PATH, "munge", "munge", "0600", (NodeType.HEAD, NodeType.COMPUTE)),
-        (SLURM_STATE_SAVE_PATH, "slurm", "slurm", "0700", (NodeType.HEAD,)),
+        (
+            COMPUTEFLEET_STATUS_PATH,
+            "pcluster-admin",
+            "pcluster-admin",
+            OWNER_WRITE,
+            GROUP_OTHER_WRITE,
+            (NodeType.HEAD,),
+        ),
+        (
+            MUNGE_KEY_PATH,
+            "munge",
+            "munge",
+            OWNER_READ,
+            GROUP_OTHER_READ_WRITE,
+            (NodeType.HEAD, NodeType.COMPUTE, NodeType.LOGIN),
+        ),
+        (
+            SLURM_STATE_SAVE_PATH,
+            "slurm",
+            "slurm",
+            OWNER_READ | OWNER_WRITE | OWNER_TRAVERSE,
+            GROUP_OTHER_WRITE,
+            (NodeType.HEAD,),
+        ),
     ],
 )
-def test_default_critical_paths_are_registered(path, owner, group, mode, node_types):
+def test_default_critical_paths_are_registered(path, owner, group, required_bits, forbidden_bits, node_types):
     entry = next(c for c in critical_paths.CRITICAL_PATHS if c.path == path)
 
-    assert (entry.owner, entry.group, entry.mode, entry.node_types) == (owner, group, mode, node_types)
+    assert (entry.owner, entry.group, entry.node_types) == (owner, group, node_types)
+    assert (entry.required_bits, entry.forbidden_bits) == (required_bits, forbidden_bits)
+    assert entry.required_bits & entry.forbidden_bits == 0
+    assert entry.allowed_modes is None, "critical paths express themselves in bits, not exact modes"
+
+
+@pytest.mark.parametrize(
+    "path, mode",
+    [
+        # 0755 is the mode Slurm itself uses when it creates the StateSaveLocation (mkdir(path, 0755)).
+        (SLURM_STATE_SAVE_PATH, "0755"),
+        (SLURM_STATE_SAVE_PATH, "0700"),
+        (MUNGE_KEY_PATH, "0400"),
+        (MUNGE_KEY_PATH, "0600"),
+        (COMPUTEFLEET_STATUS_PATH, "0600"),
+        (COMPUTEFLEET_STATUS_PATH, "0755"),
+    ],
+)
+def test_default_critical_paths_accept_every_mode_their_daemon_tolerates(monkeypatch, path, mode):
+    entry = next(c for c in critical_paths.CRITICAL_PATHS if c.path == path)
+    _fake_stat(monkeypatch, {path: PathStat(owner=entry.owner, group=entry.group, mode=mode)})
+
+    result = CriticalPathsHaveExpectedPermissions(critical_paths=[entry]).run(sample_context(NodeType.HEAD))
+
+    assert result.status is Status.PASSED, "mode {} should be tolerated for {}".format(mode, path)
+
+
+@pytest.mark.parametrize(
+    "path, mode, expected_code",
+    [
+        # 0600 strips the traverse bit slurmctld needs: tightening is as fatal as loosening here.
+        (SLURM_STATE_SAVE_PATH, "0600", CriticalPathsHaveExpectedPermissions.MISSING_PERMISSIONS.code),
+        # munged runs unprivileged, so a key it cannot read stops it from starting.
+        (MUNGE_KEY_PATH, "0000", CriticalPathsHaveExpectedPermissions.MISSING_PERMISSIONS.code),
+        (MUNGE_KEY_PATH, "0640", CriticalPathsHaveExpectedPermissions.INSECURE_PERMISSIONS.code),
+        (MUNGE_KEY_PATH, "0604", CriticalPathsHaveExpectedPermissions.INSECURE_PERMISSIONS.code),
+        (COMPUTEFLEET_STATUS_PATH, "0455", CriticalPathsHaveExpectedPermissions.MISSING_PERMISSIONS.code),
+    ],
+)
+def test_default_critical_paths_reject_modes_that_break_their_daemon(monkeypatch, path, mode, expected_code):
+    entry = next(c for c in critical_paths.CRITICAL_PATHS if c.path == path)
+    _fake_stat(monkeypatch, {path: PathStat(owner=entry.owner, group=entry.group, mode=mode)})
+
+    result = CriticalPathsHaveExpectedPermissions(critical_paths=[entry]).run(sample_context(NodeType.HEAD))
+
+    assert result.status is Status.FAILURE
+    assert _codes(result) == [expected_code]
+
+
+@pytest.mark.parametrize(
+    "path, mode, granted",
+    [
+        # slurmctld starts fine on a world-writable StateSaveLocation, and clusterstatusmgtd only needs
+        # owner write, so these expose the path without breaking the cluster.
+        (SLURM_STATE_SAVE_PATH, "0777", "group write, other write"),
+        (COMPUTEFLEET_STATUS_PATH, "0757", "other write"),
+    ],
+)
+def test_over_permissive_mode_is_a_warning_when_the_daemon_keeps_running(monkeypatch, path, mode, granted):
+    entry = next(c for c in critical_paths.CRITICAL_PATHS if c.path == path)
+    _fake_stat(monkeypatch, {path: PathStat(owner=entry.owner, group=entry.group, mode=mode)})
+
+    result = CriticalPathsHaveExpectedPermissions(critical_paths=[entry]).run(sample_context(NodeType.HEAD))
+
+    assert result.status is Status.WARNING
+    assert result.errors is None
+    assert _codes(result) == []
+    assert [w.code for w in result.warnings] == [CriticalPathsHaveExpectedPermissions.OVER_PERMISSIVE.code]
+    assert "should not grant {}".format(granted) in result.warnings[0].message
+
+
+def test_over_permissive_mode_is_a_failure_when_it_stops_the_daemon(monkeypatch):
+    # munged refuses to start from a key others can read, so here it is not merely an advisory.
+    entry = next(c for c in critical_paths.CRITICAL_PATHS if c.path == MUNGE_KEY_PATH)
+    _fake_stat(monkeypatch, {MUNGE_KEY_PATH: PathStat(owner="munge", group="munge", mode="0640")})
+
+    result = CriticalPathsHaveExpectedPermissions(critical_paths=[entry]).run(sample_context(NodeType.HEAD))
+
+    assert result.status is Status.FAILURE
+    assert _codes(result) == [CriticalPathsHaveExpectedPermissions.INSECURE_PERMISSIONS.code]
+
+
+def test_munge_key_is_inspected_on_every_node_type_that_runs_munged():
+    entry = next(c for c in critical_paths.CRITICAL_PATHS if c.path == MUNGE_KEY_PATH)
+
+    # The cookbook installs the key identically on head, compute and login nodes (setup_munge_key).
+    assert set(entry.node_types) == set(NodeType)
 
 
 def test_description():
@@ -98,7 +215,7 @@ def test_run_passes_when_no_path_applies_to_node_type(monkeypatch):
     assert inspected == []
 
 
-def test_run_passes_when_owner_group_mode_all_match(monkeypatch):
+def test_run_passes_when_ownership_and_permissions_are_satisfied(monkeypatch):
     _fake_stat(monkeypatch, {_HEAD_PATH.path: PathStat(owner="pcluster-admin", group="pcluster-admin", mode="0755")})
 
     result = _check().run(sample_context(NodeType.HEAD))
@@ -128,25 +245,64 @@ def test_run_fails_when_group_wrong(monkeypatch):
     assert "pcluster-admin:root but should be pcluster-admin:pcluster-admin" in _messages(result)
 
 
-def test_run_fails_when_mode_wrong(monkeypatch):
-    _fake_stat(monkeypatch, {_HEAD_PATH.path: PathStat(owner="pcluster-admin", group="pcluster-admin", mode="0700")})
+def test_run_fails_when_required_permission_missing(monkeypatch):
+    _fake_stat(monkeypatch, {_HEAD_PATH.path: PathStat(owner="pcluster-admin", group="pcluster-admin", mode="0555")})
 
     result = _check().run(sample_context(NodeType.HEAD))
 
     assert result.status is Status.FAILURE
-    assert _codes(result) == [CriticalPathsHaveExpectedPermissions.WRONG_MODE.code]
-    assert "has mode 0700 but should be 0755" in _messages(result)
+    assert _codes(result) == [CriticalPathsHaveExpectedPermissions.MISSING_PERMISSIONS.code]
+    assert "has mode 0555, which does not grant owner write" in _messages(result)
 
 
-def test_run_reports_both_ownership_and_mode_when_both_wrong(monkeypatch):
-    _fake_stat(monkeypatch, {_HEAD_PATH.path: PathStat(owner="root", group="root", mode="0700")})
+def test_findings_state_the_observation_without_explaining_consequences(monkeypatch):
+    # Findings describe the observation against the expectation; the impact belongs to the status.
+    _fake_stat(monkeypatch, {_HEAD_PATH.path: PathStat(owner="pcluster-admin", group="pcluster-admin", mode="0555")})
+
+    message = _messages(_check().run(sample_context(NodeType.HEAD)))
+
+    assert message == "'{}' has mode 0555, which does not grant owner write.".format(_HEAD_PATH.path)
+
+
+def test_run_warns_when_forbidden_permission_granted(monkeypatch):
+    _fake_stat(monkeypatch, {_HEAD_PATH.path: PathStat(owner="pcluster-admin", group="pcluster-admin", mode="0757")})
+
+    result = _check().run(sample_context(NodeType.HEAD))
+
+    assert result.status is Status.WARNING
+    assert "which should not grant other write" in result.warnings[0].message
+
+
+def test_run_passes_when_mode_is_stricter_than_the_cookbook_default(monkeypatch):
+    # Tightening 0755 -> 0600 keeps owner write, so it must not be reported as a failure.
+    _fake_stat(monkeypatch, {_HEAD_PATH.path: PathStat(owner="pcluster-admin", group="pcluster-admin", mode="0600")})
+
+    result = _check().run(sample_context(NodeType.HEAD))
+
+    assert result.status is Status.PASSED
+
+
+def test_run_reports_both_missing_and_over_permissive_findings(monkeypatch):
+    # 0557 has no owner write (required) and is group/other writable (advisory).
+    _fake_stat(monkeypatch, {_HEAD_PATH.path: PathStat(owner="pcluster-admin", group="pcluster-admin", mode="0557")})
+
+    result = _check().run(sample_context(NodeType.HEAD))
+
+    # A failure outranks a warning, so the check still fails overall.
+    assert result.status is Status.FAILURE
+    assert _codes(result) == [CriticalPathsHaveExpectedPermissions.MISSING_PERMISSIONS.code]
+    assert [w.code for w in result.warnings] == [CriticalPathsHaveExpectedPermissions.OVER_PERMISSIVE.code]
+
+
+def test_run_reports_both_ownership_and_permissions_when_both_wrong(monkeypatch):
+    _fake_stat(monkeypatch, {_HEAD_PATH.path: PathStat(owner="root", group="root", mode="0555")})
 
     result = _check().run(sample_context(NodeType.HEAD))
 
     assert result.status is Status.FAILURE
     assert _codes(result) == [
         CriticalPathsHaveExpectedPermissions.WRONG_OWNERSHIP.code,
-        CriticalPathsHaveExpectedPermissions.WRONG_MODE.code,
+        CriticalPathsHaveExpectedPermissions.MISSING_PERMISSIONS.code,
     ]
 
 
@@ -161,7 +317,7 @@ def test_run_fails_when_path_missing(monkeypatch):
 
 
 def test_run_only_inspects_paths_for_current_node_type(monkeypatch):
-    compute_path = ExpectedPathPermissions("/x", "root", "root", "0644", (NodeType.COMPUTE,))
+    compute_path = ExpectedPathPermissions("/x", "root", "root", (NodeType.COMPUTE,), required_bits=OWNER_READ)
     inspected = []
 
     def stat_path(path):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_slurm_accounting.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_slurm_accounting.py
@@ -560,6 +560,37 @@ def test_config_files_probe_silent_when_correct(monkeypatch):
     assert errors == []
 
 
+def test_accounting_conf_files_declare_their_expectation_as_allowed_modes():
+    # This probe only evaluates allowed_modes, so a required/forbidden-bits entry would go uninspected.
+    for expected in slurm_accounting._ACCOUNTING_CONF_FILES:
+        assert expected.allowed_modes, expected.path
+
+
+@pytest.mark.parametrize("mode", ["0600", "0640"])
+def test_config_files_probe_accepts_every_mode_slurmdbd_allows(monkeypatch, mode):
+    # slurmdbd accepts 600 or 640 and exits fatal on anything else, so 0640 must not be reported.
+    monkeypatch.setattr(slurm_accounting.path_permissions, "stat_path", lambda path: PathStat("slurm", "slurm", mode))
+    monkeypatch.setattr(slurm_accounting, "_is_readable", lambda path: True)
+    errors = []
+
+    SlurmAccounting()._probe_config_files(_local_config(), errors)
+
+    assert errors == []
+
+
+@pytest.mark.parametrize("mode", ["0400", "0644", "0660"])
+def test_config_files_probe_flags_modes_slurmdbd_rejects(monkeypatch, mode):
+    # Anything outside {600, 640} makes slurmdbd exit fatal, including stricter modes such as 0400.
+    monkeypatch.setattr(slurm_accounting.path_permissions, "stat_path", lambda path: PathStat("slurm", "slurm", mode))
+    monkeypatch.setattr(slurm_accounting, "_is_readable", lambda path: True)
+    errors = []
+
+    SlurmAccounting()._probe_config_files(_local_config(), errors)
+
+    assert SlurmAccounting.CONF_WRONG_MODE.code in _codes(errors)
+    assert "should be 0600 or 0640" in " | ".join(error.message for error in errors)
+
+
 # --- configuration-consistency probe --------------------------------------------------
 
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_expected_path_permissions.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/models/test_expected_path_permissions.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the expected-path-permissions model."""
+
+import pytest
+
+from pcluster_diag.core.constants import GROUP_OTHER_WRITE, OWNER_READ, OWNER_WRITE
+from pcluster_diag.models.context import NodeType
+from pcluster_diag.models.expected_path_permissions import ExpectedPathPermissions
+
+_HEAD = (NodeType.HEAD,)
+
+
+def _expectation(**kwargs) -> ExpectedPathPermissions:
+    """Build an expectation for ``/path``, defaulting to a single required bit."""
+    kwargs.setdefault("required_bits", OWNER_READ)
+    return ExpectedPathPermissions("/path", "owner", "group", _HEAD, **kwargs)
+
+
+def test_rejects_expectation_that_would_never_inspect_the_mode():
+    # Without any of the three mode expectations the mode would be silently unchecked.
+    with pytest.raises(ValueError, match="never inspected"):
+        ExpectedPathPermissions("/path", "owner", "group", _HEAD)
+
+
+def test_rejects_empty_allowed_modes():
+    with pytest.raises(ValueError, match="must not be empty"):
+        ExpectedPathPermissions("/path", "owner", "group", _HEAD, allowed_modes=frozenset())
+
+
+def test_rejects_allowed_modes_combined_with_bits():
+    # allowed_modes short-circuits the bit checks, so declaring both hides the bits.
+    with pytest.raises(ValueError, match="cannot be combined"):
+        ExpectedPathPermissions(
+            "/path", "owner", "group", _HEAD, required_bits=OWNER_READ, allowed_modes=frozenset({"0600"})
+        )
+
+
+def test_rejects_bit_that_is_both_required_and_forbidden():
+    with pytest.raises(ValueError, match="0200 is both required and forbidden"):
+        _expectation(required_bits=OWNER_WRITE, forbidden_bits=OWNER_WRITE)
+
+
+@pytest.mark.parametrize(
+    "mode, expected_missing",
+    [("0600", 0), ("0400", 0), ("0200", OWNER_READ), ("0000", OWNER_READ)],
+)
+def test_missing_bits(mode, expected_missing):
+    assert _expectation(required_bits=OWNER_READ).missing_bits(mode) == expected_missing
+
+
+@pytest.mark.parametrize(
+    "mode, expected_offending",
+    [("0600", 0), ("0620", 0o020), ("0602", 0o002), ("0622", 0o022)],
+)
+def test_offending_bits(mode, expected_offending):
+    expectation = _expectation(required_bits=OWNER_READ, forbidden_bits=GROUP_OTHER_WRITE)
+
+    assert expectation.offending_bits(mode) == expected_offending
+
+
+def test_bit_checks_ignore_setuid_setgid_and_sticky_bits():
+    # stat reports the full 07777 mode; those bits are outside both expectations and must not leak in.
+    expectation = _expectation(required_bits=OWNER_READ, forbidden_bits=GROUP_OTHER_WRITE)
+
+    assert expectation.missing_bits("4600") == 0
+    assert expectation.offending_bits("7600") == 0
+
+
+def test_is_disallowed_mode_is_false_without_allowed_modes():
+    assert _expectation().is_disallowed_mode("0777") is False
+
+
+@pytest.mark.parametrize("mode, disallowed", [("0600", False), ("0640", False), ("0400", True), ("0644", True)])
+def test_is_disallowed_mode(mode, disallowed):
+    expectation = _expectation(required_bits=0, allowed_modes=frozenset({"0600", "0640"}))
+
+    assert expectation.is_disallowed_mode(mode) is disallowed
+
+
+def test_allowed_modes_description_is_ordered_numerically():
+    expectation = _expectation(required_bits=0, allowed_modes=frozenset({"0640", "0600"}))
+
+    assert expectation.allowed_modes_description() == "0600 or 0640"
+
+
+def test_allowed_modes_description_is_empty_without_allowed_modes():
+    assert _expectation().allowed_modes_description() == ""
+
+
+def test_rejects_severity_flag_without_forbidden_bits():
+    with pytest.raises(ValueError, match="forbidden_bits_break_daemon without forbidden_bits"):
+        _expectation(forbidden_bits_break_daemon=True)
+
+
+def test_forbidden_bits_are_advisory_by_default():
+    assert _expectation(forbidden_bits=GROUP_OTHER_WRITE).forbidden_bits_break_daemon is False

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_path_permissions.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_path_permissions.py
@@ -17,6 +17,7 @@ import os
 import pytest
 
 from pcluster_diag.util import path_permissions
+from pcluster_diag.util.path_permissions import describe_bits, format_bits, parse_mode
 
 
 def test_stat_path_reports_owner_group_and_octal_mode(tmp_path, monkeypatch):
@@ -69,3 +70,27 @@ def test_stat_path_reports_mode_as_four_digit_octal(tmp_path, monkeypatch):
 def test_stat_path_raises_for_missing_path(tmp_path):
     with pytest.raises(FileNotFoundError):
         path_permissions.stat_path(str(tmp_path / "does-not-exist"))
+
+
+@pytest.mark.parametrize("mode, expected", [("0640", 0o640), ("0600", 0o600), ("4755", 0o4755)])
+def test_parse_mode(mode, expected):
+    assert parse_mode(mode) == expected
+
+
+@pytest.mark.parametrize("bits, expected", [(0o640, "0640"), (0o2, "0002"), (0, "0000")])
+def test_format_bits(bits, expected):
+    assert format_bits(bits) == expected
+
+
+@pytest.mark.parametrize(
+    "bits, expected",
+    [
+        (0o100, "owner execute/traverse"),
+        (0o400, "owner read"),
+        (0o022, "group write, other write"),
+        (0o040, "group read"),
+        (0, ""),
+    ],
+)
+def test_describe_bits(bits, expected):
+    assert describe_bits(bits) == expected


### PR DESCRIPTION
### Description of changes

`CriticalPathsHaveExpectedPermissions` compared each path's mode for equality with the mode the cookbook happens to set. That detects drift: it became red on modes the daemon accepts. In CI it failed a healthy cluster, because `test_slurm_rest_api` relaxes Slurm's `StateSaveLocation` to `0755`.

An upper bound would not be correct either, since tightening also breaks: `slurmctld` requires `access(R_OK|W_OK|X_OK)` on that directory as `SlurmUser`, so `0600` (no traverse bit) is as fatal as `0777`, and `munged` cannot read a `0000` key.

A mode expectation is now what the daemon enforces — `required_bits`, `forbidden_bits`, or `allowed_modes` where a daemon validates by equality (`slurmdbd.conf`: exactly `0600` or `0640`). Severity is per path: `munged` refuses to start from a key others can read (failure), while `slurmctld` runs fine on a world-writable `StateSaveLocation` (warning, so it no longer fails the run).

Two latent bugs surfaced on the way, and fixed:

- **`slurmdbd.conf`** was expected to be exactly `0600`, but `slurmdbd` accepts `600` **or** `640`, so a legitimate `0640` was flagged.
- **the munge key** was inspected on head and compute nodes only, though the cookbook installs it identically on login nodes, so a broken key there went unreported.

### Tests

Unit tests, plus a real `ubuntu2404` cluster with each daemon restarted under each mode:

```
slurmctld  0700/0755 -> active   0600 -> fatal: Incorrect permissions on state save loc
munged     0600/0400 -> active   0640/0644 -> "Keyfile is insecure"   0000 -> "Failed to open keyfile"
slurmdbd   0600/0640 -> active   0400/0644/0660 -> fatal: "should be 600 or 640"
```

### Checklist

- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
