### PR TITLE
[pcluster-diag] Use absolute path to call scontrol

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
@@ -30,6 +30,7 @@ SHARED_DIR = BASE_DIR + "/shared"
 DEFAULT_DNA_JSON_PATH = "/etc/chef/dna.json"
 DEFAULT_CLUSTER_CONFIG_PATH = SHARED_DIR + "/cluster-config.yaml"
 DEFAULT_BOOTSTRAPPED_PATH = BASE_DIR + "/.bootstrapped"
+SCONTROL_PATH = "/opt/slurm/bin/scontrol"
 
 # Written by clusterstatusmgtd (running as the cluster admin user) to drive compute-fleet status
 # transitions; mirrors the cookbook attribute computefleet_status_path.

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/slurm_accounting.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/slurm_accounting.py
@@ -26,6 +26,7 @@ from botocore.exceptions import ClientError
 from pcluster_diag.core.constants import (
     DEFAULT_DATABASE_PORT,
     DEFAULT_SLURMDBD_PORT,
+    SCONTROL_PATH,
     SLURM_PARALLELCLUSTER_SLURMDBD_CONF_PATH,
     SLURMDBD_CONF_PATH,
 )
@@ -180,7 +181,7 @@ def accounting_present_on_node() -> bool:
 def _scontrol_config() -> Dict[str, str]:
     """Return the effective Slurm configuration reported by ``scontrol show config`` as a key/value map."""
     try:
-        result = shell.run_command(["scontrol", "show", "config"], timeout=_SCONTROL_CONFIG_TIMEOUT_SECONDS)
+        result = shell.run_command([SCONTROL_PATH, "show", "config"], timeout=_SCONTROL_CONFIG_TIMEOUT_SECONDS)
     except OSError as error:
         logger.info("Could not run 'scontrol show config': %s", error)
         return {}

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_slurm_accounting.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_slurm_accounting.py
@@ -19,7 +19,7 @@ from botocore.exceptions import ClientError
 from hypothesis import given
 from hypothesis import strategies as st
 
-from pcluster_diag.core.constants import DEFAULT_DATABASE_PORT, DEFAULT_SLURMDBD_PORT
+from pcluster_diag.core.constants import DEFAULT_DATABASE_PORT, DEFAULT_SLURMDBD_PORT, SCONTROL_PATH
 from pcluster_diag.models.context import NodeType
 from pcluster_diag.util import slurm_accounting as acct
 from tests.sample_data import sample_context
@@ -324,7 +324,7 @@ def test_scontrol_config_issues_expected_command_and_parses_pairs(monkeypatch):
 
     config = acct._scontrol_config()
 
-    assert captured["argv"] == ["scontrol", "show", "config"]
+    assert captured["argv"] == [SCONTROL_PATH, "show", "config"]
     assert config["SlurmUser"] == "slurm"
     assert config["AccountingStoragePort"] == "6819"
     assert "not a kv line" not in config  # lines without '=' are skipped


### PR DESCRIPTION
### Description of changes
The path to scontrol might not be set in the environment. Use absolute path for best robustness

If the path is not set, the checks related to cluster configuration file can still execute. But the checks related to `scontrol` command cannot execute. For example, the checks will mistakenly skip if slurm accounting is not configured in cluster configuration file, but configured in Slurm manually.

### Tests
* Error message is gone:
```
Could not run 'scontrol show config': [Errno 2] No such file or directory: 'scontrol'
```

### References
* This is a bug fix of https://github.com/aws/aws-parallelcluster-cookbook/pull/3248

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
