### PR TITLE
Disable fwupd-refresh timer to reduce system jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.17.0
+------
+
+**ENHANCEMENTS**
+- Disable `fwupd-refresh.timer` to improve performance for tightly coupled workloads at scale.
+
 3.16.0
 ------
 

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/disable_services.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/disable_services.rb
@@ -37,6 +37,17 @@ service 'dnf-makecache.timer' do
   action %i(disable stop)
 end unless on_docker?
 
+# Disable fwupd-refresh timer to reduce system jitter.
+# fwupd-refresh fetches LVFS metadata and starts the fwupd daemon, which pulls
+# in udisks2 and upower. Persistent=true makes every node run one catch-up
+# refresh shortly after boot, so at scale (500+ nodes) refreshes overlap most
+# MPI collectives, causing barrier straggler effects.
+# EC2 instances have no flashable firmware and fwupdmgr reports no supported
+# devices, so cluster nodes do not need it.
+service 'fwupd-refresh.timer' do
+  action %i(disable stop mask)
+end unless on_docker?
+
 # Disable services if node['cluster']['disable_services'] is provided
 if node['cluster']['disable_services']
   node['cluster']['disable_services'].split().each do |service_name|

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
@@ -29,6 +29,12 @@ describe 'aws-parallelcluster-platform::disable_services' do
         is_expected.to stop_service('dnf-makecache.timer')
       end
 
+      it 'disables fwupd-refresh timer' do
+        is_expected.to disable_service('fwupd-refresh.timer')
+        is_expected.to stop_service('fwupd-refresh.timer')
+        is_expected.to mask_service('fwupd-refresh.timer')
+      end
+
       DISABLE_SERVICE_NAME.split().each do |service_name|
         it "disables #{service_name}" do
           is_expected.to disable_service(service_name)

--- a/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
@@ -56,3 +56,19 @@ control 'tag:testami_tag:config_dnf_makecache_timer_disabled' do
     it { should_not be_running }
   end
 end
+
+control 'tag:testami_tag:config_fwupd_refresh_timer_disabled' do
+  title 'Test that fwupd-refresh timer is disabled, stopped and masked to reduce HPC jitter'
+
+  only_if { !os_properties.on_docker? }
+
+  describe service('fwupd-refresh.timer') do
+    it { should_not be_enabled }
+    it { should_not be_running }
+  end
+
+  describe bash('systemctl show -p LoadState fwupd-refresh.timer') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match /LoadState=(masked|not-found)/ }
+  end
+end


### PR DESCRIPTION
### Description of changes
Mask `fwupd-refresh.timer` on cluster nodes at image build time, following the existing `dnf-makecache.timer` precedent in the same recipe.

`fwupd-refresh` fetches LVFS metadata and starts the `fwupd` daemon, which in turn activates `udisks2` and `upower` to enumerate devices. The unit has `Persistent=true` and its timer stamp is inherited from the AMI, so every node runs one catch-up refresh shortly after boot — that is, inside the window where a freshly created cluster runs its first jobs. Measured cost of that refresh is ~1.8s of CPU per node across the four units.

Collectives such as `MPI_Barrier` complete only when the slowest rank arrives, so a single node doing this refresh slows the whole collective. At 500 nodes the refreshes overlap most collectives, which surfaces as run-to-run variance for tightly coupled workloads.

Safe to disable: EC2 instances have no flashable firmware, and `fwupdmgr` itself reports no supported devices in the enabled remotes.

Unlike `dnf-makecache.timer`, which uses `disable stop`, this uses `disable stop mask`. The `fwupd` package is present in the image, so a later package operation could otherwise re-enable the timer.

### Tests
* Re-run `test_osu` on 500 nodes for 3 times, the jitter is gone.
* Validated on two 500-node `c5.xlarge` clusters — same AMI, AZ and placement group, compute fleets booted together, differing only in whether the timer was masked before it could fire. 140 repetitions per arm:

  | | refreshes observed | `osu_barrier` median | p90/p10 | max |
  |---|---|---|---|---|
  | timer enabled | 309 | 1877 µs | 2.10x | 5940 µs |
  | timer masked | 20 | 1496 µs | 1.82x | 3345 µs |

  Attributing conservatively for cross-cluster baseline variation, the effect on `osu_barrier` median is -10% to -20%, with the worst case roughly halved.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
