### PR TITLE
[Perf] Disable fwupd-refresh timer to reduce system jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
+3.17.0
+------
+
+**ENHANCEMENTS**
+- Disable `fwupd-refresh.timer` to improve performance for tightly coupled workloads at scale.
+
 3.16.0
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,6 @@ aws-parallelcluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the AWS ParallelCluster cookbook.
 
-3.17.0
-------
-
-**ENHANCEMENTS**
-- Disable `fwupd-refresh.timer` to improve performance for tightly coupled workloads at scale.
-
 3.16.0
 ------
 
@@ -21,6 +15,7 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 - Move all ParallelCluster-managed bootstrap files off `/tmp` into a dedicated `/opt/parallelcluster/tmp`
   directory. Therefore, Image builds, cluster creations and updates work on custom AMIs that mount `/tmp` with `noexec`.
   Image builds work on the custom AMIs only if GDRcopy installation is skipped.
+- Disable `fwupd-refresh.timer` to improve performance for tightly coupled workloads at scale.
 
 **CHANGES**
 - Enforce NFSv4-only on the ParallelCluster-managed NFS server (head node). 

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/disable_services.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/disable_services.rb
@@ -37,6 +37,17 @@ service 'dnf-makecache.timer' do
   action %i(disable stop)
 end unless on_docker?
 
+# Disable fwupd-refresh timer to reduce system jitter.
+# fwupd-refresh fetches LVFS metadata and starts the fwupd daemon, which pulls
+# in udisks2 and upower. Persistent=true makes every node run one catch-up
+# refresh shortly after boot, so at scale (500+ nodes) refreshes overlap most
+# MPI collectives, causing barrier straggler effects.
+# EC2 instances have no flashable firmware and fwupdmgr reports no supported
+# devices, so cluster nodes do not need it.
+service 'fwupd-refresh.timer' do
+  action %i(disable stop mask)
+end unless on_docker?
+
 # Disable services if node['cluster']['disable_services'] is provided
 if node['cluster']['disable_services']
   node['cluster']['disable_services'].split().each do |service_name|

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/disable_services_spec.rb
@@ -29,6 +29,12 @@ describe 'aws-parallelcluster-platform::disable_services' do
         is_expected.to stop_service('dnf-makecache.timer')
       end
 
+      it 'disables fwupd-refresh timer' do
+        is_expected.to disable_service('fwupd-refresh.timer')
+        is_expected.to stop_service('fwupd-refresh.timer')
+        is_expected.to mask_service('fwupd-refresh.timer')
+      end
+
       DISABLE_SERVICE_NAME.split().each do |service_name|
         it "disables #{service_name}" do
           is_expected.to disable_service(service_name)

--- a/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/disable_services_spec.rb
@@ -56,3 +56,19 @@ control 'tag:testami_tag:config_dnf_makecache_timer_disabled' do
     it { should_not be_running }
   end
 end
+
+control 'tag:testami_tag:config_fwupd_refresh_timer_disabled' do
+  title 'Test that fwupd-refresh timer is disabled, stopped and masked to reduce HPC jitter'
+
+  only_if { !os_properties.on_docker? }
+
+  describe service('fwupd-refresh.timer') do
+    it { should_not be_enabled }
+    it { should_not be_running }
+  end
+
+  describe bash('systemctl show -p LoadState fwupd-refresh.timer') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match /LoadState=(masked|not-found)/ }
+  end
+end


### PR DESCRIPTION
### Description of changes
Disable fwupd-refresh timer to reduce system jitter.
Cherry-picked from https://github.com/aws/aws-parallelcluster-cookbook/pull/3260

### Tests
Tested in source PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
