### PR TITLE
[pcluster-diag] Retry IMDS requests  to retrieve token and metadata to prevent false positive failures caused by transient network glitches.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/imds.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/imds.py
@@ -44,7 +44,7 @@ class Imds(Check):
     @property
     def description(self) -> str:
         """Return the human-readable description of this Check."""
-        return "Verify that IMDS is responsive and functional"
+        return "Verify that IMDS is responsive and functional."
 
     def run(self, context: Context) -> Result:
         """Pass when IMDS is responsive, reports an IAM role, and per-user access matches Imds/Secured.

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/imds.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/imds.py
@@ -33,6 +33,8 @@ _INSTANCE_TAGS_URL = _BASE_URL + "/meta-data/tags/instance"
 _IAM_SECURITY_CREDENTIALS_URL = _BASE_URL + "/meta-data/iam/security-credentials/"
 _TOKEN_TTL_SECONDS = "21600"  # nosec B105  session-token TTL (seconds), not a secret
 _TIMEOUT_SECONDS = 5
+_RETRY_MAX_ATTEMPTS = 3
+_RETRY_WAIT_SECONDS = 1
 
 
 def get_instance_id() -> str:
@@ -68,33 +70,12 @@ def get_iam_role_name() -> Optional[str]:
 
 def list_metadata(imds_version: str) -> str:
     """Return the top-level IMDS metadata listing, using the enabled IMDS version."""
-    return _get_with_retries(_METADATA_URL, imds_version)
+    return _get(_METADATA_URL, _token_for(imds_version))
 
 
 def get_instance_tags(imds_version: str) -> str:
     """Return the IMDS instance tags listing; raises when the tags category is not exposed."""
-    return _get_with_retries(_INSTANCE_TAGS_URL, imds_version)
-
-
-def _is_transient_imds_error(exception: Exception) -> bool:
-    """Return whether ``exception`` is a transient IMDS failure worth retrying.
-
-    Connection-level failures (e.g. timeouts) are transient. An ``HTTPError`` means IMDS answered
-    with a status code, so it is a definitive result and is not retried.
-    """
-    return isinstance(exception, (urllib.error.URLError, TimeoutError)) and not isinstance(
-        exception, urllib.error.HTTPError
-    )
-
-
-@retry(stop_max_attempt_number=3, wait_fixed=1000, retry_on_exception=_is_transient_imds_error)
-def _get_with_retries(url: str, imds_version: str) -> str:
-    """GET ``url`` from IMDS, retrying transient connection failures (e.g. timeouts).
-
-    A fresh token is obtained per attempt for IMDSv2. An HTTP error status is not retried, and the
-    last transient error is re-raised once the attempts are exhausted.
-    """
-    return _get(url, _token_for(imds_version))
+    return _get(_INSTANCE_TAGS_URL, _token_for(imds_version))
 
 
 def _token_for(imds_version: str) -> Optional[str]:
@@ -102,6 +83,7 @@ def _token_for(imds_version: str) -> Optional[str]:
     return fetch_token() if imds_version == IMDS_V2 else None
 
 
+@retry(stop_max_attempt_number=_RETRY_MAX_ATTEMPTS, wait_fixed=_RETRY_WAIT_SECONDS * 1000)
 def fetch_token() -> str:
     """Fetch a short-lived IMDSv2 session token."""
     request = urllib.request.Request(
@@ -139,8 +121,8 @@ def is_responsive_for_user(user: str) -> bool:
     # Exit 0 (reachable) and 7 (curl could-not-connect: lockdown REJECTed the request) are definitive
     # answers and not retried; any other exit (e.g. a timeout) is transient.
     @retry(
-        stop_max_attempt_number=3,
-        wait_fixed=1000,
+        stop_max_attempt_number=_RETRY_MAX_ATTEMPTS,
+        wait_fixed=_RETRY_WAIT_SECONDS * 1000,
         retry_on_result=lambda code: code not in (0, 7),
     )
     def probe() -> int:
@@ -152,6 +134,7 @@ def is_responsive_for_user(user: str) -> bool:
         return False  # Never got a definitive answer within the retry budget (transient timeouts).
 
 
+@retry(stop_max_attempt_number=_RETRY_MAX_ATTEMPTS, wait_fixed=_RETRY_WAIT_SECONDS * 1000)
 def _get(url: str, token: Optional[str] = None) -> str:
     """GET ``url`` from IMDS (with a session token for IMDSv2) and return the stripped body."""
     headers = {"X-aws-ec2-metadata-token": token} if token is not None else {}

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_imds.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_imds.py
@@ -61,7 +61,7 @@ def _imds_reports_role(monkeypatch):
 
 
 def test_description():
-    assert Imds().description == "Verify that IMDS is responsive and functional"
+    assert Imds().description == "Verify that IMDS is responsive and functional."
 
 
 @pytest.mark.parametrize("node_type", list(NodeType), ids=lambda nt: nt.name)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_imds.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_imds.py
@@ -153,8 +153,9 @@ def test_list_metadata_retries_transient_error_then_succeeds(monkeypatch):
     assert attempts["count"] == 2
 
 
-def test_get_instance_tags_does_not_retry_http_error(monkeypatch):
-    # A 404 means IMDS responded (tags not exposed): a definitive answer that must not be retried.
+def test_get_instance_tags_retries_http_error_then_reraises(monkeypatch):
+    # The retry is unconditional, so even a definitive 404 is retried up to the attempt limit before
+    # propagating (tags not exposed).
     calls = {"count": 0}
 
     def fake_urlopen(request, timeout=None):
@@ -165,10 +166,10 @@ def test_get_instance_tags_does_not_retry_http_error(monkeypatch):
 
     with pytest.raises(urllib.error.HTTPError):
         imds.get_instance_tags(imds.IMDS_V1)
-    assert calls["count"] == 1
+    assert calls["count"] == 3
 
 
-def test_get_with_retries_reraises_after_exhausting_attempts(monkeypatch):
+def test_get_reraises_after_exhausting_attempts(monkeypatch):
     calls = {"count": 0}
 
     def fake_urlopen(request, timeout=None):
@@ -232,3 +233,37 @@ def test_get_iam_role_name_propagates_non_404_http_errors(monkeypatch):
 
     with pytest.raises(urllib.error.HTTPError):
         imds.get_iam_role_name()
+
+
+def test_get_iam_role_name_retries_transient_timeout_then_succeeds(monkeypatch):
+    # A transient timeout on the credentials GET is retried; the next attempt returns the role.
+    attempts = {"count": 0}
+
+    def fake_urlopen(request, timeout=None):
+        if request.full_url.endswith("/api/token"):
+            return _FakeResponse(b"the-token")
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise urllib.error.URLError("timed out")
+        return _FakeResponse(b"my-instance-role\n")
+
+    monkeypatch.setattr(imds.urllib.request, "urlopen", fake_urlopen)
+
+    assert imds.get_iam_role_name() == "my-instance-role"
+    assert attempts["count"] == 2
+
+
+def test_get_iam_role_name_reraises_after_exhausting_attempts(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_urlopen(request, timeout=None):
+        if request.full_url.endswith("/api/token"):
+            return _FakeResponse(b"the-token")
+        calls["count"] += 1
+        raise urllib.error.URLError("timed out")
+
+    monkeypatch.setattr(imds.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(urllib.error.URLError):
+        imds.get_iam_role_name()
+    assert calls["count"] == 3


### PR DESCRIPTION
### Description of changes
In pcluster-diag, retry IMDS requests  to retrieve token and metadata to prevent false positive failures caused by transient network glitches.

As part of this change we simplified the retry logic: we always retry the IMDs call without checking the http error. In this way when the check fails we are always sure it is a consistent failure and we do not need to extend the list of possible transient failures.

Before this fix a transient timeout on IMDs token causes pcluster-diag failure with error:

```
    {
      "check_id": "Imds",
      "check_description": "Verify that IMDS is responsive and functional",
      "status": "CHECK_ERROR",
      "errors": [
        {
          "code": "E0",
          "message": "URLError: <urlopen error timed out>"
        }
      ]
    },
```

This wasa bad for two reasons:
1. pcluster-diag fails on transient netowkr glitches, whereas it shoudl be robust against them
2. When IMDs times out, the returned error is `E0` which is an internal error for pcluster-diag, whereas it should instead be a well determined error `E1, E2, E3`.

### Tests

#### Success (no timeout injected)
```
[root@ip-27-6-35-156 ~]# pcluster-diag run
...
 "results": [
    {
      "check_id": "Imds",
      "check_description": "Verify that IMDS is responsive and functional.",
      "status": "WARNING",
      "warnings": [
        {
          "code": "W1",
          "message": "Instance tags metadata is not reachable via IMDS."
        }
      ]
    },
...
}
[root@ip-27-6-35-156 ~]# echo $?
0
```

#### Failure (IMDS timeout injected)

```
[root@ip-27-6-35-156 ~]# sudo iptables -I OUTPUT -d 169.254.169.254 -j DROP
[root@ip-27-6-35-156 ~]# pcluster-diag run
2026-08-17 21:25:00,385 [ERROR] pcluster_diag.core.context_builder: Could not determine the current instance id from IMDS: <urlopen error timed out>
2026-08-17 21:25:17,398 [ERROR] pcluster_diag.core.context_builder: Could not determine the current instance type from IMDS: <urlopen error timed out>
2026-08-17 21:25:34,429 [ERROR] pcluster_diag.core.context_builder: Could not determine the current instance id from IMDS: <urlopen error timed out>
...
  "results": [
    {
      "check_id": "Imds",
      "check_description": "Verify that IMDS is responsive and functional.",
      "status": "FAILURE",
      "errors": [
        {
          "code": "E1",
          "message": "The IMDS version enabled for the cluster (v2.0) did not respond."
        },
        {
          "code": "E2",
          "message": "IMDS is not reachable by user 'root', but it should be."
        },
        {
          "code": "E2",
          "message": "IMDS is not reachable by user 'pcluster-admin', but it should be."
        }
      ]
    },
    {
      "check_id": "CfnHup",
      "check_description": "Verify that the cfn-hup daemon runs only on the head node and it is properly configured.",
      "status": "CHECK_ERROR",
      "errors": [
        {
          "code": "E0",
          "message": "URLError: <urlopen error timed out>"
        }
      ]
    },
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
