### PR TITLE
[Test] Replace real NVIDIA urls with fake ones in unit tests.

### DIFF
--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_cuda_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_cuda_spec.rb
@@ -50,9 +50,10 @@ describe 'nvidia_cuda helpers' do
   end
 end
 
-describe 'nvidia_cuda: overriding samples_base_url to the official NVIDIA URL' do
+describe 'nvidia_cuda: overriding samples_base_url to a public URL' do
   cached(:cuda_version) { '1.2.3' }
-  cached(:samples_base_url) { 'https://github.com/NVIDIA/cuda-samples/archive/refs/tags' }
+  # Fake URL: test only verifies the configured attribute value is used.
+  cached(:samples_base_url) { 'https://example.com/cuda-samples/archive/refs/tags' }
 
   cached(:chef_run) do
     allow_any_instance_of(Object).to receive(:nvidia_enabled?).and_return(true)
@@ -66,7 +67,7 @@ describe 'nvidia_cuda: overriding samples_base_url to the official NVIDIA URL' d
     ConvergeNvidiaCuda.setup(runner)
   end
 
-  it 'downloads the cuda samples from the official NVIDIA URL' do
+  it 'downloads the cuda samples from the configured URL' do
     is_expected.to create_remote_file('/tmp/cuda-sample.tar.gz').with(
       source: "#{samples_base_url}/v1.2.tar.gz"
     )

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_repo_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/resources/nvidia_repo_spec.rb
@@ -339,13 +339,13 @@ describe 'nvidia_repo:add_cuda_repo skip conditions' do
   end
 end
 
-describe 'nvidia_repo: overriding base_url to the official NVIDIA URLs' do
-  # Fake versions: tests only verify the configured attribute values are used.
+describe 'nvidia_repo: overriding base_url to a public URL' do
+  # Fake versions and URLs: tests only verify the configured attribute values are used.
   cached(:driver_version) { '9.8.7' }
   cached(:cuda_version) { '1.2.3' }
   cached(:cuda_suffix) { '4.5.6' }
-  cached(:driver_base_url) { "https://developer.download.nvidia.com/compute/nvidia-driver/#{driver_version}/local_installers" }
-  cached(:cuda_base_url) { "https://developer.download.nvidia.com/compute/cuda/#{cuda_version}/local_installers" }
+  cached(:driver_base_url) { "https://example.com/compute/nvidia-driver/#{driver_version}/local_installers" }
+  cached(:cuda_base_url) { "https://example.com/compute/cuda/#{cuda_version}/local_installers" }
   cached(:driver_pkg_file) { "nvidia-driver-local-repo-amzn2023-#{driver_version}-1.0-1.x86_64.rpm" }
   cached(:cuda_pkg_file) { "cuda-repo-amzn2023-1-2-local-#{cuda_version}_#{cuda_suffix}-1.x86_64.rpm" }
 
@@ -374,13 +374,13 @@ describe 'nvidia_repo: overriding base_url to the official NVIDIA URLs' do
     ConvergeNvidiaRepo.add_cuda_repo(runner)
   end
 
-  it 'downloads the driver local repo from the official NVIDIA URL' do
+  it 'downloads the driver local repo from the configured URL' do
     expect(driver_run).to create_remote_file(%r{/#{driver_pkg_file}$}).with(
       source: "#{driver_base_url}/#{driver_pkg_file}"
     )
   end
 
-  it 'downloads the cuda local repo from the official NVIDIA URL' do
+  it 'downloads the cuda local repo from the configured URL' do
     expect(cuda_run).to create_remote_file(%r{/#{cuda_pkg_file}$}).with(
       source: "#{cuda_base_url}/#{cuda_pkg_file}"
     )


### PR DESCRIPTION
### Description of changes
Replace real NVIDIA urls with fake ones in unit tests.
This is a minor fix to prevent AI allucinations.
Before this fix AI was thinking we were downloading NVIDIA artifacts from public URLs.

### Tests
PR checks

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
