### PR TITLE
[pcluster-diag] Add command describe-checks to return the list of available checks with their description.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/cli.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/cli.py
@@ -18,6 +18,7 @@ Defines the `pcluster-diag` command group and registers its subcommands.
 import click
 
 from pcluster_diag import __version__
+from pcluster_diag.commands.describe_checks import describe_checks
 from pcluster_diag.commands.run import run
 from pcluster_diag.core.constants import PACKAGE_NAME
 from pcluster_diag.core.exception_handler import ExceptionHandler
@@ -43,6 +44,7 @@ def main() -> None:
 
 
 main.add_command(run)
+main.add_command(describe_checks)
 
 
 if __name__ == "__main__":

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/commands/describe_checks.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/commands/describe_checks.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The `describe-checks` subcommand.
+
+Emits, as JSON, the registered diagnostic Checks: their identifiers and descriptions.
+"""
+
+import json
+
+import click
+
+from pcluster_diag.core.registry import DEFAULT_REGISTRY
+
+
+@click.command(name="describe-checks")
+def describe_checks() -> None:
+    """Describe the registered diagnostic checks.
+
+    Prints to stdout a JSON array listing every registered check, with its identifier
+    (``check_id``, the same key a Result carries) and its description (``check_description``), in
+    registration order. Only the registry is inspected: no check is executed, no cluster context is
+    built, and root privileges are not required.
+    """
+    checks = [
+        {"check_id": check.identifier, "check_description": check.description}
+        for check in DEFAULT_REGISTRY.registered_checks()
+    ]
+    print(json.dumps(checks, indent=2))

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/commands/test_describe_checks.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/commands/test_describe_checks.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the ``describe-checks`` subcommand: the JSON catalog of the registered checks."""
+
+import json
+import os
+
+import pytest
+from click.testing import CliRunner
+
+from pcluster_diag.cli import main
+from pcluster_diag.commands import describe_checks as describe_checks_module
+from pcluster_diag.commands.describe_checks import describe_checks
+from pcluster_diag.core.registry import DEFAULT_REGISTRY, Registry
+from tests.sample_data import FakeCheck
+
+
+@pytest.fixture
+def runner():
+    # stdout carries only the JSON document; logs go to stderr (kept separate by CliRunner).
+    return CliRunner()
+
+
+def _stub_registry_with(monkeypatch, checks):
+    """Make `describe-checks` describe a registry populated with the given checks."""
+    registry = Registry()
+    for check in checks:
+        registry.register(check)
+    monkeypatch.setattr(describe_checks_module, "DEFAULT_REGISTRY", registry)
+
+
+def test_describe_checks_help(runner):
+    result = runner.invoke(main, ["describe-checks", "--help"])
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+
+
+@pytest.mark.parametrize(
+    "target, args",
+    [(main, ["describe-checks"]), (describe_checks, [])],
+    ids=["via-group", "direct-command"],
+)
+def test_describe_checks_emits_catalog_in_registration_order(runner, monkeypatch, target, args):
+    _stub_registry_with(
+        monkeypatch,
+        [
+            FakeCheck("FirstCheck", description="what the first check verifies"),
+            FakeCheck("SecondCheck", description="what the second check verifies"),
+        ],
+    )
+
+    result = runner.invoke(target, args)
+
+    assert result.exit_code == 0
+    # stdout is the catalog itself: every registered check, with identifier and description, in order.
+    assert json.loads(result.stdout) == [
+        {"check_id": "FirstCheck", "check_description": "what the first check verifies"},
+        {"check_id": "SecondCheck", "check_description": "what the second check verifies"},
+    ]
+
+
+def test_describe_checks_emits_empty_catalog_when_nothing_is_registered(runner, monkeypatch):
+    _stub_registry_with(monkeypatch, [])
+
+    result = runner.invoke(main, ["describe-checks"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == []
+
+
+def test_describe_checks_executes_no_check(runner, monkeypatch):
+    events = []
+    check = FakeCheck("SomeCheck", events=events)
+    _stub_registry_with(monkeypatch, [check])
+
+    result = runner.invoke(main, ["describe-checks"])
+
+    assert result.exit_code == 0
+    # Describing the registry neither evaluates applicability nor runs anything.
+    assert events == []
+    assert check.ran is False
+
+
+def test_describe_checks_does_not_require_root(runner, monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000, raising=False)
+    _stub_registry_with(monkeypatch, [FakeCheck("SomeCheck")])
+
+    result = runner.invoke(main, ["describe-checks"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)[0]["check_id"] == "SomeCheck"
+
+
+def test_describe_checks_describes_the_default_registry(runner):
+    result = runner.invoke(main, ["describe-checks"])
+
+    assert result.exit_code == 0
+    described = {entry["check_id"]: entry["check_description"] for entry in json.loads(result.stdout)}
+    assert described == {check.identifier: check.description for check in DEFAULT_REGISTRY.registered_checks()}

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/test_cli.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/test_cli.py
@@ -24,11 +24,12 @@ def runner():
     return CliRunner()
 
 
-def test_group_help_lists_run_command(runner):
+@pytest.mark.parametrize("command", ["run", "describe-checks"])
+def test_group_help_lists_commands(runner, command):
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
     assert "Usage:" in result.output
-    assert "run" in result.output
+    assert command in result.output
 
 
 def test_group_version_matches_package_version(runner):


### PR DESCRIPTION
### Description of changes
In pcluster-diag, add command describe-checks to return the list of available checks with their description.

#### UX

```
[root@ip-27-6-117-209 ~]# pcluster-diag describe-checks
[
  {
    "check_id": "Imds",
    "check_description": "Verify that IMDS is responsive and functional"
  },
  {
    "check_id": "CfnHupRunsOnlyOnHeadNode",
    "check_description": "Verify that the cfn-hup daemon runs only on the head node."
  },
  {
    "check_id": "ReservedUsersAndGroups",
    "check_description": "Verify that reserved ParallelCluster users and groups exist and do not share their uid/gid."
  },
  {
    "check_id": "CriticalPathsHaveExpectedPermissions",
    "check_description": "Verify that ParallelCluster critical files have their expected owner, group, and permissions."
  },
  {
    "check_id": "ImdsRoleMatchesCfnHupConfig",
    "check_description": "Verify that the IAM role returned by IMDS matches the role configured in cfn-hup.conf."
  },
  {
    "check_id": "ClusterDaemonsAreRunning",
    "check_description": "Verify that the ParallelCluster management daemons for this node type are running."
  },
  {
    "check_id": "ClustermgtdHeartbeatIsHealthy",
    "check_description": "Verify that the clustermgtd heartbeat is fresh (clustermgtd is not stalled)."
  },
  {
    "check_id": "DirectoryService",
    "check_description": "Verify that the directory service (NSS/SSSD/AD) integration is healthy."
  },
  {
    "check_id": "LustreClientIsInstalled",
    "check_description": "Verify that the Lustre client is installed."
  },
  {
    "check_id": "FsxMountsArePresent",
    "check_description": "Verify that configured FsxLustre filesystems are mounted."
  },
  {
    "check_id": "FsxFilesystemsAreReachable",
    "check_description": "Verify that configured FsxLustre filesystems are reachable via lfs df."
  },
  {
    "check_id": "SlurmAccounting",
    "check_description": "Verify that Slurm accounting (slurmdbd, database, credentials, and configuration) is healthy."
  
```

### Tests
* Unit tests (added to this PR)
* Manually tested on a running cluster, see UX above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
