### PR TITLE
[BuildImage] Fix nvidia installation gate + epel and custom node package on proxied envs

### DIFF
--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
@@ -59,7 +59,7 @@ bash "install aws-parallelcluster-node from #{node['cluster']['custom_node_packa
     source #{node_virtualenv_path}/bin/activate
     pip uninstall --yes aws-parallelcluster-node
     if [[ "#{node['cluster']['custom_node_package']}" =~ ^s3:// ]]; then
-      custom_package_url=$(#{cookbook_virtualenv_path}/bin/aws s3 presign #{node['cluster']['custom_node_package']} --region #{node['cluster']['region']})
+      custom_package_url=$(#{cookbook_virtualenv_path}/bin/aws s3 presign #{node['cluster']['custom_node_package']} --region #{aws_region} --endpoint-url https://s3.#{aws_region}.#{aws_domain})
     else
       custom_package_url=#{node['cluster']['custom_node_package']}
     fi

--- a/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
@@ -33,7 +33,7 @@ describe 'aws-parallelcluster-computefleet::custom_parallelcluster_node' do
   source #{virtualenv_path}/bin/activate
   pip uninstall --yes aws-parallelcluster-node
   if [[ "#{custom_node_s3_url}" =~ ^s3:// ]]; then
-    custom_package_url=$(#{cookbook_virtualenv_path}/bin/aws s3 presign #{custom_node_s3_url} --region #{region})
+    custom_package_url=$(#{cookbook_virtualenv_path}/bin/aws s3 presign #{custom_node_s3_url} --region test_region --endpoint-url https://s3.test_region.test_aws_domain)
   else
     custom_package_url=#{custom_node_s3_url}
   fi

--- a/cookbooks/aws-parallelcluster-platform/libraries/nvidia.rb
+++ b/cookbooks/aws-parallelcluster-platform/libraries/nvidia.rb
@@ -14,6 +14,10 @@ def nvidia_enabled?
   ['yes', true, 'true'].include?(node['cluster']['nvidia']['enabled'])
 end
 
+def nvidia_disabled?
+  !nvidia_enabled?
+end
+
 # Convert a full CUDA version to its 'major-minor' dashed form used in CUDA repo
 # and package names, e.g. '13-0' for '13.0.2'. The patch level (the '.2') is
 # intentionally dropped because CUDA repos and packages are keyed on major-minor

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/nvidia_install.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/nvidia_install.rb
@@ -15,6 +15,10 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Skip the entire NVIDIA software stack when NVIDIA is disabled, or when the
+# driver is already present on the base AMI (e.g. Deep Learning AMIs).
+return if nvidia_disabled? || nvidia_installed?
+
 nvidia_repo 'Add NVIDIA driver local repo' do
   action :add_driver_repo
 end

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/nvidia_install_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/nvidia_install_spec.rb
@@ -3,8 +3,44 @@ require 'spec_helper'
 describe 'aws-parallelcluster-platform::nvidia_install' do
   for_all_oses do |platform, version|
     context "on #{platform}#{version}" do
+      context 'when nvidia is disabled' do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['nvidia']['enabled'] = 'no'
+          end
+          runner.converge(described_recipe)
+        end
+
+        it 'skips the entire nvidia software stack' do
+          is_expected.not_to add_driver_repo_nvidia_repo('Add NVIDIA driver local repo')
+          is_expected.not_to setup_nvidia_driver('Install Nvidia driver')
+          is_expected.not_to install_nvidia_imex('Install nvidia-imex')
+          is_expected.not_to setup_nvidia_cuda('Install Nvidia CUDA')
+        end
+      end
+
+      context 'when the nvidia driver is already installed on the base AMI' do
+        cached(:chef_run) do
+          runner = runner(platform: platform, version: version) do |node|
+            node.override['cluster']['nvidia']['enabled'] = 'yes'
+          end
+          allow_any_instance_of(Object).to receive(:nvidia_installed?).and_return(true)
+          runner.converge(described_recipe)
+        end
+
+        it 'skips the entire nvidia software stack' do
+          is_expected.not_to add_driver_repo_nvidia_repo('Add NVIDIA driver local repo')
+          is_expected.not_to setup_nvidia_driver('Install Nvidia driver')
+          is_expected.not_to install_nvidia_imex('Install nvidia-imex')
+          is_expected.not_to setup_nvidia_cuda('Install Nvidia CUDA')
+        end
+      end
+
       cached(:chef_run) do
-        runner = runner(platform: platform, version: version)
+        runner = runner(platform: platform, version: version) do |node|
+          node.override['cluster']['nvidia']['enabled'] = 'yes'
+        end
+        allow_any_instance_of(Object).to receive(:nvidia_installed?).and_return(false)
         runner.converge(described_recipe)
       end
       cached(:node) { chef_run.node }


### PR DESCRIPTION
### Description of changes
1. Fix NVIDIA installation gate: now the entire nvidia installation recipe is skipped if nvidia is disabled or the nvidia driver is already installed. Without this change, nvidia-imex installation is triggered even if the parent image has nvidia disabled. As a result, for exmaple on DLAMI, the installation will attempt to install the latest nvidia-imex from the remote repository, so wrong version from wrong source. Does not need a changelog entry because the fix became mandatory only after changing the nvidia installation, which is something we introduced in 3.16.0.
2. Presign custom node package URL against the regional S3 endpoint. Without this change, the custom aws-parallelcluster-node package download fail with 403 when the artifacts bucket lives outside us-east-1. No need for changelog entry because this is a fix to a DevSettings. We need this fix because otherwise we cannot validate the build-image in isolated networks + in the past our users needed to adopt this devsettings to mitigate issues, so it is important to fix it.

### FAQ
1. **if the problem was only the gate on nvidia-imex, why adding the general gate to the entire nvidia recipe?**
Because this is what we should have done since the beginning: a simple gate for the entire nvidia software stack. Instead we had multiple and sometimes divergent gates that may create issues, like in this case.
1. **If the general gate is the solution, then why not removing the specific gates?**
We will do it post-release as a cleanup. For now our priority is to merge the minimal change that fixes the problem. 

### Tests
SUCCESS

```
test-suites:
  createami:
    test_createami.py::test_build_image_no_internet:
      dimensions:
        # RHEL family (rhel8, rhel9) -> Red Hat Enterprise Linux reservation platform
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_2_INSTANCES_3_HOURS_NOPG_rhel9 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["rhel8", "rhel9"]
        # Non-RHEL family (alinux2023, ubuntu2204, ubuntu2404, rocky8, rocky9) -> Linux/UNIX reservation platform
        - regions: [{{ g4dn_2xlarge_CAPACITY_RESERVATION_5_INSTANCES_3_HOURS_NOPG_ubuntu2404 }}]
          instances: ["g4dn.2xlarge"]
          oss: ["alinux2023", "ubuntu2204", "ubuntu2404", "rocky8", "rocky9"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
