### PR TITLE
[Pcluster-diag] Modify FSx checks to remove unwanted checks

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -40,9 +40,9 @@ executes each probe in isolation and aggregates their findings. The probes are:
   that (re)configures LNet on every boot, then detects common root causes: no EFA device bound to LNet at
   all (so Lustre falls back to TCP), fewer devices bound than the instance type is expected to bind (the
   expected count comes from a per-instance-family table, NOT the raw device count -- several families bind
-  only a subset by design, and instance types with no known/static expectation are not flagged beyond the
-  "none bound" case), and a non-working EFA data path (typically a missing self-referencing security-group
-  rule).
+  only a subset by design; an instance type absent from that table is expected to bind all present devices,
+  and only a genuinely unknown instance type is left unflagged beyond the "none bound" case), and a
+  non-working EFA data path (typically a missing self-referencing security-group rule).
   See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html
 
 :class:`FsxTargetsAreReachable` is kept separate because it is a heavier, opt-in
@@ -180,13 +180,15 @@ class LustreFilesystem(Check):
     )
     NO_DEVICES_BOUND = CheckError(
         10,
-        "{} EFA devices are exposed but none are bound to LNet -- Lustre will fall back to TCP. "
-        "Re-run the EFA-Lustre client configuration.",
+        "{} EFA devices are exposed but none are bound to LNet -- Lustre will fall back to TCP. Check the "
+        "EFA-Lustre client configuration output (`journalctl -u {}`).",
     )
     UNDERBOUND_DEVICES = CheckError(
         17,
         "Only {} of {} expected EFA devices are bound to LNet on {} -- Lustre will not use the full EFA "
-        "fabric. Re-run the EFA-Lustre client configuration.",
+        "fabric. Check the EFA-Lustre client configuration output (`journalctl -u {}`). If this instance "
+        "type binds fewer devices by design, confirm the expected count against official FSX doc "
+        "https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html",
     )
     EFA_PING_FAILED = CheckError(
         11,
@@ -236,15 +238,16 @@ class LustreFilesystem(Check):
     EFA_SERVICE_ACTIVE = CheckInfo(4, "The EFA-Lustre configuration service {} is installed and not failed.")
     BOUND_DEVICES = CheckInfo(
         5,
-        "{} of {} EFA devices are bound to LNet (some instance families bind a subset by design).",
+        "{} of {} EFA devices are bound to LNet, matching the expected count for this instance type.",
     )
     EFA_DRIVER_VERSION = CheckInfo(6, "EFA driver version: {}.")
     KEFALND_VERSION = CheckInfo(7, "kefalnd (EFA LND) version: {}.")
     EFA_BINDING_REFERENCE = CheckInfo(
         8,
         "EFA-for-Lustre binding follows the FSx guide -- the expected number of EFA devices bound to LNet "
-        "is instance-type-specific (some families bind a subset by design). See "
-        "https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html",
+        "is instance-type-specific (some families bind a subset by design), and any type not listed binds "
+        "all present devices. "
+        "See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html",
     )
     LNETCTL_UNAVAILABLE = CheckInfo(
         9,
@@ -464,15 +467,20 @@ class LustreFilesystem(Check):
             errors.append(self.NO_EFA_DEVICES.format(EFA_INFINIBAND_SYSFS))
         elif not bound:
             # EFA devices exist but none are bound at all: Lustre cannot ride EFA on any family.
-            errors.append(self.NO_DEVICES_BOUND.format(available))
+            errors.append(self.NO_DEVICES_BOUND.format(available, EFA_LUSTRE_SYSTEMD_SERVICE))
         elif expected is not None and len(bound) < expected:
-            # We know how many this instance type should bind, and fewer are bound -- a genuine shortfall
-            # (e.g. the p6-b300 "bind all" family with only a subset bound). Compared against the expected
-            # count, NOT the raw device count, so families that bind a subset by design do not false-fire.
-            errors.append(self.UNDERBOUND_DEVICES.format(len(bound), expected, context.instance_type))
+            # Fewer devices are bound than this instance type should bind -- a genuine shortfall. Compared
+            # against the expected count, NOT the raw device count, so the fixed-count families that bind a
+            # subset by design do not false-fire. On every other family the expectation is "all present
+            # devices", so a partial bind (the load-order incident signature) is caught here.
+            errors.append(
+                self.UNDERBOUND_DEVICES.format(
+                    len(bound), expected, context.instance_type, EFA_LUSTRE_SYSTEMD_SERVICE
+                )
+            )
         else:
-            # All expected devices are bound, or we have no static expectation for this instance type
-            # (unknown/dynamic selection) -- report the count as context and pass.
+            # All expected devices are bound, or the instance type is unknown so we have no expectation --
+            # report the count as context and pass.
             infos.append(self.BOUND_DEVICES.format(len(bound), available))
 
         warnings.extend(self._traffic_warnings(efa_net))

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -191,9 +191,9 @@ class LustreFilesystem(Check):
     )
     EFA_PING_FAILED = CheckError(
         11,
-        "EFA ping from {} to every @efa peer ({}) failed -- the EFA data path is not working. Likely a "
-        "missing self-referencing security-group rule by SG-ID (EFA's SRD-over-MAC is not authorized by a "
-        "0.0.0.0/0 rule).",
+        "EFA ping from {} to every discovered @efa peer ({}) failed -- the EFA data path is not working. "
+        "Likely a missing self-referencing security-group rule by SG-ID (EFA's SRD-over-MAC is not "
+        "authorized by a 0.0.0.0/0 rule).",
     )
 
     # --- Errors: EFA prerequisites (checked before the EFA data-path probes) ------------------
@@ -231,8 +231,19 @@ class LustreFilesystem(Check):
         "expected count against the FSx guide "
         "https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html",
     )
+    SOME_EFA_PEERS_UNREACHABLE = CheckWarning(
+        4,
+        "EFA ping from {} failed for {} of the {} discovered @efa peers ({}), while the others answered -- "
+        "the local EFA path works, so whatever is wrong is specific to those peers. Confirm in `lnetctl "
+        "peer show` that those nids belong to peers this node should be reaching: an @efa nid left behind "
+        "by an earlier manual ping, or a rail of a peer that is no longer part of the filesystem, fails "
+        "exactly the same way.",
+    )
 
     # --- Infos --------------------------------------------------------------------------------
+    # I8 is retired: it carried EFA_BINDING_REFERENCE, a static pointer to FSX public doc.
+    # It was removed as we modified W3 (PARTIAL_BIND_UNVERIFIABLE) and E17 (UNDERBOUND_DEVICES)
+    # which points to the said document without causing confusion as unwanted I8 would have.
     CLIENT_VERSION = CheckInfo(1, "Lustre client version: {}.")
     ACTIVE_LNDS = CheckInfo(2, "Active LNet transports: {}.")
     EFA_SERVICE_ABSENT = CheckInfo(
@@ -248,17 +259,17 @@ class LustreFilesystem(Check):
     EFA_DRIVER_VERSION = CheckInfo(6, "EFA driver version: {}.")
     KEFALND_VERSION = CheckInfo(7, "kefalnd (EFA LND) version: {}.")
     LNETCTL_UNAVAILABLE = CheckInfo(
-        8,
+        9,
         "lnetctl is not available on this node, so the LNet transport and EFA probes were skipped "
         "(the Lustre client may not be installed).",
     )
     EFA_NOT_SUPPORTED_ON_OS = CheckInfo(
-        9,
+        10,
         "EFA-for-Lustre is not supported on this OS ({}), so the EFA probes were skipped. EFA-for-Lustre "
         "requires Amazon Linux 2023, RHEL 9.5+, or Ubuntu 22.04+.",
     )
     ALL_DEVICES_BOUND = CheckInfo(
-        10,
+        11,
         "{} of {} EFA devices are bound to LNet: every device present on this node is bound, so none is "
         "missing. The instance type could not be determined, so the expected count itself was not checked.",
     )
@@ -463,7 +474,7 @@ class LustreFilesystem(Check):
         self._probe_device_binding(context, lnet, errors, warnings, infos)
 
         warnings.extend(self._traffic_warnings(efa_net))
-        errors.extend(self._efa_ping_errors(lnet.nets))
+        self._probe_efa_ping(lnet.nets, errors, warnings)
 
     def _probe_device_binding(
         self,
@@ -607,28 +618,48 @@ class LustreFilesystem(Check):
                 warnings.append(self.NO_TRAFFIC.format(ni.nid))
         return warnings
 
-    def _efa_ping_errors(self, nets) -> List[CheckError]:
-        """Ping the @efa peers over EFA; error when the data path fails.
+    def _probe_efa_ping(self, nets, errors: List[CheckError], warnings: List[CheckWarning]) -> None:
+        """Ping the discovered @efa peers over EFA; error when none answers, warn when only some do.
 
-        Automates ``lnetctl ping --source <local>@efa <peer>@efa``. Discovers a local @efa nid and the set
-        of peer @efa nids from ``lnetctl``; when either is unavailable there is nothing to ping, so the
-        probe is skipped (a missing peer/local nid is not itself proof the data path is broken).
+        Automates ``lnetctl ping --source <local>@efa <peer>@efa``. The source is a local @efa nid, which
+        is what pins the probe to the EFA rail: without it LNet is free to answer over @tcp, which is why
+        ``lfs check servers`` cannot stand in for this.
 
-        Every @efa peer is pinged and the data path is treated as broken only when *all* of them fail. The
-        peer table can hold an @efa NID that answers nothing on a healthy fabric (see
-        ``lustre.efa_peer_nids``), so failing on one peer alone would be a false positive. A single
-        successful ping proves the SRD path works.
+        Only peers that are evidence about the data path are pinged. A leftover entry from an earlier
+        failed ping answers nothing even on a healthy fabric (see ``lustre.multi_rail_efa_peer_nids``), and
+        the node's own nids answer trivially -- a self-ping proves nothing about the fabric, yet counted as
+        a success it would downgrade a wholly broken path to a warning -- so both are excluded. When no
+        local nid or no such peer remains there is nothing to ping and the probe is skipped; that is not
+        itself proof the data path is broken.
+
+        Every remaining peer is pinged (no short-circuit) so the report can name exactly which ones failed.
+        All of them failing means the local EFA path is down -- typically the missing self-referencing
+        security-group rule, which breaks every peer at once. Only some failing localizes the problem to
+        those peers instead, which is a warning rather than an error.
+
+        A failed ping is only ever reported as "this nid did not answer over EFA from this node": the exit
+        status cannot say why (an unreachable server, or a rail LNet learned that nothing serves any more
+        both surface as ``errno: -1 ... Input/output error``), and it says nothing about what Lustre does
+        instead, so neither is claimed. The remediation points at ``lnetctl peer show`` rather than at the
+        client's import state for the same reason: a Multi-Rail peer keeps its ``@tcp`` nid as the primary
+        and carries the ``@efa`` nid as a secondary rail, so ``current_connection`` naming a ``@tcp`` nid is
+        not evidence about the EFA rail either way.
         """
         local = lustre.local_nids(nets, EFA_LNET_NET)
         if not local:
-            return []
-        peer_nids = lustre.efa_peer_nids()
+            return
+        own_nids = set(local)
+        peer_nids = [nid for nid in lustre.multi_rail_efa_peer_nids() if nid not in own_nids]
         if not peer_nids:
-            return []
+            return
         source = local[0]
-        if any(lustre.efa_ping_works(source, peer_nid) for peer_nid in peer_nids):
-            return []
-        return [self.EFA_PING_FAILED.format(source, ", ".join(peer_nids))]
+        unreachable = [nid for nid in peer_nids if not lustre.efa_ping_works(source, nid)]
+        if len(unreachable) == len(peer_nids):
+            errors.append(self.EFA_PING_FAILED.format(source, ", ".join(peer_nids)))
+        elif unreachable:
+            warnings.append(
+                self.SOME_EFA_PEERS_UNREACHABLE.format(source, len(unreachable), len(peer_nids), ", ".join(unreachable))
+            )
 
 
 class FsxTargetsAreReachable(Check):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -240,12 +240,12 @@ class LustreFilesystem(Check):
     EFA_DRIVER_VERSION = CheckInfo(6, "EFA driver version: {}.")
     KEFALND_VERSION = CheckInfo(7, "kefalnd (EFA LND) version: {}.")
     LNETCTL_UNAVAILABLE = CheckInfo(
-        9,
+        8,
         "lnetctl is not available on this node, so the LNet transport and EFA probes were skipped "
         "(the Lustre client may not be installed).",
     )
     EFA_NOT_SUPPORTED_ON_OS = CheckInfo(
-        10,
+        9,
         "EFA-for-Lustre is not supported on this OS ({}), so the EFA probes were skipped. EFA-for-Lustre "
         "requires Amazon Linux 2023, RHEL 9.5+, or Ubuntu 22.04+.",
     )

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -190,8 +190,10 @@ class LustreFilesystem(Check):
     )
     EFA_PING_FAILED = CheckError(
         11,
-        "EFA ping from {} to {} failed -- the EFA data path is not working. Check the security group "
-        "has a self-referencing rule by SG-ID (EFA's SRD-over-MAC is not authorized by a 0.0.0.0/0 rule).",
+        "EFA ping from {} to every @efa peer ({}) failed -- the EFA data path is not working. Likely a "
+        "missing self-referencing security-group rule by SG-ID (EFA's SRD-over-MAC is not authorized by a "
+        "0.0.0.0/0 rule); a server target served only on @tcp (e.g. an FSx MDT on a non-EFA NIC) is expected "
+        "to be unreachable over @efa and is not by itself a fault.",
     )
 
     # --- Errors: EFA prerequisites (checked before the EFA data-path probes) ------------------
@@ -577,22 +579,27 @@ class LustreFilesystem(Check):
         return warnings
 
     def _efa_ping_errors(self, nets) -> List[CheckError]:
-        """Ping an @efa peer over EFA (the tutorial's own validation); error when the data path fails.
+        """Ping the @efa peers over EFA (the tutorial's own validation); error when the data path fails.
 
-        Automates ``lnetctl ping --source <local>@efa <peer>@efa``. Discovers a local @efa nid and a peer
-        @efa nid from ``lnetctl``; when either is unavailable there is nothing to ping, so the probe is
-        skipped (a missing peer/local nid is not itself proof the data path is broken).
+        Automates ``lnetctl ping --source <local>@efa <peer>@efa``. Discovers a local @efa nid and the set
+        of peer @efa nids from ``lnetctl``; when either is unavailable there is nothing to ping, so the
+        probe is skipped (a missing peer/local nid is not itself proof the data path is broken).
+
+        Every @efa peer is pinged and the data path is treated as broken only when *all* of them fail.
+        LNet peer discovery can list an @efa NID for a server that does not serve EFA (e.g. an FSx MDT on a
+        plain-ENA NIC): that one NID is unpingable even on a healthy fabric, so failing on it alone would be
+        a false positive. A single successful ping proves the SRD path works.
         """
         local = lustre.local_nids(nets, EFA_LNET_NET)
         if not local:
             return []
-        peer_nid = lustre.efa_peer_nid()
-        if peer_nid is None:
+        peer_nids = lustre.efa_peer_nids()
+        if not peer_nids:
             return []
         source = local[0]
-        if not lustre.efa_ping_works(source, peer_nid):
-            return [self.EFA_PING_FAILED.format(source, peer_nid)]
-        return []
+        if any(lustre.efa_ping_works(source, peer_nid) for peer_nid in peer_nids):
+            return []
+        return [self.EFA_PING_FAILED.format(source, ", ".join(peer_nids))]
 
     def _tcp_fallback_warnings(self, nets) -> List[CheckWarning]:
         """Return a warning per target connected over @tcp while an @efa net is configured."""

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -41,8 +41,9 @@ executes each probe in isolation and aggregates their findings. The probes are:
   all (so Lustre falls back to TCP), fewer devices bound than the instance type is expected to bind (the
   expected count comes from a per-instance-family table, NOT the raw device count -- several families bind
   only a subset by design; an instance type absent from that table is expected to bind all present devices,
-  and only a genuinely unknown instance type is left unflagged beyond the "none bound" case), and a
-  non-working EFA data path (typically a missing self-referencing security-group rule).
+  and a genuinely unknown instance type yields a warning when some present device is unbound -- the one case
+  where a by-design subset cannot be told from an under-bind), and a non-working EFA data path (typically a
+  missing self-referencing security-group rule).
   See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html
 
 :class:`FsxTargetsAreReachable` is kept separate because it is a heavier, opt-in
@@ -223,6 +224,13 @@ class LustreFilesystem(Check):
         "idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent "
         "TCP fallback.",
     )
+    PARTIAL_BIND_UNVERIFIABLE = CheckWarning(
+        3,
+        "Only {} of the {} EFA devices present are bound to LNet, and the instance type could not be "
+        "determined, so this cannot be told apart from a family that binds a subset by design. Confirm the "
+        "expected count against the FSx guide "
+        "https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html",
+    )
 
     # --- Infos --------------------------------------------------------------------------------
     CLIENT_VERSION = CheckInfo(1, "Lustre client version: {}.")
@@ -248,6 +256,11 @@ class LustreFilesystem(Check):
         9,
         "EFA-for-Lustre is not supported on this OS ({}), so the EFA probes were skipped. EFA-for-Lustre "
         "requires Amazon Linux 2023, RHEL 9.5+, or Ubuntu 22.04+.",
+    )
+    ALL_DEVICES_BOUND = CheckInfo(
+        10,
+        "{} of {} EFA devices are bound to LNet: every device present on this node is bound, so none is "
+        "missing. The instance type could not be determined, so the expected count itself was not checked.",
     )
 
     @property
@@ -447,6 +460,27 @@ class LustreFilesystem(Check):
             # devices/traffic, so stop here.
             return
 
+        self._probe_device_binding(context, lnet, errors, warnings, infos)
+
+        warnings.extend(self._traffic_warnings(efa_net))
+        errors.extend(self._efa_ping_errors(lnet.nets))
+
+    def _probe_device_binding(
+        self,
+        context: Context,
+        lnet: _LnetSnapshot,
+        errors: List[CheckError],
+        warnings: List[CheckWarning],
+        infos: List[CheckInfo],
+    ) -> None:
+        """Classify how many EFA devices are bound to LNet against how many the instance type should bind.
+
+        The comparison is against the *expected* count, not the raw device count, because several families
+        bind a subset by design. When the instance type is unknown there is no expected count, and the two
+        possible readings of a partial bind -- a by-design subset or the load-order under-bind -- are
+        indistinguishable, so that case warns; a bind covering every device present cannot be missing
+        anything regardless of instance type, so it does not.
+        """
         bound = lustre.lnet_bound_interfaces(lnet.nets, EFA_LNET_NET)
         available = efa.efa_device_count()
         expected = efa.expected_bound_device_count(context.instance_type, available)
@@ -463,13 +497,17 @@ class LustreFilesystem(Check):
             errors.append(
                 self.UNDERBOUND_DEVICES.format(len(bound), expected, context.instance_type, EFA_LUSTRE_SYSTEMD_SERVICE)
             )
+        elif expected is None and len(bound) < available:
+            # The instance type is unknown AND some present device is unbound: the one binding outcome the
+            # check cannot decide, since a by-design subset and a real under-bind look identical. Warn.
+            warnings.append(self.PARTIAL_BIND_UNVERIFIABLE.format(len(bound), available))
+        elif expected is None:
+            # The instance type is unknown, but every device present is bound -- the maximum any family can
+            # bind -- so no device can be missing and the unknown expected count does not matter.
+            infos.append(self.ALL_DEVICES_BOUND.format(len(bound), available))
         else:
-            # All expected devices are bound, or the instance type is unknown so we have no expectation --
-            # report the count as context and pass.
+            # All expected devices are bound -- report the count as context and pass.
             infos.append(self.BOUND_DEVICES.format(len(bound), available))
-
-        warnings.extend(self._traffic_warnings(efa_net))
-        errors.extend(self._efa_ping_errors(lnet.nets))
 
     def _probe_efa_prerequisites(self, context: Context, errors: List[CheckError], infos: List[CheckInfo]) -> bool:
         """Verify the EFA-for-Lustre client prerequisites; return whether kefalnd is present.

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -46,9 +46,9 @@ executes each probe in isolation and aggregates their findings. The probes are:
   See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html
 
 :class:`FsxTargetsAreReachable` is kept separate because it is a heavier, opt-in
-(``approval_required``) deep probe (``lfs check servers`` + per-target import state); the framework's
-approval gate is per-check, so folding it into the always-on check would either force the deep probe to
-run every time or gate the whole check behind a prompt.
+(``approval_required``) deep probe (``lfs check servers``); the framework's approval gate is per-check, so
+folding it into the always-on check would either force the deep probe to run every time or gate the whole
+check behind a prompt.
 
 Both checks run on every node type that has a FsxLustre mount configured, and skip
 (SKIPPED_NOT_APPLICABLE) when the cluster configures no FsxLustre filesystem. Every probe is read-only.
@@ -68,8 +68,6 @@ from pcluster_diag.core.constants import (
     FSX_LFS_CHECK_TIMEOUT_SECONDS,
     FSX_LFS_DF_TIMEOUT_SECONDS,
     FSX_LNET_SHOW_TIMEOUT_SECONDS,
-    FSX_OST_QUERY_TIMEOUT_SECONDS,
-    HEALTHY_TARGET_STATE,
     LUSTRE_CLIENT_MIN_VERSION_BY_OS,
     LUSTRE_CLIENT_MIN_VERSION_DEFAULT,
     MIN_EFA_DRIVER_VERSION,
@@ -225,7 +223,6 @@ class LustreFilesystem(Check):
         "idle or freshly-booted node; if the node has been driving filesystem I/O it may indicate a silent "
         "TCP fallback.",
     )
-    TCP_FALLBACK = CheckWarning(3, "target {} is connected over @tcp despite EFA being configured (TCP fallback).")
 
     # --- Infos --------------------------------------------------------------------------------
     CLIENT_VERSION = CheckInfo(1, "Lustre client version: {}.")
@@ -485,7 +482,6 @@ class LustreFilesystem(Check):
 
         warnings.extend(self._traffic_warnings(efa_net))
         errors.extend(self._efa_ping_errors(lnet.nets))
-        warnings.extend(self._tcp_fallback_warnings(lnet.nets))
 
     def _probe_efa_prerequisites(self, context: Context, errors: List[CheckError], infos: List[CheckInfo]) -> bool:
         """Verify the EFA-for-Lustre client prerequisites; return whether kefalnd is present.
@@ -608,30 +604,14 @@ class LustreFilesystem(Check):
             return []
         return [self.EFA_PING_FAILED.format(source, ", ".join(peer_nids))]
 
-    def _tcp_fallback_warnings(self, nets) -> List[CheckWarning]:
-        """Return a warning per target connected over @tcp while an @efa net is configured."""
-        if lustre.lnet_net(nets, EFA_LNET_NET) is None:
-            return []
-        result = time_command(
-            ["lctl", "get_param", "osc.*.import", "mdc.*.import"], timeout=FSX_OST_QUERY_TIMEOUT_SECONDS
-        )
-        if result.timed_out or result.returncode != 0:
-            return []
-        return [
-            self.TCP_FALLBACK.format(state.target or state.param)
-            for state in lustre.parse_lctl_import(result.stdout)
-            if state.connected_over == "tcp"
-        ]
-
 
 class FsxTargetsAreReachable(Check):
     """Opt-in deep check pinpointing an unreachable OST/MDT -- a common cause of a hung directory listing.
 
-    Runs ``lfs check servers`` (the per-target reachability diagnostic) via ``time_command`` and inspects
-    client-side import state (``lctl get_param osc.*.import`` / ``mdc.*.import``). Because probing
-    individual targets is heavier and can itself block, this check is gated behind ``approval_required`` so
-    it runs only when the operator opts in (or passes ``--yes``). It is kept separate from
-    :class:`LustreFilesystem` because the approval gate is per-check.
+    Runs ``lfs check servers`` (the per-target reachability diagnostic) via ``time_command``. Because
+    probing individual targets is heavier and can itself block, this check is gated behind
+    ``approval_required`` so it runs only when the operator opts in (or passes ``--yes``). It is kept
+    separate from :class:`LustreFilesystem` because the approval gate is per-check.
     """
 
     LFS_CHECK_TIMED_OUT = CheckError(
@@ -640,12 +620,6 @@ class FsxTargetsAreReachable(Check):
     )
     LFS_CHECK_FAILED = CheckError(2, "lfs check servers failed: {}")
     TARGET_UNREACHABLE = CheckError(3, "target {} is unreachable (lfs check servers: {}).")
-    IMPORT_NOT_FULL = CheckError(4, "target {} import state is {} (not {}) -- the client is not fully connected.")
-    FAILOVER_PINNED = CheckInfo(
-        1,
-        "target {} current_connection {} equals its failover_nids -- no distinct failover NID "
-        "(a primary-server failure has no real failover).",
-    )
 
     @property
     def description(self) -> str:
@@ -661,16 +635,8 @@ class FsxTargetsAreReachable(Check):
         return True
 
     def run(self, context: Context) -> Result:
-        """Aggregate ``lfs check servers`` and import-state findings across every Lustre target."""
-        errors: List[CheckError] = []
-        infos: List[CheckInfo] = []
-
-        errors.extend(self._check_servers())
-        import_errors, import_infos = self._check_imports()
-        errors.extend(import_errors)
-        infos.extend(import_infos)
-
-        return Result.from_findings(self, errors=errors, infos=infos)
+        """Aggregate ``lfs check servers`` findings across every Lustre target."""
+        return Result.from_findings(self, errors=self._check_servers())
 
     def _check_servers(self) -> List[CheckError]:
         """Return CheckErrors from ``lfs check servers``: a hang, a command failure, or per-target errors."""
@@ -683,20 +649,3 @@ class FsxTargetsAreReachable(Check):
             self.TARGET_UNREACHABLE.format(server.target, server.detail)
             for server in lustre.unreachable_servers(result.stdout)
         ]
-
-    def _check_imports(self):
-        """Return (errors, infos) from client-side import state: non-FULL targets and failover pinning."""
-        errors: List[CheckError] = []
-        infos: List[CheckInfo] = []
-        result = time_command(
-            ["lctl", "get_param", "osc.*.import", "mdc.*.import"], timeout=FSX_OST_QUERY_TIMEOUT_SECONDS
-        )
-        if result.timed_out or result.returncode != 0:
-            return errors, infos
-        for state in lustre.parse_lctl_import(result.stdout):
-            name = state.target or state.param
-            if not state.healthy:
-                errors.append(self.IMPORT_NOT_FULL.format(name, state.state or "unknown", HEALTHY_TARGET_STATE))
-            if state.current_connection and state.failover_nids == [state.current_connection]:
-                infos.append(self.FAILOVER_PINNED.format(name, state.current_connection))
-        return errors, infos

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -239,13 +239,6 @@ class LustreFilesystem(Check):
     )
     EFA_DRIVER_VERSION = CheckInfo(6, "EFA driver version: {}.")
     KEFALND_VERSION = CheckInfo(7, "kefalnd (EFA LND) version: {}.")
-    EFA_BINDING_REFERENCE = CheckInfo(
-        8,
-        "EFA-for-Lustre binding follows the FSx guide -- the expected number of EFA devices bound to LNet "
-        "is instance-type-specific (some families bind a subset by design), and any type not listed binds "
-        "all present devices. "
-        "See https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html",
-    )
     LNETCTL_UNAVAILABLE = CheckInfo(
         9,
         "lnetctl is not available on this node, so the LNet transport and EFA probes were skipped "
@@ -457,9 +450,6 @@ class LustreFilesystem(Check):
         bound = lustre.lnet_bound_interfaces(lnet.nets, EFA_LNET_NET)
         available = efa.efa_device_count()
         expected = efa.expected_bound_device_count(context.instance_type, available)
-        # Note (once) that the expected binding is instance-type-specific per the FSx guide, so an operator
-        # reading the device-count findings knows "fewer than all bound" can be intentional.
-        infos.append(self.EFA_BINDING_REFERENCE)
         if available == 0:
             errors.append(self.NO_EFA_DEVICES.format(EFA_INFINIBAND_SYSFS))
         elif not bound:
@@ -471,9 +461,7 @@ class LustreFilesystem(Check):
             # subset by design do not false-fire. On every other family the expectation is "all present
             # devices", so a partial bind (the load-order incident signature) is caught here.
             errors.append(
-                self.UNDERBOUND_DEVICES.format(
-                    len(bound), expected, context.instance_type, EFA_LUSTRE_SYSTEMD_SERVICE
-                )
+                self.UNDERBOUND_DEVICES.format(len(bound), expected, context.instance_type, EFA_LUSTRE_SYSTEMD_SERVICE)
             )
         else:
             # All expected devices are bound, or the instance type is unknown so we have no expectation --

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -582,7 +582,7 @@ class LustreFilesystem(Check):
         return warnings
 
     def _efa_ping_errors(self, nets) -> List[CheckError]:
-        """Ping the @efa peers over EFA (the tutorial's own validation); error when the data path fails.
+        """Ping the @efa peers over EFA; error when the data path fails.
 
         Automates ``lnetctl ping --source <local>@efa <peer>@efa``. Discovers a local @efa nid and the set
         of peer @efa nids from ``lnetctl``; when either is unavailable there is nothing to ping, so the
@@ -624,7 +624,7 @@ class FsxTargetsAreReachable(Check):
     @property
     def description(self) -> str:
         """Return the human-readable description of this Check."""
-        return "Deep-probe each FsxLustre OST/MDT for reachability (lfs check servers + import state)."
+        return "Deep-probe each FsxLustre OST/MDT for reachability (lfs check servers)."
 
     def should_run(self, context: Context) -> bool:
         """Run only when a FsxLustre filesystem is configured."""

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/checks/fsx_connectivity.py
@@ -192,8 +192,7 @@ class LustreFilesystem(Check):
         11,
         "EFA ping from {} to every @efa peer ({}) failed -- the EFA data path is not working. Likely a "
         "missing self-referencing security-group rule by SG-ID (EFA's SRD-over-MAC is not authorized by a "
-        "0.0.0.0/0 rule); a server target served only on @tcp (e.g. an FSx MDT on a non-EFA NIC) is expected "
-        "to be unreachable over @efa and is not by itself a fault.",
+        "0.0.0.0/0 rule).",
     )
 
     # --- Errors: EFA prerequisites (checked before the EFA data-path probes) ------------------
@@ -585,10 +584,10 @@ class LustreFilesystem(Check):
         of peer @efa nids from ``lnetctl``; when either is unavailable there is nothing to ping, so the
         probe is skipped (a missing peer/local nid is not itself proof the data path is broken).
 
-        Every @efa peer is pinged and the data path is treated as broken only when *all* of them fail.
-        LNet peer discovery can list an @efa NID for a server that does not serve EFA (e.g. an FSx MDT on a
-        plain-ENA NIC): that one NID is unpingable even on a healthy fabric, so failing on it alone would be
-        a false positive. A single successful ping proves the SRD path works.
+        Every @efa peer is pinged and the data path is treated as broken only when *all* of them fail. The
+        peer table can hold an @efa NID that answers nothing on a healthy fabric (see
+        ``lustre.efa_peer_nids``), so failing on one peer alone would be a false positive. A single
+        successful ping proves the SRD path works.
         """
         local = lustre.local_nids(nets, EFA_LNET_NET)
         if not local:

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
@@ -122,8 +122,6 @@ FSX_LFS_DF_TIMEOUT_SECONDS = 30
 FSX_LFS_CHECK_TIMEOUT_SECONDS = 60
 # `lnetctl net show` is a fast, local query; cap it low so a wedged LNet cannot stall the check.
 FSX_LNET_SHOW_TIMEOUT_SECONDS = 15
-# `lctl get_param` reads client-side import state; bound it so a stuck import cannot hang the check.
-FSX_OST_QUERY_TIMEOUT_SECONDS = 30
 # `lnetctl ping` over EFA; a hang here is the signal the EFA data path is not working.
 FSX_EFA_PING_TIMEOUT_SECONDS = 15
 # The StorageType value a FSx for Lustre mount carries in the cluster configuration's SharedStorage.
@@ -131,8 +129,6 @@ LUSTRE_STORAGE_TYPE = "FsxLustre"
 # NFS-based shared-storage types. Reserved for a future NFS reachability check (a sibling of the Lustre
 # checks); not consumed yet.
 NFS_STORAGE_TYPES = ("FsxOntap", "FsxOpenZfs", "Efs")
-# The osc/mdc import ``state:`` value indicating a reachable, fully-connected target.
-HEALTHY_TARGET_STATE = "FULL"
 # --- EFA-for-Lustre client parameters -----------------------------------------------------
 # TODO/TO-CHECK: every value in this section mirrors the FSx EFA-Lustre client setup, which we cannot
 # import. If that setup bumps a version floor, adds/renames a p6+ family, or changes how many EFA devices a

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/core/constants.py
@@ -171,12 +171,15 @@ P6PLUS_INSTANCE_PREFIXES = ("p6-b200", "p6e-gb200", "p6-b300")
 
 # How many EFA devices the FSx-for-Lustre EFA client setup binds to LNet by default, keyed by exact
 # instance type. Values mirror the "Default Number of EFA Interfaces" table in
-# https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html#add-efa-interfaces --
-# these are the counts the setup script configures automatically per instance type. An int is exactly the
-# number of devices bound (capped at devices actually present). An instance type NOT in this table follows
-# the doc's dynamic fallback ("Other instances with multiple/single network cards" -> 2/1); we do not
-# encode that fallback because it depends on live NIC count, so unknown types get no static expectation
-# here and the underbinding check only flags a total absence of bound devices.
+# https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html -- these are the counts the
+# setup configures automatically per instance type. An int is exactly the number of devices bound (capped
+# at devices actually present). Kept row-for-row with the doc table so it can be verified against that page
+# at a glance; do not collapse rows even when a value equals the node's total device count.
+#
+# An instance type NOT in this table binds ALL present EFA devices -- see expected_bound_device_count().
+# The doc's "Other instances with multiple network cards -> 2" row describes the behaviour of the previous
+# setup script; the current one binds every device on those instance types instead. Confirmed empirically
+# on trn1.32xlarge (8 present, 8 bound on a correctly configured node).
 EFA_EXPECTED_BOUND_DEVICES = {
     "p5.48xlarge": 8,
     "p5e.48xlarge": 8,

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/efa.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/efa.py
@@ -81,16 +81,26 @@ def _is_efa_device(name: str) -> bool:
 def expected_bound_device_count(instance_type: Optional[str], available: int) -> Optional[int]:
     """Return how many EFA devices the FSx-for-Lustre EFA setup binds on ``instance_type``, or None.
 
-    Values come from EFA_EXPECTED_BOUND_DEVICES (mirroring the FSx-for-Lustre configure-efa-clients doc).
     ``available`` is the number of EFA devices actually present; the expected count is capped at it, so we
-    never expect more than exist. Returns None when the instance type is unknown or not in the table -- the
-    caller then makes no underbinding assertion beyond "at least one device must be bound".
+    never expect more than exist.
+
+    Instance types listed in EFA_EXPECTED_BOUND_DEVICES (mirroring the FSx-for-Lustre
+    configure-efa-clients doc) get that table's count -- these are the families the setup deliberately
+    binds a fixed number of devices on. Every other instance type is expected to bind ALL present devices,
+    derived from the node rather than hardcoded: the doc's "Other instances with multiple network cards
+    -> 2" row describes the previous setup script's behaviour, whereas the current one binds every device
+    on those instance types, so that row is stale and deliberately not encoded.
+
+    Returns None only when the instance type itself is unknown (e.g. IMDS was unreachable at
+    context-build time); the caller then makes no underbinding assertion beyond "at least one device must
+    be bound".
     """
     if not instance_type:
         return None
     expected = EFA_EXPECTED_BOUND_DEVICES.get(instance_type)
     if expected is None:
-        return None
+        # Not one of the fixed-count families: the setup binds every EFA device present on the node.
+        return available
     return min(expected, available)
 
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
@@ -10,11 +10,11 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Lustre helpers: ``lfs``/``lctl`` protocol parsing plus the LNet transport layer.
+"""Lustre helpers: ``lfs`` protocol parsing plus the LNet transport layer.
 
-Holds the Lustre-side logic: the ``lfs df`` / ``lfs check servers`` / ``lctl ...import`` protocol parsing,
-and the LNet transport layer (parsing ``lnetctl net show`` / ``lnetctl peer show`` and the ``lnetctl
-ping`` reachability probe) -- LNet is Lustre's own networking layer, driven by ``lnetctl``.
+Holds the Lustre-side logic: the ``lfs df`` / ``lfs check servers`` protocol parsing, and the LNet
+transport layer (parsing ``lnetctl net show`` / ``lnetctl peer show`` and the ``lnetctl ping``
+reachability probe) -- LNet is Lustre's own networking layer, driven by ``lnetctl``.
 """
 
 import logging
@@ -41,9 +41,6 @@ _ROLE_RE = re.compile(r"(MDT|OST)", re.IGNORECASE)
 
 # Matches a `lfs df -h` size column (e.g. "10.0T", "512", "1.5G"); healthy target rows start with one.
 _SIZE_RE = re.compile(r"^\d[\d.]*[KMGTPE]?$")
-
-# Matches the header line that opens each `lctl get_param ...import` block: e.g. `osc.fs-OST0000-osc-ffff.import=`.
-_IMPORT_HEADER_RE = re.compile(r"^(?P<param>\S+)\.import=\s*$")
 
 
 @dataclass
@@ -356,82 +353,3 @@ def parse_lfs_check_servers(output: str) -> List[ServerCheck]:
 def unreachable_servers(output: str) -> List[ServerCheck]:
     """Return the ``lfs check servers`` targets that did not report active (reachable)."""
     return [server for server in parse_lfs_check_servers(output) if not server.active]
-
-
-# --- lctl get_param ...import parsing -------------------------------------------------
-
-# A Lustre network id (e.g. 10.0.0.2@tcp, 10.0.0.2@efa), used to extract connection/failover nids.
-_NID_RE = re.compile(r"[\w.:\-]+@\w+")
-
-
-@dataclass
-class ImportState:
-    """Client-side import state for one target, parsed from ``lctl get_param osc.*.import`` / ``mdc.*.import``.
-
-    Attributes:
-        param: The parameter path identifying the target (e.g. ``osc.fs-OST0000-osc-ffff``).
-        target: The target UUID reported in the import block, or None when absent.
-        state: The import ``state:`` (e.g. ``FULL``, ``DISCONN``, ``RECOVER``), or None when absent.
-        current_connection: The nid the client is currently connected to, or None when absent.
-        failover_nids: The failover nids advertised for the target (may equal ``current_connection``).
-    """
-
-    param: str
-    target: Optional[str] = None
-    state: Optional[str] = None
-    current_connection: Optional[str] = None
-    failover_nids: List[str] = field(default_factory=list)
-
-    @property
-    def healthy(self) -> bool:
-        """Return whether the import reported a fully-connected state (case-insensitive ``FULL``)."""
-        return (self.state or "").upper() == "FULL"
-
-    @property
-    def connected_over(self) -> Optional[str]:
-        """Return the LND net type of the current connection (e.g. ``tcp``, ``efa``), or None."""
-        if not self.current_connection or "@" not in self.current_connection:
-            return None
-        return self.current_connection.rsplit("@", 1)[1]
-
-
-def parse_lctl_import(output: str) -> List[ImportState]:
-    """Parse ``lctl get_param osc.*.import`` / ``mdc.*.import`` output into per-target ``ImportState`` rows.
-
-    The output is a sequence of blocks, each opened by a ``<param>.import=`` header followed by indented
-    fields. Rather than YAML-parse the (not always YAML-clean) import blob, the loanable fields --
-    ``state``, ``target``, ``current_connection``, ``failover_nids`` -- are scanned line by line.
-    """
-    imports: List[ImportState] = []
-    current: Optional[ImportState] = None
-    for raw in output.splitlines():
-        header = _IMPORT_HEADER_RE.match(raw.strip())
-        if header:
-            current = ImportState(param=header.group("param"))
-            imports.append(current)
-            continue
-        if current is None:
-            continue
-        line = raw.strip()
-        target = _scan_field(line, "target")
-        if target is not None:
-            current.target = target
-        state = _scan_field(line, "state")
-        if state is not None:
-            current.state = state
-        connection = _scan_field(line, "current_connection")
-        if connection is not None:
-            nids = _NID_RE.findall(connection)
-            current.current_connection = nids[0] if nids else connection or None
-        failover = _scan_field(line, "failover_nids")
-        if failover is not None:
-            current.failover_nids = _NID_RE.findall(failover)
-    return imports
-
-
-def _scan_field(line: str, key: str) -> Optional[str]:
-    """Return the value of ``key: value`` in ``line`` (stripped), or None when the line is not that field."""
-    prefix = key + ":"
-    if line.startswith(prefix):
-        return line[len(prefix) :].strip()
-    return None

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
@@ -342,7 +342,11 @@ def parse_lfs_check_servers(output: str) -> List[ServerCheck]:
             results.append(ServerCheck(target=error_match.group("target"), active=False, detail=detail))
             continue
         tokens = line.split()
-        if len(tokens) < 2:
+        # Only a line whose first token names an MDT/OST is a per-target status row. `lfs` also emits
+        # command-level diagnostics (e.g. `lfs check: error: ...`), which carry no quoted target and would
+        # otherwise be read as a non-active target literally named "lfs". Mirrors _parse_target_line, which
+        # likewise requires a target role before treating a non-capacity row as a target.
+        if len(tokens) < 2 or not _ROLE_RE.search(tokens[0]):
             continue
         status = " ".join(tokens[1:])
         active = "active" in status.lower()

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
@@ -271,9 +271,10 @@ def nids_on_net(nids: List[str], net_type: str) -> List[str]:
 def efa_peer_nids() -> List[str]:
     """Return every ``@efa`` peer nid from ``lnetctl peer show`` (empty when none/unavailable).
 
-    LNet peer discovery can list an ``@efa`` NID for a server that does not actually serve EFA (e.g.
-    an FSx MDT whose server NIC is a plain ENA): that NID is unpingable even when the EFA fabric is
-    healthy. Callers therefore probe the whole set rather than trusting any single peer.
+    The peer table can hold an ``@efa`` NID that answers nothing even when the fabric is healthy: a
+    failed ``lnetctl ping`` to a NID nothing serves leaves a peer entry behind, carrying that NID as its
+    own primary with no ``@tcp`` rail (a discovered peer instead has a ``@tcp`` primary and ``@efa`` as a
+    secondary rail). Callers therefore probe the whole set rather than trusting any single peer.
     """
     result = time_command(["lnetctl", "peer", "show"], timeout=FSX_LNET_SHOW_TIMEOUT_SECONDS)
     if result.timed_out or result.returncode != 0:

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
@@ -224,11 +224,26 @@ def local_nids(nets: List[LnetNet], net_type: str) -> List[str]:
 # --- LNet transport: lnetctl peer show parsing ----------------------------------------
 
 
-def parse_lnet_peer_show(output: str) -> List[str]:
-    """Return the peer nids parsed from ``lnetctl peer show`` YAML (empty when unparseable/none).
+@dataclass
+class LnetPeer:
+    """A peer entry parsed from ``lnetctl peer show``.
+
+    Attributes:
+        primary_nid: The nid LNet identifies this peer by (the rail it was first reached on).
+        nids: Every nid on the peer -- the primary first, then each additional ``peer ni`` rail.
+    """
+
+    primary_nid: str
+    nids: List[str] = field(default_factory=list)
+
+
+def parse_lnet_peer_show(output: str) -> List[LnetPeer]:
+    """Parse ``lnetctl peer show`` YAML into ``LnetPeer`` entries (empty when unparseable/none).
 
     ``lnetctl peer show`` emits a top-level ``peer`` list; each entry carries a ``primary nid`` and a
-    ``peer ni`` list of ``nid`` mappings. Both are collected so callers can pick, e.g., the ``@efa`` nids.
+    ``peer ni`` list of ``nid`` mappings. Which nid is the primary is kept rather than flattened away,
+    because that is what tells a real discovered peer apart from a leftover one (see
+    :func:`multi_rail_efa_peer_nids`).
     """
     try:
         data = yaml.safe_load(output)
@@ -237,17 +252,19 @@ def parse_lnet_peer_show(output: str) -> List[str]:
         return []
     if not isinstance(data, dict):
         return []
-    nids: List[str] = []
+    peers: List[LnetPeer] = []
     for entry in data.get("peer") or []:
         if not isinstance(entry, dict):
             continue
         primary = entry.get("primary nid")
-        if primary:
-            nids.append(str(primary))
+        if not primary:
+            continue
+        nids = [str(primary)]
         for peer_ni in entry.get("peer ni") or []:
-            if isinstance(peer_ni, dict) and peer_ni.get("nid"):
+            if isinstance(peer_ni, dict) and peer_ni.get("nid") and str(peer_ni["nid"]) not in nids:
                 nids.append(str(peer_ni["nid"]))
-    return nids
+        peers.append(LnetPeer(primary_nid=str(primary), nids=nids))
+    return peers
 
 
 def nids_on_net(nids: List[str], net_type: str) -> List[str]:
@@ -265,24 +282,27 @@ def nids_on_net(nids: List[str], net_type: str) -> List[str]:
 # --- LNet transport: the lnetctl ping reachability probe ------------------------------
 
 
-def efa_peer_nids() -> List[str]:
-    """Return every ``@efa`` peer nid from ``lnetctl peer show`` (empty when none/unavailable).
-
-    The peer table can hold an ``@efa`` NID that answers nothing even when the fabric is healthy: a
-    failed ``lnetctl ping`` to a NID nothing serves leaves a peer entry behind, carrying that NID as its
-    own primary with no ``@tcp`` rail (a discovered peer instead has a ``@tcp`` primary and ``@efa`` as a
-    secondary rail). Callers therefore probe the whole set rather than trusting any single peer.
-    """
+def lnet_peers() -> List[LnetPeer]:
+    """Return the LNet peer table from ``lnetctl peer show`` (empty when it fails, times out, or is garbage)."""
     result = time_command(["lnetctl", "peer", "show"], timeout=FSX_LNET_SHOW_TIMEOUT_SECONDS)
     if result.timed_out or result.returncode != 0:
         return []
-    return nids_on_net(parse_lnet_peer_show(result.stdout), EFA_LNET_NET)
+    return parse_lnet_peer_show(result.stdout)
 
 
-def efa_peer_nid() -> Optional[str]:
-    """Return the first ``@efa`` peer nid from ``lnetctl peer show``, or None when none is available."""
-    efa_peers = efa_peer_nids()
-    return efa_peers[0] if efa_peers else None
+def multi_rail_efa_peer_nids() -> List[str]:
+    """Return the ``@efa`` rails of the peers LNet actually discovered (empty when there are none).
+
+    A real server reached over EFA is a Multi-Rail peer: LNet contacted it on its ``@tcp`` primary nid and
+    discovery then learned its ``@efa`` rail, so the entry carries a non-``@efa`` primary with an ``@efa``
+    nid among its rails. An entry of the opposite shape -- an ``@efa`` NID as its own primary -- is what a
+    failed ``lnetctl ping`` leaves behind, and that NID answers nothing even on a healthy fabric. Only the
+    discovered shape is evidence about the EFA data path, so callers that ping to prove the path works
+    probe these nids rather than every ``@efa`` nid in the table.
+    """
+    suffix = "@" + EFA_LNET_NET
+    discovered = [nid for peer in lnet_peers() if not peer.primary_nid.endswith(suffix) for nid in peer.nids]
+    return nids_on_net(discovered, EFA_LNET_NET)
 
 
 def efa_ping_works(source_nid: str, peer_nid: str) -> bool:

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/pcluster_diag/util/lustre.py
@@ -268,12 +268,22 @@ def nids_on_net(nids: List[str], net_type: str) -> List[str]:
 # --- LNet transport: the lnetctl ping reachability probe ------------------------------
 
 
-def efa_peer_nid() -> Optional[str]:
-    """Return an ``@efa`` peer nid from ``lnetctl peer show``, or None when none is available."""
+def efa_peer_nids() -> List[str]:
+    """Return every ``@efa`` peer nid from ``lnetctl peer show`` (empty when none/unavailable).
+
+    LNet peer discovery can list an ``@efa`` NID for a server that does not actually serve EFA (e.g.
+    an FSx MDT whose server NIC is a plain ENA): that NID is unpingable even when the EFA fabric is
+    healthy. Callers therefore probe the whole set rather than trusting any single peer.
+    """
     result = time_command(["lnetctl", "peer", "show"], timeout=FSX_LNET_SHOW_TIMEOUT_SECONDS)
     if result.timed_out or result.returncode != 0:
-        return None
-    efa_peers = nids_on_net(parse_lnet_peer_show(result.stdout), EFA_LNET_NET)
+        return []
+    return nids_on_net(parse_lnet_peer_show(result.stdout), EFA_LNET_NET)
+
+
+def efa_peer_nid() -> Optional[str]:
+    """Return the first ``@efa`` peer nid from ``lnetctl peer show``, or None when none is available."""
+    efa_peers = efa_peer_nids()
     return efa_peers[0] if efa_peers else None
 
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -643,6 +643,9 @@ def test_efa_all_bound_and_pinging_no_error(monkeypatch):
 
     assert errors == []
     assert LustreFilesystem.BOUND_DEVICES.code in _codes(infos)
+    # The instance type is known here, so the confident "matches the expected count" wording is the right
+    # one -- the unverifiable-bind warning must not also fire.
+    assert LustreFilesystem.PARTIAL_BIND_UNVERIFIABLE.code not in _codes(warnings)
 
 
 def test_efa_partial_bind_on_non_fixed_count_instance_type_fails(monkeypatch):
@@ -675,9 +678,9 @@ def test_efa_partial_bind_on_non_fixed_count_instance_type_fails(monkeypatch):
     assert "https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html" in _messages(errors)
 
 
-def test_efa_partial_bind_with_unknown_instance_type_makes_no_assertion(monkeypatch):
+def test_efa_partial_bind_with_unknown_instance_type_warns(monkeypatch):
     # IMDS could not report the instance type: we cannot say how many devices should be bound, so a partial
-    # bind is reported as context and passes rather than guessing.
+    # bind is warned about rather than either guessing an error or passing it off as context.
     _patch_efa_prereqs(monkeypatch)
     _route_time_command(
         monkeypatch,
@@ -696,8 +699,40 @@ def test_efa_partial_bind_with_unknown_instance_type_makes_no_assertion(monkeypa
 
     assert LustreFilesystem.NO_DEVICES_BOUND.code not in _codes(errors)
     assert LustreFilesystem.UNDERBOUND_DEVICES.code not in _codes(errors)
-    assert LustreFilesystem.BOUND_DEVICES.code in _codes(infos)
-    assert "1 of 16" in _messages(infos)
+    assert LustreFilesystem.PARTIAL_BIND_UNVERIFIABLE.code in _codes(warnings)
+    assert "1 of the 16" in _messages(warnings)
+    # 1 of 16 bound is the under-bind signature: without an expected count to compare against, the report
+    # must not claim the bind matches expectations, and must point at the doc that carries the real count.
+    # It is a warning, not context: an unverifiable partial bind is a risk an operator has to resolve.
+    assert LustreFilesystem.BOUND_DEVICES.code not in _codes(infos)
+    assert LustreFilesystem.ALL_DEVICES_BOUND.code not in _codes(infos)
+    assert "https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html" in _messages(warnings)
+
+
+def test_efa_every_present_device_bound_with_unknown_instance_type_does_not_warn(monkeypatch):
+    # IMDS could not report the instance type, but every EFA device present is bound -- the most any family
+    # can bind -- so no device can be missing and there is nothing to warn about.
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(stdout="ping ok"),
+            "import": _timed(stdout=_IMPORT_EFA),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    context = sample_context_with_lustre(NodeType.COMPUTE)
+    context.instance_type = None
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(context, _snapshot(_LNET_TCP_EFA), errors, warnings, infos)
+
+    assert LustreFilesystem.PARTIAL_BIND_UNVERIFIABLE.code not in _codes(warnings)
+    assert LustreFilesystem.ALL_DEVICES_BOUND.code in _codes(infos)
+    assert "1 of 1" in _messages(infos)
+    # The count is reported without claiming it was checked against an expectation we never computed.
+    assert LustreFilesystem.BOUND_DEVICES.code not in _codes(infos)
 
 
 def test_efa_underbound_fails_when_expected_equals_available(monkeypatch):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -1122,6 +1122,18 @@ def test_targets_unreachable_server_fails(monkeypatch):
     assert "fs-OST000b-osc-ffff" in _messages(result.errors)
 
 
+def test_targets_command_level_error_line_is_not_a_target(monkeypatch):
+    # Real `lfs check servers` output can carry a command-level diagnostic alongside the per-target rows.
+    # It names no target, so it must not surface as a phantom unreachable target (previously "lfs").
+    noisy = _LFS_CHECK_HEALTHY + "lfs check: error: Input/output error (5)\n"
+    _route_time_command(monkeypatch, {"lfs check": _timed(stdout=noisy)})
+
+    result = FsxTargetsAreReachable().run(sample_context_with_lustre(NodeType.COMPUTE))
+
+    assert result.status is Status.PASSED
+    assert not result.errors
+
+
 def test_targets_lfs_check_timeout_fails(monkeypatch):
     _route_time_command(
         monkeypatch,

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -450,6 +450,18 @@ peer:
         - nid: 10.0.1.5@efa
 """
 
+# Two @efa peers: e.g. an FSx OSS on an EFA NIC (10.0.1.5, pingable) plus a metadata/TCP-only server
+# whose discovered @efa NID (10.0.1.6) is never pingable even on a healthy fabric.
+_LNET_PEER_EFA_MULTI = """\
+peer:
+    - primary nid: 10.0.1.5@efa
+      peer ni:
+        - nid: 10.0.1.5@efa
+    - primary nid: 10.0.1.6@efa
+      peer ni:
+        - nid: 10.0.1.6@efa
+"""
+
 _IMPORT_EFA = """\
 osc.fs-OST0000-osc-ffff.import=
     import:
@@ -751,7 +763,8 @@ def test_efa_no_devices_bound_fails(monkeypatch):
     assert "16" in _messages(errors)
 
 
-def test_efa_ping_failure_points_at_security_group(monkeypatch):
+def test_efa_ping_failure_when_all_peers_fail(monkeypatch):
+    # Every @efa peer ping fails -> the data path is genuinely down; E11 fires and names the SG cause.
     _patch_efa_prereqs(monkeypatch)
     _route_time_command(
         monkeypatch,
@@ -769,7 +782,32 @@ def test_efa_ping_failure_points_at_security_group(monkeypatch):
     )
 
     assert LustreFilesystem.EFA_PING_FAILED.code in _codes(errors)
-    assert "security group" in _messages(errors)
+    assert "security-group" in _messages(errors)
+
+
+def test_efa_no_ping_error_when_any_peer_reachable(monkeypatch):
+    # One @efa peer is unpingable (10.0.1.6, e.g. a TCP-only server's discovered @efa NID) but another
+    # (10.0.1.5) pings clean: the SRD path is proven working, so E11 must NOT fire. This is the FSx
+    # mixed-target case (EFA-capable OSS + TCP-only metadata) that must read WARNING, not FAILURE.
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA_MULTI),
+            "10.0.1.6@efa": _timed(returncode=1, stderr="cannot reach"),
+            "ping": _timed(stdout="ok"),
+            "import": _timed(stdout=_IMPORT_TCP_FALLBACK),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.EFA_PING_FAILED.code not in _codes(errors)
+    assert LustreFilesystem.TCP_FALLBACK.code in _codes(warnings)
 
 
 def test_efa_no_traffic_is_warning(monkeypatch):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -439,23 +439,103 @@ net:
               health value: 1000
 """
 
+# One discovered server, in the shape a real FSx server appears in: LNet reached 10.0.1.5 on its @tcp
+# primary nid and discovery then learned its other rails -- a 198.19.0.0/16 @tcp1 nid on the filesystem's
+# internal net (the client has no local @tcp1 NI, so it is never a probe target) and the @efa rail. Only
+# this Multi-Rail shape is evidence about the EFA data path (see lustre.multi_rail_efa_peer_nids). The
+# second entry is the internal net standing on its own, as live tables carry it: @tcp1 primary, no @efa
+# rail, so it contributes no probe target either.
 _LNET_PEER_EFA = """\
 peer:
-    - primary nid: 10.0.1.5@efa
+    - primary nid: 10.0.1.5@tcp
+      Multi-Rail: True
       peer ni:
+        - nid: 10.0.1.5@tcp
+          state: NA
+        - nid: 198.19.0.5@tcp1
+          state: NA
         - nid: 10.0.1.5@efa
+          state: NA
+    - primary nid: 198.19.1.78@tcp1
+      Multi-Rail: True
+      peer ni:
+        - nid: 198.19.1.78@tcp1
+          state: NA
 """
 
-# Two @efa peers, each its own primary nid: a real server (10.0.1.5, pingable) plus an @efa NID that
-# answers nothing (10.0.1.6) -- the shape a failed ping to a non-existent NID leaves behind.
-_LNET_PEER_EFA_MULTI = """\
+# Two discovered servers, each with an @efa rail: enough to tell "every peer is unreachable over EFA"
+# (a local problem) from "one peer is" (that server's problem).
+_LNET_PEER_EFA_TWO_SERVERS = """\
 peer:
-    - primary nid: 10.0.1.5@efa
+    - primary nid: 10.0.1.5@tcp
       peer ni:
+        - nid: 10.0.1.5@tcp
+        - nid: 198.19.0.5@tcp1
         - nid: 10.0.1.5@efa
-    - primary nid: 10.0.1.6@efa
+    - primary nid: 10.0.1.6@tcp
       peer ni:
+        - nid: 10.0.1.6@tcp
+        - nid: 198.19.0.6@tcp1
         - nid: 10.0.1.6@efa
+"""
+
+# The shape a failed `lnetctl ping` leaves behind: the pinged @efa NID as its own primary, no other rail.
+# It answers nothing even on a healthy fabric, so it is no evidence either way.
+_LNET_PEER_EFA_LEFTOVER = """\
+peer:
+    - primary nid: 10.0.1.9@efa
+      Multi-Rail: False
+      peer ni:
+        - nid: 10.0.1.9@efa
+"""
+
+# A peer table polluted by hand-debugging, as seen on a live node: `lnetctl ping --source <server efa nid>
+# <own efa nid>` cannot use a remote nid as its source, so it fails -- and leaves this node's OWN @efa nid
+# behind as a Multi-Rail False entry that is its own primary. 10.0.1.99@efa is the other way to pollute the
+# table, a ping to a nid nothing serves. Both exclusions are needed here: the self nid answers every ping,
+# and the phantom nid answers none, so counting either one misreads the fabric.
+_LNET_PEER_EFA_POLLUTED = """\
+peer:
+    - primary nid: 10.0.0.1@efa
+      Multi-Rail: False
+      peer ni:
+        - nid: 10.0.0.1@efa
+          state: NA
+    - primary nid: 10.0.1.99@efa
+      Multi-Rail: False
+      peer ni:
+        - nid: 10.0.1.99@efa
+          state: NA
+    - primary nid: 198.19.1.78@tcp1
+      Multi-Rail: True
+      peer ni:
+        - nid: 198.19.1.78@tcp1
+          state: NA
+    - primary nid: 10.0.1.5@tcp
+      Multi-Rail: True
+      peer ni:
+        - nid: 10.0.1.5@tcp
+          state: NA
+        - nid: 198.19.0.5@tcp1
+          state: NA
+        - nid: 10.0.1.5@efa
+          state: NA
+"""
+
+# A peer entry carrying this node's OWN @efa nid (10.0.0.1@efa, the local nid in _LNET_TCP_EFA) as a rail,
+# alongside the real server. The node has no @tcp1 NI of its own, so its entry carries no @tcp1 rail.
+# Pinging yourself always succeeds and proves nothing about the fabric.
+_LNET_PEER_EFA_SELF_AND_SERVER = """\
+peer:
+    - primary nid: 10.0.0.1@tcp
+      peer ni:
+        - nid: 10.0.0.1@tcp
+        - nid: 10.0.0.1@efa
+    - primary nid: 10.0.1.5@tcp
+      peer ni:
+        - nid: 10.0.1.5@tcp
+        - nid: 198.19.0.5@tcp1
+        - nid: 10.0.1.5@efa
 """
 
 _IMPORT_EFA = """\
@@ -828,14 +908,15 @@ def test_efa_ping_failure_when_all_peers_fail(monkeypatch):
     assert "security-group" in _messages(errors)
 
 
-def test_efa_no_ping_error_when_any_peer_reachable(monkeypatch):
-    # One @efa peer is unpingable (10.0.1.6, e.g. a phantom peer left by an earlier failed ping) but
-    # another (10.0.1.5) pings clean: the SRD path is proven working, so E11 must NOT fire.
+def test_efa_one_unreachable_peer_warns_instead_of_failing(monkeypatch):
+    # 10.0.1.6 is unreachable over EFA while 10.0.1.5 pings clean: the local EFA path works, so this is that
+    # one server's problem -- a warning naming it, not the E11 "the data path is down" failure. Under the
+    # old "one success is enough" rule the unreachable peer was reported as nothing at all.
     _patch_efa_prereqs(monkeypatch)
     _route_time_command(
         monkeypatch,
         {
-            "peer show": _timed(stdout=_LNET_PEER_EFA_MULTI),
+            "peer show": _timed(stdout=_LNET_PEER_EFA_TWO_SERVERS),
             "10.0.1.6@efa": _timed(returncode=1, stderr="cannot reach"),
             "ping": _timed(stdout="ok"),
         },
@@ -848,6 +929,85 @@ def test_efa_no_ping_error_when_any_peer_reachable(monkeypatch):
     )
 
     assert LustreFilesystem.EFA_PING_FAILED.code not in _codes(errors)
+    assert LustreFilesystem.SOME_EFA_PEERS_UNREACHABLE.code in _codes(warnings)
+    # The report has to name the peer that failed, not just the count: that is what an operator acts on.
+    assert "10.0.1.6@efa" in _messages(warnings)
+    assert "1 of the 2" in _messages(warnings)
+
+
+def test_efa_ping_ignores_own_local_nid_in_the_peer_table(monkeypatch):
+    # A peer entry for this node's own @efa nid answers trivially. Counting that self-ping as a success let a
+    # genuinely dead data path pass: with the real server (10.0.1.5) unreachable, E11 must still fire.
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA_SELF_AND_SERVER),
+            "10.0.0.1@efa 10.0.0.1@efa": _timed(stdout="ok"),
+            "ping": _timed(returncode=1, stderr="cannot reach"),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.EFA_PING_FAILED.code in _codes(errors)
+    assert "10.0.1.5@efa" in _messages(errors)
+    # Not a partial failure either: the self nid is excluded from the probe, so it counts as neither a
+    # reachable peer nor an unreachable one.
+    assert LustreFilesystem.SOME_EFA_PEERS_UNREACHABLE.code not in _codes(warnings)
+
+
+def test_efa_ping_fails_despite_a_peer_table_polluted_by_hand_debugging(monkeypatch):
+    # The live-node case: a failed reverse ping injected this node's own @efa nid into the peer table. That
+    # entry answers every ping, so counting it let a dead data path report PASSED. With the real server
+    # (10.0.1.5) unreachable, the check must report E11 -- the pollution buys the fabric no credit.
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA_POLLUTED),
+            "10.0.0.1@efa 10.0.0.1@efa": _timed(stdout="ok"),
+            "ping": _timed(returncode=1, stderr="failed to ping 10.0.1.5@efa: Input/output error"),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.EFA_PING_FAILED.code in _codes(errors)
+    assert "10.0.1.5@efa" in _messages(errors)
+    # Neither injected nid is treated as a peer, so neither shows up in the report...
+    assert "10.0.1.99@efa" not in _messages(errors)
+    # ...and the phantom nid failing alongside the real server is not read as a partial failure either.
+    assert LustreFilesystem.SOME_EFA_PEERS_UNREACHABLE.code not in _codes(warnings)
+
+
+def test_efa_ping_skipped_when_only_a_leftover_peer_entry_exists(monkeypatch):
+    # The peer table holds nothing but an @efa NID that is its own primary -- a leftover from an earlier
+    # failed ping. There is no discovered peer to probe, so no ping runs and nothing is reported.
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(monkeypatch, {"peer show": _timed(stdout=_LNET_PEER_EFA_LEFTOVER)})
+
+    def _boom_ping(source_nid, peer_nid):
+        raise AssertionError("a leftover peer entry must not be pinged: it answers nothing when healthy")
+
+    monkeypatch.setattr(fsx_connectivity.lustre, "efa_ping_works", _boom_ping)
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(
+        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
+    )
+
+    assert LustreFilesystem.EFA_PING_FAILED.code not in _codes(errors)
+    assert LustreFilesystem.SOME_EFA_PEERS_UNREACHABLE.code not in _codes(warnings)
 
 
 def test_efa_no_traffic_is_warning(monkeypatch):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -669,9 +669,10 @@ def test_efa_all_bound_and_pinging_no_error(monkeypatch):
     assert LustreFilesystem.BOUND_DEVICES.code in _codes(infos)
 
 
-def test_efa_partial_bind_on_unknown_instance_type_is_not_an_error(monkeypatch):
-    # 1 of 16 bound on an instance type with no expected-count entry (the sample context's fake type):
-    # we make no underbinding assertion, so it is an info + pass, not an error.
+def test_efa_partial_bind_on_non_fixed_count_instance_type_fails(monkeypatch):
+    # An instance type with no entry in the doc table (the sample context's fake type, like trn1.32xlarge)
+    # is expected to bind ALL present devices, so 1 of 16 bound is the load-order incident signature and
+    # must be an error -- not the silent pass the stale "2 for other instances" doc row used to produce.
     _patch_efa_prereqs(monkeypatch)
     _route_time_command(
         monkeypatch,
@@ -687,6 +688,35 @@ def test_efa_partial_bind_on_unknown_instance_type_is_not_an_error(monkeypatch):
     LustreFilesystem()._probe_efa(
         sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_EFA_PARTIAL_BIND), errors, warnings, infos
     )
+
+    assert LustreFilesystem.UNDERBOUND_DEVICES.code in _codes(errors)
+    assert "1 of 16" in _messages(errors)
+    # The remediation points at the setup script's own output, not at re-running it (a re-run cannot help
+    # while libcfs is already loaded with the wrong partition count).
+    assert "journalctl -u configure-efa-fsx-lustre-client.service" in _messages(errors)
+    # An instance type absent from the table carries an assertion rather than silence, so a family that
+    # binds a subset by design would false-fire here: the message must name the FSx doc to check against.
+    assert "https://docs.aws.amazon.com/fsx/latest/LustreGuide/configure-efa-clients.html" in _messages(errors)
+
+
+def test_efa_partial_bind_with_unknown_instance_type_makes_no_assertion(monkeypatch):
+    # IMDS could not report the instance type: we cannot say how many devices should be bound, so a partial
+    # bind is reported as context and passes rather than guessing.
+    _patch_efa_prereqs(monkeypatch)
+    _route_time_command(
+        monkeypatch,
+        {
+            "peer show": _timed(stdout=_LNET_PEER_EFA),
+            "ping": _timed(stdout="ping ok"),
+            "import": _timed(stdout=_IMPORT_EFA),
+        },
+    )
+    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 16)
+    context = sample_context_with_lustre(NodeType.COMPUTE)
+    context.instance_type = None
+    errors, warnings, infos = [], [], []
+
+    LustreFilesystem()._probe_efa(context, _snapshot(_LNET_EFA_PARTIAL_BIND), errors, warnings, infos)
 
     assert LustreFilesystem.NO_DEVICES_BOUND.code not in _codes(errors)
     assert LustreFilesystem.UNDERBOUND_DEVICES.code not in _codes(errors)
@@ -761,6 +791,8 @@ def test_efa_no_devices_bound_fails(monkeypatch):
 
     assert LustreFilesystem.NO_DEVICES_BOUND.code in _codes(errors)
     assert "16" in _messages(errors)
+    # Same remediation shape as the underbound case: read the setup script's output, do not re-run it.
+    assert "journalctl -u configure-efa-fsx-lustre-client.service" in _messages(errors)
 
 
 def test_efa_ping_failure_when_all_peers_fail(monkeypatch):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -450,8 +450,8 @@ peer:
         - nid: 10.0.1.5@efa
 """
 
-# Two @efa peers: e.g. an FSx OSS on an EFA NIC (10.0.1.5, pingable) plus a metadata/TCP-only server
-# whose discovered @efa NID (10.0.1.6) is never pingable even on a healthy fabric.
+# Two @efa peers, each its own primary nid: a real server (10.0.1.5, pingable) plus an @efa NID that
+# answers nothing (10.0.1.6) -- the shape a failed ping to a non-existent NID leaves behind.
 _LNET_PEER_EFA_MULTI = """\
 peer:
     - primary nid: 10.0.1.5@efa
@@ -786,9 +786,8 @@ def test_efa_ping_failure_when_all_peers_fail(monkeypatch):
 
 
 def test_efa_no_ping_error_when_any_peer_reachable(monkeypatch):
-    # One @efa peer is unpingable (10.0.1.6, e.g. a TCP-only server's discovered @efa NID) but another
-    # (10.0.1.5) pings clean: the SRD path is proven working, so E11 must NOT fire. This is the FSx
-    # mixed-target case (EFA-capable OSS + TCP-only metadata) that must read WARNING, not FAILURE.
+    # One @efa peer is unpingable (10.0.1.6, e.g. a phantom peer left by an earlier failed ping) but
+    # another (10.0.1.5) pings clean: the SRD path is proven working, so E11 must NOT fire.
     _patch_efa_prereqs(monkeypatch)
     _route_time_command(
         monkeypatch,
@@ -807,7 +806,6 @@ def test_efa_no_ping_error_when_any_peer_reachable(monkeypatch):
     )
 
     assert LustreFilesystem.EFA_PING_FAILED.code not in _codes(errors)
-    assert LustreFilesystem.TCP_FALLBACK.code in _codes(warnings)
 
 
 def test_efa_no_traffic_is_warning(monkeypatch):

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/checks/test_fsx_connectivity.py
@@ -59,10 +59,6 @@ def _messages(findings):
     return " | ".join(finding.message for finding in (findings or []))
 
 
-def _info_codes(result):
-    return [finding.code for finding in (result.infos or [])]
-
-
 def _snapshot(stdout):
     """Build an _LnetSnapshot from parsed ``lnetctl net show -v`` output (as the check would fetch it)."""
     from pcluster_diag.util import lustre
@@ -472,26 +468,6 @@ osc.fs-OST0000-osc-ffff.import=
             failover_nids: [ 10.0.1.5@efa ]
 """
 
-_IMPORT_TCP_FALLBACK = """\
-osc.fs-OST0000-osc-ffff.import=
-    import:
-        target: fs-OST0000_UUID
-        state: FULL
-        connection:
-            current_connection: 10.0.1.5@tcp
-            failover_nids: [ 10.0.1.5@tcp ]
-"""
-
-_IMPORT_DISCONN = """\
-osc.fs-OST0000-osc-ffff.import=
-    import:
-        target: fs-OST0000_UUID
-        state: DISCONN
-        connection:
-            current_connection: 10.0.1.5@efa
-            failover_nids: [ 10.0.1.5@efa ]
-"""
-
 _LFS_CHECK_HEALTHY = "fs-OST0000-osc-ffff active.\nfs-MDT0000-mdc-ffff active.\n"
 _LFS_CHECK_BAD = "fs-OST0000-osc-ffff active.\ncheck 'fs-OST000b-osc-ffff': Input/output error (5)\n"
 
@@ -827,7 +803,6 @@ def test_efa_no_ping_error_when_any_peer_reachable(monkeypatch):
             "peer show": _timed(stdout=_LNET_PEER_EFA_MULTI),
             "10.0.1.6@efa": _timed(returncode=1, stderr="cannot reach"),
             "ping": _timed(stdout="ok"),
-            "import": _timed(stdout=_IMPORT_TCP_FALLBACK),
         },
     )
     monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
@@ -858,26 +833,6 @@ def test_efa_no_traffic_is_warning(monkeypatch):
     )
 
     assert LustreFilesystem.NO_TRAFFIC.code in _codes(warnings)
-
-
-def test_efa_tcp_fallback_is_warning(monkeypatch):
-    _patch_efa_prereqs(monkeypatch)
-    _route_time_command(
-        monkeypatch,
-        {
-            "peer show": _timed(stdout=_LNET_PEER_EFA),
-            "ping": _timed(stdout="ok"),
-            "import": _timed(stdout=_IMPORT_TCP_FALLBACK),
-        },
-    )
-    monkeypatch.setattr(fsx_connectivity.efa, "efa_device_count", lambda: 1)
-    errors, warnings, infos = [], [], []
-
-    LustreFilesystem()._probe_efa(
-        sample_context_with_lustre(NodeType.COMPUTE), _snapshot(_LNET_TCP_EFA), errors, warnings, infos
-    )
-
-    assert LustreFilesystem.TCP_FALLBACK.code in _codes(warnings)
 
 
 # --- EFA prerequisites & systemd service (checked before the data-path probes) --------
@@ -1180,28 +1135,3 @@ def test_targets_lfs_check_timeout_fails(monkeypatch):
 
     assert result.status is Status.FAILURE
     assert _codes(result.errors) == [FsxTargetsAreReachable.LFS_CHECK_TIMED_OUT.code]
-
-
-def test_targets_non_full_import_fails(monkeypatch):
-    _route_time_command(
-        monkeypatch,
-        {"lfs check": _timed(stdout=_LFS_CHECK_HEALTHY), "import": _timed(stdout=_IMPORT_DISCONN)},
-    )
-
-    result = FsxTargetsAreReachable().run(sample_context_with_lustre(NodeType.COMPUTE))
-
-    assert result.status is Status.FAILURE
-    assert FsxTargetsAreReachable.IMPORT_NOT_FULL.code in _codes(result.errors)
-    assert "DISCONN" in _messages(result.errors)
-
-
-def test_targets_failover_pin_is_info(monkeypatch):
-    _route_time_command(
-        monkeypatch,
-        {"lfs check": _timed(stdout=_LFS_CHECK_HEALTHY), "import": _timed(stdout=_IMPORT_EFA)},
-    )
-
-    result = FsxTargetsAreReachable().run(sample_context_with_lustre(NodeType.COMPUTE))
-
-    assert result.status is Status.PASSED
-    assert FsxTargetsAreReachable.FAILOVER_PINNED.code in _info_codes(result)

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_efa.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_efa.py
@@ -104,8 +104,12 @@ def test_is_p6plus_instance(instance_type, expected):
         # Expected count is capped at devices actually present.
         ("p5.48xlarge", 4, 4),
         ("p6-b300.48xlarge", 8, 8),
-        # Instance types not in the table have no static expectation.
-        ("c5n.18xlarge", 2, None),
+        # Instance types not in the table bind ALL present devices: the expectation is derived from the
+        # node, not from the doc's stale "other instances with multiple network cards -> 2" row.
+        ("trn1.32xlarge", 8, 8),
+        ("c5n.18xlarge", 2, 2),
+        ("c5n.18xlarge", 1, 1),
+        # An unknown instance type (IMDS unreachable) yields no expectation at all.
         (None, 16, None),
     ],
 )

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_lustre.py
@@ -12,6 +12,8 @@
 
 """Unit tests for the Lustre-specific helpers: lfs df parsing and client detection."""
 
+import pytest
+
 from pcluster_diag.util import kernel_module, lustre
 from tests.test_helpers import DEGRADED_LFS_DF as _DEGRADED_LFS_DF
 from tests.test_helpers import HEALTHY_LFS_DF as _HEALTHY_LFS_DF
@@ -193,6 +195,7 @@ _LFS_CHECK_SERVERS = """\
 fs-MDT0000-mdc-ffff active.
 fs-OST0000-osc-ffff active.
 check 'fs-OST000b-osc-ffff': Input/output error (5)
+lfs check: error: Input/output error (5)
 """
 
 
@@ -216,6 +219,19 @@ def test_unreachable_servers_flags_only_errored():
 
 def test_unreachable_servers_empty_when_all_active():
     assert lustre.unreachable_servers("fs-OST0000-osc-ffff active.\n") == []
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # Command-level diagnostics name no target; reading them as one invented a target called "lfs".
+        "lfs check: error: Input/output error (5)",
+        "lfs check: cannot check target 'servers': No such device (19)",
+        "lfs: error: no device found",
+    ],
+)
+def test_parse_lfs_check_servers_ignores_command_level_errors(line):
+    assert lustre.parse_lfs_check_servers(line + "\n") == []
 
 
 # --- LNet ping (lnetctl peer show + ping) ---------------------------------------------

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_lustre.py
@@ -266,6 +266,21 @@ def test_parse_lctl_import_empty_when_no_blocks():
 # --- LNet ping (lnetctl peer show + ping) ---------------------------------------------
 
 
+def test_efa_peer_nids_returns_all_efa_peers(monkeypatch):
+    two_efa_peers = (
+        "peer:\n"
+        "    - primary nid: 10.0.1.5@efa\n      peer ni:\n        - nid: 10.0.1.5@efa\n"
+        "    - primary nid: 10.0.1.6@efa\n      peer ni:\n        - nid: 10.0.1.6@efa\n"
+    )
+    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(stdout=two_efa_peers))
+    assert lustre.efa_peer_nids() == ["10.0.1.5@efa", "10.0.1.6@efa"]
+
+
+def test_efa_peer_nids_empty_on_command_failure(monkeypatch):
+    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(returncode=1))
+    assert lustre.efa_peer_nids() == []
+
+
 def test_efa_peer_nid_returns_first_efa_peer(monkeypatch):
     monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(stdout=_LNET_PEER_SHOW))
     assert lustre.efa_peer_nid() == "10.0.1.5@efa"

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_lustre.py
@@ -218,51 +218,6 @@ def test_unreachable_servers_empty_when_all_active():
     assert lustre.unreachable_servers("fs-OST0000-osc-ffff active.\n") == []
 
 
-# --- lctl get_param import parsing ----------------------------------------------------
-
-_LCTL_IMPORT = """\
-osc.fs-OST0000-osc-ffff.import=
-    import:
-        target: fs-OST0000_UUID
-        state: FULL
-        connection:
-            current_connection: 10.0.1.5@efa
-            failover_nids: [ 10.0.1.5@efa ]
-mdc.fs-MDT0000-mdc-ffff.import=
-    import:
-        target: fs-MDT0000_UUID
-        state: DISCONN
-        connection:
-            current_connection: 10.0.1.6@tcp
-            failover_nids: [ 10.0.1.7@tcp ]
-"""
-
-
-def test_parse_lctl_import_extracts_state_and_connection():
-    imports = lustre.parse_lctl_import(_LCTL_IMPORT)
-
-    assert [i.param for i in imports] == ["osc.fs-OST0000-osc-ffff", "mdc.fs-MDT0000-mdc-ffff"]
-    assert imports[0].state == "FULL"
-    assert imports[0].healthy is True
-    assert imports[0].current_connection == "10.0.1.5@efa"
-    assert imports[0].connected_over == "efa"
-    assert imports[0].failover_nids == ["10.0.1.5@efa"]
-
-
-def test_parse_lctl_import_flags_non_full_state():
-    imports = lustre.parse_lctl_import(_LCTL_IMPORT)
-
-    mdt = imports[1]
-    assert mdt.state == "DISCONN"
-    assert mdt.healthy is False
-    assert mdt.connected_over == "tcp"
-    assert mdt.failover_nids == ["10.0.1.7@tcp"]
-
-
-def test_parse_lctl_import_empty_when_no_blocks():
-    assert lustre.parse_lctl_import("some noise\nno import here\n") == []
-
-
 # --- LNet ping (lnetctl peer show + ping) ---------------------------------------------
 
 

--- a/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_lustre.py
+++ b/cookbooks/aws-parallelcluster-platform/files/pcluster-diag/tests/util/test_lustre.py
@@ -160,29 +160,52 @@ def test_parse_lnet_net_show_empty_on_garbage():
 
 # --- lnetctl peer show parsing --------------------------------------------------------
 
+# The three entry shapes a real client's peer table mixes: a discovered server (@tcp primary, Multi-Rail,
+# with a 198.19.0.0/16 @tcp1 rail on the filesystem's internal net plus the @efa rail), an entry for that
+# internal net alone (@tcp1 primary, no rail this client can use -- it has no local @tcp1 NI), and a
+# leftover from a failed `lnetctl ping` (@efa primary, Multi-Rail False).
 _LNET_PEER_SHOW = """\
 peer:
-    - primary nid: 10.0.1.5@efa
+    - primary nid: 10.0.1.5@tcp
+      Multi-Rail: True
       peer ni:
-        - nid: 10.0.1.5@efa
         - nid: 10.0.1.5@tcp
-    - primary nid: 10.0.1.6@tcp
+          state: NA
+        - nid: 198.19.0.5@tcp1
+          state: NA
+        - nid: 10.0.1.5@efa
+          state: NA
+    - primary nid: 198.19.1.78@tcp1
+      Multi-Rail: True
       peer ni:
-        - nid: 10.0.1.6@tcp
+        - nid: 198.19.1.78@tcp1
+          state: NA
+    - primary nid: 10.0.1.9@efa
+      Multi-Rail: False
+      peer ni:
+        - nid: 10.0.1.9@efa
+          state: NA
 """
 
 
-def test_parse_lnet_peer_show_collects_nids():
-    nids = lustre.parse_lnet_peer_show(_LNET_PEER_SHOW)
+def test_parse_lnet_peer_show_keeps_primary_and_rails_per_peer():
+    peers = lustre.parse_lnet_peer_show(_LNET_PEER_SHOW)
 
-    assert "10.0.1.5@efa" in nids
-    assert "10.0.1.6@tcp" in nids
+    # Which nid is the primary is what tells a discovered peer from a leftover ping entry, so it is kept
+    # per peer rather than flattened in with the rails.
+    assert [peer.primary_nid for peer in peers] == ["10.0.1.5@tcp", "198.19.1.78@tcp1", "10.0.1.9@efa"]
+    assert peers[0].nids == ["10.0.1.5@tcp", "198.19.0.5@tcp1", "10.0.1.5@efa"]
+    assert peers[1].nids == ["198.19.1.78@tcp1"]
+    assert peers[2].nids == ["10.0.1.9@efa"]
 
 
 def test_nids_on_net_filters_and_dedupes():
-    nids = lustre.parse_lnet_peer_show(_LNET_PEER_SHOW)
+    nids = ["10.0.1.5@efa", "10.0.1.5@tcp", "10.0.1.5@efa", "198.19.0.5@tcp1", "10.0.1.6@tcp"]
 
     assert lustre.nids_on_net(nids, "efa") == ["10.0.1.5@efa"]
+    # The net is matched on the whole "@<net>" suffix, so a @tcp1 nid is not a @tcp nid.
+    assert lustre.nids_on_net(nids, "tcp") == ["10.0.1.5@tcp", "10.0.1.6@tcp"]
+    assert lustre.nids_on_net(nids, "tcp1") == ["198.19.0.5@tcp1"]
 
 
 def test_parse_lnet_peer_show_empty_on_garbage():
@@ -237,35 +260,54 @@ def test_parse_lfs_check_servers_ignores_command_level_errors(line):
 # --- LNet ping (lnetctl peer show + ping) ---------------------------------------------
 
 
-def test_efa_peer_nids_returns_all_efa_peers(monkeypatch):
-    two_efa_peers = (
-        "peer:\n"
-        "    - primary nid: 10.0.1.5@efa\n      peer ni:\n        - nid: 10.0.1.5@efa\n"
-        "    - primary nid: 10.0.1.6@efa\n      peer ni:\n        - nid: 10.0.1.6@efa\n"
+_LNET_PEER_TWO_SERVERS = (
+    "peer:\n"
+    "    - primary nid: 10.0.1.5@tcp\n      Multi-Rail: True\n      peer ni:\n"
+    "        - nid: 10.0.1.5@tcp\n        - nid: 198.19.0.5@tcp1\n        - nid: 10.0.1.5@efa\n"
+    "    - primary nid: 10.0.1.6@tcp\n      Multi-Rail: True\n      peer ni:\n"
+    "        - nid: 10.0.1.6@tcp\n        - nid: 198.19.0.6@tcp1\n        - nid: 10.0.1.6@efa\n"
+)
+
+
+def test_multi_rail_efa_peer_nids_returns_the_efa_rail_of_each_discovered_peer(monkeypatch):
+    monkeypatch.setattr(
+        lustre, "time_command", lambda command, timeout: _completed_timed(stdout=_LNET_PEER_TWO_SERVERS)
     )
-    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(stdout=two_efa_peers))
-    assert lustre.efa_peer_nids() == ["10.0.1.5@efa", "10.0.1.6@efa"]
+    # Only the @efa rails: the @tcp primary and the @tcp1 rail on the filesystem's internal net are not
+    # EFA and are not probed.
+    assert lustre.multi_rail_efa_peer_nids() == ["10.0.1.5@efa", "10.0.1.6@efa"]
 
 
-def test_efa_peer_nids_empty_on_command_failure(monkeypatch):
-    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(returncode=1))
-    assert lustre.efa_peer_nids() == []
-
-
-def test_efa_peer_nid_returns_first_efa_peer(monkeypatch):
+def test_multi_rail_efa_peer_nids_skips_leftover_and_efa_less_peers(monkeypatch):
+    # Of the three shapes in a real table, only the discovered server contributes: the @efa NID that is its
+    # own primary is a leftover from a failed `lnetctl ping` (it answers nothing even on a healthy fabric),
+    # and the @tcp1-primary entry has no @efa rail at all.
     monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(stdout=_LNET_PEER_SHOW))
-    assert lustre.efa_peer_nid() == "10.0.1.5@efa"
+    assert lustre.multi_rail_efa_peer_nids() == ["10.0.1.5@efa"]
 
 
-def test_efa_peer_nid_none_when_no_efa_peer(monkeypatch):
-    tcp_only_peer = "peer:\n    - primary nid: 1.2.3.4@tcp\n"
-    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(stdout=tcp_only_peer))
-    assert lustre.efa_peer_nid() is None
+def test_multi_rail_efa_peer_nids_empty_when_no_peer_has_an_efa_rail(monkeypatch):
+    # An FSx-internal peer as it appears on a live node: reachable only on @tcp1, which this client has no
+    # local NI for, and carrying no @efa rail -- nothing here says anything about the EFA data path.
+    internal_net_peer_only = (
+        "peer:\n"
+        "    - primary nid: 198.19.1.78@tcp1\n      Multi-Rail: True\n      peer ni:\n"
+        "        - nid: 198.19.1.78@tcp1\n          state: NA\n"
+    )
+    monkeypatch.setattr(
+        lustre, "time_command", lambda command, timeout: _completed_timed(stdout=internal_net_peer_only)
+    )
+    assert lustre.multi_rail_efa_peer_nids() == []
 
 
-def test_efa_peer_nid_none_on_command_failure(monkeypatch):
+def test_multi_rail_efa_peer_nids_empty_on_command_failure(monkeypatch):
     monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(returncode=1))
-    assert lustre.efa_peer_nid() is None
+    assert lustre.multi_rail_efa_peer_nids() == []
+
+
+def test_lnet_peers_empty_on_command_failure(monkeypatch):
+    monkeypatch.setattr(lustre, "time_command", lambda command, timeout: _completed_timed(returncode=1))
+    assert lustre.lnet_peers() == []
 
 
 def test_efa_ping_works_true_on_success(monkeypatch):


### PR DESCRIPTION
### Description of changes
**EFA data-path ping**
  - Ping all discovered `@efa` peers, not just the first, so one bad NID no longer fails a healthy fabric.
  - Only ping peers LNet actually discovered (`@tcp` primary with an `@efa` rail). Leftover entries from a failed manual ping, and the node's own nids, are skipped — a self-ping was previously enough to make a fully broken path look healthy.
  - New W4 `SOME_EFA_PEERS_UNREACHABLE` when only some peers fail; E11 now means *all* failed, i.e. local breakage (usually the missing self-referencing SG rule).
  - Messages no longer claim traffic "falls back to TCP" — a failed ping can't tell us that.

  **EFA device binding**
  - Instance types not in the FSx doc table now expect all devices bound, so a partial bind reports E17 instead of passing silently.
  - I5 no longer claims the count matched an expectation that was never computed: new W3 `PARTIAL_BIND_UNVERIFIABLE` when it's undecidable, I10 when every device is bound.

  **Removed checks that fired on healthy filesystems or added no coverage**
  - Import-state (E4), failover-pin (I1), TCP-fallback (W3), and I8 binding reference, plus the now-dead `lctl ...import` parser.

  **Parsing fix**
  - `lfs check: error: ...` was read as a target named "lfs", producing a phantom E3. Now a row must name an MDT/OST.

  Note: W3 is reused mid-series (`TCP_FALLBACK` is deleted, then the number is reassigned to `PARTIAL_BIND_UNVERIFIABLE`), so reviewing commit-by-commit is clearer than the squashed diff.

### Tests
* Unit tests
* Integ test as part of https://github.com/aws/aws-parallelcluster/pull/7572
* Added a unknown peer ` lnetctl peer add --prim_nid 192.168.5.161@tcp --nid 5.162.0.0@efa` (so polluted a peer table)
```
 {
      "check_id": "LustreFilesystem",
      "check_description": "Verify that FsxLustre filesystems are installed, mounted, reachable, and riding EFA.",
      "status": "WARNING",
      "warnings": [
        {
          "code": "W4",
          "message": "EFA ping from 66.248.0.248@efa failed for 1 of the 2 discovered @efa peers (5.162.0.0@efa), while the others answered -- the local EFA path works, so whatever is wrong is specific to those peers. Confirm in `lnetctl peer show` that those nids belong to peers this node should be reaching: an @efa nid left behind by an earlier manual ping, or a rail of a peer that is no longer part of the filesystem, fails exactly the same way."
        }
      ],
      "infos": [
        {
          "code": "I1",
          "message": "Lustre client version: 2.15.6."
        },
        {
          "code": "I2",
          "message": "Active LNet transports: tcp, efa."
        },
        {
          "code": "I6",
          "message": "EFA driver version: 3.1.0g."
        },
        {
          "code": "I7",
          "message": "kefalnd (EFA LND) version: 1.2.2."
        },
        {
          "code": "I4",
          "message": "The EFA-Lustre configuration service configure-efa-fsx-lustre-client.service is installed and not failed."
        },
        {
          "code": "I5",
          "message": "1 of 1 EFA devices are bound to LNet, matching the expected count for this instance type."
        }
      ]
    },
    {
      "check_id": "FsxTargetsAreReachable",
      "check_description": "Deep-probe each FsxLustre OST/MDT for reachability (lfs check servers).",
      "status": "PASSED"
    }
  ]
}
```
* Passing checks 
 ```
 {
      "check_id": "LustreFilesystem",
      "check_description": "Verify that FsxLustre filesystems are installed, mounted, reachable, and riding EFA.",
      "status": "PASSED",
      "infos": [
        {
          "code": "I1",
          "message": "Lustre client version: 2.15.6."
        },
        {
          "code": "I2",
          "message": "Active LNet transports: tcp, efa."
        },
        {
          "code": "I6",
          "message": "EFA driver version: 3.1.0g."
        },
        {
          "code": "I7",
          "message": "kefalnd (EFA LND) version: 1.2.2."
        },
        {
          "code": "I4",
          "message": "The EFA-Lustre configuration service configure-efa-fsx-lustre-client.service is installed and not failed."
        },
        {
          "code": "I5",
          "message": "1 of 1 EFA devices are bound to LNet, matching the expected count for this instance type."
        }
      ]
    },
    {
      "check_id": "FsxTargetsAreReachable",
      "check_description": "Deep-probe each FsxLustre OST/MDT for reachability (lfs check servers).",
      "status": "PASSED"
    }
  ]
}
 ```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
