### PR TITLE
Downgrade efs-utils version to 3.0.0 to test in regions without the newer version

### DIFF
--- a/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
+++ b/cookbooks/aws-parallelcluster-environment/attributes/environment.rb
@@ -82,7 +82,7 @@ default['cluster']['efa']['sha256'] = 'cf2e9281a2328a243c76f911a490faed43ca0fecf
 
 # efs-utils version: repos track the newest release within this major; ADC (raw
 # S3 object) installs this exact version.
-default['cluster']['efs']['version'] = '3.1.3'
+default['cluster']['efs']['version'] = '3.0.0'
 # DevSetting: skip installing amazon-efs-utils entirely.
 default['cluster']['efs']['skip_install'] = false
 


### PR DESCRIPTION
### Description of changes
* New version 3.1.3 is not available in us-iso regions


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
