### PR TITLE
Ship only AWS CLI v2 in ParallelCluster AMIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is used to list changes made in each version of the AWS ParallelCluste
 3.17.0
 ------
 
+**CHANGES**
+- Ship only AWS CLI v2 in ParallelCluster AMIs. AWS CLI v1 is no longer installed in the cookbook Python virtual environment.
+
 **BUG FIXES**
 - Fix cluster update hanging on the `fuser` probe that ran before every shared storage unmount when the storage was unresponsive.
 

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/config/fleet_status.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/config/fleet_status.rb
@@ -53,7 +53,7 @@ when 'HeadNode'
   unless on_docker? || kitchen_test? && !node['interact_with_ddb']
     execute 'initialize compute fleet status in DynamoDB' do
       # Initialize the status of the compute fleet in the DynamoDB table. Set it to RUNNING.
-      command "#{node['cluster']['aws_cli_bin']} dynamodb put-item --table-name #{node['cluster']['ddb_table']}"\
+      command "/usr/local/bin/aws dynamodb put-item --table-name #{node['cluster']['ddb_table']}"\
               " --item '{\"Id\": {\"S\": \"COMPUTE_FLEET\"}, \"Data\": {\"M\": {\"status\": {\"S\": \"RUNNING\"}, \"lastStatusUpdatedTime\": {\"S\": \"#{Time.now.utc}\"}}}}'" \
               " --region #{node['cluster']['region']}"
       retries 3

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/config/fleet_status.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/config/fleet_status.rb
@@ -53,7 +53,7 @@ when 'HeadNode'
   unless on_docker? || kitchen_test? && !node['interact_with_ddb']
     execute 'initialize compute fleet status in DynamoDB' do
       # Initialize the status of the compute fleet in the DynamoDB table. Set it to RUNNING.
-      command "#{cookbook_virtualenv_path}/bin/aws dynamodb put-item --table-name #{node['cluster']['ddb_table']}"\
+      command "#{node['cluster']['aws_cli_bin']} dynamodb put-item --table-name #{node['cluster']['ddb_table']}"\
               " --item '{\"Id\": {\"S\": \"COMPUTE_FLEET\"}, \"Data\": {\"M\": {\"status\": {\"S\": \"RUNNING\"}, \"lastStatusUpdatedTime\": {\"S\": \"#{Time.now.utc}\"}}}}'" \
               " --region #{node['cluster']['region']}"
       retries 3

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
@@ -59,7 +59,7 @@ bash "install aws-parallelcluster-node from #{node['cluster']['custom_node_packa
     source #{node_virtualenv_path}/bin/activate
     pip uninstall --yes aws-parallelcluster-node
     if [[ "#{node['cluster']['custom_node_package']}" =~ ^s3:// ]]; then
-      custom_package_url=$(#{node['cluster']['aws_cli_bin']} s3 presign #{node['cluster']['custom_node_package']} --region #{aws_region} --endpoint-url https://s3.#{aws_region}.#{aws_domain})
+      custom_package_url=$(/usr/local/bin/aws s3 presign #{node['cluster']['custom_node_package']} --region #{aws_region} --endpoint-url https://s3.#{aws_region}.#{aws_domain})
     else
       custom_package_url=#{node['cluster']['custom_node_package']}
     fi

--- a/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/recipes/install/custom_parallelcluster_node.rb
@@ -59,7 +59,7 @@ bash "install aws-parallelcluster-node from #{node['cluster']['custom_node_packa
     source #{node_virtualenv_path}/bin/activate
     pip uninstall --yes aws-parallelcluster-node
     if [[ "#{node['cluster']['custom_node_package']}" =~ ^s3:// ]]; then
-      custom_package_url=$(#{cookbook_virtualenv_path}/bin/aws s3 presign #{node['cluster']['custom_node_package']} --region #{aws_region} --endpoint-url https://s3.#{aws_region}.#{aws_domain})
+      custom_package_url=$(#{node['cluster']['aws_cli_bin']} s3 presign #{node['cluster']['custom_node_package']} --region #{aws_region} --endpoint-url https://s3.#{aws_region}.#{aws_domain})
     else
       custom_package_url=#{node['cluster']['custom_node_package']}
     fi

--- a/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-computefleet/spec/unit/recipes/custom_parallelcluster_node_spec.rb
@@ -11,7 +11,7 @@ describe 'aws-parallelcluster-computefleet::custom_parallelcluster_node' do
       cached(:dependency_pkg_name_suffix) { "pypi-node-dependencies-#{python_version}-#{arch}" }
       cached(:dependency_folder_name_suffix) { dependency_pkg_name_suffix }
       cached(:virtualenv_path) { "#{base_dir}/pyenv/versions/#{python_version}/envs/node_virtualenv" }
-      cached(:cookbook_virtualenv_path) { "#{base_dir}/pyenv/versions/#{python_version}/envs/cookbook_virtualenv" }
+      cached(:aws_cli_bin) { '/usr/local/bin/aws' }
       cached(:custom_node_s3_url) { "#{s3_url}/pyenv/versions/#{python_version}/envs/node_virtualenv" }
       cached(:pip_install_bash_code) do
         <<-REQ
@@ -33,7 +33,7 @@ describe 'aws-parallelcluster-computefleet::custom_parallelcluster_node' do
   source #{virtualenv_path}/bin/activate
   pip uninstall --yes aws-parallelcluster-node
   if [[ "#{custom_node_s3_url}" =~ ^s3:// ]]; then
-    custom_package_url=$(#{cookbook_virtualenv_path}/bin/aws s3 presign #{custom_node_s3_url} --region test_region --endpoint-url https://s3.test_region.test_aws_domain)
+    custom_package_url=$(#{aws_cli_bin} s3 presign #{custom_node_s3_url} --region test_region --endpoint-url https://s3.test_region.test_aws_domain)
   else
     custom_package_url=#{custom_node_s3_url}
   fi

--- a/cookbooks/aws-parallelcluster-platform/files/cookbook_virtualenv/requirements.txt
+++ b/cookbooks/aws-parallelcluster-platform/files/cookbook_virtualenv/requirements.txt
@@ -3,7 +3,6 @@ supervisor
 requests
 jsonschema
 jinja2
-requests
 PyYAML
 retrying
 click

--- a/cookbooks/aws-parallelcluster-platform/files/cookbook_virtualenv/requirements.txt
+++ b/cookbooks/aws-parallelcluster-platform/files/cookbook_virtualenv/requirements.txt
@@ -1,4 +1,3 @@
-awscli
 boto3
 supervisor
 requests

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/awscli.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/awscli.rb
@@ -16,7 +16,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-return if ::File.exist?("/usr/local/bin/aws") || redhat_on_docker?
+return if ::File.exist?(node['cluster']['aws_cli_bin']) || redhat_on_docker?
 
 file_cache_path = Chef::Config[:file_cache_path]
 region = aws_region

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/awscli.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/awscli.rb
@@ -16,7 +16,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-return if ::File.exist?(node['cluster']['aws_cli_bin']) || redhat_on_docker?
+return if ::File.exist?("/usr/local/bin/aws") || redhat_on_docker?
 
 file_cache_path = Chef::Config[:file_cache_path]
 region = aws_region

--- a/cookbooks/aws-parallelcluster-platform/recipes/install/cookbook_virtualenv.rb
+++ b/cookbooks/aws-parallelcluster-platform/recipes/install/cookbook_virtualenv.rb
@@ -29,16 +29,16 @@ activate_virtual_env cookbook_virtualenv_name do
   not_if { ::File.exist?("#{cookbook_virtualenv_path}/bin/activate") }
 end
 
+cookbook_file "#{node['cluster']['base_dir']}/cookbook-requirements.txt" do
+  source 'cookbook_virtualenv/requirements.txt'
+  cookbook 'aws-parallelcluster-platform'
+  mode '0644'
+end
+
 # Install dependencies based on install_python_from_internet setting
 # When true, dependencies are installed from PyPI (for testing new Python versions)
 # When false (default), dependencies are installed from S3 pre-built packages (production mode)
 if node['cluster']['install_python_from_internet']
-  cookbook_file "#{node['cluster']['base_dir']}/cookbook-requirements.txt" do
-    source 'cookbook_virtualenv/requirements.txt'
-    cookbook 'aws-parallelcluster-platform'
-    mode '0644'
-  end
-
   bash 'pip install cookbook dependencies from internet' do
     user 'root'
     group 'root'
@@ -64,7 +64,7 @@ else
       set -e
       tar xzf cookbook-dependencies.tgz
       cd #{dependency_package_name}
-      #{virtualenv_path}/bin/pip install * -f ./ --no-index
+      #{virtualenv_path}/bin/pip install -r #{node['cluster']['base_dir']}/cookbook-requirements.txt -f ./ --no-index
     REQ
   end
 end

--- a/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
@@ -112,7 +112,7 @@ action_class do # rubocop:disable Metrics/BlockLength
   end
 
   def fetch_s3_object(command_label, key, output, version_id = nil)
-    fetch_s3_object_command = "#{cookbook_virtualenv_path}/bin/aws s3api get-object" \
+    fetch_s3_object_command = "#{node['cluster']['aws_cli_bin']} s3api get-object" \
                          " --bucket #{node['cluster']['cluster_s3_bucket']}" \
                          " --key #{key}" \
                          " --region #{node['cluster']['region']}" \

--- a/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
+++ b/cookbooks/aws-parallelcluster-platform/resources/fetch_config.rb
@@ -112,7 +112,7 @@ action_class do # rubocop:disable Metrics/BlockLength
   end
 
   def fetch_s3_object(command_label, key, output, version_id = nil)
-    fetch_s3_object_command = "#{node['cluster']['aws_cli_bin']} s3api get-object" \
+    fetch_s3_object_command = "/usr/local/bin/aws s3api get-object" \
                          " --bucket #{node['cluster']['cluster_s3_bucket']}" \
                          " --key #{key}" \
                          " --region #{node['cluster']['region']}" \

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/awscli_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/awscli_spec.rb
@@ -29,13 +29,13 @@ describe 'aws-parallelcluster-platform::awscli' do
           )
         end
 
-        it 'installs awscli into cookbook virtualev path' do
+        it 'installs awscli system-wide' do
           is_expected.to run_bash('install awscli')
             .with_code "#{file_cache_path}/awscli/aws/install -i /usr/local/aws -b /usr/local/bin"
         end
       end
 
-      context "when awscli is not installed" do
+      context "when awscli is already installed" do
         cached(:chef_run) do
           allow(File).to receive(:exist?).with('/usr/local/bin/aws').and_return(true)
           runner(platform: platform, version: version).converge(described_recipe)

--- a/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cookbook_virtualenv_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/spec/unit/recipes/cookbook_virtualenv_spec.rb
@@ -17,7 +17,7 @@ describe 'aws-parallelcluster-platform::cookbook_virtualenv' do
       set -e
       tar xzf cookbook-dependencies.tgz
       cd #{dependency_package_name}
-      #{virtualenv_path}/bin/pip install * -f ./ --no-index
+      #{virtualenv_path}/bin/pip install -r #{base_dir}/cookbook-requirements.txt -f ./ --no-index
         REQ
       end
       cached(:pip_install_internet_bash_code) do
@@ -62,6 +62,10 @@ describe 'aws-parallelcluster-platform::cookbook_virtualenv' do
               is_expected.to write_node_attributes('dump node attributes')
             end
 
+            it 'creates cookbook requirements file' do
+              is_expected.to create_cookbook_file("#{base_dir}/cookbook-requirements.txt")
+            end
+
             if install_from_internet
               it 'does not download cookbook dependencies from S3' do
                 is_expected.not_to create_remote_file("#{base_dir}/cookbook-dependencies.tgz")
@@ -71,10 +75,6 @@ describe 'aws-parallelcluster-platform::cookbook_virtualenv' do
                 is_expected.not_to run_bash("pip install cookbook dependencies from S3")
                   .with(user: 'root', group: 'root', cwd: base_dir)
                   .with(code: pip_install_s3_bash_code)
-              end
-
-              it 'creates cookbook requirements file' do
-                is_expected.to create_cookbook_file("#{base_dir}/cookbook-requirements.txt")
               end
 
               it 'installs python packages from internet' do
@@ -91,10 +91,6 @@ describe 'aws-parallelcluster-platform::cookbook_virtualenv' do
                 is_expected.to run_bash("pip install cookbook dependencies from S3")
                   .with(user: 'root', group: 'root', cwd: base_dir)
                   .with(code: pip_install_s3_bash_code)
-              end
-
-              it 'does not create cookbook requirements file' do
-                is_expected.not_to create_cookbook_file("#{base_dir}/cookbook-requirements.txt")
               end
 
               it 'does not install python packages from internet' do

--- a/cookbooks/aws-parallelcluster-platform/test/controls/awscli_spec.rb
+++ b/cookbooks/aws-parallelcluster-platform/test/controls/awscli_spec.rb
@@ -10,23 +10,32 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 control 'tag:install_awscli_installed' do
-  title 'awscli package should be installed in cookbook virtualenv'
+  title 'only awscli v2 should be installed, system-wide'
 
   only_if { !os_properties.redhat_on_docker? }
 
-  describe bash("#{node['cluster']['cookbook_virtualenv_path']}/bin/pip list") do
-    its('exit_status') { should eq(0) }
-    its('stdout')      { should match('awscli') }
-  end
-
   describe file('/usr/local/bin/aws') do
     it { should exist }
+  end
+
+  describe bash('/usr/local/bin/aws --version') do
+    its('exit_status') { should eq(0) }
+    its('stdout')      { should match(%r{^aws-cli/2\.}) }
+  end
+
+  # AWS CLI v2 is not published on PyPI, so any awscli package in the virtualenv would be v1.
+  describe bash("#{node['cluster']['cookbook_virtualenv_path']}/bin/pip list") do
+    its('exit_status') { should eq(0) }
+    its('stdout')      { should_not match('awscli') }
+  end
+
+  describe file("#{node['cluster']['cookbook_virtualenv_path']}/bin/aws") do
+    it { should_not exist }
   end
 end
 
 control 'tag:testami_awscli_can_run_as_cluster_user_and_as_root' do
   only_if { !os_properties.redhat_on_docker? }
-  virtualenv_path = node['cluster']['cookbook_virtualenv_path']
 
   describe "aws cli can run as cluster default user #{node['cluster']['cluster_user']}" do
     subject { bash("sudo su - #{node['cluster']['cluster_user']} -c 'aws --version'") }
@@ -35,11 +44,6 @@ control 'tag:testami_awscli_can_run_as_cluster_user_and_as_root' do
 
   describe 'aws cli can run as root' do
     subject { bash("sudo su - -c 'aws --version'") }
-    its('exit_status') { should eq 0 }
-  end
-
-  describe 'aws cli can run as root in cookbook virtualenv' do
-    subject { bash("#{virtualenv_path}/bin/aws --version") }
     its('exit_status') { should eq 0 }
   end
 end

--- a/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
@@ -8,7 +8,6 @@ default['cluster']['examples_dir'] = "#{node['cluster']['base_dir']}/examples"
 default['cluster']['shared_dir_login_nodes'] = "#{node['cluster']['base_dir']}/shared_login_nodes"
 default['cluster']['log_base_dir'] = '/var/log/parallelcluster'
 default['cluster']['etc_dir'] = '/etc/parallelcluster'
-default['cluster']['aws_cli_bin'] = '/usr/local/bin/aws'
 
 default['cluster']['exec_tmp_dir'] = "#{node['cluster']['base_dir']}/tmp"
 default['cluster']['tmp_noexec'] = 'false'

--- a/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
+++ b/cookbooks/aws-parallelcluster-shared/attributes/cluster.rb
@@ -8,6 +8,7 @@ default['cluster']['examples_dir'] = "#{node['cluster']['base_dir']}/examples"
 default['cluster']['shared_dir_login_nodes'] = "#{node['cluster']['base_dir']}/shared_login_nodes"
 default['cluster']['log_base_dir'] = '/var/log/parallelcluster'
 default['cluster']['etc_dir'] = '/etc/parallelcluster'
+default['cluster']['aws_cli_bin'] = '/usr/local/bin/aws'
 
 default['cluster']['exec_tmp_dir'] = "#{node['cluster']['base_dir']}/tmp"
 default['cluster']['tmp_noexec'] = 'false'

--- a/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
@@ -36,7 +36,7 @@ def save_instance_config_version_to_dynamodb(status)
     item = "{\"Id\": {\"S\": \"#{item_id}\"}, \"Data\": {\"M\": #{item_data}}}"
 
     execute "Save cluster config version to DynamoDB" do
-      command "#{cookbook_virtualenv_path}/bin/aws dynamodb put-item" \
+      command "#{node['cluster']['aws_cli_bin']} dynamodb put-item" \
                 " --table-name #{table_name}"\
                 " --item '#{item}'" \
                 " --region #{node['cluster']['region']}"

--- a/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/dynamo.rb
@@ -36,7 +36,7 @@ def save_instance_config_version_to_dynamodb(status)
     item = "{\"Id\": {\"S\": \"#{item_id}\"}, \"Data\": {\"M\": #{item_data}}}"
 
     execute "Save cluster config version to DynamoDB" do
-      command "#{node['cluster']['aws_cli_bin']} dynamodb put-item" \
+      command "/usr/local/bin/aws dynamodb put-item" \
                 " --table-name #{table_name}"\
                 " --item '#{item}'" \
                 " --region #{node['cluster']['region']}"

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -28,7 +28,7 @@ end
 # Retrieve compute and head node info from dynamo db (Slurm only)
 #
 def dynamodb_info(aws_connection_timeout_seconds: 10, aws_read_timeout_seconds: 30, shell_timeout_seconds: 60)
-  cmd = Mixlib::ShellOut.new("#{cookbook_virtualenv_path}/bin/aws dynamodb " \
+  cmd = Mixlib::ShellOut.new("#{node['cluster']['aws_cli_bin']} dynamodb " \
                       "--region #{node['cluster']['region']} query --table-name #{node['cluster']['slurm_ddb_table']} " \
                       "--index-name InstanceId --key-condition-expression 'InstanceId = :instanceid' " \
                       "--expression-attribute-values '{\":instanceid\": {\"S\":\"#{node['ec2']['instance_id']}\"}}' " \

--- a/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
+++ b/cookbooks/aws-parallelcluster-slurm/libraries/helpers.rb
@@ -28,7 +28,7 @@ end
 # Retrieve compute and head node info from dynamo db (Slurm only)
 #
 def dynamodb_info(aws_connection_timeout_seconds: 10, aws_read_timeout_seconds: 30, shell_timeout_seconds: 60)
-  cmd = Mixlib::ShellOut.new("#{node['cluster']['aws_cli_bin']} dynamodb " \
+  cmd = Mixlib::ShellOut.new("/usr/local/bin/aws dynamodb " \
                       "--region #{node['cluster']['region']} query --table-name #{node['cluster']['slurm_ddb_table']} " \
                       "--index-name InstanceId --key-condition-expression 'InstanceId = :instanceid' " \
                       "--expression-attribute-values '{\":instanceid\": {\"S\":\"#{node['ec2']['instance_id']}\"}}' " \

--- a/cookbooks/aws-parallelcluster-slurm/resources/remote_object/remote_object.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/remote_object/remote_object.rb
@@ -42,7 +42,7 @@ action :get do
     if source_url.start_with?("s3")
       Chef::Log.debug("Retrieving remote Object from #{source_url} to #{local_path} using S3 protocol")
       # download file using s3 protocol
-      fetch_command = "#{node['cluster']['aws_cli_bin']} s3 cp" \
+      fetch_command = "/usr/local/bin/aws s3 cp" \
                   " --region #{node['cluster']['region']}" \
                   " #{no_sign_request}" \
                   " #{source_url}" \

--- a/cookbooks/aws-parallelcluster-slurm/resources/remote_object/remote_object.rb
+++ b/cookbooks/aws-parallelcluster-slurm/resources/remote_object/remote_object.rb
@@ -42,7 +42,7 @@ action :get do
     if source_url.start_with?("s3")
       Chef::Log.debug("Retrieving remote Object from #{source_url} to #{local_path} using S3 protocol")
       # download file using s3 protocol
-      fetch_command = "#{cookbook_virtualenv_path}/bin/aws s3 cp" \
+      fetch_command = "#{node['cluster']['aws_cli_bin']} s3 cp" \
                   " --region #{node['cluster']['region']}" \
                   " #{no_sign_request}" \
                   " #{source_url}" \

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_compute_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_compute_spec.rb
@@ -16,7 +16,7 @@ require 'spec_helper'
 describe 'aws-parallelcluster-slurm::finalize_compute' do
   for_all_oses do |platform, version|
     node_type = "ComputeFleet"
-    aws_cli_bin = "MOCK_AWS_CLI_BIN"
+    aws_cli_bin = "/usr/local/bin/aws"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
@@ -28,7 +28,6 @@ describe 'aws-parallelcluster-slurm::finalize_compute' do
         runner = runner(platform: platform, version: version) do |node|
           allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
           allow_any_instance_of(Object).to receive(:dig).and_return(true)
-          node.override['cluster']['aws_cli_bin'] = aws_cli_bin
           allow_any_instance_of(Object).to receive(:is_static_node?).and_return(false)
           allow(Time).to receive(:now).and_return(Time.parse(time_now))
           RSpec::Mocks.configuration.allow_message_expectations_on_nil = true

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_compute_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_compute_spec.rb
@@ -16,7 +16,7 @@ require 'spec_helper'
 describe 'aws-parallelcluster-slurm::finalize_compute' do
   for_all_oses do |platform, version|
     node_type = "ComputeFleet"
-    cookbook_venv_path = "MOCK_COOKBOOK_VENV_PATH"
+    aws_cli_bin = "MOCK_AWS_CLI_BIN"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
@@ -28,7 +28,7 @@ describe 'aws-parallelcluster-slurm::finalize_compute' do
         runner = runner(platform: platform, version: version) do |node|
           allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
           allow_any_instance_of(Object).to receive(:dig).and_return(true)
-          allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
+          node.override['cluster']['aws_cli_bin'] = aws_cli_bin
           allow_any_instance_of(Object).to receive(:is_static_node?).and_return(false)
           allow(Time).to receive(:now).and_return(Time.parse(time_now))
           RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
@@ -44,7 +44,7 @@ describe 'aws-parallelcluster-slurm::finalize_compute' do
 
       status = "DEPLOYED_BOOTSTRAP"
       it "saves the cluster config version to dynamodb with status #{status}" do
-        expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
+        expected_command = "#{aws_cli_bin} dynamodb put-item" \
           " --table-name parallelcluster-#{cluster_name}"\
           " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"status\": {\"S\": \"#{status}\"}, \"node_type\": {\"S\": \"#{node_type}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
           " --region #{region}"

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_login_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_login_node_spec.rb
@@ -16,7 +16,7 @@ require 'spec_helper'
 describe 'aws-parallelcluster-slurm::finalize_login_node' do
   for_all_oses do |platform, version|
     node_type = "LoginNode"
-    aws_cli_bin = "MOCK_AWS_CLI_BIN"
+    aws_cli_bin = "/usr/local/bin/aws"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
@@ -28,7 +28,6 @@ describe 'aws-parallelcluster-slurm::finalize_login_node' do
         runner = runner(platform: platform, version: version) do |node|
           allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
           allow_any_instance_of(Object).to receive(:dig).and_return(true)
-          node.override['cluster']['aws_cli_bin'] = aws_cli_bin
           allow_any_instance_of(Object).to receive(:is_static_node?).and_return(false)
           allow(Time).to receive(:now).and_return(Time.parse(time_now))
           RSpec::Mocks.configuration.allow_message_expectations_on_nil = true

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_login_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/finalize_login_node_spec.rb
@@ -16,7 +16,7 @@ require 'spec_helper'
 describe 'aws-parallelcluster-slurm::finalize_login_node' do
   for_all_oses do |platform, version|
     node_type = "LoginNode"
-    cookbook_venv_path = "MOCK_COOKBOOK_VENV_PATH"
+    aws_cli_bin = "MOCK_AWS_CLI_BIN"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
@@ -28,7 +28,7 @@ describe 'aws-parallelcluster-slurm::finalize_login_node' do
         runner = runner(platform: platform, version: version) do |node|
           allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(false)
           allow_any_instance_of(Object).to receive(:dig).and_return(true)
-          allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
+          node.override['cluster']['aws_cli_bin'] = aws_cli_bin
           allow_any_instance_of(Object).to receive(:is_static_node?).and_return(false)
           allow(Time).to receive(:now).and_return(Time.parse(time_now))
           RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
@@ -44,7 +44,7 @@ describe 'aws-parallelcluster-slurm::finalize_login_node' do
 
       status = "DEPLOYED_BOOTSTRAP"
       it "saves the cluster config version to dynamodb with status #{status}" do
-        expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
+        expected_command = "#{aws_cli_bin} dynamodb put-item" \
           " --table-name parallelcluster-#{cluster_name}"\
           " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"status\": {\"S\": \"#{status}\"}, \"node_type\": {\"S\": \"#{node_type}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
           " --region #{region}"

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_compute_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_compute_spec.rb
@@ -16,7 +16,7 @@ require 'spec_helper'
 describe 'aws-parallelcluster-slurm::update_compute' do
   for_all_oses do |platform, version|
     node_type = "ComputeFleet"
-    aws_cli_bin = "MOCK_AWS_CLI_BIN"
+    aws_cli_bin = "/usr/local/bin/aws"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
@@ -33,7 +33,6 @@ describe 'aws-parallelcluster-slurm::update_compute' do
                   allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(are_mount_or_unmount_required)
                   allow_any_instance_of(Object).to receive(:storage_change_supports_live_update?).and_return(storage_change_supports_live_update)
                   allow_any_instance_of(Object).to receive(:dig).and_return(true)
-                  node.override['cluster']['aws_cli_bin'] = aws_cli_bin
                   allow(Time).to receive(:now).and_return(Time.parse(time_now))
                   RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_compute_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_compute_spec.rb
@@ -16,7 +16,7 @@ require 'spec_helper'
 describe 'aws-parallelcluster-slurm::update_compute' do
   for_all_oses do |platform, version|
     node_type = "ComputeFleet"
-    cookbook_venv_path = "MOCK_COOKBOOK_VENV_PATH"
+    aws_cli_bin = "MOCK_AWS_CLI_BIN"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
@@ -33,7 +33,7 @@ describe 'aws-parallelcluster-slurm::update_compute' do
                   allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(are_mount_or_unmount_required)
                   allow_any_instance_of(Object).to receive(:storage_change_supports_live_update?).and_return(storage_change_supports_live_update)
                   allow_any_instance_of(Object).to receive(:dig).and_return(true)
-                  allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
+                  node.override['cluster']['aws_cli_bin'] = aws_cli_bin
                   allow(Time).to receive(:now).and_return(Time.parse(time_now))
                   RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
@@ -58,7 +58,7 @@ describe 'aws-parallelcluster-slurm::update_compute' do
 
               status = "DEPLOYED_UPDATE"
               it "saves the cluster config version to dynamodb with status #{status}" do
-                expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
+                expected_command = "#{aws_cli_bin} dynamodb put-item" \
                   " --table-name parallelcluster-#{cluster_name}"\
                   " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"status\": {\"S\": \"#{status}\"}, \"node_type\": {\"S\": \"#{node_type}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
                   " --region #{region}"

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_login_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_login_node_spec.rb
@@ -16,7 +16,7 @@ require 'spec_helper'
 describe 'aws-parallelcluster-slurm::update_login_node' do
   for_all_oses do |platform, version|
     node_type = "LoginNode"
-    cookbook_venv_path = "MOCK_COOKBOOK_VENV_PATH"
+    aws_cli_bin = "MOCK_AWS_CLI_BIN"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
@@ -33,7 +33,7 @@ describe 'aws-parallelcluster-slurm::update_login_node' do
                   allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(are_mount_or_unmount_required)
                   allow_any_instance_of(Object).to receive(:storage_change_supports_live_update?).and_return(storage_change_supports_live_update)
                   allow_any_instance_of(Object).to receive(:dig).and_return(true)
-                  allow_any_instance_of(Object).to receive(:cookbook_virtualenv_path).and_return(cookbook_venv_path)
+                  node.override['cluster']['aws_cli_bin'] = aws_cli_bin
                   allow(Time).to receive(:now).and_return(Time.parse(time_now))
                   RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
@@ -58,7 +58,7 @@ describe 'aws-parallelcluster-slurm::update_login_node' do
 
               status = "DEPLOYED_UPDATE"
               it "saves the cluster config version to dynamodb with status #{status}" do
-                expected_command = "#{cookbook_venv_path}/bin/aws dynamodb put-item" \
+                expected_command = "#{aws_cli_bin} dynamodb put-item" \
                   " --table-name parallelcluster-#{cluster_name}"\
                   " --item '{\"Id\": {\"S\": \"CLUSTER_CONFIG.#{instance_id}\"}, \"Data\": {\"M\": {\"cluster_config_version\": {\"S\": \"#{cluster_config_version}\"}, \"status\": {\"S\": \"#{status}\"}, \"node_type\": {\"S\": \"#{node_type}\"}, \"lastUpdateTime\": {\"S\": \"#{time_now}\"}}}}'" \
                   " --region #{region}"

--- a/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_login_node_spec.rb
+++ b/cookbooks/aws-parallelcluster-slurm/spec/unit/recipes/update_login_node_spec.rb
@@ -16,7 +16,7 @@ require 'spec_helper'
 describe 'aws-parallelcluster-slurm::update_login_node' do
   for_all_oses do |platform, version|
     node_type = "LoginNode"
-    aws_cli_bin = "MOCK_AWS_CLI_BIN"
+    aws_cli_bin = "/usr/local/bin/aws"
     cluster_name = "MOCK_CLUSTER_NAME"
     region = "MOCK_REGION"
     instance_id = "MOCK_INSTANCE_ID"
@@ -33,7 +33,6 @@ describe 'aws-parallelcluster-slurm::update_login_node' do
                   allow_any_instance_of(Object).to receive(:are_mount_or_unmount_required?).and_return(are_mount_or_unmount_required)
                   allow_any_instance_of(Object).to receive(:storage_change_supports_live_update?).and_return(storage_change_supports_live_update)
                   allow_any_instance_of(Object).to receive(:dig).and_return(true)
-                  node.override['cluster']['aws_cli_bin'] = aws_cli_bin
                   allow(Time).to receive(:now).and_return(Time.parse(time_now))
                   RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 


### PR DESCRIPTION
### Description of changes
ParallelCluster AMIs shipped two AWS CLIs: v2 at `/usr/local/bin/aws`, installed system-wide by the `awscli` recipe, and v1 inside the cookbook virtualenv. The v1 copy came from the `awscli` entry in `cookbook_virtualenv/requirements.txt`: AWS CLI v2 is not published on PyPI, so `pip install awscli` always resolves to v1.

This PR makes the cookbook use only the system-wide AWS CLI v2:

* Add a `cluster/aws_cli_bin` attribute (`/usr/local/bin/aws`) and repoint every `#{cookbook_virtualenv_path}/bin/aws` call to it.
* Remove `awscli` from `cookbook_virtualenv/requirements.txt`.
* Install the cookbook virtualenv dependencies from S3 with `pip install -r cookbook-requirements.txt -f ./ --no-index` instead of `pip install *`. The pre-built bundle is used as an offline package index, so `requirements.txt` is the single source of truth for both install paths and the virtualenv stops picking up `awscli` (and its exclusive dependencies `colorama`, `docutils`, `rsa`, `pyasn1`) without rebuilding the S3 bundle.
* Invert the `awscli` InSpec control: `/usr/local/bin/aws` must be v2 and the cookbook virtualenv must not contain `awscli`.

No S3 artifact needs to be uploaded or removed. With this change the extra wheel is simply not installed.

Side effect: in air-gapped environments, the node package presign no longer needs the extra SigV4 configuration that AWS CLI v1 required.

### Tests
* ChefSpec for `aws-parallelcluster-platform`, `aws-parallelcluster-computefleet` and `aws-parallelcluster-slurm` (0 failures); cookstyle clean.
* pip dry-run of `requirements.txt` against the live `pypi-cookbook-dependencies-3.14-x86_64.tgz` bundle resolves 22 packages with the same versions as today, `awscli` excluded.
* `pcluster build-image` (alinux2023, x86_64) with this cookbook through the production install path, i.e. the S3 bundle that still contains `awscli-1.44.18`: build succeeded, the cookbook virtualenv contains the 22 packages from `requirements.txt` and no `awscli`/`bin/aws`, `/usr/local/bin/aws` is `aws-cli/2.36.40`, and the node package presign through CLI v2 worked.
* Cluster created from the resulting AMI. chef-client.log shows every call going through `/usr/local/bin/aws`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
