### PR TITLE
[pcluster-diag] Remove advance FSx with EFA checks

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -41,8 +41,8 @@ executes each probe in isolation and aggregates their findings. The probes are:
   all (so Lustre falls back to TCP), fewer devices bound than the instance type is expected to bind (the
   expected count comes from a per-instance-family table, NOT the raw device count -- several families bind
   only a subset by design, and instance types with no known/static expectation are not flagged beyond the
-  "none bound" case), and a non-working EFA data path (typically a missing self-referencing security-group
-  rule).
+  "none bound" case), and an ``@efa`` interface carrying no traffic at all.
+  ``lnetctl net show -v`` is the only LNet command any probe runs, so the check cannot mutate LNet state.
   See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html
 
 :class:`FsxTargetsAreReachable` is kept separate because it is a heavier, opt-in
@@ -259,7 +259,7 @@ class LustreFilesystem(Check):
     @property
     def description(self) -> str:
         """Return the human-readable description of this Check."""
-        return "Verify that FsxLustre filesystems are installed, mounted, reachable, and riding EFA."
+        return "Verify that FsxLustre filesystems are installed, mounted, reachable, and configured for EFA."
 
     def should_run(self, context: Context) -> bool:
         """Run only when a FsxLustre filesystem is configured."""
@@ -416,9 +416,10 @@ class LustreFilesystem(Check):
         client supports EFA"), the EFA driver version, and on the p6+ families the kefalnd version. A
         missing ``kefalnd`` is reported (``KEFALND_MISSING``) and short-circuits the rest: without it there
         can be no working ``@efa`` net, so the follow-on probes would add nothing. Then it reports the
-        systemd service state and, when a live ``@efa`` net exists, automates the FSx tutorial's "Validate
-        FSx with EFA is working" commands (``lnetctl net show --net efa -v``, ``lnetctl ping ...@efa``), to
-        name -- not fix -- the failures. Read-only: never re-binds devices or edits the security group.
+        systemd service state and, when a live ``@efa`` net exists, the devices bound to LNet and their
+        traffic counters, to name -- not fix -- the failures. ``lnetctl net show -v`` is the only LNet
+        command run: it is read-only and cannot mutate LNet state, unlike ``lnetctl ping``, which leaves a
+        peer entry behind. Never re-binds devices or edits the security group.
         """
         if lnet.timed_out or lnet.unavailable:
             # The LNet probe already reported the hang / missing lnetctl; there is nothing to inspect here.
@@ -474,9 +475,9 @@ class LustreFilesystem(Check):
             infos.append(self.BOUND_DEVICES.format(len(bound), available))
 
         warnings.extend(self._traffic_warnings(efa_net))
-        errors.extend(self._efa_ping_errors(lnet.nets))
-        # _tcp_fallback_warnings is deliberately not called: current_connection reads @tcp on a healthy EFA
-        # client, so it would warn on every node. See its docstring.
+        # ``lnetctl net show -v`` is the only LNet command this check runs. _efa_ping_errors (lnetctl peer
+        # show + lnetctl ping) and _tcp_fallback_warnings (lctl get_param ...import) are deliberately not
+        # called; see their docstrings.
 
     def _probe_efa_prerequisites(self, context: Context, errors: List[CheckError], infos: List[CheckInfo]) -> bool:
         """Verify the EFA-for-Lustre client prerequisites; return whether kefalnd is present.
@@ -577,11 +578,10 @@ class LustreFilesystem(Check):
         return warnings
 
     def _efa_ping_errors(self, nets) -> List[CheckError]:
-        """Ping an @efa peer over EFA (the tutorial's own validation); error when the data path fails.
+        """Ping an @efa peer over EFA and error when the ping fails. NOT EXECUTED.
 
-        Automates ``lnetctl ping --source <local>@efa <peer>@efa``. Discovers a local @efa nid and a peer
-        @efa nid from ``lnetctl``; when either is unavailable there is nothing to ping, so the probe is
-        skipped (a missing peer/local nid is not itself proof the data path is broken).
+        Kept for reference but no longer called from ``_probe_efa``: we could not establish a reliable way to
+        pick the nid to ping, so this check is not reliable enough to report.
         """
         local = lustre.local_nids(nets, EFA_LNET_NET)
         if not local:
@@ -597,11 +597,9 @@ class LustreFilesystem(Check):
     def _tcp_fallback_warnings(self, nets) -> List[CheckWarning]:
         """Return a warning per target connected over @tcp while an @efa net is configured. NOT EXECUTED.
 
-        Kept for reference but no longer called from ``_probe_efa``: ``current_connection`` reads @tcp on a
-        healthy EFA client, because FSx documents the mount target as ``<dns_name>@tcp`` for EFA-enabled
-        file systems too and LNet Multi-Rail selects the rail below ptlrpc, where the import cannot see it.
-        The warning would therefore fire on every healthy node. The signal that does distinguish the two is
-        a per-NI ``send_count``/``recv_count`` delta measured across filesystem I/O.
+        Kept for reference but no longer called from ``_probe_efa``: we could not establish that the import's
+        connection nid tells us which transport actually carries the data, so this check is not reliable
+        enough to report.
         """
         if lustre.lnet_net(nets, EFA_LNET_NET) is None:
             return []

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -48,9 +48,9 @@ executes each probe in isolation and aggregates their findings. The probes are:
 :class:`FsxTargetsAreReachable` is kept separate because it is a heavier, opt-in
 (``approval_required``) deep probe (``lfs check servers`` + per-target import state); the framework's
 approval gate is per-check, so folding it into the always-on check would either force the deep probe to
-run every time or gate the whole check behind a prompt.
+run every time or gate the whole check behind a prompt. It is currently not registered -- see its docstring.
 
-Both checks run on every node type that has a FsxLustre mount configured, and skip
+:class:`LustreFilesystem` runs on every node type that has a FsxLustre mount configured, and skips
 (SKIPPED_NOT_APPLICABLE) when the cluster configures no FsxLustre filesystem. Every probe is read-only.
 """
 
@@ -417,9 +417,8 @@ class LustreFilesystem(Check):
         missing ``kefalnd`` is reported (``KEFALND_MISSING``) and short-circuits the rest: without it there
         can be no working ``@efa`` net, so the follow-on probes would add nothing. Then it reports the
         systemd service state and, when a live ``@efa`` net exists, automates the FSx tutorial's "Validate
-        FSx with EFA is working" commands (``lnetctl net show --net efa -v``, ``lnetctl ping ...@efa``) and
-        the client-side import state, to name -- not fix -- the failures. Read-only: never re-binds devices
-        or edits the security group.
+        FSx with EFA is working" commands (``lnetctl net show --net efa -v``, ``lnetctl ping ...@efa``), to
+        name -- not fix -- the failures. Read-only: never re-binds devices or edits the security group.
         """
         if lnet.timed_out or lnet.unavailable:
             # The LNet probe already reported the hang / missing lnetctl; there is nothing to inspect here.
@@ -476,7 +475,8 @@ class LustreFilesystem(Check):
 
         warnings.extend(self._traffic_warnings(efa_net))
         errors.extend(self._efa_ping_errors(lnet.nets))
-        warnings.extend(self._tcp_fallback_warnings(lnet.nets))
+        # _tcp_fallback_warnings is deliberately not called: current_connection reads @tcp on a healthy EFA
+        # client, so it would warn on every node. See its docstring.
 
     def _probe_efa_prerequisites(self, context: Context, errors: List[CheckError], infos: List[CheckInfo]) -> bool:
         """Verify the EFA-for-Lustre client prerequisites; return whether kefalnd is present.
@@ -595,7 +595,14 @@ class LustreFilesystem(Check):
         return []
 
     def _tcp_fallback_warnings(self, nets) -> List[CheckWarning]:
-        """Return a warning per target connected over @tcp while an @efa net is configured."""
+        """Return a warning per target connected over @tcp while an @efa net is configured. NOT EXECUTED.
+
+        Kept for reference but no longer called from ``_probe_efa``: ``current_connection`` reads @tcp on a
+        healthy EFA client, because FSx documents the mount target as ``<dns_name>@tcp`` for EFA-enabled
+        file systems too and LNet Multi-Rail selects the rail below ptlrpc, where the import cannot see it.
+        The warning would therefore fire on every healthy node. The signal that does distinguish the two is
+        a per-NI ``send_count``/``recv_count`` delta measured across filesystem I/O.
+        """
         if lustre.lnet_net(nets, EFA_LNET_NET) is None:
             return []
         result = time_command(
@@ -612,6 +619,11 @@ class LustreFilesystem(Check):
 
 class FsxTargetsAreReachable(Check):
     """Opt-in deep check pinpointing an unreachable OST/MDT -- a common cause of a hung directory listing.
+
+    NOT REGISTERED: kept for reference but left out of ``DEFAULT_REGISTRY``, so nothing here runs. Its
+    import-state findings rest on ``current_connection``/``failover_nids``, which do not carry the meaning
+    they were read with (see :meth:`LustreFilesystem._tcp_fallback_warnings`), and its ``lfs check servers``
+    parsing reports a phantom target for the bare ``lfs check: error:`` line real output contains.
 
     Runs ``lfs check servers`` (the per-target reachability diagnostic) via ``time_command`` and inspects
     client-side import state (``lctl get_param osc.*.import`` / ``mdc.*.import``). Because probing

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/registry.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/registry.py
@@ -24,7 +24,7 @@ from pcluster_diag.checks.cfn_hup import CfnHup
 from pcluster_diag.checks.critical_paths import CriticalPathsHaveExpectedPermissions
 from pcluster_diag.checks.daemon_health import ClusterDaemonsAreRunning, ClustermgtdHeartbeatIsHealthy
 from pcluster_diag.checks.directory_lookup import DirectoryService
-from pcluster_diag.checks.fsx_connectivity import FsxTargetsAreReachable, LustreFilesystem
+from pcluster_diag.checks.fsx_connectivity import LustreFilesystem
 from pcluster_diag.checks.imds import Imds
 from pcluster_diag.checks.reserved_users import ReservedUsersAndGroups
 from pcluster_diag.checks.slurm_accounting import SlurmAccounting
@@ -140,5 +140,6 @@ DEFAULT_REGISTRY = (
     .register(DirectoryService())
     .register(SlurmAccounting())
     .register(LustreFilesystem())
-    .register(FsxTargetsAreReachable())  # approval_required: heavier per-target probe
+    # FsxTargetsAreReachable (approval_required: heavier per-target probe) is deliberately left out: its
+    # findings are not signals we trust yet. See its docstring in checks/fsx_connectivity.py.
 )

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -792,7 +792,9 @@ def test_efa_no_traffic_is_warning(monkeypatch):
     assert LustreFilesystem.NO_TRAFFIC.code in _codes(warnings)
 
 
-def test_efa_tcp_fallback_is_warning(monkeypatch):
+def test_efa_import_over_tcp_is_not_a_finding(monkeypatch):
+    # A healthy EFA client reads @tcp in its import (FSx documents the mount target as @tcp and Multi-Rail
+    # picks the rail below ptlrpc), so the import transport must not produce a finding.
     _patch_efa_prereqs(monkeypatch)
     _route_time_command(
         monkeypatch,
@@ -809,7 +811,7 @@ def test_efa_tcp_fallback_is_warning(monkeypatch):
         sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
     )
 
-    assert LustreFilesystem.TCP_FALLBACK.code in _codes(warnings)
+    assert LustreFilesystem.TCP_FALLBACK.code not in _codes(warnings)
 
 
 # --- EFA prerequisites & systemd service (checked before the data-path probes) --------
@@ -1064,7 +1066,7 @@ def test_run_missing_lnetctl_does_not_sink_other_probes(monkeypatch):
     assert LustreFilesystem.NOT_MOUNTED.code not in _codes(result.errors)
 
 
-# --- FsxTargetsAreReachable (unchanged, still its own gated check) --------------------
+# --- FsxTargetsAreReachable (kept, but not registered) --------------------------------
 
 
 def test_targets_description():

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -751,16 +751,29 @@ def test_efa_no_devices_bound_fails(monkeypatch):
     assert "16" in _messages(errors)
 
 
-def test_efa_ping_failure_points_at_security_group(monkeypatch):
+def test_efa_probe_runs_no_lnetctl_beyond_net_show(monkeypatch):
+    # `lnetctl net show -v` (already fetched into the snapshot) is the probe's only LNet command: peer show
+    # and ping are not run, so E11 cannot fire even with every ping failing and a @tcp-connected import.
+    from pcluster_diag.util import lustre
+
+    commands = []
     _patch_efa_prereqs(monkeypatch)
     _route_time_command(
         monkeypatch,
         {
             "peer show": _timed(stdout=_LNET_PEER_EFA),
             "ping": _timed(returncode=1, stderr="cannot reach"),
-            "import": _timed(stdout=_IMPORT_EFA),
+            "import": _timed(stdout=_IMPORT_TCP_FALLBACK),
         },
     )
+    routed = fsx_connectivity.time_command
+
+    def recording_time_command(command, timeout):
+        commands.append(" ".join(command))
+        return routed(command, timeout)
+
+    monkeypatch.setattr(fsx_connectivity, "time_command", recording_time_command)
+    monkeypatch.setattr(lustre, "time_command", recording_time_command)
     monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
     errors, warnings, infos = [], [], []
 
@@ -768,8 +781,8 @@ def test_efa_ping_failure_points_at_security_group(monkeypatch):
         sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
     )
 
-    assert LustreFilesystem.EFA_PING_FAILED.code in _codes(errors)
-    assert "security group" in _messages(errors)
+    assert [command for command in commands if "lnetctl" in command or "lctl" in command] == []
+    assert LustreFilesystem.EFA_PING_FAILED.code not in _codes(errors)
 
 
 def test_efa_no_traffic_is_warning(monkeypatch):
@@ -793,8 +806,8 @@ def test_efa_no_traffic_is_warning(monkeypatch):
 
 
 def test_efa_import_over_tcp_is_not_a_finding(monkeypatch):
-    # A healthy EFA client reads @tcp in its import (FSx documents the mount target as @tcp and Multi-Rail
-    # picks the rail below ptlrpc), so the import transport must not produce a finding.
+    # A @tcp import connection does not tell us which transport carries the data, so it must not produce a
+    # finding.
     _patch_efa_prereqs(monkeypatch)
     _route_time_command(
         monkeypatch,

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_registry.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/core/test_registry.py
@@ -147,3 +147,8 @@ def test_default_registry_wires_in_permission_checks(identifier):
 
 def test_default_registry_does_not_register_sample_check():
     assert registry_module.DEFAULT_REGISTRY.get("SampleCheck") is None
+
+
+def test_default_registry_wires_in_lustre_but_not_the_target_deep_probe():
+    assert registry_module.DEFAULT_REGISTRY.get("LustreFilesystem") is not None
+    assert registry_module.DEFAULT_REGISTRY.get("FsxTargetsAreReachable") is None


### PR DESCRIPTION
### Description of changes

Stops pcluster-diag's Lustre checks from reporting EFA findings we cannot back up.

  ## What changed

  - No longer runs `lctl get_param osc.*.import mdc.*.import`, `lnetctl peer show`, or
    `lnetctl ping`. `lnetctl net show -v` is now the only LNet command any probe issues, so the
    checks cannot change LNet state.
  - `FsxTargetsAreReachable` is left out of `DEFAULT_REGISTRY`. It was already
    `approval_required`, so it never ran unattended; now it does not run at all.
  - The check description drops the "riding EFA" claim: what the probe verifies is that the
    EFA-for-Lustre client is configured and its devices are bound to LNet, not that Lustre
    traffic uses them.
  - No code is deleted — the disabled probe bodies, their finding constants and the parsers stay,
    each with a docstring saying why it does not run.

  ## Why
  
  **Import state does not tell us the transport.** We could not establish that an import's
  `current_connection` says which transport actually carries the data, so W3 `TCP_FALLBACK`
  cannot read a TCP fallback out of it. `FsxTargetsAreReachable`'s nid-derived findings read the
  same fields.

  **An EFA ping does not either.** We could not establish a reliable way to pick which peer nid
  to ping: a server's `@efa` nid cannot be derived from its `@tcp` nid, and which nids land in
  the peer table depends on incidental traffic rather than on which peers are Lustre servers. A
  ping to a nid nothing serves also leaves a phantom peer entry behind, so a failed ping pollutes
  the peer table the next run reads. So if we run the check on a polluted peer table its going to fail
 and cause more confusion.

  **Latent parser bug.** `lustre.parse_lfs_check_servers` turns the bare `lfs check: error:` line
  that real output contains into a phantom E3 `TARGET_UNREACHABLE` naming a target called `lfs`.
  Nothing runs it while `FsxTargetsAreReachable` is unregistered, but it must be fixed before
  that check is registered again.

  ## Follow-up
  
  `lfs check servers` and `lfs df -h` overlap — both surface an unreachable target, and each is
  bounded by our own `time_command` cap rather than by the tool. One of the two is probably
  enough.

  ## What still runs
  
  Client install/version, mount presence, `lfs df -h` reachability, active LNet transports, and the
  EFA prerequisites: `kefalnd`, driver version, service state, devices bound to LNet, traffic
  counters.



### Tests
* Tested on an EFS cluster which followed https://docs.aws.amazon.com/parallelcluster/latest/ug/tutorial-efa-enabled-fsx-lustre.html
```
 {
      "check_id": "LustreFilesystem",
      "check_description": "Verify that FsxLustre filesystems are installed, mounted, reachable, and configured for EFA.",
      "status": "PASSED",
      "infos": [
        {
          "code": "I1",
          "message": "Lustre client version: 2.15.6."
        },
        {
          "code": "I2",
          "message": "Active LNet transports: tcp, efa."
        },
        {
          "code": "I6",
          "message": "EFA driver version: 3.1.0g."
        },
        {
          "code": "I7",
          "message": "kefalnd (EFA LND) version: 1.2.2."
        },
        {
          "code": "I4",
          "message": "The EFA-Lustre configuration service configure-efa-fsx-lustre-client.service is installed and not failed."
        },
        {
          "code": "I8",
          "message": "EFA-for-Lustre binding follows the FSx guide -- the expected number of EFA devices bound to LNet is instance-type-specific (some families bind a subset by design). See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html"
        },
        {
          "code": "I5",
          "message": "8 of 8 EFA devices are bound to LNet (some instance families bind a subset by design)."
        }
      ]
    }
  ]
}
root@efa-enabled-st-efa-enabled-i1-1:~#

```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
